### PR TITLE
[P0.5-08] infra(tf): add storage module (media / static / backup S3 buckets)

### DIFF
--- a/terraform/modules/storage/README.md
+++ b/terraform/modules/storage/README.md
@@ -1,0 +1,59 @@
+# `storage` module
+
+3 本の S3 バケットを共通ポリシーで作成する。
+
+| 論理名 | bucket name | 用途 | Lifecycle |
+|---|---|---|---|
+| `media` | `<project>-<env>-media` | アバター・ツイート画像・DM 添付 | noncurrent 90 日削除 |
+| `static` | `<project>-<env>-static` | Next.js 静的アセット (CloudFront 配信) | 30 日で IA 移行 |
+| `backup` | `<project>-<env>-backup` | RDS / Meilisearch / アプリバックアップ | 30 日 IA → 90 日 Glacier → 730 日削除 |
+
+## 共通設定
+
+- **Versioning**: 有効（誤削除復旧 + 監査）
+- **Encryption**: SSE-S3 (AES256) + Bucket Key 有効化でコスト節約
+- **Public Access Block**: 4 項目すべて True
+- **Object Ownership**: `BucketOwnerEnforced` (ACL 無効化)
+- **force_destroy**: false (誤削除防止)
+- **中断済み Multipart Upload**: 7 日後自動破棄
+
+## CORS
+
+`media` バケットのみに 2 rule:
+- **GET/HEAD**: all origins (CloudFront 経由配信なので広め)
+- **PUT/POST**: フロントエンド origin のみ (presigned URL 経由の直アップロード用、Phase 3 DM 添付等)
+
+## CloudFront OAC 連携 (optional)
+
+`var.cloudfront_oac_arn` を与えると、media / static バケットの bucket policy を
+CloudFront Origin Access Control 経由のみ許可するよう設定する。
+edge モジュール (Phase 0.5-05) 実装前は空のままで OK (policy がそもそも付かない)。
+
+## 使用例
+
+```hcl
+module "storage" {
+  source = "../../modules/storage"
+
+  environment = "stg"
+  project     = "sns"
+
+  # edge モジュール完成後に値を入れる
+  cloudfront_oac_arn = module.edge.oac_arn
+}
+```
+
+## 運用上の注意
+
+- バケット名は global unique。名前衝突時は `project` を変更するか suffix 追加を検討
+- `force_destroy = false` なので `terraform destroy` 前に手動で全オブジェクト削除が必要
+  （versioning あるため delete markers + versions の削除は
+   [docs/operations/tf-state-bootstrap.md](../../../docs/operations/tf-state-bootstrap.md) 末尾の手順を参考に）
+- 本モジュールは **KMS CMK 暗号化に切替える余地**あり。prod では backup bucket だけ
+  CMK にすると監査性が上がる（要 ADR）
+
+## 今後の拡張
+
+- Access Logs 有効化 (S3 Access Logs を同リージョンの別バケットへ)
+- Intelligent-Tiering への自動移行 (media バケット、アクセスパターンが読めない場合)
+- Replication (prod 昇格時に別リージョンへ backup 複製)

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -88,6 +88,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 # ---------------------------------------------------------------------------
 
 # backup: IA -> Glacier -> 期限削除
