### PR TITLE
[P0.5-01] infra(tf): bootstrap Terraform state backend

### DIFF
--- a/docs/operations/tf-state-bootstrap.md
+++ b/docs/operations/tf-state-bootstrap.md
@@ -70,15 +70,61 @@ aws dynamodb describe-table --table-name sns-stg-tf-lock --query 'Table.TableSta
 
 ## 削除
 
-stg 環境を破棄する際は state file が含まれる S3 バケットも明示的に削除する:
+stg 環境を完全に破棄する際は以下の**厳密な順序**で実行する。バージョニングが有効な
+バケットは **全バージョン + delete markers** を個別削除しないと `BucketNotEmpty` で失敗する。
+
+### 前提
+- 先に `terraform destroy` で AWS 上の stg リソースを削除済み
+- state ファイルはもう使わないことを確認
+
+### 手順
 
 ```bash
-# state バケット内の全オブジェクト (全バージョン含む) を削除
-aws s3api delete-objects --bucket sns-stg-tf-state ...
-# バケット削除
-aws s3api delete-bucket --bucket sns-stg-tf-state
-# lock テーブル削除
-aws dynamodb delete-table --table-name sns-stg-tf-lock
+BUCKET=sns-stg-tf-state
+TABLE=sns-stg-tf-lock
+REGION=ap-northeast-1
+
+# 1. まず現行 state オブジェクトの全バージョンを列挙して削除
+aws s3api list-object-versions \
+  --bucket "${BUCKET}" \
+  --region "${REGION}" \
+  --output json \
+  --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}}' \
+  > /tmp/versions.json
+
+if [ "$(jq '.Objects | length' /tmp/versions.json)" -gt 0 ]; then
+  aws s3api delete-objects \
+    --bucket "${BUCKET}" \
+    --region "${REGION}" \
+    --delete "file:///tmp/versions.json"
+fi
+
+# 2. Delete markers も列挙して削除 (バージョニング有効バケット特有)
+aws s3api list-object-versions \
+  --bucket "${BUCKET}" \
+  --region "${REGION}" \
+  --output json \
+  --query '{Objects: DeleteMarkers[].{Key:Key,VersionId:VersionId}}' \
+  > /tmp/markers.json
+
+if [ "$(jq '.Objects | length' /tmp/markers.json)" -gt 0 ]; then
+  aws s3api delete-objects \
+    --bucket "${BUCKET}" \
+    --region "${REGION}" \
+    --delete "file:///tmp/markers.json"
+fi
+
+# 3. バケット削除 (空になっていることを確認してから)
+aws s3api delete-bucket --bucket "${BUCKET}" --region "${REGION}"
+
+# 4. DynamoDB lock テーブル削除
+aws dynamodb delete-table --table-name "${TABLE}" --region "${REGION}"
 ```
 
-**警告**: 消すと `terraform destroy` 前の state も消えるため、順序に注意。
+### 警告
+
+- 手順 1-2 を飛ばすと `delete-bucket` が `BucketNotEmpty` で失敗する
+- MFA Delete が有効化されている場合は root account + MFA デバイスが必要
+- `terraform destroy` 前に state を消すと、実リソースが残ったまま Terraform
+  から追跡不能になる。必ず **terraform destroy → state 削除** の順を守ること
+- prod 環境では state を消す前にスナップショット (別バケットへコピー) 推奨

