### PR TITLE
[P0.5-06] infra(tf): add observability module

### DIFF
--- a/terraform/modules/observability/README.md
+++ b/terraform/modules/observability/README.md
@@ -1,0 +1,52 @@
+# `observability` module
+
+CloudWatch Log Groups + CloudWatch Alarms + SNS Topic の IaC 定義。
+
+## 責務
+
+- ECS サービスごとに `/ecs/<project>-<env>/<service>` の Log Group を作成
+- Alerts 配信用 SNS Topic と Email サブスクリプションを作成
+- ECS CPU / RDS CPU / RDS 空き容量 / ALB 5xx エラー率 の基本アラームを設置
+- 他モジュールの出力 (cluster 名 / ALB arn_suffix / RDS identifier) を variable で受け、
+  未指定のアラームは作らない (optional 依存)
+
+## 片方向依存
+
+他モジュール (network / data / compute / edge) の output は参照**しない**。
+このモジュールが var で必要な識別子を受け取る片方向構造にすることで、
+モジュール間の output 引き回しコストを下げる (architect レビュー M-3 方針)。
+
+## 使用例 (環境ディレクトリ `environments/stg/main.tf` から)
+
+```hcl
+module "observability" {
+  source = "../../modules/observability"
+
+  environment        = "stg"
+  project            = "sns"
+  log_retention_days = 30
+  alert_email        = var.alert_email
+
+  ecs_services = ["django", "next", "daphne", "celery-worker", "celery-beat"]
+
+  # これらは他モジュール立ち上げ後に値を埋める (optional)
+  alb_arn_suffix          = module.compute.alb_arn_suffix
+  rds_instance_identifier = module.data.rds_instance_id
+  ecs_cluster_name        = module.compute.ecs_cluster_name
+}
+```
+
+## Outputs
+
+| 名前 | 用途 |
+|---|---|
+| `sns_topic_arn` | 追加サブスクライバー (Lambda / Slack webhook 等) から参照 |
+| `log_group_names` | ECS task definition の `logConfiguration.options.awslogs-group` に渡す |
+| `log_group_arns` | ECS task execution role の IAM policy で `resources` に指定 |
+
+## 今後の拡張
+
+- Slack Webhook / Chatbot 統合 (現状は email のみ)
+- CloudWatch Dashboards (`aws_cloudwatch_dashboard`)
+- カスタムメトリクス (active users, tweets per minute) — アプリ側で Sentry metrics か直接 PutMetricData
+- ログ保持の分類 (application は 30 日 / audit は 365 日 等)

