### PR TITLE
[P0.5-09] infra(tf): add secrets module (Secrets Manager entries)

### DIFF
--- a/terraform/modules/secrets/README.md
+++ b/terraform/modules/secrets/README.md
@@ -1,0 +1,114 @@
+# `secrets` module
+
+Secrets Manager にシークレットの枠を一括で作成する。
+
+## 命名規約
+
+```
+sns/<env>/<category>/<key>
+```
+
+例:
+- `sns/stg/django/secret-key`
+- `sns/stg/django/db-password`
+- `sns/stg/stripe/secret-key`
+- `sns/stg/openai/api-key`
+
+ECS task definition の `secrets` 属性で ARN 参照し、ランタイム環境変数にバインドする。
+
+## 2 種類のシークレット
+
+### 自動生成 (terraform が put)
+
+| キー | 用途 | 方式 |
+|---|---|---|
+| `django/secret-key` | Django SECRET_KEY | `random_password` (length 64, special 可) |
+| `django/db-password` | RDS master password | `random_password` (length 40, RDS 互換の記号のみ) |
+
+`var.generate_random_values = true` (default) の時だけ put される。
+`lifecycle.ignore_changes = [secret_string]` で、運用者が `aws secretsmanager
+put-secret-value` で手動ローテートした後、次回 apply が戻さないようにしている。
+
+### Placeholder (運用者が手動 put)
+
+外部由来のシークレットは terraform では枠のみ作成:
+
+| キー | 取得元 |
+|---|---|
+| `sentry/dsn` | Sentry プロジェクト設定 |
+| `mailgun/api-key` | Mailgun コントロールパネル |
+| `mailgun/signing-key` | Mailgun Webhook signing key |
+| `stripe/secret-key` | Stripe ダッシュボード (test / live) |
+| `stripe/webhook-secret` | Stripe Webhook endpoint の signing secret |
+| `openai/api-key` | OpenAI platform |
+| `anthropic/api-key` | Anthropic console |
+
+初期状態では `{"note": "SET_VIA_AWS_CLI: ..."}` という placeholder が入る。
+運用者が実値を書き込むコマンド例:
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id sns/stg/stripe/secret-key \
+  --secret-string "sk_test_xxxxx"
+```
+
+## recovery_window_in_days
+
+Secrets Manager は削除時に論理削除状態になり、指定日数内に `restore-secret` で復旧可能。
+- stg: 7 日 (default)
+- prod: 30 日を推奨
+
+`0` を指定すると即時削除 (テスト環境で作り直したいとき用)。
+
+## 使用例
+
+```hcl
+module "secrets" {
+  source = "../../modules/secrets"
+
+  environment              = "stg"
+  project                  = "sns"
+  generate_random_values   = true
+  recovery_window_in_days  = 7
+}
+
+# 他モジュールに ARN を渡す
+module "data" {
+  source              = "../../modules/data"
+  db_password_arn     = module.secrets.db_password_arn
+  db_password_value   = module.secrets.db_password_value # RDS 作成時の MasterUserPassword
+  # ...
+}
+
+module "compute" {
+  source          = "../../modules/compute"
+  secret_arns_map = module.secrets.secret_arns
+  # ...
+}
+```
+
+## IAM 連携
+
+ECS task execution role が必要な `secretsmanager:GetSecretValue` permission:
+
+```hcl
+resource "aws_iam_role_policy" "task_execution_read_secrets" {
+  role   = aws_iam_role.ecs_task_execution.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = module.secrets.all_secret_arns_list
+    }]
+  })
+}
+```
+
+## 今後の拡張
+
+- **ローテーション自動化**: `aws_secretsmanager_secret_rotation` + Lambda (DB password を 30 日ごと)
+- **KMS CMK**: 現状は AWS managed key。prod では CMK で IAM / CloudTrail 可視化強化
+- **tfvars に生 secret を入れない**: 本モジュールは terraform state に DB password が
+  入るが、state は暗号化 S3 backend (P0.5-01) + DynamoDB lock の下で保存される。
+  prod では別途 External Secret Store (1Password / HashiCorp Vault) との同期を検討

--- a/terraform/modules/secrets/README.md
+++ b/terraform/modules/secrets/README.md
@@ -105,10 +105,94 @@ resource "aws_iam_role_policy" "task_execution_read_secrets" {
 }
 ```
 
