### PR TITLE
[P0.5-03] infra(tf): add data module (RDS PostgreSQL + ElastiCache Redis)

### DIFF
--- a/terraform/modules/data/README.md
+++ b/terraform/modules/data/README.md
@@ -1,0 +1,104 @@
+# `data` module
+
+RDS PostgreSQL + ElastiCache Redis + 付随する subnet/parameter group。
+
+## 前提依存
+
+- network モジュール: `db_subnet_ids`, `rds_security_group_id`, `redis_security_group_id`
+- secrets モジュール: `db_master_password` (`db_password_value` output を sensitive で渡す)
+
+## リソース
+
+### RDS PostgreSQL
+- Engine: postgres 15.8 (stg)、`aws_db_instance.this`
+- Instance class: `db.t4g.micro` (stg) — ARCHITECTURE.md §4.1 で t4g.small 昇格判断条件あり
+- Storage: gp3 20GB → 最大 100GB 自動スケール、暗号化 (AWS managed KMS)
+- Multi-AZ: stg=false / prod=true 推奨
+- **Parameter group**: `shared_preload_libraries = pg_bigm` でローディング、
+  `log_min_duration_statement = 1000ms` で slow query ログ有効化
+- Backup: 7 日、JST 03:00-04:00
+- Maintenance: JST 水曜 04:00-05:00
+- Performance Insights: 有効、stg は 7 日保持 (無料枠)
+- CloudWatch Logs: postgresql + upgrade
+
+### ElastiCache Redis
+- Engine: Redis 7.1、Single-node `cache.t4g.micro`
+- Parameter group: `maxmemory-policy = allkeys-lru` (Channels + cache 兼用)
+- stg は snapshot 無効、AUTH token なし (SG で十分守る)
+- Maintenance: JST 木曜 04:00-05:00
+- **prod 昇格時**: replication group + transit encryption + at-rest encryption +
+  auth_token に切替 (別モジュール `data_replication` を新設予定)
+
+## pg_bigm / pg_trgm の有効化
+
+`shared_preload_libraries` で load は済むが、Django 初回 migrate 時に以下を実行する必要がある:
+
+```python
+# apps/common/migrations/0001_extensions.py (Phase 1 で作成予定)
+from django.contrib.postgres.operations import BigmExtension, TrigramExtension
+
+class Migration(migrations.Migration):
+    operations = [
+        BigmExtension(),
+        TrigramExtension(),
+    ]
+```
+
+## lifecycle.ignore_changes
+
+- `password`: secrets モジュールの ignore_changes と対になる。手動 put で
+  secret を更新しても RDS 側の master_user_password は自動同期しないため、
+  RDS を更新したい場合は別途 `aws rds modify-db-instance` を実行する運用
+- `final_snapshot_identifier`: `timestamp()` で差分が無限に出る問題を回避
+
+## 使用例
+
+```hcl
+module "data" {
+  source = "../../modules/data"
+
+  environment = "stg"
+  project     = "sns"
+
+  # network モジュールから
+  db_subnet_ids           = module.network.db_subnet_ids
+  rds_security_group_id   = module.network.rds_security_group_id
+  redis_security_group_id = module.network.redis_security_group_id
+
+  # secrets モジュールから
+  db_master_password = module.secrets.db_password_value
+
+  # stg 向け設定 (デフォルト値でも OK)
+  rds_instance_class  = "db.t4g.micro"
+  rds_multi_az        = false
+  redis_node_type     = "cache.t4g.micro"
+}
+```
+
+## 運用上の注意
+
+### destroy 時の final snapshot
+
+`rds_skip_final_snapshot = false` (default) だと destroy で final snapshot が作られる。
+stg teardown を頻繁に行う場合は環境変数で `true` にしつつ、`rds_deletion_protection = false`
+にする。prod は `true` 固定。
+
+### ストレージ自動スケール
+
+`max_allocated_storage_gb = 100` で 20GB → 100GB まで自動拡張。その先は手動で
+`allocated_storage` を変更する。CloudWatch アラームは observability モジュールで
+20% 閾値を設定済み。
+
+### 接続数
+
+t4g.micro のデフォルト `max_connections` は約 81。Django (`CONN_MAX_AGE=60`) +
+Celery worker + Daphne の合計が超えないよう監視する。超えたら PgBouncer を
+compute モジュール側に導入する。
+
+## 今後の拡張
+
+- PgBouncer (Fargate サイドカー) 導入で接続プーリング
+- prod の Multi-AZ + read replica
+- RDS Proxy (Lambda / Fargate からの cold connection 吸収)
+- KMS CMK 暗号化
+- `data_replication` モジュールで ElastiCache replication group