--- a/docs/operations/tf-state-bootstrap.md
+++ b/docs/operations/tf-state-bootstrap.md
@@ -1,0 +1,84 @@
+# Terraform state backend bootstrap
+
+Terraform state 保存用の AWS リソース (S3 バケット + DynamoDB lock テーブル) を
+**Terraform 以外の手段** で 1 回だけ作成する手順。
+
+state を保存するためのリソースを Terraform で管理してしまうと、
+「state がまだ無い時点で state を作る」 chicken-and-egg が発生するため、
+この 2 リソースだけはスクリプトで bootstrap する。
+
+## 対象リソース
+
+| リソース | 名前 (既定) | 用途 |
+|---|---|---|
+| S3 bucket | `sns-stg-tf-state` | terraform state file の保存先 |
+| DynamoDB table | `sns-stg-tf-lock` | terraform apply の排他ロック |
+
+両リソースとも:
+- リージョン: `ap-northeast-1`
+- 暗号化: SSE-S3 (bucket) / PAY_PER_REQUEST (table)
+- Public Access: 完全遮断
+- バージョニング有効 (bucket)
+
+## 前提
+
+- AWS アカウント (ハルナさんが管理)
+- `aws` CLI v2 インストール済み
+- `aws sso login` もしくは `aws configure` で管理権限のクレデンシャルを取得済み
+
+## 手順
+
+### 1. リポジトリ直下で実行
+
+```bash
+./scripts/bootstrap-tf-state.sh
+```
+
+引数で bucket 名・table 名・region を上書き可能:
+
+```bash
+./scripts/bootstrap-tf-state.sh \
+  --region ap-northeast-1 \
+  --bucket sns-stg-tf-state \
+  --table  sns-stg-tf-lock
+```
+
+### 2. 冪等性
+
+スクリプトは既に存在する場合スキップする。バージョニング・暗号化・Public Access Block
+は毎回 apply するため、設定ドリフトは自動修復される。
+
+### 3. 作成確認
+
+```bash
+aws s3api head-bucket --bucket sns-stg-tf-state
+aws dynamodb describe-table --table-name sns-stg-tf-lock --query 'Table.TableStatus'
+```
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対応 |
+|---|---|---|
+| `InvalidBucketName` | bucket 名が既に世界中で使用中 | `--bucket <your-prefix>-tf-state` で unique な名前を指定 |
+| `AccessDenied` | IAM 権限不足 | S3:CreateBucket / DynamoDB:CreateTable / sts:GetCallerIdentity を確認 |
+| `BucketAlreadyOwnedByYou` | 既に同じアカウントで作成済み | 正常。スクリプトは続行して設定を更新する |
+
+## 今後の拡張
+
+- prod 環境では別バケット `sns-prod-tf-state` を推奨 (環境分離・権限境界)
+- KMS カスタム CMK での暗号化に移行する場合、既存 state の再暗号化が必要
+
+## 削除
+
+stg 環境を破棄する際は state file が含まれる S3 バケットも明示的に削除する:
+
+```bash
+# state バケット内の全オブジェクト (全バージョン含む) を削除
+aws s3api delete-objects --bucket sns-stg-tf-state ...
+# バケット削除
+aws s3api delete-bucket --bucket sns-stg-tf-state
+# lock テーブル削除
+aws dynamodb delete-table --table-name sns-stg-tf-lock
+```
+
+**警告**: 消すと `terraform destroy` 前の state も消えるため、順序に注意。

--- a/scripts/bootstrap-tf-state.sh
+++ b/scripts/bootstrap-tf-state.sh
@@ -58,14 +58,28 @@ else
   echo "📦 S3 bucket 作成中..."
   if [[ "${REGION}" == "us-east-1" ]]; then
     # us-east-1 だけは LocationConstraint を指定しない特殊仕様
-    aws s3api create-bucket --bucket "${BUCKET}" --region "${REGION}"
+    aws s3api create-bucket --bucket "${BUCKET}" --region "${REGION}" \
+      --object-ownership BucketOwnerEnforced
   else
     aws s3api create-bucket \
       --bucket "${BUCKET}" \
       --region "${REGION}" \
+      --object-ownership BucketOwnerEnforced \
       --create-bucket-configuration "LocationConstraint=${REGION}"
   fi
 fi
+
+# SECURITY: Public Access Block は最初に適用する (architect PR #45 HIGH)。
+# 他の設定より前に置くことで、create-bucket 直後の短い窓で public ACL を
+# 受け付けてしまう race condition を塞ぐ。
+aws s3api put-public-access-block \
+  --bucket "${BUCKET}" \
+  --public-access-block-configuration '{
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": true,
+    "RestrictPublicBuckets": true
+  }'
 
 # バージョニング (state の巻き戻し・監査目的)
 aws s3api put-bucket-versioning \
@@ -81,15 +95,14 @@ aws s3api put-bucket-encryption \
     ]
   }'
 
-# Public Access を全て遮断
-aws s3api put-public-access-block \
+# タグ付け (コスト配分・監査用。DynamoDB テーブルとキーを揃える)
+aws s3api put-bucket-tagging \
   --bucket "${BUCKET}" \
-  --public-access-block-configuration '{
-    "BlockPublicAcls": true,
-    "IgnorePublicAcls": true,
-    "BlockPublicPolicy": true,
-    "RestrictPublicBuckets": true
-  }'
+  --tagging "TagSet=[
+    {Key=Project,Value=engineer-sns},
+    {Key=Environment,Value=stg},
+    {Key=ManagedBy,Value=bootstrap-tf-state}
+  ]"
 
 echo "✅ S3 bucket 準備完了"
 

