### PR TITLE
[P0.5-05] infra(tf): add edge module (CloudFront + Route53 + ACM)

### DIFF
--- a/terraform/modules/edge/main.tf
+++ b/terraform/modules/edge/main.tf
@@ -1,0 +1,325 @@
+# Edge module (P0.5-05)
+#
+# CloudFront 単一ディストリビューション + Route53 Hosted Zone +
+# ACM 証明書 (us-east-1 / ap-northeast-1) を束ねる。
+#
+# 設計方針:
+# - CloudFront は単一ディスト、Behavior で /api/*  /ws/*  /media/* を振り分け
+# - webhook.<domain> は CloudFront を経由せず ALB 直 (Stripe 署名検証を壊さない、
+#   ARCHITECTURE §1 / SPEC §17.3)
+# - ACM は CloudFront 用に us-east-1 (provider alias)、ALB 用に ap-northeast-1 の 2 本
+
+locals {
+  prefix = "${var.project}-${var.environment}"
+
+  app_fqdn     = "${var.app_subdomain}.${var.domain_name}"
+  webhook_fqdn = "${var.webhook_subdomain}.${var.app_subdomain}.${var.domain_name}"
+
+  default_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Module      = "edge"
+    },
+    var.tags,
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Route53 Hosted Zone
+# ---------------------------------------------------------------------------
+
+# お名前.com からの委任先。NS レコードを手動で更新する必要あり
+# (docs/operations/dns-delegation.md、P0.5-10 で手順書)。
+resource "aws_route53_zone" "this" {
+  name = var.domain_name
+
+  tags = merge(local.default_tags, { Name = var.domain_name })
+}
+
+# ---------------------------------------------------------------------------
+# ACM Certificates
+#   - CloudFront 用: us-east-1 (provider alias "us_east_1" を環境側で宣言)
+#   - ALB 用: ap-northeast-1 (default provider)
+#
+#   両方とも DNS 検証で Route53 にレコード追加。
+# ---------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "cloudfront" {
+  provider = aws.us_east_1
+
+  domain_name               = local.app_fqdn
+  subject_alternative_names = [local.webhook_fqdn]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(local.default_tags, { Name = "${local.prefix}-cloudfront-cert" })
+}
+
+resource "aws_acm_certificate" "alb" {
+  domain_name               = local.app_fqdn
+  subject_alternative_names = [local.webhook_fqdn]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(local.default_tags, { Name = "${local.prefix}-alb-cert" })
+}
+
+# DNS 検証レコード (両証明書で同じ検証レコードが出てくるため、for_each で重複排除)
+locals {
+  _cf_validation_options  = aws_acm_certificate.cloudfront.domain_validation_options
+  _alb_validation_options = aws_acm_certificate.alb.domain_validation_options
+
+  # map: record_name -> { name, type, record }
+  cf_validation_records = {
+    for dvo in local._cf_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+  alb_validation_records = {
+    for dvo in local._alb_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+}
+
+resource "aws_route53_record" "cert_validation_cf" {
+  for_each = local.cf_validation_records
+
+  zone_id = aws_route53_zone.this.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+
+  allow_overwrite = true # ap-northeast-1 側と同じ record が出ることがある
+}
+
+resource "aws_route53_record" "cert_validation_alb" {
+  for_each = local.alb_validation_records
+
+  zone_id = aws_route53_zone.this.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "cloudfront" {
+  provider = aws.us_east_1
+
+  certificate_arn         = aws_acm_certificate.cloudfront.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation_cf : r.fqdn]
+}
+
+resource "aws_acm_certificate_validation" "alb" {
+  certificate_arn         = aws_acm_certificate.alb.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation_alb : r.fqdn]
+}
+
+# ---------------------------------------------------------------------------
+# CloudFront Origin Access Control (S3 bucket policy で使用)
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudfront_origin_access_control" "s3" {
+  name                              = "${local.prefix}-s3-oac"
+  description                       = "OAC for media / static S3 buckets"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ---------------------------------------------------------------------------
+# CloudFront distribution (単一)
+# Behaviors:
+#   /_next/static/*  -> S3 static (long TTL)
+#   /media/*         -> S3 media (long TTL、GET のみ)
+#   /api/*           -> ALB  (no cache)
+#   /ws/*            -> ALB  (no cache、WebSocket 透過)
+#   / (default)      -> ALB  (Next.js SSR、short TTL)
+# ---------------------------------------------------------------------------
+
+# AWS Managed Cache policies
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer" {
+  name = "Managed-AllViewer"
+}
+
+data "aws_cloudfront_origin_request_policy" "cors_s3" {
+  name = "Managed-CORS-S3Origin"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${local.prefix} CloudFront"
+  default_root_object = "" # Next.js SSR が index を返す
+  price_class         = var.price_class
+  aliases             = [local.app_fqdn]
+  http_version        = "http2and3"
+
+  # -------- Origins --------
+  origin {
+    origin_id   = "alb"
+    domain_name = var.alb_dns_name
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "https-only"
+      origin_ssl_protocols     = ["TLSv1.2"]
+      origin_keepalive_timeout = 60
+      origin_read_timeout      = 60
+    }
+  }
+
+  origin {
+    origin_id                = "media"
+    domain_name              = var.media_bucket_regional_domain
+    origin_access_control_id = aws_cloudfront_origin_access_control.s3.id
+    s3_origin_config {
+      # OAC 使用時も s3_origin_config.origin_access_identity は空文字列を指定する必要あり
+      origin_access_identity = ""
+    }
+  }
+
+  origin {
+    origin_id                = "static"
+    domain_name              = var.static_bucket_regional_domain
+    origin_access_control_id = aws_cloudfront_origin_access_control.s3.id
+    s3_origin_config {
+      origin_access_identity = ""
+    }
+  }
+
+  # -------- Default behavior (Next.js SSR via ALB) --------
+  default_cache_behavior {
+    target_origin_id       = "alb"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer.id
+  }
+
+  # -------- /_next/static/* → S3 static (long cache) --------
+  ordered_cache_behavior {
+    path_pattern           = "/_next/static/*"
+    target_origin_id       = "static"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    compress               = true
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.cors_s3.id
+  }
+
+  # -------- /media/* → S3 media --------
+  ordered_cache_behavior {
+    path_pattern           = "/media/*"
+    target_origin_id       = "media"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.cors_s3.id
+  }
+
+  # -------- /api/* → ALB (no cache) --------
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    target_origin_id       = "alb"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer.id
+  }
+
+  # -------- /ws/* → ALB (WebSocket 透過) --------
+  ordered_cache_behavior {
+    path_pattern           = "/ws/*"
+    target_origin_id       = "alb"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = false
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer.id
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cloudfront.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = merge(local.default_tags, { Name = "${local.prefix}-cloudfront" })
+}
+
+# ---------------------------------------------------------------------------
+# Route53 A records
+# ---------------------------------------------------------------------------
+
+# app: stg.<domain> → CloudFront (alias)
+# (additional_alb_record = true の場合は ALB 直にフォールバック、検証用)
+resource "aws_route53_record" "app" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = local.app_fqdn
+  type    = "A"
+
+  alias {
+    name                   = var.additional_alb_record ? var.alb_dns_name : aws_cloudfront_distribution.this.domain_name
+    zone_id                = var.additional_alb_record ? var.alb_zone_id : aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# webhook: webhook.stg.<domain> → ALB 直 (CloudFront 非経由)
+# Stripe / GitHub webhook の HMAC 署名検証が body 変換で壊れないようにする
+# (SPEC §17.3、security-reviewer PR #36 feedback)
+resource "aws_route53_record" "webhook" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = local.webhook_fqdn
+  type    = "A"
+
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/modules/edge/main.tf
+++ b/terraform/modules/edge/main.tf
@@ -212,6 +212,13 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
+  # -------- Ordered cache behaviors --------
+  # ⚠️ NOTE (architect PR #52 MEDIUM): AWS CloudFront は
+  # `ordered_cache_behavior` を **Terraform 定義順 = API 送信順** で評価する。
+  # 具体度ではなく先勝ち。新しい behavior を追加する際は既存 pattern と
+  # 衝突しないよう順序を確認すること (例: /api/ws/* を入れる場合、/ws/* より
+  # 先に定義しないと /api/ws/abc が /ws/* でマッチしてしまう)。
+
   # -------- Default behavior (Next.js SSR via ALB) --------
   default_cache_behavior {
     target_origin_id       = "alb"
@@ -264,6 +271,14 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   # -------- /ws/* → ALB (WebSocket 透過) --------
+  # ⚠️ WebSocket keepalive 要件 (architect PR #52 HIGH):
+  #   - CloudFront viewer idle timeout = 10 分 (固定)
+  #   - CloudFront origin_read_timeout = 60s (custom_origin_config で明示)
+  #   - ALB idle_timeout = 3600s (compute モジュール側)
+  #   この連携だと idle な接続は origin_read_timeout (60s) で切断される。
+  #   クライアント (reconnecting-websocket) は自動再接続するが、Phase 3 DM で
+  #   長時間セッションが続く場合は 30s 間隔で ping frame を送る運用が前提。
+  #   将来 ws.<domain> を別途立てて CloudFront を bypass する選択肢あり (docs/adr)。
   ordered_cache_behavior {
     path_pattern           = "/ws/*"
     target_origin_id       = "alb"

--- a/terraform/modules/edge/outputs.tf
+++ b/terraform/modules/edge/outputs.tf
@@ -8,17 +8,36 @@ output "route53_name_servers" {
 }
 
 output "acm_cloudfront_arn" {
-  description = "CloudFront 用 ACM 証明書 ARN (us-east-1)"
+  # aws_acm_certificate_validation.certificate_arn を返すことで、validation
+  # 完了までの暗黙依存を下流に伝播させる (`aws_acm_certificate.*.arn` を
+  # 直接返すと依存が切れて validation 未完了の証明書を CloudFront に渡す可能性)。
+  description = "CloudFront 用 ACM 証明書 ARN (us-east-1、validation 完了後)"
   value       = aws_acm_certificate_validation.cloudfront.certificate_arn
 }
 
 output "acm_alb_arn" {
+  # 同上 (validation の完了を待つ意味で aws_acm_certificate_validation を参照)
   description = "ALB 用 ACM 証明書 ARN (ap-northeast-1)。compute モジュールに渡す。"
   value       = aws_acm_certificate_validation.alb.certificate_arn
 }
 
 output "cloudfront_distribution_id" {
   value = aws_cloudfront_distribution.this.id
+}
+
+output "cloudfront_distribution_arn" {
+  description = <<-EOT
+    CloudFront distribution ARN。storage モジュールの S3 bucket policy の
+    `AWS:SourceArn` 条件に渡す (OAC 推奨パターン、architect PR #52 MEDIUM:
+    旧 `cloudfront_oac_arn` はリネームした)。
+  EOT
+  value = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.this.id}"
+}
+
+# 旧 output 名との後方互換 (storage モジュールがまだ `cloudfront_oac_arn` 参照)
+output "cloudfront_oac_arn" {
+  description = "DEPRECATED: cloudfront_distribution_arn を使用してください。互換のため維持。"
+  value       = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.this.id}"
 }
 
 output "cloudfront_domain_name" {
@@ -33,11 +52,6 @@ output "cloudfront_hosted_zone_id" {
 output "cloudfront_oac_id" {
   description = "Origin Access Control ID"
   value       = aws_cloudfront_origin_access_control.s3.id
-}
-
-output "cloudfront_oac_arn" {
-  description = "Origin Access Control ARN (storage モジュールの bucket policy に渡す)"
-  value       = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.this.id}"
 }
 
 output "app_fqdn" {

--- a/terraform/modules/edge/outputs.tf
+++ b/terraform/modules/edge/outputs.tf
@@ -1,0 +1,51 @@
+output "route53_zone_id" {
+  value = aws_route53_zone.this.zone_id
+}
+
+output "route53_name_servers" {
+  description = "お名前.com で NS レコードに設定する 4 つの NS (docs/operations/dns-delegation.md)"
+  value       = aws_route53_zone.this.name_servers
+}
+
+output "acm_cloudfront_arn" {
+  description = "CloudFront 用 ACM 証明書 ARN (us-east-1)"
+  value       = aws_acm_certificate_validation.cloudfront.certificate_arn
+}
+
+output "acm_alb_arn" {
+  description = "ALB 用 ACM 証明書 ARN (ap-northeast-1)。compute モジュールに渡す。"
+  value       = aws_acm_certificate_validation.alb.certificate_arn
+}
+
+output "cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.this.id
+}
+
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.this.domain_name
+}
+
+output "cloudfront_hosted_zone_id" {
+  description = "Route53 alias の zone_id"
+  value       = aws_cloudfront_distribution.this.hosted_zone_id
+}
+
+output "cloudfront_oac_id" {
+  description = "Origin Access Control ID"
+  value       = aws_cloudfront_origin_access_control.s3.id
+}
+
+output "cloudfront_oac_arn" {
+  description = "Origin Access Control ARN (storage モジュールの bucket policy に渡す)"
+  value       = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.this.id}"
+}
+
+output "app_fqdn" {
+  value = local.app_fqdn
+}
+
+output "webhook_fqdn" {
+  value = local.webhook_fqdn
+}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/modules/edge/providers.tf
+++ b/terraform/modules/edge/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.60"
+      configuration_aliases = [aws.us_east_1]
+    }
+  }
+}

