### PR TITLE
[P0-05] feat(observability): initialize @sentry/nextjs on client/server/edge

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -8,7 +8,10 @@ const nextConfig = {};
 const sentryWebpackPluginOptions = {
   // 組織・プロジェクト名は CI で env から渡す (SENTRY_ORG / SENTRY_PROJECT)。
   // Auth token も SENTRY_AUTH_TOKEN (GitHub Actions secret) で提供。
-  silent: true, // ビルドログのノイズを減らす
+  //
+  // silent: false で sourceMap upload 失敗等をビルドログに表示する
+  // (security-reviewer PR #36 フィードバック)。CI で拾えるようにしておく。
+  silent: false,
   // sourceMaps を Sentry にアップロードするがクライアントには公開しない
   hideSourceMaps: true,
   // 未使用のバンドル解析を省略
@@ -23,9 +26,24 @@ const sentryOptions = {
 
 // DSN が未設定のローカル環境では Sentry ラッピングをスキップし、
 // ビルド時の auth token エラーを避ける。
+//
+// production / stg では DSN が必須なので、env で "production" 指定されている
+// にも関わらず DSN が空の場合はビルドを fail させる
+// (security-reviewer PR #36 フィードバック: prod 誤スキップ防止)。
 const hasDsn = Boolean(
   process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN,
 );
+const environment =
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ||
+  process.env.SENTRY_ENVIRONMENT ||
+  "local";
+
+if (!hasDsn && (environment === "production" || environment === "stg")) {
+  throw new Error(
+    `Sentry DSN is required for environment="${environment}". ` +
+      `Set NEXT_PUBLIC_SENTRY_DSN (and SENTRY_DSN for server runtime).`,
+  );
+}
 
 export default hasDsn
   ? withSentryConfig(nextConfig, sentryWebpackPluginOptions, sentryOptions)

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,4 +1,32 @@
+import { withSentryConfig } from "@sentry/nextjs";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-export default nextConfig;
+// Sentry webpack plugin options. DSN やプロジェクト設定は env 経由。
+// See: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+const sentryWebpackPluginOptions = {
+  // 組織・プロジェクト名は CI で env から渡す (SENTRY_ORG / SENTRY_PROJECT)。
+  // Auth token も SENTRY_AUTH_TOKEN (GitHub Actions secret) で提供。
+  silent: true, // ビルドログのノイズを減らす
+  // sourceMaps を Sentry にアップロードするがクライアントには公開しない
+  hideSourceMaps: true,
+  // 未使用のバンドル解析を省略
+  disableLogger: true,
+};
+
+const sentryOptions = {
+  // Sentry SDK の tunneling を有効化してアドブロッカー経由での計測漏れを抑止
+  // 参考: https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/adblockers/
+  tunnelRoute: "/monitoring/sentry",
+};
+
+// DSN が未設定のローカル環境では Sentry ラッピングをスキップし、
+// ビルド時の auth token エラーを避ける。
+const hasDsn = Boolean(
+  process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN,
+);
+
+export default hasDsn
+  ? withSentryConfig(nextConfig, sentryWebpackPluginOptions, sentryOptions)
+  : nextConfig;

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -23,4 +23,14 @@ Sentry.init({
   // PII は送らない (ユーザーの投稿本文・プロフィール画像 URL など)。
   // 必要に応じて beforeSend で個別マスキングすること。
   sendDefaultPii: false,
+  integrations: [
+    // Session Replay の PII 漏洩対策 (security-reviewer PR #36 フィードバック)。
+    // DM / ツイート本文 / プロフィール編集等を録画に含めないため、デフォルトで
+    // 全文マスクと全メディアブロックを有効化する。特定のコンポーネントで
+    // 表示内容を確認したい場合は DOM に `data-sentry-unmask` 属性を付与する。
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
 });

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,0 +1,26 @@
+// Browser-side Sentry SDK initialization.
+// Runs in the user's browser for client components / App Router client boundaries.
+//
+// Configured from next.config.mjs via withSentryConfig().
+// See: https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from "@sentry/nextjs";
+
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const environment = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? "local";
+const release = process.env.NEXT_PUBLIC_SENTRY_RELEASE; // set by CI via git SHA
+
+Sentry.init({
+  dsn,
+  environment,
+  release,
+  // stg では低めのサンプリングに抑え、prod は Phase 9 で調整する。
+  tracesSampleRate: environment === "production" ? 0.1 : 1.0,
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: 1.0,
+  // DSN が未設定のローカル環境では SDK を無効化してノイズを避ける。
+  enabled: Boolean(dsn),
+  // PII は送らない (ユーザーの投稿本文・プロフィール画像 URL など)。
+  // 必要に応じて beforeSend で個別マスキングすること。
+  sendDefaultPii: false,
+});

--- a/client/sentry.edge.config.ts
+++ b/client/sentry.edge.config.ts
@@ -1,0 +1,17 @@
+// Edge runtime Sentry SDK initialization.
+// Runs in Edge Functions / middleware (limited Node APIs).
+
+import * as Sentry from "@sentry/nextjs";
+
+const dsn = process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN;
+const environment = process.env.SENTRY_ENVIRONMENT ?? "local";
+const release = process.env.SENTRY_RELEASE;
+
+Sentry.init({
+  dsn,
+  environment,
+  release,
+  tracesSampleRate: environment === "production" ? 0.1 : 1.0,
+  enabled: Boolean(dsn),
+  sendDefaultPii: false,
+});

--- a/client/sentry.server.config.ts
+++ b/client/sentry.server.config.ts
@@ -1,0 +1,17 @@
+// Server-side Sentry SDK initialization.
+// Runs in the Node.js server process for SSR / Route Handlers.
+
+import * as Sentry from "@sentry/nextjs";
+
+const dsn = process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN;
+const environment = process.env.SENTRY_ENVIRONMENT ?? "local";
+const release = process.env.SENTRY_RELEASE;
+
+Sentry.init({
+  dsn,
+  environment,
+  release,
+  tracesSampleRate: environment === "production" ? 0.1 : 1.0,
+  enabled: Boolean(dsn),
+  sendDefaultPii: false,
+});


### PR DESCRIPTION
Closes #5

## 概要
Next.js の 3 ランタイム (client / server / edge) で Sentry を初期化。DSN が未設定のローカル環境ではラッピングをスキップしビルドを通す。

## 追加ファイル
- \`client/sentry.client.config.ts\` - ブラウザ SDK
- \`client/sentry.server.config.ts\` - Node SSR / Route Handler
- \`client/sentry.edge.config.ts\` - Edge Middleware / Functions

## 変更
- \`client/next.config.mjs\`: \`withSentryConfig\` で wrap、DSN 有無で分岐

## 期待する env vars
### ランタイム
- \`NEXT_PUBLIC_SENTRY_DSN\` / \`SENTRY_DSN\`
- \`NEXT_PUBLIC_SENTRY_ENVIRONMENT\` / \`SENTRY_ENVIRONMENT\`
- \`NEXT_PUBLIC_SENTRY_RELEASE\` / \`SENTRY_RELEASE\` (CI で git SHA)

### ビルド時 (source map upload)
- \`SENTRY_ORG\`
- \`SENTRY_PROJECT\`
- \`SENTRY_AUTH_TOKEN\` (GitHub Actions secret)

## ポリシー
- \`tracesSampleRate\`: local/stg=1.0、production=0.1
- \`sendDefaultPii: false\` (ユーザー投稿本文・URL は送らない)
- \`replaysSessionSampleRate: 0\` / \`replaysOnErrorSampleRate: 1.0\` (エラー時のみ)
- \`tunnelRoute\`: \`/monitoring/sentry\` でアドブロッカー迂回

## 依存
P0-02 (#31 @sentry/nextjs 追加) がマージ済みのため依存解決できる前提。

## 受け入れ基準
- [x] 3 config ファイル作成
- [x] next.config.mjs が DSN なしでも build 成功する分岐付き
- [ ] \`npm run build\` / \`npm run dev\` ローカル確認
- [ ] typescript-reviewer / security-reviewer 承認

## サブエージェントレビュー対象
- [ ] typescript-reviewer
- [ ] security-reviewer (PII policy / DSN 取扱い)
- [ ] code-reviewer