--- a/terraform/modules/data/main.tf
+++ b/terraform/modules/data/main.tf
@@ -40,8 +40,17 @@ resource "aws_db_parameter_group" "postgres15" {
   description = "Postgres 15 parameters with pg_bigm + pg_trgm preloaded"
 
   parameter {
+    # pg_bigm: 日本語全文検索 (Phase 1/2 で CREATE EXTENSION)
+    # pg_stat_statements: Performance Insights が参照するクエリ統計 (DB reviewer PR #50 HIGH)
     name         = "shared_preload_libraries"
-    value        = "pg_bigm"
+    value        = "pg_bigm,pg_stat_statements"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    # pg_stat_statements の追跡対象: IN 句などの正規化した文
+    name         = "pg_stat_statements.track"
+    value        = "all"
     apply_method = "pending-reboot"
   }
 
@@ -78,6 +87,8 @@ resource "aws_db_instance" "this" {
   allocated_storage      = var.rds_allocated_storage_gb
   max_allocated_storage  = var.rds_max_allocated_storage_gb > 0 ? var.rds_max_allocated_storage_gb : null
   storage_type           = "gp3"
+  iops                   = var.rds_storage_iops
+  storage_throughput     = var.rds_storage_throughput_mbs
   storage_encrypted      = true
   # KMS は AWS managed key (aws/rds)。prod で CMK 移行時は kms_key_id を variable 化する。
 
@@ -102,9 +113,14 @@ resource "aws_db_instance" "this" {
   backup_window           = "18:00-19:00" # JST 03:00-04:00
   maintenance_window      = "Wed:19:00-Wed:20:00" # JST 水曜 04:00-05:00
 
-  deletion_protection       = var.rds_deletion_protection
-  skip_final_snapshot       = var.rds_skip_final_snapshot
-  final_snapshot_identifier = var.rds_skip_final_snapshot ? null : "${local.prefix}-postgres-final-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  deletion_protection = var.rds_deletion_protection
+  skip_final_snapshot = var.rds_skip_final_snapshot
+  # final_snapshot_identifier は timestamp() を使わず固定名にする
+  # (database-reviewer PR #50 MEDIUM: timestamp() は毎 plan で差分を生む)。
+  # 実行時刻は copy_tags_to_snapshot で引き継いだ tags + AWS 側の作成時刻から追える。
+  # teardown を複数回行う場合は手動で snapshot 名を別にする (e.g. `final_snapshot_identifier`
+  # 変数化は本モジュールでは未対応、必要になれば追加)。
+  final_snapshot_identifier = var.rds_skip_final_snapshot ? null : "${local.prefix}-postgres-final"
   copy_tags_to_snapshot     = true
 
   performance_insights_enabled          = true
@@ -117,10 +133,9 @@ resource "aws_db_instance" "this" {
   })
 
   lifecycle {
-    # password と engine_version は手動運用に委ねる
+    # password は手動運用に委ねる (secrets モジュール側の ignore_changes と対)
     ignore_changes = [
       password,
-      final_snapshot_identifier, # timestamp() で差分が出続けるため
     ]
   }
 }
@@ -146,11 +161,20 @@ resource "aws_elasticache_parameter_group" "redis7" {
   family      = "redis7"
   description = "Redis 7 parameters for stg (Channels layer + Celery broker + cache)"
 
-  # Celery broker として使うので AOF 有効化、Channels layer として使うので
-  # maxmemory-policy は allkeys-lru。
+  # maxmemory-policy の選択 (database-reviewer PR #50 HIGH):
+  #
+  # この Redis は 3 種類のワークロードを相乗りしている:
+  #   1. Celery broker (キューの key は TTL なし、evict されるとジョブ消失)
+  #   2. Django Channels layer (WebSocket state、key に TTL あり)
+  #   3. 汎用キャッシュ (ツイート TL / OGP / トレンドタグ等、key に TTL あり)
+  #
+  # allkeys-lru は 1 も evict するため stg でもジョブ消失のリスクがある。
+  # volatile-lru は「TTL を明示的に設定した key のみを LRU で evict」するため、
+  # Channels と cache (両方 TTL 付き) は evict されつつ、Celery の broker キュー
+  # は保持される。Phase 3+ で job 量が増えたら Celery 用を別 Redis に分離する。
   parameter {
     name  = "maxmemory-policy"
-    value = "allkeys-lru"
+    value = "volatile-lru"
   }
 
   lifecycle {

--- a/terraform/modules/data/main.tf
+++ b/terraform/modules/data/main.tf
@@ -1,0 +1,187 @@
+# Data module (P0.5-03)
+#
+# - RDS PostgreSQL (Single-AZ for stg, Multi-AZ opt for prod)
+# - ElastiCache Redis (Single-node for stg)
+# - Subnet groups + parameter groups for pg_bigm / pg_trgm
+# - db_password は secrets モジュールから var 経由で渡す (state 漏洩の緩和は
+#   docs/adr/ + secrets/README.md に記載)
+
+locals {
+  prefix = "${var.project}-${var.environment}"
+
+  default_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Module      = "data"
+    },
+    var.tags,
+  )
+}
+
+# ---------------------------------------------------------------------------
+# RDS PostgreSQL
+# ---------------------------------------------------------------------------
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${local.prefix}-rds-subnet-group"
+  subnet_ids = var.db_subnet_ids
+
+  tags = merge(local.default_tags, { Name = "${local.prefix}-rds-subnet-group" })
+}
+
+# pg_bigm (日本語全文検索) + pg_trgm (タグ編集距離) を有効化。
+# shared_preload_libraries は静的パラメータなので適用には RDS 再起動が必要
+# (terraform apply 時に自動で再起動される)。
+resource "aws_db_parameter_group" "postgres15" {
+  name_prefix = "${local.prefix}-pg15-"
+  family      = "postgres15"
+  description = "Postgres 15 parameters with pg_bigm + pg_trgm preloaded"
+
+  parameter {
+    name         = "shared_preload_libraries"
+    value        = "pg_bigm"
+    apply_method = "pending-reboot"
+  }
+
+  # Bot 投稿や TL キャッシュ更新で slow query を把握できるようにログ化
+  parameter {
+    name         = "log_min_duration_statement"
+    value        = "1000" # 1 秒超えるクエリをログ
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "log_statement"
+    value        = "ddl" # DDL のみログ
+    apply_method = "immediate"
+  }
+
+  # 接続数管理: Daphne + Gunicorn + Celery の合計に合わせて
+  # t4g.micro default は 81 前後だが、CONN_MAX_AGE を効かせる前提で据え置き。
+  # PgBouncer 導入時はここを絞って過剰接続を拒否する。
+
+  tags = local.default_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_db_instance" "this" {
+  identifier = "${local.prefix}-postgres"
+
+  engine                 = "postgres"
+  engine_version         = var.rds_engine_version
+  instance_class         = var.rds_instance_class
+  allocated_storage      = var.rds_allocated_storage_gb
+  max_allocated_storage  = var.rds_max_allocated_storage_gb > 0 ? var.rds_max_allocated_storage_gb : null
+  storage_type           = "gp3"
+  storage_encrypted      = true
+  # KMS は AWS managed key (aws/rds)。prod で CMK 移行時は kms_key_id を variable 化する。
+
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  parameter_group_name   = aws_db_parameter_group.postgres15.name
+  vpc_security_group_ids = [var.rds_security_group_id]
+
+  username = var.db_master_username
+  password = var.db_master_password
+  # password 変更は手動運用 (secrets 側の ignore_changes と整合)。
+  # AWS RDS 側で手動 password 変更した場合、次回 terraform apply で
+  # "in-place update" が走るため、lifecycle.ignore_changes でガードする。
+
+  port     = 5432
+  db_name  = "sns"
+
+  multi_az                = var.rds_multi_az
+  publicly_accessible     = false
+  auto_minor_version_upgrade = true
+
+  backup_retention_period = var.rds_backup_retention_days
+  backup_window           = "18:00-19:00" # JST 03:00-04:00
+  maintenance_window      = "Wed:19:00-Wed:20:00" # JST 水曜 04:00-05:00
+
+  deletion_protection       = var.rds_deletion_protection
+  skip_final_snapshot       = var.rds_skip_final_snapshot
+  final_snapshot_identifier = var.rds_skip_final_snapshot ? null : "${local.prefix}-postgres-final-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  copy_tags_to_snapshot     = true
+
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7 # stg は 7 日、prod は 731 (2 年) を別途指定
+
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
+  tags = merge(local.default_tags, {
+    Name = "${local.prefix}-postgres"
+  })
+
+  lifecycle {
+    # password と engine_version は手動運用に委ねる
+    ignore_changes = [
+      password,
+      final_snapshot_identifier, # timestamp() で差分が出続けるため
+    ]
+  }
+}
+
+# pg_bigm / pg_trgm は shared_preload_libraries で有効化済みだが、
+# CREATE EXTENSION はスキーマレベルで別途実行が必要。
+# 初回 migrate 時に apps.common のマイグレーションで CREATE EXTENSION IF NOT EXISTS を
+# 実行する Django データマイグレーションを追加する (Phase 1 作業、別 Issue)。
+
+# ---------------------------------------------------------------------------
+# ElastiCache Redis
+# ---------------------------------------------------------------------------
+
+resource "aws_elasticache_subnet_group" "this" {
+  name       = "${local.prefix}-redis-subnet-group"
+  subnet_ids = var.db_subnet_ids
+
+  tags = merge(local.default_tags, { Name = "${local.prefix}-redis-subnet-group" })
+}
+
+resource "aws_elasticache_parameter_group" "redis7" {
+  name_prefix = "${local.prefix}-redis7-"
+  family      = "redis7"
+  description = "Redis 7 parameters for stg (Channels layer + Celery broker + cache)"
+
+  # Celery broker として使うので AOF 有効化、Channels layer として使うので
+  # maxmemory-policy は allkeys-lru。
+  parameter {
+    name  = "maxmemory-policy"
+    value = "allkeys-lru"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_elasticache_cluster" "this" {
+  cluster_id           = "${local.prefix}-redis"
+  engine               = "redis"
+  engine_version       = var.redis_engine_version
+  node_type            = var.redis_node_type
+  num_cache_nodes      = var.redis_num_cache_nodes
+  parameter_group_name = aws_elasticache_parameter_group.redis7.name
+  port                 = 6379
+
+  subnet_group_name  = aws_elasticache_subnet_group.this.name
+  security_group_ids = [var.redis_security_group_id]
+
+  # stg は AUTH token 無効 (SG で十分守る)。prod では
+  # replication group + transit encryption + at-rest encryption + auth_token が推奨で、
+  # 別モジュール (data_replication) で提供する前提。
+  snapshot_retention_limit = 0 # stg は snapshot なし (Redis は壊れても再作成で OK)
+  apply_immediately        = false
+  auto_minor_version_upgrade = true
+
+  maintenance_window = "thu:19:00-thu:20:00" # JST 木曜 04:00-05:00
+
+  tags = merge(local.default_tags, {
+    Name = "${local.prefix}-redis"
+  })
+}

--- a/terraform/modules/data/outputs.tf
+++ b/terraform/modules/data/outputs.tf
@@ -1,0 +1,52 @@
+output "rds_instance_id" {
+  description = "RDS インスタンス識別子 (observability モジュールの alarm dimension に渡す)"
+  value       = aws_db_instance.this.id
+}
+
+output "rds_endpoint" {
+  description = "RDS endpoint (host:port 形式)"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "rds_address" {
+  description = "RDS hostname (port なし)"
+  value       = aws_db_instance.this.address
+}
+
+output "rds_port" {
+  value = aws_db_instance.this.port
+}
+
+output "rds_database_name" {
+  value = aws_db_instance.this.db_name
+}
+
+output "rds_master_username" {
+  value = aws_db_instance.this.username
+}
+
+output "rds_parameter_group_name" {
+  value = aws_db_parameter_group.postgres15.name
+}
+
+output "rds_arn" {
+  value = aws_db_instance.this.arn
+}
+
+output "redis_id" {
+  value = aws_elasticache_cluster.this.id
+}
+
+output "redis_primary_endpoint" {
+  description = "Redis primary endpoint (Single-node なので cluster_address とほぼ同じ)"
+  value       = aws_elasticache_cluster.this.cache_nodes[0].address
+}
+
+output "redis_port" {
+  value = aws_elasticache_cluster.this.port
+}
+
+output "redis_connection_url" {
+  description = "Django settings / Celery に渡す REDIS_URL"
+  value       = "redis://${aws_elasticache_cluster.this.cache_nodes[0].address}:${aws_elasticache_cluster.this.port}/0"
+}

--- a/terraform/modules/data/variables.tf
+++ b/terraform/modules/data/variables.tf
@@ -56,9 +56,25 @@ variable "db_master_password" {
 # ---------- RDS ----------
 
 variable "rds_engine_version" {
-  description = "PostgreSQL バージョン"
+  description = <<-EOT
+    PostgreSQL バージョン。
+    `auto_minor_version_upgrade = true` のためマイナーはメンテナンスウィンドウで
+    自動更新される。メジャーアップグレード (15→16) は ADR 化して明示的に実施する。
+  EOT
   type        = string
-  default     = "15.8"
+  default     = "15.12"
+}
+
+variable "rds_storage_iops" {
+  description = "gp3 IOPS。null で AWS デフォルト (3000 IOPS)。allocated_storage が 400GB を超える場合は指定推奨。"
+  type        = number
+  default     = null
+}
+
+variable "rds_storage_throughput_mbs" {
+  description = "gp3 スループット (MB/s)。null で AWS デフォルト (125 MB/s)。"
+  type        = number
+  default     = null
 }
 
 variable "rds_instance_class" {

--- a/terraform/modules/data/variables.tf
+++ b/terraform/modules/data/variables.tf
@@ -1,0 +1,134 @@
+variable "environment" {
+  description = "環境名 (stg / prod)"
+  type        = string
+  validation {
+    condition     = contains(["stg", "prod"], var.environment)
+    error_message = "environment は stg / prod のいずれか。"
+  }
+}
+
+variable "project" {
+  description = "プロジェクト名 (リソース prefix)"
+  type        = string
+  default     = "sns"
+}
+
+# ---------- network 依存 (片方向: identifier を受け取る) ----------
+
+variable "db_subnet_ids" {
+  description = "RDS / ElastiCache の subnet group に使う DB subnet ID リスト"
+  type        = list(string)
+  validation {
+    condition     = length(var.db_subnet_ids) >= 2
+    error_message = "DB subnet は 2 AZ 以上必要 (RDS subnet group の要件)。"
+  }
+}
+
+variable "rds_security_group_id" {
+  description = "RDS インスタンスに付与する SG ID (network モジュールの rds-sg)"
+  type        = string
+}
+
+variable "redis_security_group_id" {
+  description = "ElastiCache に付与する SG ID (network モジュールの redis-sg)"
+  type        = string
+}
+
+# ---------- secrets 依存 ----------
+
+variable "db_master_username" {
+  description = "RDS master ユーザー名"
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_master_password" {
+  description = <<-EOT
+    RDS master password (sensitive)。secrets モジュールの db_password_value を渡す。
+    secrets モジュール側で lifecycle.ignore_changes しているので、RDS 作成後に
+    手動ローテートしても RDS 側の master_password は同期されない点に注意
+    (必要なら `aws rds modify-db-instance --master-user-password` で別途更新)。
+  EOT
+  type        = string
+  sensitive   = true
+}
+
+# ---------- RDS ----------
+
+variable "rds_engine_version" {
+  description = "PostgreSQL バージョン"
+  type        = string
+  default     = "15.8"
+}
+
+variable "rds_instance_class" {
+  description = "RDS インスタンスクラス"
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "rds_allocated_storage_gb" {
+  description = "RDS ストレージ (GB)"
+  type        = number
+  default     = 20
+  validation {
+    condition     = var.rds_allocated_storage_gb >= 20
+    error_message = "RDS gp3 の最小は 20GB。"
+  }
+}
+
+variable "rds_max_allocated_storage_gb" {
+  description = "ストレージ自動スケール上限 (GB)。0 で自動スケール無効。"
+  type        = number
+  default     = 100
+}
+
+variable "rds_multi_az" {
+  description = "Multi-AZ にするか (stg は false、prod は true 推奨)"
+  type        = bool
+  default     = false
+}
+
+variable "rds_backup_retention_days" {
+  description = "自動バックアップ保持日数 (0 で無効)"
+  type        = number
+  default     = 7
+}
+
+variable "rds_deletion_protection" {
+  description = "誤 destroy 防止"
+  type        = bool
+  default     = true
+}
+
+variable "rds_skip_final_snapshot" {
+  description = "destroy 時の final snapshot をスキップ (stg の teardown 効率化)"
+  type        = bool
+  default     = false
+}
+
+# ---------- ElastiCache ----------
+
+variable "redis_engine_version" {
+  description = "Redis engine version"
+  type        = string
+  default     = "7.1"
+}
+
+variable "redis_node_type" {
+  description = "ElastiCache node type"
+  type        = string
+  default     = "cache.t4g.micro"
+}
+
+variable "redis_num_cache_nodes" {
+  description = "stg は Single-node の 1。prod は replication group で 2+ (別モジュールで拡張)"
+  type        = number
+  default     = 1
+}
+
+variable "tags" {
+  description = "全リソース共通タグ"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Closes #16

## 概要
ARCHITECTURE §4.1-4.2 に基づく DB / キャッシュ層の IaC。

## リソース
### RDS PostgreSQL 15.8
- `db.t4g.micro`, gp3 20GB (max 100GB auto-scale), encrypted
- parameter group で `shared_preload_libraries = pg_bigm` + slow query ログ
- Multi-AZ: stg=false / prod=true 推奨
- Backup 7 日、JST 03-04 / Maintenance 水曜 04-05
- Performance Insights 7 日、CloudWatch Logs postgresql + upgrade
- deletion_protection デフォルト on、final snapshot デフォルトあり

### ElastiCache Redis 7.1
- Single-node `cache.t4g.micro`
- maxmemory-policy=allkeys-lru (Channels + Celery + cache 兼用)
- stg は snapshot / AUTH なし、prod は data_replication モジュールで拡張予定

## pg_bigm / pg_trgm
`shared_preload_libraries` で load、`CREATE EXTENSION` は Phase 1 の Django migration で実行。

## サブエージェントレビュー
- [ ] architect (インスタンスサイズ / parameter group / Multi-AZ 方針)
- [ ] database-reviewer (Postgres パラメータ / バックアップ戦略)