### PR TITLE
[P0-06] feat(observability): wire Sentry SDK into Django settings

### DIFF
--- a/apps/common/urls.py
+++ b/apps/common/urls.py
@@ -1,0 +1,10 @@
+"""URL patterns for common utility views (debug-sentry etc.)."""
+from __future__ import annotations
+
+from django.urls import URLPattern, URLResolver, path
+
+from apps.common.views import debug_sentry
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("", debug_sentry, name="debug-sentry"),
+]

--- a/apps/common/views.py
+++ b/apps/common/views.py
@@ -1,3 +1,22 @@
-from django.shortcuts import render
+"""Views shared across apps.
 
-# Create your views here.
+Currently hosts the Sentry smoke-test endpoint used in P0-06.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+from django.http import Http404, HttpRequest, HttpResponse
+
+
+def debug_sentry(_request: HttpRequest) -> HttpResponse:
+    """Intentionally raise to verify Sentry capture works.
+
+    Only exposed when DEBUG is True; this view never runs in stg/prod
+    where DEBUG is disabled. Returns without executing if someone wires
+    it up in production by mistake.
+    """
+    if not settings.DEBUG:
+        raise Http404("debug endpoint is only available when DEBUG=True")
+    # The explicit ZeroDivisionError gives Sentry a unique fingerprint
+    # that is easy to find in the dashboard.
+    return HttpResponse(1 / 0)  # noqa: B018  (intentional)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -5,6 +5,11 @@ from os import getenv,path
 from dotenv import load_dotenv
 from datetime import timedelta
 
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
+
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 APPS_DIR = BASE_DIR / "apps"
 
@@ -12,6 +17,31 @@ local_env_file = path.join(BASE_DIR, ".envs", ".env.local")
 
 if path.isfile(local_env_file):
     load_dotenv(local_env_file)
+
+
+# --- Sentry observability (P0-06) ---
+# DSN / environment / release はすべて env 経由。未設定なら SDK を無効化する。
+# stg/prod では CI で必ず設定する（欠落は CD ワークフローで fail させる方針）。
+SENTRY_DSN = getenv("SENTRY_DSN", "")
+SENTRY_ENVIRONMENT = getenv("SENTRY_ENVIRONMENT", "local")
+SENTRY_RELEASE = getenv("SENTRY_RELEASE")  # CI で git SHA を渡す
+
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        environment=SENTRY_ENVIRONMENT,
+        release=SENTRY_RELEASE,
+        integrations=[
+            DjangoIntegration(),
+            CeleryIntegration(),
+            RedisIntegration(),
+        ],
+        # production のみサンプリングを絞り、local/stg は全量送信して検知感度を上げる。
+        traces_sample_rate=0.1 if SENTRY_ENVIRONMENT == "production" else 1.0,
+        # PII は送らない。投稿本文やユーザー名が誤って Sentry に載らないようにする。
+        # 必要に応じて個別イベントで scope.user / tags を設定する。
+        send_default_pii=False,
+    )
 
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -26,6 +26,31 @@ SENTRY_DSN = getenv("SENTRY_DSN", "")
 SENTRY_ENVIRONMENT = getenv("SENTRY_ENVIRONMENT", "local")
 SENTRY_RELEASE = getenv("SENTRY_RELEASE")  # CI で git SHA を渡す
 
+
+def _sentry_before_send(event, _hint):
+    """Strip request body / form data / query string from Sentry events.
+
+    security-reviewer (PR #38) フィードバック: DjangoIntegration は例外発生時に
+    request.data / request.query_string をコンテキストとして送信する可能性がある。
+    ツイート本文や DM 等のユーザー入力はどの API でも発生し得るため、一律で除去する。
+    """
+    request = event.get("request")
+    if request:
+        request.pop("data", None)
+        request.pop("query_string", None)
+        cookies = request.get("cookies")
+        if cookies:
+            # セッション Cookie などは PII に該当するため送らない
+            request["cookies"] = {k: "[Filtered]" for k in cookies}
+    return event
+
+
+_SENTRY_SAMPLE_RATES = {
+    "production": 0.1,
+    "stg": 0.5,
+    "local": 1.0,
+}
+
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
@@ -36,11 +61,11 @@ if SENTRY_DSN:
             CeleryIntegration(),
             RedisIntegration(),
         ],
-        # production のみサンプリングを絞り、local/stg は全量送信して検知感度を上げる。
-        traces_sample_rate=0.1 if SENTRY_ENVIRONMENT == "production" else 1.0,
+        # stg は prod より粗く、local はフルサンプリング。
+        traces_sample_rate=_SENTRY_SAMPLE_RATES.get(SENTRY_ENVIRONMENT, 1.0),
         # PII は送らない。投稿本文やユーザー名が誤って Sentry に載らないようにする。
-        # 必要に応じて個別イベントで scope.user / tags を設定する。
         send_default_pii=False,
+        before_send=_sentry_before_send,
     )
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -27,6 +27,8 @@ urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
     path("api/v1/auth/", include("djoser.urls")),
     path("api/v1/auth/", include("apps.users.urls")),
+    # Sentry smoke test (DEBUG 時のみ有効、stg/prod では 404 を返す)
+    path("debug-sentry/", include("apps.common.urls")),
     # Phase 0 scaffold (P0-04). Each app ships empty urlpatterns until
     # the owning phase adds real endpoints (see docs/ROADMAP.md).
     path("api/v1/tweets/", include("apps.tweets.urls")),

--- a/config/urls.py
+++ b/config/urls.py
@@ -27,8 +27,6 @@ urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
     path("api/v1/auth/", include("djoser.urls")),
     path("api/v1/auth/", include("apps.users.urls")),
-    # Sentry smoke test (DEBUG 時のみ有効、stg/prod では 404 を返す)
-    path("debug-sentry/", include("apps.common.urls")),
     # Phase 0 scaffold (P0-04). Each app ships empty urlpatterns until
     # the owning phase adds real endpoints (see docs/ROADMAP.md).
     path("api/v1/tweets/", include("apps.tweets.urls")),
@@ -45,6 +43,14 @@ urlpatterns = [
     path("api/v1/billing/", include("apps.billing.urls")),
     path("api/v1/search/", include("apps.search.urls")),
 ]
+
+# Sentry smoke test endpoint (P0-06). DEBUG=True の環境だけ URL 登録すること自体を
+# 行い、本番デプロイのルーティングテーブルに載らないようにする。
+# (security-reviewer PR #38 MEDIUM 指摘反映)
+if settings.DEBUG:
+    urlpatterns += [
+        path("debug-sentry/", include("apps.common.urls")),
+    ]
 
 admin.site.site_header = "Admin"
 admin.site.site_title = "Admin Portal"


### PR DESCRIPTION
Closes #6

## 概要
Django + Celery + Redis 用 Sentry SDK を初期化。Next.js 側 (#36) と対になる。

## 変更
- `config/settings/base.py`: `sentry_sdk.init()` を追加、DjangoIntegration + CeleryIntegration + RedisIntegration
- `apps/common/views.py`: DEBUG 時のみ動作する `/debug-sentry/` エンドポイント
- `apps/common/urls.py`: 新規、debug エンドポイントのみ登録
- `config/urls.py`: include 追加

## ポリシー
- DSN 未設定時は SDK 無効化 (fresh clone でも動作)
- `send_default_pii=False` (投稿本文・ユーザー名を漏らさない)
- `traces_sample_rate`: production=0.1、その他=1.0
- debug-sentry は DEBUG=False で 404

## 受け入れ基準
- [x] 4 ファイル syntax check OK
- [ ] `python manage.py check` (ローカル確認後)
- [ ] Sentry ダッシュボードで `/debug-sentry/` 経由のエラー受信確認
- [ ] python-reviewer / security-reviewer 承認

## サブエージェントレビュー
- [ ] python-reviewer
- [ ] security-reviewer (DSN / PII policy)