+## シークレットの値のフォーマット (重要)
+
+**すべてのシークレット値は JSON オブジェクト `{"value": "<実値>"}` 形式で保存する**
+(security-reviewer PR #49 HIGH)。
+
+理由: アプリ側が JSON parse で統一的に取り出せるようにし、Placeholder ↔ 実値の
+フォーマット不一致による運用初期のバグを防ぐため。
+
+### 手動 put の正しいコマンド
+
+```bash
+# 実際の Stripe secret key は Stripe ダッシュボードから取得して
+# <STRIPE_SECRET_KEY> のところに貼り付ける
+aws secretsmanager put-secret-value \
+  --secret-id sns/stg/stripe/secret-key \
+  --secret-string '{"value":"<STRIPE_SECRET_KEY>"}'
+```
+
+### アプリ側の取得パターン (Django)
+
+```python
+import json
+import boto3
+
+client = boto3.client("secretsmanager")
+response = client.get_secret_value(SecretId="sns/stg/stripe/secret-key")
+secret = json.loads(response["SecretString"])
+api_key = secret["value"]
+```
+
+### 例外: 自動生成シークレット (django/secret-key, django/db-password)
+
+自動生成グループは `random_password.result` が直接 string として入る
+(JSON ラップなし、歴史的経緯 + RDS の master_user_password が JSON を受け付けない)。
+アプリ・data モジュール側は string として扱うこと。
+
+## IAM policy で必要な action
+
+ECS task execution role には最低:
+
+- `secretsmanager:GetSecretValue`
+
+SDK によっては追加で必要になるケース (describe / list-versions 等) がある:
+
+- `secretsmanager:DescribeSecret`
+- `secretsmanager:ListSecretVersionIds`
+
+`Resource` には `var.secret_arns` マップから**必要なシークレットのみ**を抜き出し、
+`all_secret_arns_list` は便利だが過剰権限になりがちなので、サービスごとに絞ることを推奨:
+
+```hcl
+resource "aws_iam_role_policy" "django_read_secrets" {
+  role   = aws_iam_role.ecs_task_execution.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+      Resource = [
+        module.secrets.secret_arns["django/secret-key"],
+        module.secrets.secret_arns["django/db-password"],
+        module.secrets.secret_arns["sentry/dsn"],
+      ]
+    }]
+  })
+}
+```
+
+## db_password_value の取扱い注意
+
+output `db_password_value` は `sensitive = true` が付いており、CLI 表示や
+ログへの平文漏洩は防がれる。ただし以下の制約を認識すること
+(security-reviewer PR #49 HIGH):
+
+1. **terraform state には平文で記録される**。state ファイルは S3 backend
+   (SSE-S3) + DynamoDB lock で保護されるが、state 閲覧権限を持つ IAM principal
+   は全シークレットを取得可能
+2. **呼び出し元 (data モジュール) の state にも複製される**。RDS master_user_password
+   引数に渡した瞬間、data モジュールの state にも平文値が入る
+3. **代替案**: RDS で `manage_master_user_password = true` を使うと AWS が自動で
+   Secrets Manager 管理し、値が terraform state に入らない。ただし secret 名を
+   `sns/stg/django/db-password` にコントロールできなくなる (`rds!db-<random>` 形式)
+4. **現方針**: secret 名のコントロール性を優先し、state 保護 (S3 暗号化 + IAM 最小化)
+   で緩和する。prod で要件が厳しくなれば `manage_master_user_password` へ切替
+
 ## 今後の拡張
 
 - **ローテーション自動化**: `aws_secretsmanager_secret_rotation` + Lambda (DB password を 30 日ごと)
-- **KMS CMK**: 現状は AWS managed key。prod では CMK で IAM / CloudTrail 可視化強化
-- **tfvars に生 secret を入れない**: 本モジュールは terraform state に DB password が
-  入るが、state は暗号化 S3 backend (P0.5-01) + DynamoDB lock の下で保存される。
-  prod では別途 External Secret Store (1Password / HashiCorp Vault) との同期を検討
+- **KMS CMK**: `var.kms_key_id` は用意済み。prod では CMK で IAM / CloudTrail 可視化強化 (ADR 発行予定)
+- **manage_master_user_password**: prod 移行時に state 漏洩リスク最小化で検討
+- **External Secret Store**: 1Password / HashiCorp Vault との同期

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -68,15 +68,22 @@ resource "aws_secretsmanager_secret" "generated" {
   name                    = "${local.prefix}/${each.key}"
   description             = each.value.description
   recovery_window_in_days = var.recovery_window_in_days
+  kms_key_id              = var.kms_key_id
 
   tags = merge(local.default_tags, { Key = each.key })
 }
 
 resource "aws_secretsmanager_secret_version" "generated" {
-  for_each = var.generate_random_values ? local.generated_secrets : {}
+  # security-reviewer PR #49 MEDIUM: generate_random_values=false の時でも
+  # version を作らないと AWSCURRENT が存在せず GetSecretValue が
+  # ResourceNotFoundException を返す。値が無い状態でも必ず placeholder を
+  # 入れておき、後から手動 put で上書きする。
+  for_each = local.generated_secrets
 
-  secret_id     = aws_secretsmanager_secret.generated[each.key].id
-  secret_string = random_password.generated[each.key].result
+  secret_id = aws_secretsmanager_secret.generated[each.key].id
+  secret_string = var.generate_random_values ? random_password.generated[each.key].result : jsonencode({
+    value = "SET_VIA_AWS_CLI: aws secretsmanager put-secret-value --secret-id ${local.prefix}/${each.key} --secret-string ...",
+  })
 
   # 運用者が手動で put-secret-value で上書きした場合、terraform がそれを
   # revert しないように ignore する。random_password を変更すると意図的に
@@ -96,16 +103,24 @@ resource "aws_secretsmanager_secret" "placeholder" {
   name                    = "${local.prefix}/${each.key}"
   description             = each.value
   recovery_window_in_days = var.recovery_window_in_days
+  kms_key_id              = var.kms_key_id
 
   tags = merge(local.default_tags, { Key = each.key })
 }
 
+# Placeholder の初期値は実運用の書式 (plain value) と合わせるため、
+# アプリが直接 parse して key "value" を取り出すことを前提とした JSON にする。
+# 運用者が手動 put する際も同じ `{"value": "<actual-secret>"}` 形式を使う想定
+# (security-reviewer PR #49 HIGH: 書式不一致バグの予防)。
+# アプリ側コード例:
+#   secret_dict = json.loads(secrets_manager_client.get_secret_value(...)["SecretString"])
+#   api_key = secret_dict["value"]
 resource "aws_secretsmanager_secret_version" "placeholder_initial" {
   for_each = local.placeholder_secrets
 
-  secret_id     = aws_secretsmanager_secret.placeholder[each.key].id
+  secret_id = aws_secretsmanager_secret.placeholder[each.key].id
   secret_string = jsonencode({
-    note = "SET_VIA_AWS_CLI: aws secretsmanager put-secret-value --secret-id ${local.prefix}/${each.key} --secret-string ...",
+    value = "SET_VIA_AWS_CLI: aws secretsmanager put-secret-value --secret-id ${local.prefix}/${each.key} --secret-string '{\"value\":\"<actual-secret>\"}'",
   })
 
   # 手動 put で上書きされても terraform が戻さない

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -1,0 +1,115 @@
+# Secrets module (P0.5-09)
+#
+# Secrets Manager に Django / RDS / 外部 API のシークレット "枠" を作る。
+#
+# 方針:
+# 1. 自動生成できるもの (Django SECRET_KEY / DB password): random_password で生成して
+#    put-secret-value。terraform state には入るが、.tfstate は暗号化済み S3 backend
+#    に保存されるので漏洩リスクは限定的。
+# 2. 外部由来のシークレット (Mailgun / Stripe / OpenAI / Claude / Sentry DSN):
+#    placeholder で作成し、運用者が `aws secretsmanager put-secret-value` で
+#    実値を書き込む。terraform で管理するのは「存在と ARN」のみ。
+#
+# 命名規則: sns/<env>/<category>/<key>
+#   - Django:   sns/stg/django/secret-key, sns/stg/django/db-password
+#   - Sentry:   sns/stg/sentry/dsn
+#   - Mailgun:  sns/stg/mailgun/api-key, sns/stg/mailgun/signing-key
+#   - Stripe:   sns/stg/stripe/secret-key, sns/stg/stripe/webhook-secret
+#   - OpenAI:   sns/stg/openai/api-key
+#   - Anthropic sns/stg/anthropic/api-key
+
+locals {
+  prefix = "sns/${var.environment}"
+
+  default_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Module      = "secrets"
+    },
+    var.tags,
+  )
+
+  # 自動生成グループ: terraform が値を put する
+  generated_secrets = {
+    "django/secret-key"  = { description = "Django SECRET_KEY", length = 64, special = true }
+    "django/db-password" = { description = "RDS master password", length = 40, special = false } # RDS の制約で記号制限あり
+  }
+
+  # Placeholder グループ: terraform は枠だけ作る
+  placeholder_secrets = {
+    "sentry/dsn"             = "Sentry Django/Celery DSN (https://...@sentry.io/...)"
+    "mailgun/api-key"        = "Mailgun API key (Phase 1 以降で利用)"
+    "mailgun/signing-key"    = "Mailgun webhook signing key"
+    "stripe/secret-key"      = "Stripe Secret Key (sk_test_... / sk_live_...)"
+    "stripe/webhook-secret"  = "Stripe webhook signing secret (whsec_...)"
+    "openai/api-key"         = "OpenAI API key (Phase 7 Bot 要約)"
+    "anthropic/api-key"      = "Anthropic API key (Phase 8 記事下書き AI)"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Auto-generated secrets
+# ---------------------------------------------------------------------------
+
+resource "random_password" "generated" {
+  for_each = var.generate_random_values ? local.generated_secrets : {}
+
+  length  = each.value.length
+  special = each.value.special
+  # RDS master password に使える記号のみ (RDS 制約: / @ " space は NG)
+  override_special = each.value.special ? "_-+=!#$%^&*()" : ""
+}
+
+resource "aws_secretsmanager_secret" "generated" {
+  for_each = local.generated_secrets
+
+  name                    = "${local.prefix}/${each.key}"
+  description             = each.value.description
+  recovery_window_in_days = var.recovery_window_in_days
+
+  tags = merge(local.default_tags, { Key = each.key })
+}
+
+resource "aws_secretsmanager_secret_version" "generated" {
+  for_each = var.generate_random_values ? local.generated_secrets : {}
+
+  secret_id     = aws_secretsmanager_secret.generated[each.key].id
+  secret_string = random_password.generated[each.key].result
+
+  # 運用者が手動で put-secret-value で上書きした場合、terraform がそれを
+  # revert しないように ignore する。random_password を変更すると意図的に
+  # ローテートする運用。
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Placeholder secrets (terraform は枠だけ、値は運用者が手動 put)
+# ---------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "placeholder" {
+  for_each = local.placeholder_secrets
+
+  name                    = "${local.prefix}/${each.key}"
+  description             = each.value
+  recovery_window_in_days = var.recovery_window_in_days
+
+  tags = merge(local.default_tags, { Key = each.key })
+}
+
+resource "aws_secretsmanager_secret_version" "placeholder_initial" {
+  for_each = local.placeholder_secrets
+
+  secret_id     = aws_secretsmanager_secret.placeholder[each.key].id
+  secret_string = jsonencode({
+    note = "SET_VIA_AWS_CLI: aws secretsmanager put-secret-value --secret-id ${local.prefix}/${each.key} --secret-string ...",
+  })
+
+  # 手動 put で上書きされても terraform が戻さない
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/terraform/modules/secrets/outputs.tf
+++ b/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,31 @@
+output "secret_arns" {
+  description = "シークレット論理名 (例: django/secret-key) -> ARN のマップ。ECS task execution role / task role の IAM policy で resources に指定する。"
+  value = merge(
+    { for k, s in aws_secretsmanager_secret.generated : k => s.arn },
+    { for k, s in aws_secretsmanager_secret.placeholder : k => s.arn },
+  )
+}
+
+output "all_secret_arns_list" {
+  description = "全シークレット ARN のリスト形式 (IAM policy の resources にそのまま渡せる)"
+  value = concat(
+    [for s in aws_secretsmanager_secret.generated : s.arn],
+    [for s in aws_secretsmanager_secret.placeholder : s.arn],
+  )
+}
+
+output "django_secret_key_arn" {
+  description = "Django SECRET_KEY の ARN (convenience accessor)"
+  value       = aws_secretsmanager_secret.generated["django/secret-key"].arn
+}
+
+output "db_password_arn" {
+  description = "RDS master password の ARN (data モジュールが参照)"
+  value       = aws_secretsmanager_secret.generated["django/db-password"].arn
+}
+
+output "db_password_value" {
+  description = "RDS master password の現在値。terraform apply 直後に data モジュールへ値を渡す用途で sensitive = true。"
+  value       = var.generate_random_values ? random_password.generated["django/db-password"].result : null
+  sensitive   = true
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -36,6 +36,17 @@ variable "generate_random_values" {
   default     = true
 }
 
+variable "kms_key_id" {
+  description = <<-EOT
+    シークレット暗号化用の KMS CMK ID または ARN。null (default) の場合は
+    AWS managed key (alias/aws/secretsmanager) を使う。
+    security-reviewer PR #49 LOW: 先に変数化しておくことで prod CMK 移行時に
+    ForceNew を避ける。CMK 採用時の ADR は別途発行予定。
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "全リソース共通タグ"
   type        = map(string)

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -1,0 +1,43 @@
+variable "environment" {
+  description = "環境名 (stg / prod)"
+  type        = string
+  validation {
+    condition     = contains(["stg", "prod"], var.environment)
+    error_message = "environment は stg / prod のいずれか。"
+  }
+}
+
+variable "project" {
+  description = "プロジェクト名 (シークレット名 prefix)"
+  type        = string
+  default     = "sns"
+}
+
+variable "recovery_window_in_days" {
+  description = <<-EOT
+    Secrets Manager の論理削除猶予期間。0 にすると即時削除。
+    stg は 7 日で運用、prod は 30 日を推奨 (誤 destroy からの復旧余地)。
+  EOT
+  type        = number
+  default     = 7
+  validation {
+    condition     = var.recovery_window_in_days == 0 || (var.recovery_window_in_days >= 7 && var.recovery_window_in_days <= 30)
+    error_message = "0 (即時削除) または 7-30 日を指定。"
+  }
+}
+
+variable "generate_random_values" {
+  description = <<-EOT
+    true にすると Django SECRET_KEY / DB パスワードなどをランダム値で生成する。
+    false にすると placeholder (AWSCURRENT: "CHANGEME") で作成し、運用者が
+    別途 `aws secretsmanager put-secret-value` で書き換える運用。
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "全リソース共通タグ"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Closes #22

## 概要
Secrets Manager のシークレット枠を一括作成。ECS task definition が ARN 参照でランタイム環境変数に展開する運用。

## 命名規約
`sns/<env>/<category>/<key>`

## 2 階層ポリシー

### 自動生成 (terraform が put)
- `sns/stg/django/secret-key` (random, 64 chars, symbols 可)
- `sns/stg/django/db-password` (random, 40 chars, RDS 互換記号)

`lifecycle.ignore_changes = [secret_string]` で手動ローテーション後も terraform が戻さない。

### Placeholder (運用者が CLI で手動 put)
- sentry/dsn, mailgun/api-key, mailgun/signing-key
- stripe/secret-key, stripe/webhook-secret
- openai/api-key, anthropic/api-key

初期値は `{"note":"SET_VIA_AWS_CLI..."}`。

## recovery_window_in_days
- stg: 7 日 (default)
- prod: 30 日を推奨

## 出力
- `secret_arns` map: 論理名 -> ARN
- `all_secret_arns_list`: IAM policy resources に渡す
- `db_password_arn` / `db_password_value` (sensitive): data モジュールが RDS 作成時に直接参照

## サブエージェントレビュー
- [ ] security-reviewer (state 内平文値 / ignore_changes / recovery_window)
- [ ] architect (命名規約 / 2 階層方針)