### PR TITLE
[P0.5-04] infra(tf): add compute module (ECS cluster + ALB + ECR + IAM)

### DIFF
--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -1,0 +1,329 @@
+# Compute module (P0.5-04)
+#
+# - ECS Cluster with FARGATE + FARGATE_SPOT capacity providers
+# - ALB with sticky sessions (for Daphne WebSocket) and long idle_timeout
+# - ALB target groups for app (Django nginx) / next (Next.js) / daphne (WS) /
+#   webhook (Stripe + GitHub 直受け用)
+# - ALB listener rules: host + path-based routing matching ARCHITECTURE.md §3.4
+# - ECR repositories (one per service that publishes an image)
+# - IAM roles: ecs_task_execution (shared) + placeholder for task roles
+#
+# Task definitions / services themselves are NOT created here. Each ECS
+# service will land as part of the corresponding feature Phase (Phase 0.5-11
+# for Hello-World, Phase 1+ for real apps).
+
+locals {
+  prefix = "${var.project}-${var.environment}"
+
+  default_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Module      = "compute"
+    },
+    var.tags,
+  )
+
+  # ECR を作る対象 (celery-worker と celery-beat は django イメージを共有するため
+  # ECR レポジトリは個別には作らない)
+  ecr_services = ["backend", "frontend", "nginx"]
+
+  # ALB target group 設定 (service -> port / health check path)
+  target_groups = {
+    app = {
+      port     = 80
+      protocol = "HTTP"
+      health   = "/api/health/"
+      sticky   = false
+    }
+    next = {
+      port     = 3000
+      protocol = "HTTP"
+      health   = "/"
+      sticky   = false
+    }
+    daphne = {
+      port     = 8001
+      protocol = "HTTP"
+      health   = "/ws/health/"
+      # WebSocket 再接続を同じタスクに張り付かせるため sticky (ARCHITECTURE §3.4)
+      sticky   = true
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# ECS Cluster
+# ---------------------------------------------------------------------------
+
+resource "aws_ecs_cluster" "this" {
+  name = "${local.prefix}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name = aws_ecs_cluster.this.name
+
+  capacity_providers = var.enable_fargate_spot ? ["FARGATE", "FARGATE_SPOT"] : ["FARGATE"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+}
+
+# ---------------------------------------------------------------------------
+# ECR Repositories
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "this" {
+  for_each = toset(local.ecr_services)
+
+  name                 = "${local.prefix}-${each.value}"
+  image_tag_mutability = "MUTABLE" # stg は latest tag を許可。prod は IMMUTABLE 推奨
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+  tags = merge(local.default_tags, { Service = each.value })
+}
+
+# 古いイメージ削除ポリシー: tagged は 30 個、untagged は 7 日で消す
+resource "aws_ecr_lifecycle_policy" "cleanup" {
+  for_each = aws_ecr_repository.this
+
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 30 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPatternList = ["*"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 30
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Expire untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = { type = "expire" }
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# ALB
+# ---------------------------------------------------------------------------
+
+resource "aws_lb" "this" {
+  name               = "${local.prefix}-alb"
+  load_balancer_type = "application"
+  internal           = false
+
+  subnets         = var.public_subnet_ids
+  security_groups = [var.alb_security_group_id]
+
+  idle_timeout               = var.alb_idle_timeout_seconds
+  enable_deletion_protection = var.environment == "prod"
+  enable_http2               = true
+  # WebSocket 超過トラフィックで HTTP/2 が切れるのを防ぐため、必要なら false に
+
+  dynamic "access_logs" {
+    for_each = var.alb_access_logs_bucket == "" ? [] : [1]
+    content {
+      bucket  = var.alb_access_logs_bucket
+      prefix  = "alb/${var.environment}"
+      enabled = true
+    }
+  }
+
+  tags = merge(local.default_tags, { Name = "${local.prefix}-alb" })
+}
+
+resource "aws_lb_target_group" "this" {
+  for_each = local.target_groups
+
+  name        = "${local.prefix}-${each.key}-tg"
+  port        = each.value.port
+  protocol    = each.value.protocol
+  vpc_id      = var.vpc_id
+  target_type = "ip" # Fargate awsvpc mode
+
+  deregistration_delay = 30
+
+  health_check {
+    path                = each.value.health
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    matcher             = "200-399"
+  }
+
+  dynamic "stickiness" {
+    for_each = each.value.sticky ? [1] : []
+    content {
+      type            = "lb_cookie"
+      cookie_duration = 86400 # 24 時間 (ARCHITECTURE §3.4)
+      enabled         = true
+    }
+  }
+
+  tags = merge(local.default_tags, { Service = each.key })
+}
+
+# ---------------------------------------------------------------------------
+# ALB Listeners
+# ---------------------------------------------------------------------------
+
+# HTTP: HTTPS にリダイレクトするだけ
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# HTTPS: edge モジュールから ACM 証明書を受け取ってから作成
+# (alb_certificate_arn が空なら未作成 = ブートストラップ用)
+resource "aws_lb_listener" "https" {
+  count = var.alb_certificate_arn == "" ? 0 : 1
+
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.alb_certificate_arn
+
+  # default は Next.js SSR へ。paths で api / ws / webhook へ振り分け。
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this["next"].arn
+  }
+}
+
+# /api/* → app tg (Django)
+resource "aws_lb_listener_rule" "api" {
+  count = var.alb_certificate_arn == "" ? 0 : 1
+
+  listener_arn = aws_lb_listener.https[0].arn
+  priority     = 10
+
+  condition {
+    path_pattern {
+      values = ["/api/*"]
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this["app"].arn
+  }
+}
+
+# /ws/* → daphne tg (sticky session 有効)
+resource "aws_lb_listener_rule" "ws" {
+  count = var.alb_certificate_arn == "" ? 0 : 1
+
+  listener_arn = aws_lb_listener.https[0].arn
+  priority     = 20
+
+  condition {
+    path_pattern {
+      values = ["/ws/*"]
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this["daphne"].arn
+  }
+}
+
+# webhook.* host header → app tg (Stripe/GitHub webhook、CloudFront 非経由)
+resource "aws_lb_listener_rule" "webhook" {
+  count = var.alb_certificate_arn == "" ? 0 : 1
+
+  listener_arn = aws_lb_listener.https[0].arn
+  priority     = 5 # host header マッチを path より先に
+
+  condition {
+    host_header {
+      values = ["webhook.*"]
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this["app"].arn
+  }
+}
+
+# ---------------------------------------------------------------------------
+# IAM Roles
+# ---------------------------------------------------------------------------
+
+# Task execution role: ECR pull / CloudWatch Logs / Secrets Manager read
+data "aws_iam_policy_document" "ecs_task_execution_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name               = "${local.prefix}-ecs-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume.json
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_managed" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Secrets Manager / CloudWatch Logs の細かい権限は利用側 (環境ディレクトリ)
+# で必要なシークレット ARN に絞った policy を別途アタッチする想定。
+# この module はロールだけ用意して、policy は min-privilege 優先で外で書く。
+
+# Task role (アプリケーション権限): S3 / SES / SSM 等。
+# Phase が進むにつれて必要な権限が増えるため、ここではスケルトンのみ。
+resource "aws_iam_role" "ecs_task" {
+  name               = "${local.prefix}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume.json # 同じ trust
+
+  tags = local.default_tags
+}

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -98,7 +98,12 @@ resource "aws_ecr_repository" "this" {
   tags = merge(local.default_tags, { Service = each.value })
 }
 
-# 古いイメージ削除ポリシー: tagged は 30 個、untagged は 7 日で消す
+# 古いイメージ削除ポリシー (architect PR #51 HIGH 指摘反映):
+#   - release-* tag (手動タグ、本番ロールバック用): 30 個保持
+#   - stg-* tag (CI 自動タグ、PR/merge ごとに生成): 100 個保持
+#     毎 PR で stg-<sha> を push するため、30 個だとすぐ枯渇する
+#   - latest tag: 最新のみ保持
+#   - untagged: 7 日で削除
 resource "aws_ecr_lifecycle_policy" "cleanup" {
   for_each = aws_ecr_repository.this
 
@@ -108,17 +113,28 @@ resource "aws_ecr_lifecycle_policy" "cleanup" {
     rules = [
       {
         rulePriority = 1
-        description  = "Keep last 30 tagged images"
+        description  = "Keep last 30 release-* tagged images (prod rollback pool)"
         selection = {
-          tagStatus     = "tagged"
-          tagPatternList = ["*"]
-          countType     = "imageCountMoreThan"
-          countNumber   = 30
+          tagStatus      = "tagged"
+          tagPatternList = ["release-*"]
+          countType      = "imageCountMoreThan"
+          countNumber    = 30
         }
         action = { type = "expire" }
       },
       {
         rulePriority = 2
+        description  = "Keep last 100 stg-* tagged images (CI pool, high churn)"
+        selection = {
+          tagStatus      = "tagged"
+          tagPatternList = ["stg-*"]
+          countType      = "imageCountMoreThan"
+          countNumber    = 100
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 10
         description  = "Expire untagged images after 7 days"
         selection = {
           tagStatus   = "untagged"
@@ -144,10 +160,15 @@ resource "aws_lb" "this" {
   subnets         = var.public_subnet_ids
   security_groups = [var.alb_security_group_id]
 
+  # idle_timeout=3600s は Daphne WebSocket が再接続なしで最大 1h 生きるため。
+  # architect PR #51 HIGH: CloudFront origin_read_timeout (default 60s / edge
+  # モジュールで 60s 明示) とミスマッチするので、/ws/* は **edge モジュールの
+  # CloudFront behavior で origin read timeout を長めに設定する** か、または
+  # WebSocket は CloudFront を迂回する経路 (将来の別サブドメイン ws.<domain>)
+  # を検討。現状は CloudFront 経由で 60s ごとに keepalive ping を打つ前提で運用。
   idle_timeout               = var.alb_idle_timeout_seconds
   enable_deletion_protection = var.environment == "prod"
   enable_http2               = true
-  # WebSocket 超過トラフィックで HTTP/2 が切れるのを防ぐため、必要なら false に
 
   dynamic "access_logs" {
     for_each = var.alb_access_logs_bucket == "" ? [] : [1]
@@ -172,13 +193,18 @@ resource "aws_lb_target_group" "this" {
 
   deregistration_delay = 30
 
+  # architect PR #51 MEDIUM: matcher を "200" に絞り、リダイレクトを
+  # 健全状態と誤認しないようにする。
+  # TODO(Phase1): Next.js 側で軽量な /api/healthz route handler を用意し、
+  # next target group の health path を / から /api/healthz に差し替える。
+  # 現状 / は SSR をフルレンダするので 30s 間隔でコストが嵩む。
   health_check {
     path                = each.value.health
     interval            = 30
     timeout             = 5
     healthy_threshold   = 2
     unhealthy_threshold = 3
-    matcher             = "200-399"
+    matcher             = "200"
   }
 
   dynamic "stickiness" {

--- a/terraform/modules/compute/outputs.tf
+++ b/terraform/modules/compute/outputs.tf
@@ -1,0 +1,74 @@
+output "ecs_cluster_id" {
+  value = aws_ecs_cluster.this.id
+}
+
+output "ecs_cluster_name" {
+  description = "observability モジュールの ECS CPU alarm ClusterName dimension に渡す"
+  value       = aws_ecs_cluster.this.name
+}
+
+output "ecs_cluster_arn" {
+  value = aws_ecs_cluster.this.arn
+}
+
+output "alb_arn" {
+  value = aws_lb.this.arn
+}
+
+output "alb_arn_suffix" {
+  description = "observability モジュールの ALB 5xx alarm LoadBalancer dimension に渡す"
+  value       = aws_lb.this.arn_suffix
+}
+
+output "alb_dns_name" {
+  description = "ALB の DNS 名。edge モジュールが Route53 A record の alias target に指定する"
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Route53 alias target に必要な canonical hosted zone ID"
+  value       = aws_lb.this.zone_id
+}
+
+output "target_group_arns" {
+  description = "target group 論理名 -> ARN のマップ。ECS service の load_balancer ブロックに渡す。"
+  value       = { for k, tg in aws_lb_target_group.this : k => tg.arn }
+}
+
+output "ecr_repository_urls" {
+  description = "service 名 -> ECR repository URL のマップ"
+  value       = { for k, r in aws_ecr_repository.this : k => r.repository_url }
+}
+
+output "ecr_repository_arns" {
+  description = "service 名 -> ECR repository ARN のマップ (IAM policy 用)"
+  value       = { for k, r in aws_ecr_repository.this : k => r.arn }
+}
+
+output "ecs_task_execution_role_arn" {
+  description = "ECS task definition の executionRoleArn に渡す"
+  value       = aws_iam_role.ecs_task_execution.arn
+}
+
+output "ecs_task_execution_role_name" {
+  description = "Secrets Manager 読み取り policy を追加でアタッチする際に使う"
+  value       = aws_iam_role.ecs_task_execution.name
+}
+
+output "ecs_task_role_arn" {
+  description = "ECS task definition の taskRoleArn に渡す (アプリの AWS SDK 用)"
+  value       = aws_iam_role.ecs_task.arn
+}
+
+output "ecs_task_role_name" {
+  value = aws_iam_role.ecs_task.name
+}
+
+output "service_names" {
+  description = <<-EOT
+    observability モジュールの ecs_service_name_map に渡す用の予定サービス名。
+    将来 aws_ecs_service を本 module で管理するようになったら、そちらから
+    直接参照する。現状は命名規約を先に固定するためマップを出している。
+  EOT
+  value = { for svc in var.ecs_services : svc => "${local.prefix}-${svc}" }
+}

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -1,0 +1,92 @@
+variable "environment" {
+  description = "環境名 (stg / prod)"
+  type        = string
+  validation {
+    condition     = contains(["stg", "prod"], var.environment)
+    error_message = "environment は stg / prod のいずれか。"
+  }
+}
+
+variable "project" {
+  description = "プロジェクト名 (リソース prefix)"
+  type        = string
+  default     = "sns"
+}
+
+# ---------- network 依存 ----------
+
+variable "vpc_id" {
+  description = "VPC ID (target group の vpc_id に使う)"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "ALB を配置する public subnet ID リスト (2 AZ)"
+  type        = list(string)
+  validation {
+    condition     = length(var.public_subnet_ids) >= 2
+    error_message = "ALB は 2 AZ 以上のサブネットを要求する。"
+  }
+}
+
+variable "alb_security_group_id" {
+  description = "ALB に付与する SG (network モジュールの alb-sg)"
+  type        = string
+}
+
+# ---------- ALB ----------
+
+variable "alb_certificate_arn" {
+  description = <<-EOT
+    ALB HTTPS listener で使う ACM 証明書 ARN (ap-northeast-1 リージョン)。
+    edge モジュールが発行する *.stg.example.com 証明書の ARN を渡す。
+    未指定 (空) の場合は HTTPS listener をスキップし HTTP のみで起動する
+    (edge モジュール未実装時のブートストラップ用)。
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "alb_idle_timeout_seconds" {
+  description = "ALB idle timeout (WebSocket 維持のため長め)"
+  type        = number
+  default     = 3600 # 1 時間
+}
+
+variable "alb_access_logs_bucket" {
+  description = "ALB access logs を保存する S3 bucket 名 (storage モジュールの backup か専用バケット)。空ならログ無効化。"
+  type        = string
+  default     = ""
+}
+
+# ---------- ECS ----------
+
+variable "ecs_services" {
+  description = <<-EOT
+    ECS サービス論理名リスト。observability モジュールと揃える。
+    実際の task definition は各 Phase で段階的に追加するので、この module は
+    ECR + ALB 側の受け皿だけ用意する。
+  EOT
+  type        = list(string)
+  default = [
+    "django",
+    "next",
+    "daphne",
+    "celery-worker",
+    "celery-beat",
+  ]
+}
+
+variable "enable_fargate_spot" {
+  description = "Celery worker を Fargate Spot で動かすか (stg=true、beat は常に非 Spot)"
+  type        = bool
+  default     = true
+}
+
+# ---------- タグ ----------
+
+variable "tags" {
+  description = "全リソース共通タグ"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -78,7 +78,20 @@ variable "ecs_services" {
 }
 
 variable "enable_fargate_spot" {
-  description = "Celery worker を Fargate Spot で動かすか (stg=true、beat は常に非 Spot)"
+  description = <<-EOT
+    Cluster の capacity providers に FARGATE_SPOT を含めるか。
+    **本 module は cluster 定義までしか行わない**ため、実際に Spot で動かすには
+    環境ディレクトリの aws_ecs_service 側で以下のように明示的に上書きする必要がある
+    (architect PR #51 HIGH):
+
+    capacity_provider_strategy {
+      capacity_provider = "FARGATE_SPOT"
+      weight            = 1
+    }
+
+    celery-beat は Spot 絶対不可 (二重発火防止)、celery-worker と cold 系 batch は
+    Spot 推奨、django/next/daphne は FARGATE (on-demand) 推奨。
+  EOT
   type        = bool
   default     = true
 }


### PR DESCRIPTION
Closes #17

## 概要
ECS コンテナ実行基盤 + ALB + ECR + IAM ロール。task definition / aws_ecs_service はこの module には含めず、Phase 0.5-11 (Hello World) 以降で追加する。

## リソース
### ECS Cluster
- FARGATE + FARGATE_SPOT capacity provider、containerInsights 有効
- stg は Spot 許可、prod で調整

### ALB
- 2 AZ public subnets、idle_timeout=3600s (WebSocket 維持)
- deletion_protection: prod のみ on、HTTP/2 有効
- Listeners:
  - :80 → :443 redirect
  - :443 → (証明書が渡された時のみ作成) Next.js SSR デフォルト
- Target Groups (port / health / sticky):
  - app (80 / /api/health/ / no sticky)
  - next (3000 / / / no sticky)
  - daphne (8001 / /ws/health/ / **sticky lb_cookie 24h**)
- Listener rules:
  - host header `webhook.*` → app (priority 5)
  - /api/* → app (10)
  - /ws/* → daphne (20)
  - default → next

### ECR
- 3 repositories: backend / frontend / nginx (celery reuses backend)
- scan_on_push, AES256, MUTABLE tags (stg)
- Lifecycle: tagged 30 個保持 / untagged 7 日削除

### IAM
- `ecs_task_execution` (AmazonECSTaskExecutionRolePolicy attach)
- `ecs_task` (アプリ側、Phase 進行で policy 追加)
- Secrets Manager fine-grained policy は環境側で合成

## サブエージェントレビュー
- [ ] architect (capacity provider / listener 優先度 / sticky / IAM 境界)
- [ ] security-reviewer (IAM 最小権限 / ECR policy / ALB access logs 不足)