--- a/scripts/bootstrap-tf-state.sh
+++ b/scripts/bootstrap-tf-state.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# bootstrap-tf-state.sh - Terraform state 保存用 S3 + DynamoDB lock テーブルを作成 (P0.5-01)
+#
+# 前提:
+#   - aws CLI v2 がインストール済み (`aws --version`)
+#   - 事前に `aws sso login` or `aws configure` で管理権限が取得済み
+#   - 実行するアカウントで S3 CreateBucket / DynamoDB CreateTable が許可されている
+#
+# 使い方:
+#   ./scripts/bootstrap-tf-state.sh
+#     [--region ap-northeast-1]
+#     [--bucket sns-stg-tf-state]
+#     [--table  sns-stg-tf-lock]
+#
+# 冪等性:
+#   S3 バケット / DynamoDB テーブルが既に存在する場合はスキップし exit 0。
+#   バージョニング・暗号化・Public Access Block は毎回 apply し直す (差分なければ no-op)。
+
+set -euo pipefail
+
+REGION="ap-northeast-1"
+BUCKET="sns-stg-tf-state"
+TABLE="sns-stg-tf-lock"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region) REGION="$2"; shift 2 ;;
+    --bucket) BUCKET="$2"; shift 2 ;;
+    --table)  TABLE="$2";  shift 2 ;;
+    *) echo "❌ unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "❌ aws CLI が見つかりません。https://docs.aws.amazon.com/cli/ からインストールしてください" >&2
+  exit 1
+fi
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)
+if [[ -z "$ACCOUNT_ID" ]]; then
+  echo "❌ AWS 認証情報が取得できません。aws sso login または aws configure を先に実行してください" >&2
+  exit 1
+fi
+
+echo "🔐 AWS Account: ${ACCOUNT_ID}  /  Region: ${REGION}"
+echo "📦 Bucket: ${BUCKET}"
+echo "🔒 Lock table: ${TABLE}"
+echo ""
+read -r -p "続行しますか? (y/N) " confirm
+if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+  echo "中止しました"; exit 0
+fi
+
+# ---------- S3 bucket ----------
+if aws s3api head-bucket --bucket "${BUCKET}" --region "${REGION}" 2>/dev/null; then
+  echo "ℹ️  S3 bucket ${BUCKET} は既に存在します。設定更新のみ行います。"
+else
+  echo "📦 S3 bucket 作成中..."
+  if [[ "${REGION}" == "us-east-1" ]]; then
+    # us-east-1 だけは LocationConstraint を指定しない特殊仕様
+    aws s3api create-bucket --bucket "${BUCKET}" --region "${REGION}"
+  else
+    aws s3api create-bucket \
+      --bucket "${BUCKET}" \
+      --region "${REGION}" \
+      --create-bucket-configuration "LocationConstraint=${REGION}"
+  fi
+fi
+
+# バージョニング (state の巻き戻し・監査目的)
+aws s3api put-bucket-versioning \
+  --bucket "${BUCKET}" \
+  --versioning-configuration Status=Enabled
+
+# 暗号化 (SSE-S3、KMS でも可だが bootstrap はシンプルに S3 managed)
+aws s3api put-bucket-encryption \
+  --bucket "${BUCKET}" \
+  --server-side-encryption-configuration '{
+    "Rules": [
+      { "ApplyServerSideEncryptionByDefault": { "SSEAlgorithm": "AES256" } }
+    ]
+  }'
+
+# Public Access を全て遮断
+aws s3api put-public-access-block \
+  --bucket "${BUCKET}" \
+  --public-access-block-configuration '{
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": true,
+    "RestrictPublicBuckets": true
+  }'
+
+echo "✅ S3 bucket 準備完了"
+
+# ---------- DynamoDB lock table ----------
+if aws dynamodb describe-table --table-name "${TABLE}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "ℹ️  DynamoDB table ${TABLE} は既に存在します。スキップ。"
+else
+  echo "🔒 DynamoDB lock table 作成中..."
+  aws dynamodb create-table \
+    --table-name "${TABLE}" \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST \
+    --region "${REGION}" \
+    --tags Key=Project,Value=engineer-sns Key=ManagedBy,Value=bootstrap-tf-state
+  aws dynamodb wait table-exists --table-name "${TABLE}" --region "${REGION}"
+fi
+
+echo "✅ DynamoDB table 準備完了"
+
+cat <<MSG
+
+🎉 Bootstrap 完了。
+
+次のステップ:
+  cd terraform/environments/stg
+  terraform init    # -> S3 backend に state が保存される
+  terraform plan
+
+詳細は docs/operations/tf-state-bootstrap.md を参照。
+MSG

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,47 @@
+# Terraform
+
+本プロジェクトの Infrastructure-as-Code。
+
+## ディレクトリ構成
+
+```
+terraform/
+├── backend.tf              # S3 backend 設定 (全環境共通)
+├── versions.tf             # Terraform / provider バージョン制約
+├── modules/                # 再利用可能モジュール (Phase 0.5 で順次追加)
+│   ├── network/            # VPC, subnets, SG, fck-nat, VPC Endpoints
+│   ├── data/               # RDS + ElastiCache
+│   ├── compute/            # ECS Cluster, ALB, ECR
+│   ├── edge/               # CloudFront, Route53, ACM
+│   └── observability/      # CloudWatch Log Groups, Alarms, SNS Topic
+└── environments/
+    └── stg/                # stg 環境 (Phase 0.5 で立ち上げ)
+        ├── main.tf         # モジュール呼び出し
+        ├── variables.tf
+        └── terraform.tfvars
+```
+
+## Bootstrap (初回のみ)
+
+Terraform state を保存する S3 バケットと DynamoDB lock テーブルは
+Terraform 自身では管理しない (chicken-and-egg)。 以下のスクリプトで作成する:
+
+```bash
+./scripts/bootstrap-tf-state.sh
+```
+
+詳細は [docs/operations/tf-state-bootstrap.md](../docs/operations/tf-state-bootstrap.md) を参照。
+
+## 通常の運用
+
+```bash
+cd terraform/environments/stg
+terraform init
+terraform plan
+terraform apply   # ← 手動承認 (CD でも手動ステップを通す)
+```
+
+## ADR
+
+Terraform / AWS 設計に関する決定は [docs/adr/](../docs/adr/) に記録:
+- [ADR-0001](../docs/adr/0001-use-ecs-fargate-for-stg.md) — stg に ECS Fargate を採用

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,22 @@
+# Terraform state backend.
+#
+# IMPORTANT: このブロックは環境共通の既定値だが、`terraform init` は
+# 実際には環境ディレクトリ (`environments/stg/` 等) から実行する。
+# 各環境では `-backend-config="key=<env>/terraform.tfstate"` を渡して
+# state のキーだけ上書きする運用とする。
+#
+# Bootstrap:
+#   S3 bucket "sns-stg-tf-state" と DynamoDB table "sns-stg-tf-lock" は
+#   Terraform ではなく scripts/bootstrap-tf-state.sh で事前に作成する。
+#   詳細は docs/operations/tf-state-bootstrap.md。
+
+terraform {
+  backend "s3" {
+    bucket         = "sns-stg-tf-state"
+    # key は環境ごとに override (terraform init -backend-config="key=stg/terraform.tfstate")
+    key            = "UNSET-override-with-backend-config"
+    region         = "ap-northeast-1"
+    dynamodb_table = "sns-stg-tf-lock"
+    encrypt        = true
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}


### PR DESCRIPTION
Closes #14

## 概要
Terraform state を保存する S3 バケット + DynamoDB lock テーブルを bootstrap するスクリプトと、共通 backend 定義を追加。

## 追加ファイル
- `scripts/bootstrap-tf-state.sh`: 冪等な bootstrap (S3 versioning + SSE + Public Access Block、DynamoDB PAY_PER_REQUEST)
- `terraform/backend.tf`: 共通 S3 backend (key は環境ごとに `-backend-config=" で override)
- `terraform/versions.tf`: Terraform >= 1.9 + aws ~> 5.60 + random ~> 3.6
- `terraform/README.md`: モジュール/環境ディレクトリ構成の索引
- `docs/operations/tf-state-bootstrap.md`: 実行手順 + トラブルシューティング + 削除手順

## ハルナさん側のアクション
```bash
aws sso login       # or aws configure
./scripts/bootstrap-tf-state.sh
```

## サブエージェントレビュー
- [ ] architect (bootstrap 手順・backend 設計)
- [ ] security-reviewer (S3 Public Access / IAM 前提)