### PR TITLE
[P0-09] feat(ui): add Dialog component + /components-demo visual check

### DIFF
--- a/client/src/app/components-demo/page.tsx
+++ b/client/src/app/components-demo/page.tsx
@@ -1,0 +1,198 @@
+/**
+ * Dev-only visual smoke test for shadcn/ui core components.
+ *
+ * Available at /components-demo. Intentionally returns `notFound()`
+ * outside of development so the route disappears from stg/prod bundles
+ * once `NODE_ENV=production`. Having a Storybook replacement here
+ * (per docs/issues/phase-0.md P0-09) keeps the token swap at Phase 10
+ * cheap to verify visually.
+ */
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { notFound } from "next/navigation";
+
+export default function ComponentsDemo() {
+  if (process.env.NODE_ENV !== "development") {
+    notFound();
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl space-y-16 px-4 py-12 sm:px-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Components Demo</h1>
+        <p className="text-muted-foreground">
+          Dev-only preview. Swap the design tokens in
+          <code className="mx-1 rounded bg-muted px-1 py-0.5 text-sm">client/src/styles/tokens.css</code>
+          and reload to verify every component still looks intentional.
+        </p>
+      </header>
+
+      <Section title="Buttons">
+        <div className="flex flex-wrap gap-4">
+          <Button>Default</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="destructive">Destructive</Button>
+          <Button variant="outline">Outline</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="link">Link</Button>
+          <Button disabled>Disabled</Button>
+        </div>
+      </Section>
+
+      <Section title="Typography tokens">
+        <div className="space-y-2">
+          <p className="text-hero font-bold">Hero headline</p>
+          <p className="text-3xl font-semibold">3xl heading</p>
+          <p className="text-2xl font-semibold">2xl heading</p>
+          <p className="text-xl">xl heading</p>
+          <p className="text-lg">lg heading</p>
+          <p className="text-base">
+            Base paragraph (<code className="rounded bg-muted px-1 py-0.5">--text-base</code>) reads
+            at 16–17px with fluid scaling up to 1440px.
+          </p>
+          <p className="text-sm">Small paragraph (meta / helper text).</p>
+          <p className="text-xs text-muted-foreground">
+            xs is reserved for timestamps and captions (never body).
+          </p>
+        </div>
+      </Section>
+
+      <Section title="Form controls">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="handle">@handle</Label>
+            <Input id="handle" placeholder="your-handle" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="bio">自己紹介</Label>
+            <Textarea id="bio" placeholder="300 字まで。Markdown 一部対応。" />
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Avatar + Badge">
+        <div className="flex items-center gap-4">
+          <Avatar>
+            <AvatarImage src="https://github.com/haruna0712.png" alt="haruna" />
+            <AvatarFallback>HA</AvatarFallback>
+          </Avatar>
+          <Badge>python</Badge>
+          <Badge variant="secondary">nextjs</Badge>
+          <Badge variant="outline">claude-code</Badge>
+          <Badge variant="destructive">deprecated</Badge>
+        </div>
+      </Section>
+
+      <Section title="Tabs">
+        <Tabs defaultValue="following" className="w-full">
+          <TabsList>
+            <TabsTrigger value="following">フォロー中</TabsTrigger>
+            <TabsTrigger value="home">ホーム</TabsTrigger>
+            <TabsTrigger value="trending">トレンド</TabsTrigger>
+          </TabsList>
+          <TabsContent value="following" className="pt-4 text-sm text-muted-foreground">
+            フォロー中タブの中身。TL はフォロー中 70% + 全体上位 30% のアルゴリズム配信。
+          </TabsContent>
+          <TabsContent value="home" className="pt-4 text-sm text-muted-foreground">
+            ホームタブの中身。
+          </TabsContent>
+          <TabsContent value="trending" className="pt-4 text-sm text-muted-foreground">
+            トレンドタブの中身。24h のタグ上位 10 件をサイドバーに連動表示。
+          </TabsContent>
+        </Tabs>
+      </Section>
+
+      <Section title="Card">
+        <Card>
+          <CardHeader>
+            <CardTitle>@haruna</CardTitle>
+            <CardDescription>Engineer SNS のドッグフーディング中</CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm">
+            Fluid typography と shadow-card の確認用ダミー。
+          </CardContent>
+          <CardFooter>
+            <Button variant="outline" size="sm">
+              プロフィールへ
+            </Button>
+          </CardFooter>
+        </Card>
+      </Section>
+
+      <Section title="Dialog">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button>Dialog を開く</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>ツイートを削除しますか？</DialogTitle>
+              <DialogDescription>
+                この操作は取り消せません。削除すると元ツイートへのリプライには「削除済みツイートです」と表示されます。
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline">キャンセル</Button>
+              </DialogClose>
+              <Button variant="destructive">削除する</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </Section>
+
+      <Section title="DropdownMenu">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline">メニュー</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuLabel>アカウント</DropdownMenuLabel>
+            <DropdownMenuItem>プロフィールを編集</DropdownMenuItem>
+            <DropdownMenuItem>通知設定</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="text-destructive">ログアウト</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Section>
+    </main>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function Section({ title, children }: SectionProps) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -41,9 +41,11 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+      {/* Close ボタンは SC 2.5.8 (Target Size 24x24px 最小、44x44px 推奨) を満たすため
+          h-11 w-11 = 44px のクリック領域を確保。アイコンは inline-flex で中央配置。 */}
+      <DialogPrimitive.Close className="absolute right-3 top-3 inline-flex h-11 w-11 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" aria-hidden="true" />
+        <span className="sr-only">閉じる</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-overlay bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-modal grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-normal data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+DialogHeader.displayName = "DialogHeader";
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};


### PR DESCRIPTION
Closes #9

## 概要
shadcn/ui コア群は既に概ね揃っているため、不足していた **Dialog** だけ追加し、
`/components-demo` ページで全コンポーネントの動作確認を可能にする。

## 既存 (確認のみ)
button / input / textarea / card / avatar / badge / tabs / dropdown-menu / label / select / form / sheet / skeleton / pagination / password-input / menubar

## 追加
- `client/src/components/ui/dialog.tsx` (Radix Dialog ベース、--z-modal/--z-overlay 使用)
- `client/src/app/components-demo/page.tsx` (NODE_ENV !== development で 404)

## Toast について
既存の `react-toastify` 運用を維持 (layout.tsx で配線済み)。shadcn Sonner への移行は別 Issue。

## 受け入れ基準
- [x] dialog.tsx が tokens.css の z-index を使用
- [x] components-demo が dev 限定
- [ ] `npm run build` ローカル確認
- [ ] typescript-reviewer / a11y-architect 承認

## サブエージェントレビュー
- [ ] typescript-reviewer
- [ ] a11y-architect (Dialog の focus trap / aria 属性)