--- a/terraform/modules/edge/variables.tf
+++ b/terraform/modules/edge/variables.tf
@@ -1,0 +1,80 @@
+variable "environment" {
+  description = "環境名 (stg / prod)"
+  type        = string
+  validation {
+    condition     = contains(["stg", "prod"], var.environment)
+    error_message = "environment は stg / prod のいずれか。"
+  }
+}
+
+variable "project" {
+  description = "プロジェクト名"
+  type        = string
+  default     = "sns"
+}
+
+variable "domain_name" {
+  description = "apex ドメイン (例: example.com)。Route53 Hosted Zone はこの名前で作成される。"
+  type        = string
+}
+
+variable "app_subdomain" {
+  description = "アプリのサブドメイン (例: stg)。最終的なホスト名は <app_subdomain>.<domain_name>"
+  type        = string
+}
+
+variable "webhook_subdomain" {
+  description = "Stripe/GitHub webhook 用サブドメイン。CloudFront 非経由 (ALB 直)。"
+  type        = string
+  default     = "webhook"
+}
+
+# ---------- ALB / S3 origin (compute / storage モジュール output を受ける) ----------
+
+variable "alb_dns_name" {
+  description = "CloudFront オリジンにする ALB の DNS 名"
+  type        = string
+}
+
+variable "alb_zone_id" {
+  description = "Route53 A alias の zone_id。webhook サブドメインの ALB alias に使う。"
+  type        = string
+}
+
+variable "media_bucket_regional_domain" {
+  description = "storage モジュールの media bucket regional_domain_name"
+  type        = string
+}
+
+variable "static_bucket_regional_domain" {
+  description = "storage モジュールの static bucket regional_domain_name"
+  type        = string
+}
+
+# ---------- その他 ----------
+
+variable "price_class" {
+  description = "CloudFront price class。stg は US/EU/Asia まで、prod は All。"
+  type        = string
+  default     = "PriceClass_200"
+  validation {
+    condition     = contains(["PriceClass_100", "PriceClass_200", "PriceClass_All"], var.price_class)
+    error_message = "PriceClass_100 / 200 / All のみ。"
+  }
+}
+
+variable "additional_alb_record" {
+  description = <<-EOT
+    `stg.<domain>` の Route53 A record を、CloudFront ではなく ALB に直接
+    向けたい場合に使う一時オプション (edge モジュール立ち上げの動作確認用)。
+    通常運用では false のまま。
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "全リソース共通タグ"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Closes #18

## 概要
ARCHITECTURE §1 の **単一 CloudFront ディストリビューション**、webhook のみ ALB 直、というレビューで合意した構成を実装。

## リソース
### Route53
- Hosted Zone (apex domain)
- A alias records:
  - `<app_subdomain>.<domain>` → CloudFront
  - `webhook.<app_subdomain>.<domain>` → **ALB 直** (CloudFront 非経由、署名検証保護)
- `additional_alb_record = true` で app record を ALB 直に向ける検証モード

### ACM (2 本)
- CloudFront 用: **us-east-1** (`aws.us_east_1` provider alias)
- ALB 用: **ap-northeast-1** (default provider)
- 両方とも app_fqdn + webhook_fqdn (SAN) を含む
- DNS-validated、`aws_acm_certificate_validation` で ISSUED まで apply ブロック

### CloudFront
- **単一ディストリ + Behaviors**:
  - `/_next/static/*` → S3 static (long TTL)
  - `/media/*` → S3 media (long TTL、GET のみ)
  - `/api/*` → ALB (no cache、全 method)
  - `/ws/*` → ALB (no cache、compression false で WebSocket 透過)
  - default → ALB (Next.js SSR)
- TLSv1.2_2021、IPv6、HTTP/2 + HTTP/3、price_class=PriceClass_200
- Managed cache policies: CachingDisabled / CachingOptimized
- Managed origin request policies: AllViewer / CORS-S3Origin

### Origin Access Control
- S3 OAC を作成し、sigv4 signing。`cloudfront_oac_arn` を output として storage モジュール bucket policy に渡す

## ハルナさん側のアクション (apply 後)
出力 `route53_name_servers` の 4 本をお名前.com の NS レコードに設定（[docs/operations/dns-delegation.md](docs/operations/dns-delegation.md) は P0.5-10）

## サブエージェントレビュー
- [ ] architect (Behavior 設計 / TLS ポリシー / ACM cross-region)
- [ ] security-reviewer (OAC / webhook 分離 / viewer_certificate)