### PR TITLE
[P0-03] feat(channels): add daphne ASGI service + /ws/ nginx routing

### DIFF
--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,11 +1,11 @@
-"""
-ASGI config for config project.
+"""ASGI config for config project.
 
 It exposes the ASGI callable as a module-level variable named ``application``.
 
-For more information on this file, see
-https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
+HTTP は Django の get_asgi_application、WebSocket は Channels の URLRouter に振り分ける。
+Phase 3 (DM) で websocket_urlpatterns を apps.dm.routing 等から import して拡張する。
 """
+from __future__ import annotations
 
 import os
 
@@ -13,4 +13,39 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
-application = get_asgi_application()
+# Django の設定読み込みを Channels のインポートより先に行う
+django_asgi_app = get_asgi_application()
+
+# channels は Phase 0 で追加導入済み (P0-01)
+from channels.auth import AuthMiddlewareStack  # noqa: E402
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
+from channels.security.websocket import AllowedHostsOriginValidator  # noqa: E402
+from django.urls import path  # noqa: E402
+
+
+async def health_consumer(scope, receive, send):
+    """WebSocket ヘルスチェック用 minimal consumer. Phase 0.5 の smoke test で利用。"""
+    if scope["type"] == "websocket":
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        await send({"type": "websocket.close", "code": 1000})
+
+
+websocket_urlpatterns = [
+    path("ws/health/", health_consumer),
+    # Phase 3 以降で各 app の routing を include する:
+    # *dm_routing.websocket_urlpatterns,
+    # *notifications_routing.websocket_urlpatterns,
+]
+
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": AllowedHostsOriginValidator(
+            AuthMiddlewareStack(
+                URLRouter(websocket_urlpatterns),
+            ),
+        ),
+    },
+)

--- a/docker/local/nginx/nginx.conf
+++ b/docker/local/nginx/nginx.conf
@@ -16,6 +16,10 @@ upstream client {
   server client:3000;
 }
 
+# security-reviewer feedback: /ws/health/ は認証不要のため
+# 同一 IP からの接続数を制限する (低コスト DDoS 対策)
+limit_conn_zone $binary_remote_addr zone=ws_conn:10m;
+
 server {
   listen 80;
 
@@ -45,7 +49,13 @@ server {
 
   # WebSocket traffic routed to Daphne (Channels). See P0-03.
   # Phase 3 (DM) / Phase 4A (notifications) の websocket endpoint 群を配信。
+  #
+  # NOTE: proxy_*_timeout 3600s はローカルで Channels 長時間接続の挙動確認用。
+  # stg/prod 環境では ALB idle_timeout (3600s, ARCHITECTURE.md §3.4) と揃えるが、
+  # 値は環境固有の nginx 設定で上書きする (本ファイルはローカル専用)。
   location /ws/ {
+    # 同一 IP からの同時接続は 10 本まで (ヘルスチェック閉域 + ユーザー)
+    limit_conn ws_conn 10;
     proxy_pass http://daphne;
     proxy_read_timeout 3600s;
     proxy_send_timeout 3600s;

--- a/docker/local/nginx/nginx.conf
+++ b/docker/local/nginx/nginx.conf
@@ -2,6 +2,11 @@ upstream api {
   server api:8000;
 }
 
+# Daphne (Channels ASGI) for WebSocket traffic. See P0-03.
+upstream daphne {
+  server daphne:8001;
+}
+
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' close;
@@ -36,6 +41,16 @@ server {
     proxy_pass http://api;
     access_log /var/log/nginx/api_access.log;
     error_log /var/log/nginx/api_error.log error;
+  }
+
+  # WebSocket traffic routed to Daphne (Channels). See P0-03.
+  # Phase 3 (DM) / Phase 4A (notifications) の websocket endpoint 群を配信。
+  location /ws/ {
+    proxy_pass http://daphne;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+    access_log /var/log/nginx/ws_access.log;
+    error_log /var/log/nginx/ws_error.log error;
   }
 
   location /supersecret {

--- a/local.yml
+++ b/local.yml
@@ -92,7 +92,16 @@ services:
       - "5555:5555"
     command: /start-flower
 
-  
+  # WebSocket ASGI server via Django Channels + Daphne
+  # Phase 3 (DM real-time), Phase 4A (realtime notifications) で利用
+  daphne:
+    <<: *api
+    image: daphne
+    container_name: daphne
+    expose:
+      - "8001"
+    command: daphne -b 0.0.0.0 -p 8001 config.asgi:application
+
   nginx:
     build:
       context: ./docker/local/nginx
@@ -107,6 +116,7 @@ services:
     depends_on:
       - api
       - client
+      - daphne
     networks:
       - app_nw
     

--- a/local.yml
+++ b/local.yml
@@ -98,6 +98,9 @@ services:
     <<: *api
     image: daphne
     container_name: daphne
+    # security-reviewer: api から <<: *api で継承すると user: root になるため上書き
+    # (django ベースイメージの非 root ユーザーを使用)
+    user: django
     expose:
       - "8001"
     command: daphne -b 0.0.0.0 -p 8001 config.asgi:application


### PR DESCRIPTION
Closes #3

## 概要
Phase 3 (DM) / Phase 4A (通知) 用の WebSocket 基盤を Phase 0 時点で先行整備。

## 変更内容

### `local.yml`
- 新サービス \`daphne\`（既存 api イメージを再利用、`config.asgi:application` を :8001 で配信）
- nginx の depends_on に daphne を追加

### `config/asgi.py`
- ProtocolTypeRouter でルーティング分離:
  - `http` → `get_asgi_application()`
  - `websocket` → `AllowedHostsOriginValidator(AuthMiddlewareStack(URLRouter(...)))`
- 最小の `/ws/health/` consumer（Phase 0.5 smoke test 用）
- Phase 3 以降で各 app の routing を include する構造

### `docker/local/nginx/nginx.conf`
- upstream daphne 追加
- `location /ws/` で daphne へプロキシ
- proxy_read_timeout / proxy_send_timeout = 3600s（ARCHITECTURE.md §3.4 の ALB idle_timeout と揃える）

## 依存
- P0-01 (#1) で channels / channels-redis / daphne を追加済み前提
- ただしブランチ上は独立しているため、main でのマージ順に関わらず動作（main マージ後の CI で依存解決確認）

## 受け入れ基準
- [x] `docker compose -f local.yml up daphne` で起動する構造
- [x] nginx /ws/ → daphne:8001 へのルーティング
- [ ] `curl http://localhost:8080/ws/health/` で WebSocket ハンドシェイク成立（P0-01 マージ後に確認）
- [ ] code-reviewer / python-reviewer / security-reviewer 承認

## サブエージェントレビュー対象
- [ ] python-reviewer (asgi.py)
- [ ] security-reviewer (AllowedHostsOriginValidator の妥当性)
- [ ] code-reviewer