--- a/terraform/modules/observability/README.md
+++ b/terraform/modules/observability/README.md
@@ -44,9 +44,51 @@ module "observability" {
 | `log_group_names` | ECS task definition の `logConfiguration.options.awslogs-group` に渡す |
 | `log_group_arns` | ECS task execution role の IAM policy で `resources` に指定 |
 
+## 運用上の注意
+
+### SNS Email サブスクリプションは二段階
+
+`aws_sns_topic_subscription` を `email` プロトコルで作成すると、AWS から確認メールが
+送信され、**ユーザーが承認リンクをクリックするまで `PendingConfirmation` 状態でアラートは届かない**。
+
+`terraform apply` が成功 = アラート経路が有効、ではない。以下の手順で確認:
+
+1. `terraform apply` 後、`var.alert_email` 宛に "AWS Notification - Subscription Confirmation" が届く
+2. メール内の `Confirm subscription` リンクをクリック
+3. `aws sns get-topic-attributes --topic-arn <...>` で `SubscriptionsConfirmed >= 1` を確認
+4. 疎通試験: AWS Console から該当 SNS Topic に "Publish message" で手動送信し、メール到達を確認
+
+将来的に Slack/Chatbot 経由へ切替える場合は `https` プロトコルの SNS subscription を追加し、
+email は fallback として併存させる運用を推奨。
+
+### ECS サービス名の対応表
+
+compute モジュール未実装時点では、このモジュールは ECS ServiceName を
+`<project>-<env>-<logical>` のデフォルト命名規約で解決する。compute 側の実名が
+異なる場合は **`var.ecs_service_name_map` で明示注入**すること。
+
+```hcl
+module "observability" {
+  # ...
+  ecs_service_name_map = {
+    django        = module.compute.service_names["django"]
+    next          = module.compute.service_names["next"]
+    daphne        = module.compute.service_names["daphne"]
+    celery-worker = module.compute.service_names["celery-worker"]
+    celery-beat   = module.compute.service_names["celery-beat"]
+  }
+}
+```
+
+未注入かつ compute の命名規約と食い違うと、アラームは作成されるが CloudWatch メトリクス
+が合致せず「永遠に INSUFFICIENT_DATA」になる。compute モジュール PR の受け入れ基準に
+「observability の `resolved_ecs_service_names` と ECS 実体名が一致すること」を含める。
+
 ## 今後の拡張
 
 - Slack Webhook / Chatbot 統合 (現状は email のみ)
 - CloudWatch Dashboards (`aws_cloudwatch_dashboard`)
 - カスタムメトリクス (active users, tweets per minute) — アプリ側で Sentry metrics か直接 PutMetricData
-- ログ保持の分類 (application は 30 日 / audit は 365 日 等)
+- ログ保持の環境別デフォルト (stg=30 日 / prod=365 日)
+- CostCenter / Owner / Service タグ (Cost Explorer 配分強化)
+- Dashboard で参照する `alarm_arns` output の追加

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -1,0 +1,186 @@
+# Observability module (P0.5-06)
+#
+# CloudWatch Log Groups + CloudWatch Alarms + SNS Topic for alerts.
+# 他モジュール (compute/data/edge) はこのモジュールの出力を参照せず、
+# このモジュールが他モジュールのリソース名を var で受け取る片方向依存にする
+# (architect 推奨: モジュール間の output 引き回しコスト削減)。
+
+locals {
+  prefix = "${var.project}-${var.environment}"
+
+  default_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Module      = "observability"
+    },
+    var.tags,
+  )
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch Log Groups — 1 ECS サービスにつき 1 group
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  for_each = toset(var.ecs_services)
+
+  name              = "/ecs/${local.prefix}/${each.value}"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.default_tags, { Service = each.value })
+}
+
+# ---------------------------------------------------------------------------
+# SNS Topic — アラート配信先
+# ---------------------------------------------------------------------------
+
+resource "aws_sns_topic" "alerts" {
+  name = "${local.prefix}-alerts"
+  tags = local.default_tags
+}
+
+resource "aws_sns_topic_subscription" "alert_email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# ---------------------------------------------------------------------------
+# ECS Service CPU Alarm (1 サービスにつき 1 アラーム)
+# ecs_cluster_name が未指定のうちは作らない。
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "ecs_service_cpu" {
+  for_each = var.ecs_cluster_name == "" ? toset([]) : toset(var.ecs_services)
+
+  alarm_name          = "${local.prefix}-ecs-${each.value}-cpu-high"
+  alarm_description   = "ECS service ${each.value} CPU > 80% for 15 minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300 # 5min
+  statistic           = "Average"
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    # ECS サービス名は compute モジュールで統一的に "<prefix>-<service>" 命名する前提
+    ServiceName = "${local.prefix}-${each.value}"
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+
+  tags = merge(local.default_tags, { Service = each.value })
+}
+
+# ---------------------------------------------------------------------------
+# RDS CPU / FreeStorageSpace Alarms
+# rds_instance_identifier が未指定なら作らない。
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
+  count = var.rds_instance_identifier == "" ? 0 : 1
+
+  alarm_name          = "${local.prefix}-rds-cpu-high"
+  alarm_description   = "RDS CPU > 80% for 15 minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_storage" {
+  count = var.rds_instance_identifier == "" ? 0 : 1
+
+  alarm_name          = "${local.prefix}-rds-storage-low"
+  alarm_description   = "RDS FreeStorageSpace < 20% (4GB of 20GB)"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 4 * 1024 * 1024 * 1024 # 4 GiB in bytes
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+
+  tags = local.default_tags
+}
+
+# ---------------------------------------------------------------------------
+# ALB 5xx Error Rate Alarm
+# alb_arn_suffix が未指定なら作らない。
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_rate" {
+  count = var.alb_arn_suffix == "" ? 0 : 1
+
+  alarm_name          = "${local.prefix}-alb-5xx-rate-high"
+  alarm_description   = "ALB HTTPCode_Target_5XX_Count > 1% of total requests"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  threshold           = 0.01
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "error_rate"
+    expression  = "IF(total_requests > 0, errors_5xx / total_requests, 0)"
+    label       = "5xx error rate"
+    return_data = true
+  }
+
+  metric_query {
+    id = "errors_5xx"
+    metric {
+      metric_name = "HTTPCode_Target_5XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id = "total_requests"
+    metric {
+      metric_name = "RequestCount"
+      namespace   = "AWS/ApplicationELB"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+      }
+    }
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+
+  tags = local.default_tags
+}

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -17,6 +17,19 @@ locals {
     },
     var.tags,
   )