+# NOTE: Glacier (90 日最小) を採用し Deep Archive (180 日最小) を選ばないのは、
+# stg の監査要件が 730 日で、Deep Archive の 180 日最小 + 取出し遅延 (最大 48 時間)
+# を避けるため (security-reviewer PR #48 LOW 指摘)。prod で保持期間を 5 年以上に
+# 延ばす場合は Deep Archive 併用を再検討する。
 resource "aws_s3_bucket_lifecycle_configuration" "backup" {
   bucket = aws_s3_bucket.this["backup"].id
 
@@ -184,14 +188,20 @@ resource "aws_s3_bucket_cors_configuration" "media" {
     max_age_seconds = 3600
   }
 
-  cors_rule {
-    id              = "presigned-upload"
-    allowed_methods = ["PUT", "POST"]
-    # フロントエンドの origin のみ。Phase 0.5-07 の stg 環境で上書きする。
-    allowed_origins = ["https://stg.*"] # 仮、edge モジュール導入時に上書き
-    allowed_headers = ["Content-Type", "Content-MD5", "x-amz-*"]
-    expose_headers  = ["ETag"]
-    max_age_seconds = 3600
+  # PUT/POST は var.frontend_origins に明示列挙された origin 限定
+  # (security-reviewer PR #48 HIGH)。S3 CORS の allowed_origins は末尾
+  # 1 箇所の `*` しか効かず、`https://stg.*` のような書き方は
+  # `https://stg.evil.com` 等の攻撃者 origin を通してしまう。
+  dynamic "cors_rule" {
+    for_each = length(var.frontend_origins) > 0 ? [1] : []
+    content {
+      id              = "presigned-upload"
+      allowed_methods = ["PUT", "POST"]
+      allowed_origins = var.frontend_origins
+      allowed_headers = ["Content-Type", "Content-MD5", "x-amz-*"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3600
+    }
   }
 }
 
@@ -219,6 +229,18 @@ data "aws_iam_policy_document" "cloudfront_read" {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
       values   = [var.cloudfront_oac_arn]
+    }
+
+    # AWS 公式推奨の追加ガード (security-reviewer PR #48 MEDIUM)。
+    # SourceArn だけでなく SourceAccount でも絞ると、将来 CloudFront
+    # ディストリを別アカウントに移す可能性への保険になる。
+    dynamic "condition" {
+      for_each = var.aws_account_id == "" ? [] : [1]
+      content {
+        test     = "StringEquals"
+        variable = "AWS:SourceAccount"
+        values   = [var.aws_account_id]
+      }
     }
   }
 }

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -1,0 +1,231 @@
+# Storage module (P0.5-08)
+#
+# S3 buckets: media (ユーザー画像) / static (Next.js 静的アセット) / backup
+# (RDS スナップショット・Meilisearch ダンプ等)。
+#
+# 共通ポリシー:
+# - Versioning: 有効 (誤削除復旧 + 監査)
+# - Encryption: SSE-S3 (AES256)
+# - Public Access: 完全遮断
+# - Object Ownership: BucketOwnerEnforced (ACL 無効化)
+# - Lifecycle: bucket ごとに個別定義
+
+locals {
+  prefix = "${var.project}-${var.environment}"
+
+  default_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Module      = "storage"
+    },
+    var.tags,
+  )
+
+  buckets = {
+    media   = { name = "${local.prefix}-media", purpose = "user-uploaded content (avatars, tweet images, DM attachments)" }
+    static  = { name = "${local.prefix}-static", purpose = "Next.js static assets via CloudFront" }
+    backup  = { name = "${local.prefix}-backup", purpose = "RDS / Meilisearch / app-level backups" }
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  for_each = local.buckets
+
+  bucket        = each.value.name
+  force_destroy = false # 誤削除防止。prod teardown 時のみ override。
+
+  tags = merge(local.default_tags, {
+    Name    = each.value.name
+    Purpose = each.value.purpose
+    Bucket  = each.key
+  })
+}
+
+resource "aws_s3_bucket_ownership_controls" "this" {
+  for_each = aws_s3_bucket.this
+
+  bucket = each.value.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  for_each = aws_s3_bucket.this
+
+  bucket                  = each.value.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  for_each = aws_s3_bucket.this
+
+  bucket = each.value.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  for_each = aws_s3_bucket.this
+
+  bucket = each.value.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Lifecycle rules — bucket ごとに個別の方針
+# ---------------------------------------------------------------------------
+
+# backup: IA -> Glacier -> 期限削除
+resource "aws_s3_bucket_lifecycle_configuration" "backup" {
+  bucket = aws_s3_bucket.this["backup"].id
+
+  rule {
+    id     = "transition-to-glacier"
+    status = "Enabled"
+
+    filter {} # 全オブジェクト対象
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+    transition {
+      days          = var.backup_transition_to_glacier_days
+      storage_class = "GLACIER"
+    }
+
+    dynamic "expiration" {
+      for_each = var.backup_expiration_days > 0 ? [1] : []
+      content {
+        days = var.backup_expiration_days
+      }
+    }
+
+    # 旧バージョンは 30 日後に削除 (バージョニングで無限に膨らむのを防ぐ)
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# media: 旧バージョンのみ削除、本体は永続
+resource "aws_s3_bucket_lifecycle_configuration" "media" {
+  bucket = aws_s3_bucket.this["media"].id
+
+  rule {
+    id     = "cleanup-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# static: CloudFront 配信なのでキャッシュが効く。古いデプロイの静的ファイルは
+# CloudFront invalidation 後に IA へ移して節約。
+resource "aws_s3_bucket_lifecycle_configuration" "static" {
+  bucket = aws_s3_bucket.this["static"].id
+
+  rule {
+    id     = "static-transition-to-ia"
+    status = "Enabled"
+
+    filter {}
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# CORS — media バケットは直接 PUT (S3 presigned URL) の対象
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket_cors_configuration" "media" {
+  bucket = aws_s3_bucket.this["media"].id
+
+  cors_rule {
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"] # CloudFront 経由配信なので GET は広めで許容
+    allowed_headers = []
+    max_age_seconds = 3600
+  }
+
+  cors_rule {
+    id              = "presigned-upload"
+    allowed_methods = ["PUT", "POST"]
+    # フロントエンドの origin のみ。Phase 0.5-07 の stg 環境で上書きする。
+    allowed_origins = ["https://stg.*"] # 仮、edge モジュール導入時に上書き
+    allowed_headers = ["Content-Type", "Content-MD5", "x-amz-*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Bucket policy for CloudFront OAC (media / static)
+# - cloudfront_oac_arn が空なら policy を作らない (edge モジュール未導入時)
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "cloudfront_read" {
+  for_each = var.cloudfront_oac_arn == "" ? {} : { media = true, static = true }
+
+  statement {
+    sid     = "AllowCloudFrontServicePrincipalRead"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+
+    resources = ["${aws_s3_bucket.this[each.key].arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [var.cloudfront_oac_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudfront_read" {
+  for_each = data.aws_iam_policy_document.cloudfront_read
+
+  bucket = aws_s3_bucket.this[each.key].id
+  policy = each.value.json
+}

--- a/terraform/modules/storage/outputs.tf
+++ b/terraform/modules/storage/outputs.tf
@@ -1,0 +1,38 @@
+output "bucket_ids" {
+  description = "論理名 -> bucket ID のマップ (= bucket 名)。Django storages や Next.js の BUCKET 環境変数に渡す。"
+  value       = { for k, b in aws_s3_bucket.this : k => b.id }
+}
+
+output "bucket_arns" {
+  description = "論理名 -> bucket ARN のマップ。IAM policy の resources に入れる。"
+  value       = { for k, b in aws_s3_bucket.this : k => b.arn }
+}
+
+output "bucket_regional_domains" {
+  description = "論理名 -> regional_domain_name (CloudFront オリジンに指定)"
+  value       = { for k, b in aws_s3_bucket.this : k => b.bucket_regional_domain_name }
+}
+
+output "media_bucket_id" {
+  value = aws_s3_bucket.this["media"].id
+}
+
+output "media_bucket_arn" {
+  value = aws_s3_bucket.this["media"].arn
+}
+
+output "static_bucket_id" {
+  value = aws_s3_bucket.this["static"].id
+}
+
+output "static_bucket_arn" {
+  value = aws_s3_bucket.this["static"].arn
+}
+
+output "backup_bucket_id" {
+  value = aws_s3_bucket.this["backup"].id
+}
+
+output "backup_bucket_arn" {
+  value = aws_s3_bucket.this["backup"].arn
+}

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -1,0 +1,47 @@
+variable "environment" {
+  description = "環境名 (stg / prod)"
+  type        = string
+  validation {
+    condition     = contains(["stg", "prod"], var.environment)
+    error_message = "environment は stg / prod のいずれか。"
+  }
+}
+
+variable "project" {
+  description = "プロジェクト名 (リソース prefix)"
+  type        = string
+  default     = "sns"
+}
+
+variable "backup_transition_to_glacier_days" {
+  description = "バックアップバケットで IA -> Glacier へ移行する日数"
+  type        = number
+  default     = 90
+}
+
+variable "backup_expiration_days" {
+  description = "バックアップの完全削除までの日数。0 で削除しない。"
+  type        = number
+  default     = 730 # 2 年
+  validation {
+    condition     = var.backup_expiration_days == 0 || var.backup_expiration_days >= 7
+    error_message = "0 (無期限) か 7 日以上を指定。"
+  }
+}
+
+variable "cloudfront_oac_arn" {
+  description = <<-EOT
+    CloudFront Origin Access Control の ARN。
+    media / static バケットは CloudFront 経由でのみ配信するため、bucket policy
+    で sourceArn をこの OAC に限定する。空なら bucket policy をスキップ
+    (edge モジュール実装前のフェーズで使用)。
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "全リソース共通タグ"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -40,6 +40,34 @@ variable "cloudfront_oac_arn" {
   default     = ""
 }
 
+variable "aws_account_id" {
+  description = <<-EOT
+    自 AWS アカウント ID。OAC bucket policy の AWS:SourceAccount 条件に使う
+    (security-reviewer PR #48 MEDIUM)。未指定なら SourceAccount 条件をスキップ
+    (SourceArn のみで絞る)。
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "frontend_origins" {
+  description = <<-EOT
+    media bucket の PUT/POST CORS で許可する frontend origin のリスト。
+    例: ["https://stg.example.com"]。S3 CORS は正規表現ではなく完全一致 + 末尾
+    ワイルドカードしか効かないため、必ず具体的な値を指定する
+    (security-reviewer PR #48 HIGH)。
+    空リストの場合は PUT/POST ルールを作成しない (presigned URL 直アップロード不可)。
+  EOT
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for o in var.frontend_origins : can(regex("^https://[^*]+$", o))
+    ])
+    error_message = "frontend_origins は https:// で始まる完全な origin (ワイルドカード不可) のリスト。"
+  }
+}
+
 variable "tags" {
   description = "全リソース共通タグ"
   type        = map(string)


### PR DESCRIPTION
Closes #21

## 概要
用途別に 3 本の S3 バケットを共通ポリシーで作成。

## バケット構成

| 論理名 | 用途 | Lifecycle |
|---|---|---|
| `media` | アバター / ツイート画像 / DM 添付 | noncurrent 90 日削除 |
| `static` | Next.js 静的アセット (CloudFront 配信) | 30 日で IA 移行 |
| `backup` | RDS / Meilisearch / アプリバックアップ | 30 日 IA → 90 日 Glacier → 730 日削除 |

## 共通セキュリティ
- Versioning 有効
- SSE-S3 (AES256) + Bucket Key 有効化
- Public Access Block 4 項目すべて true
- Object Ownership = BucketOwnerEnforced (ACL 無効化)
- force_destroy = false (誤削除防止)
- 7 日後の incomplete multipart upload 自動破棄

## CORS (media のみ)
- GET/HEAD: * (CloudFront 経由配信)
- PUT/POST: フロントエンド origin のみ (presigned URL 直アップロード用、Phase 3 DM 添付)

## CloudFront OAC 連携 (optional)
`var.cloudfront_oac_arn` が空なら policy を作らない。edge モジュール導入後に OAC ARN を渡すと、媒体バケットを CloudFront 経由のみ許可に変更。

## サブエージェントレビュー
- [ ] security-reviewer (Public Access / CORS / ポリシー)
- [ ] architect (Lifecycle / コスト)