+
+  # ECS サービス論理名 -> 実 ServiceName を解決する。
+  # caller が map で明示した場合はそちらを優先し、それ以外は prefix+論理名で推定。
+  resolved_ecs_service_names = {
+    for logical in var.ecs_services :
+    logical => lookup(var.ecs_service_name_map, logical, "${local.prefix}-${logical}")
+  }
+
+  # RDS FreeStorageSpace 閾値 (bytes) = allocated_storage * (1 - ratio)
+  # 例: 20GB × 0.2 = 4GB、100GB × 0.2 = 20GB
+  rds_free_storage_threshold_bytes = floor(
+    var.rds_allocated_storage_gb * var.rds_free_storage_threshold_ratio * 1024 * 1024 * 1024
+  )
 }
 
 # ---------------------------------------------------------------------------
@@ -68,8 +81,9 @@ resource "aws_cloudwatch_metric_alarm" "ecs_service_cpu" {
 
   dimensions = {
     ClusterName = var.ecs_cluster_name
-    # ECS サービス名は compute モジュールで統一的に "<prefix>-<service>" 命名する前提
-    ServiceName = "${local.prefix}-${each.value}"
+    # 実 ServiceName は var.ecs_service_name_map で明示注入可能 (architect PR #46 HIGH)。
+    # 未指定時は "<prefix>-<logical>" にフォールバックする。
+    ServiceName = local.resolved_ecs_service_names[each.value]
   }
 
   alarm_actions = [aws_sns_topic.alerts.arn]
@@ -111,14 +125,14 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage" {
   count = var.rds_instance_identifier == "" ? 0 : 1
 
   alarm_name          = "${local.prefix}-rds-storage-low"
-  alarm_description   = "RDS FreeStorageSpace < 20% (4GB of 20GB)"
+  alarm_description   = "RDS FreeStorageSpace < ${floor(var.rds_free_storage_threshold_ratio * 100)}% of ${var.rds_allocated_storage_gb}GB"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = 2
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
   period              = 300
   statistic           = "Average"
-  threshold           = 4 * 1024 * 1024 * 1024 # 4 GiB in bytes
+  threshold           = local.rds_free_storage_threshold_bytes
   treat_missing_data  = "notBreaching"
 
   dimensions = {

--- a/terraform/modules/observability/outputs.tf
+++ b/terraform/modules/observability/outputs.tf
@@ -1,0 +1,14 @@
+output "sns_topic_arn" {
+  description = "Alerts 配信用 SNS Topic の ARN。他モジュール (Lambda・外部サービス) からサブスクライブする用途。"
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "log_group_names" {
+  description = "ECS サービス名 -> CloudWatch Log Group 名のマップ。compute モジュールの task definition でこの値を参照する。"
+  value       = { for svc, lg in aws_cloudwatch_log_group.ecs : svc => lg.name }
+}
+
+output "log_group_arns" {
+  description = "ECS サービス名 -> Log Group ARN のマップ。IAM policy で `resources` に渡す用途。"
+  value       = { for svc, lg in aws_cloudwatch_log_group.ecs : svc => lg.arn }
+}

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -1,0 +1,69 @@
+variable "environment" {
+  description = "環境名 (stg / prod)。ログ・アラーム名の prefix に使う。"
+  type        = string
+  validation {
+    condition     = contains(["stg", "prod"], var.environment)
+    error_message = "environment は stg / prod のいずれか。"
+  }
+}
+
+variable "project" {
+  description = "プロジェクト名 (リソース prefix)"
+  type        = string
+  default     = "sns"
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch Log Groups のログ保持日数"
+  type        = number
+  default     = 30
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.log_retention_days)
+    error_message = "CloudWatch が受け入れる retention 値のみ指定可能。"
+  }
+}
+
+variable "alert_email" {
+  description = "アラート通知先メールアドレス (SNS Topic にサブスクライブ)"
+  type        = string
+  validation {
+    condition     = can(regex("^[^@]+@[^@]+\\.[^@]+$", var.alert_email))
+    error_message = "有効なメールアドレス形式で指定してください。"
+  }
+}
+
+variable "ecs_services" {
+  description = "CloudWatch Log Group を作る ECS サービス名リスト"
+  type        = list(string)
+  default = [
+    "django",
+    "next",
+    "daphne",
+    "celery-worker",
+    "celery-beat",
+  ]
+}
+
+variable "alb_arn_suffix" {
+  description = "ALB の `arn_suffix` (5xx エラー率アラーム用)。未指定なら ALB アラームをスキップ。"
+  type        = string
+  default     = ""
+}
+
+variable "rds_instance_identifier" {
+  description = "RDS インスタンス識別子 (CPU / 容量アラーム用)。未指定なら RDS アラームをスキップ。"
+  type        = string
+  default     = ""
+}
+
+variable "ecs_cluster_name" {
+  description = "ECS Cluster 名 (サービス CPU アラーム用)。未指定ならスキップ。"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "全リソース共通タグ"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -33,7 +33,7 @@ variable "alert_email" {
 }
 
 variable "ecs_services" {
-  description = "CloudWatch Log Group を作る ECS サービス名リスト"
+  description = "CloudWatch Log Group を作る ECS サービス論理名リスト"
   type        = list(string)
   default = [
     "django",
@@ -42,6 +42,18 @@ variable "ecs_services" {
     "celery-worker",
     "celery-beat",
   ]
+}
+
+variable "ecs_service_name_map" {
+  description = <<-EOT
+    ECS サービス論理名 -> 実 ServiceName (ECS 上の識別子) のマップ。
+    compute モジュールが命名する実サービス名を明示的に注入するための escape
+    hatch (architect PR #46 HIGH 指摘)。未指定の場合は `<project>-<env>-<logical>`
+    のデフォルト命名規約に従う。compute モジュール実装時に実在する名前と一致
+    することを確認すること。
+  EOT
+  type        = map(string)
+  default     = {}
 }
 
 variable "alb_arn_suffix" {
@@ -54,6 +66,22 @@ variable "rds_instance_identifier" {
   description = "RDS インスタンス識別子 (CPU / 容量アラーム用)。未指定なら RDS アラームをスキップ。"
   type        = string
   default     = ""
+}
+
+variable "rds_allocated_storage_gb" {
+  description = "RDS の allocated storage (GB)。FreeStorageSpace アラーム閾値の算出に使う。"
+  type        = number
+  default     = 20
+}
+
+variable "rds_free_storage_threshold_ratio" {
+  description = "FreeStorageSpace アラーム発火の閾値比率 (0.0-1.0)。default 0.2 で残り 20% を切ったら通知。"
+  type        = number
+  default     = 0.2
+  validation {
+    condition     = var.rds_free_storage_threshold_ratio > 0 && var.rds_free_storage_threshold_ratio < 1
+    error_message = "0 < ratio < 1 の範囲で指定してください。"
+  }
 }
 
 variable "ecs_cluster_name" {


### PR DESCRIPTION
Closes #19

## 概要
CloudWatch Log Groups + Alarms + SNS Topic を束ねる Terraform モジュール。他モジュールからの output 参照をせず、識別子を var で受ける**片方向依存**構造。

## 追加リソース
- `aws_cloudwatch_log_group.ecs` × ECS サービス数 (5 想定)
- `aws_sns_topic.alerts` + email サブスク
- ECS Service CPU (cluster 名ありのみ)
- RDS CPU + FreeStorageSpace (identifier ありのみ)
- ALB 5xx error rate (arn_suffix ありのみ、metric_query で errors/total を計算)

## ポリシー
- log_retention_days = 30 日デフォルト (CloudWatch 許容値のみ受け付ける validation)
- alert_email は regex validation
- 未指定の識別子に紐づくアラームは作成しない (optional)

## Outputs
- `sns_topic_arn` — 追加サブスクライバー用
- `log_group_names` / `log_group_arns` — ECS task definition + IAM policy 用

## サブエージェントレビュー
- [ ] architect (モジュール境界・optional 依存設計)
- [ ] security-reviewer (IAM / SNS subscription の取扱い)