### PR TITLE
[P0.5-07] infra(tf): wire 7 modules into environments/stg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,17 @@ client/next-env.d.ts
 
 # git worktrees (parallel branches)
 .worktrees/
+
+# Terraform (P0.5-07)
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars
+!**/terraform.tfvars.example
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraform.lock.hcl

--- a/terraform/environments/stg/README.md
+++ b/terraform/environments/stg/README.md
@@ -25,21 +25,51 @@ terraform apply
 
 このディレクトリは以下の循環依存を抱えている:
 
-- `storage` bucket policy には `edge` の OAC ARN が必要
+- `storage` bucket policy には `edge` の OAC ARN (実体は CloudFront distribution ARN) が必要
 - `compute` HTTPS listener には `edge` の ACM ARN が必要
 
-初回 apply はこの 2 点を**空文字列**にして通す (main.tf の `cloudfront_oac_arn = ""`、
-`alb_certificate_arn = ""`)。apply 後、以下の手順で埋める:
+main.tf の編集を避けるため、**変数経由**で値を受け渡す運用にしている
+(architect PR #53 HIGH 指摘対応):
 
-1. edge モジュール apply 完了後、`terraform output -raw route53_name_servers` で NS を取得
-2. お名前.com で NS レコードを変更 ([docs/operations/dns-delegation.md](../../../docs/operations/dns-delegation.md) 参照)
-3. NS 伝播を待ち (15 分〜数時間)、ACM 証明書が `ISSUED` になることを確認
-4. **main.tf を編集**: `module.storage.cloudfront_oac_arn = module.edge.cloudfront_distribution_arn`、
-   `module.compute.alb_certificate_arn = module.edge.acm_alb_arn`
-5. 2 度目の `terraform apply`
+```hcl
+# variables.tf
+variable "cloudfront_distribution_arn_override" { default = "" }
+variable "alb_certificate_arn_override"         { default = "" }
 
-**Phase 0.5-07 時点では初回 apply の成功までがスコープ**。二段階目の手順書は
-[docs/operations/stg-deployment.md](../../../docs/operations/stg-deployment.md) (P0.5-16) で整備。
+# main.tf
+module "storage" {
+  cloudfront_oac_arn = var.cloudfront_distribution_arn_override
+}
+module "compute" {
+  alb_certificate_arn = var.alb_certificate_arn_override
+}
+```
+
+### 運用手順
+
+1. **初回 apply** (両 override 空のまま):
+   ```bash
+   terraform apply
+   ```
+2. Route 53 NS を出力から取得し、お名前.com で設定
+   ([docs/operations/dns-delegation.md](../../../docs/operations/dns-delegation.md))
+3. NS 伝播を待ち (15 分〜数時間)、ACM 証明書が `ISSUED` になることを確認:
+   ```bash
+   aws acm describe-certificate --region us-east-1 --certificate-arn $(terraform output -raw acm_cloudfront_arn)
+   ```
+4. **二段階目**: override 値を取得して tfvars に追記:
+   ```bash
+   terraform output -raw cloudfront_distribution_arn
+   terraform output -raw acm_alb_arn
+   # terraform.tfvars に以下を追記
+   cloudfront_distribution_arn_override = "<cf.arn>"
+   alb_certificate_arn_override         = "<acm.arn>"
+
+   terraform apply
+   ```
+
+**main.tf を編集する必要はない**。tfvars 変更のみで二段階目に進めるので
+CI/CD 自動化も可能 (Phase 0.5-14 の cd-stg.yml で 2 回 apply する pipeline)。
 
 ## リソース一覧 (概算)
 

--- a/terraform/environments/stg/README.md
+++ b/terraform/environments/stg/README.md
@@ -1,0 +1,75 @@
+# stg environment
+
+Phase 0.5 で立ち上げる staging 環境。全 7 モジュールを結合する。
+
+## 前提
+
+1. `scripts/bootstrap-tf-state.sh` を実行済み
+   (S3 bucket `sns-stg-tf-state` + DynamoDB `sns-stg-tf-lock` 作成済)
+2. apex ドメインを取得済み (お名前.com 等)
+3. AWS CLI / Terraform 1.9+ / 適切な IAM 権限
+
+## 初期化 & Apply
+
+```bash
+cd terraform/environments/stg
+cp terraform.tfvars.example terraform.tfvars
+# terraform.tfvars を編集して domain_name / alert_email を設定
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## 二段階 apply (chicken-and-egg 回避)
+
+このディレクトリは以下の循環依存を抱えている:
+
+- `storage` bucket policy には `edge` の OAC ARN が必要
+- `compute` HTTPS listener には `edge` の ACM ARN が必要
+
+初回 apply はこの 2 点を**空文字列**にして通す (main.tf の `cloudfront_oac_arn = ""`、
+`alb_certificate_arn = ""`)。apply 後、以下の手順で埋める:
+
+1. edge モジュール apply 完了後、`terraform output -raw route53_name_servers` で NS を取得
+2. お名前.com で NS レコードを変更 ([docs/operations/dns-delegation.md](../../../docs/operations/dns-delegation.md) 参照)
+3. NS 伝播を待ち (15 分〜数時間)、ACM 証明書が `ISSUED` になることを確認
+4. **main.tf を編集**: `module.storage.cloudfront_oac_arn = module.edge.cloudfront_distribution_arn`、
+   `module.compute.alb_certificate_arn = module.edge.acm_alb_arn`
+5. 2 度目の `terraform apply`
+
+**Phase 0.5-07 時点では初回 apply の成功までがスコープ**。二段階目の手順書は
+[docs/operations/stg-deployment.md](../../../docs/operations/stg-deployment.md) (P0.5-16) で整備。
+
+## リソース一覧 (概算)
+
+| モジュール | 主要リソース |
+|---|---|
+| network | VPC, 6 subnets, 6 SGs, fck-nat ASG, 6 VPC Endpoints |
+| data | RDS Postgres 15.12 (db.t4g.micro), ElastiCache Redis 7.1 (cache.t4g.micro) |
+| storage | 3 S3 buckets (media / static / backup) |
+| secrets | 9 Secrets Manager entries (2 自動生成 + 7 placeholder) |
+| compute | ECS cluster, ALB, 3 ECR repos, 2 IAM roles |
+| edge | CloudFront, Route53 zone + 2 A records, 2 ACM certs |
+| observability | 5 Log Groups, SNS topic, 最大 8 alarms |
+
+## 削除
+
+```bash
+# 二段階削除 (chicken-and-egg の逆)
+# まず edge の OAC 参照を外す (storage / compute の変数を "" に戻す)
+terraform apply
+
+# 次に全 destroy
+terraform destroy
+
+# state bucket / lock table を削除する場合は
+# docs/operations/tf-state-bootstrap.md の削除手順を参照
+```
+
+## コスト目安
+
+ARCHITECTURE.md §11 参照: **~$153/月** (¥22-25k)
+
+- VPC Interface Endpoints をオフにすれば $35 削減
+- fck-nat と Interface Endpoint 両方オフなら外部 API 通信が失敗するので注意

--- a/terraform/environments/stg/backend.tf
+++ b/terraform/environments/stg/backend.tf
@@ -1,0 +1,16 @@
+# S3 backend for stg state.
+#
+# ハルナさんが scripts/bootstrap-tf-state.sh を先に実行して
+# `sns-stg-tf-state` bucket と `sns-stg-tf-lock` DynamoDB table を作成している前提。
+# 初期化コマンド:
+#   cd terraform/environments/stg
+#   terraform init
+terraform {
+  backend "s3" {
+    bucket         = "sns-stg-tf-state"
+    key            = "stg/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "sns-stg-tf-lock"
+    encrypt        = true
+  }
+}

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -94,10 +94,9 @@ module "storage" {
   aws_account_id   = data.aws_caller_identity.current.account_id
   frontend_origins = ["https://${var.app_subdomain}.${var.domain_name}"]
 
-  # cloudfront_oac_arn は edge 作成後に埋める (terraform.tfvars の更新で対応)。
-  # 変数未設定時は bucket policy がスキップされるが、Public Access Block と
-  # IAM 署名リクエストで保護されているので脆弱ではない (see storage/README.md)。
-  cloudfront_oac_arn = ""
+  # 二段階 apply (architect PR #53 HIGH): 初回は空、edge 作成後に tfvars で
+  # `cloudfront_distribution_arn_override` を埋めて再 apply。
+  cloudfront_oac_arn = var.cloudfront_distribution_arn_override
 }
 
 # ---------------------------------------------------------------------------
@@ -116,9 +115,9 @@ module "compute" {
   public_subnet_ids     = module.network.public_subnet_ids
   alb_security_group_id = module.network.alb_security_group_id
 
-  # edge 作成後に acm_alb_arn を渡す (二段階 apply)。
+  # edge 作成後に acm_alb_arn を渡す (二段階 apply、architect PR #53 HIGH)。
   # 最初の apply は空文字列 = HTTP only で ALB を起動。
-  alb_certificate_arn = ""
+  alb_certificate_arn = var.alb_certificate_arn_override
 
   alb_idle_timeout_seconds = 3600
   enable_fargate_spot      = true
@@ -141,7 +140,7 @@ module "edge" {
 
   domain_name        = var.domain_name
   app_subdomain      = var.app_subdomain
-  webhook_subdomain  = "webhook"
+  webhook_subdomain  = var.webhook_subdomain
 
   alb_dns_name = module.compute.alb_dns_name
   alb_zone_id  = module.compute.alb_zone_id

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -1,0 +1,175 @@
+# stg environment composition (P0.5-07).
+#
+# 7 モジュールを結合して stg 環境を立ち上げる。`terraform apply` 一回で
+# 全リソースが起動する状態を目指す (ECS task definition / aws_ecs_service は
+# Hello World 相当を P0.5-11 / P0.5-12 で追加する)。
+#
+# モジュール呼び出し順 (実質的な依存):
+#   secrets (独立)
+#   network (独立) ────┬──▶ data (network の subnet / sg を受ける)
+#                      │
+#                      └──▶ storage (ほぼ独立、edge の OAC を後で受ける)
+#   edge (ALB DNS を受ける必要があるので compute の後)
+#   compute (network / (後から) edge の ACM を受ける)
+#   observability (compute / data / (後から) edge を識別子で参照)
+#
+# 循環を避けるため、edge の OAC を storage に渡すのは第二フェーズで行う
+# (最初は OAC なしで storage を作り、edge 作成後に bucket policy を付ける)。
+# stg はまだサービスを公開していないので、この二段階運用は Phase 0.5 では許容。
+
+locals {
+  project = var.project
+
+  common_tags = {
+    Project     = var.project
+    Environment = "stg"
+    ManagedBy   = "terraform"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------
+# 1. Secrets Manager
+# ---------------------------------------------------------------------------
+
+module "secrets" {
+  source = "../../modules/secrets"
+
+  environment             = "stg"
+  project                 = var.project
+  recovery_window_in_days = 7 # stg
+  generate_random_values  = true
+}
+
+# ---------------------------------------------------------------------------
+# 2. Network (VPC / subnets / SG / fck-nat / VPC endpoints)
+# ---------------------------------------------------------------------------
+
+module "network" {
+  source = "../../modules/network"
+
+  environment          = "stg"
+  project              = var.project
+  enable_vpc_endpoints = var.enable_vpc_endpoints
+}
+
+# ---------------------------------------------------------------------------
+# 3. Data (RDS + ElastiCache)
+# ---------------------------------------------------------------------------
+
+module "data" {
+  source = "../../modules/data"
+
+  environment = "stg"
+  project     = var.project
+
+  db_subnet_ids           = module.network.db_subnet_ids
+  rds_security_group_id   = module.network.rds_security_group_id
+  redis_security_group_id = module.network.redis_security_group_id
+
+  db_master_password = module.secrets.db_password_value
+
+  rds_instance_class        = var.rds_instance_class
+  rds_allocated_storage_gb  = var.rds_allocated_storage_gb
+  rds_multi_az              = var.rds_multi_az
+  rds_skip_final_snapshot   = var.rds_skip_final_snapshot
+
+  redis_node_type = var.redis_node_type
+}
+
+# ---------------------------------------------------------------------------
+# 4. Storage (S3 buckets)
+# 最初は OAC なしで作成。edge 作成後に bucket policy を足すため、
+# 本環境では `cloudfront_oac_arn` は 2 度目の apply で埋める想定
+# (chicken-and-egg を許容)。
+# ---------------------------------------------------------------------------
+
+module "storage" {
+  source = "../../modules/storage"
+
+  environment = "stg"
+  project     = var.project
+
+  aws_account_id   = data.aws_caller_identity.current.account_id
+  frontend_origins = ["https://${var.app_subdomain}.${var.domain_name}"]
+
+  # cloudfront_oac_arn は edge 作成後に埋める (terraform.tfvars の更新で対応)。
+  # 変数未設定時は bucket policy がスキップされるが、Public Access Block と
+  # IAM 署名リクエストで保護されているので脆弱ではない (see storage/README.md)。
+  cloudfront_oac_arn = ""
+}
+
+# ---------------------------------------------------------------------------
+# 5. Compute (ECS + ALB + ECR + IAM)
+# HTTPS listener は edge 作成後 (ACM ARN 渡し) に enable されるため、
+# 初回 apply は HTTP のみで ALB を起動する二段階運用。
+# ---------------------------------------------------------------------------
+
+module "compute" {
+  source = "../../modules/compute"
+
+  environment = "stg"
+  project     = var.project
+
+  vpc_id                = module.network.vpc_id
+  public_subnet_ids     = module.network.public_subnet_ids
+  alb_security_group_id = module.network.alb_security_group_id
+
+  # edge 作成後に acm_alb_arn を渡す (二段階 apply)。
+  # 最初の apply は空文字列 = HTTP only で ALB を起動。
+  alb_certificate_arn = ""
+
+  alb_idle_timeout_seconds = 3600
+  enable_fargate_spot      = true
+}
+
+# ---------------------------------------------------------------------------
+# 6. Edge (CloudFront + Route53 + ACM)
+# ---------------------------------------------------------------------------
+
+module "edge" {
+  source = "../../modules/edge"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  environment = "stg"
+  project     = var.project
+
+  domain_name        = var.domain_name
+  app_subdomain      = var.app_subdomain
+  webhook_subdomain  = "webhook"
+
+  alb_dns_name = module.compute.alb_dns_name
+  alb_zone_id  = module.compute.alb_zone_id
+
+  media_bucket_regional_domain  = module.storage.bucket_regional_domains["media"]
+  static_bucket_regional_domain = module.storage.bucket_regional_domains["static"]
+}
+
+# ---------------------------------------------------------------------------
+# 7. Observability (Log Groups + Alarms + SNS Topic)
+# ---------------------------------------------------------------------------
+
+module "observability" {
+  source = "../../modules/observability"
+
+  environment        = "stg"
+  project            = var.project
+  log_retention_days = 30
+  alert_email        = var.alert_email
+
+  ecs_services = ["django", "next", "daphne", "celery-worker", "celery-beat"]
+
+  # compute モジュールが `service_names` output で実サービス名を返す。
+  ecs_service_name_map = module.compute.service_names
+  ecs_cluster_name     = module.compute.ecs_cluster_name
+
+  alb_arn_suffix = module.compute.alb_arn_suffix
+
+  rds_instance_identifier    = module.data.rds_instance_id
+  rds_allocated_storage_gb   = var.rds_allocated_storage_gb
+}

--- a/terraform/environments/stg/outputs.tf
+++ b/terraform/environments/stg/outputs.tf
@@ -1,0 +1,55 @@
+# stg environment outputs — 運用で参照する値のみ露出する。
+
+output "app_url" {
+  description = "アプリの公開 URL (Route53 NS 伝播後にアクセス可能)"
+  value       = "https://${var.app_subdomain}.${var.domain_name}"
+}
+
+output "webhook_url" {
+  description = "Stripe / GitHub webhook エンドポイントのベース URL"
+  value       = "https://webhook.${var.app_subdomain}.${var.domain_name}"
+}
+
+output "route53_name_servers" {
+  description = "お名前.com の NS レコードに設定する 4 本 (docs/operations/dns-delegation.md)"
+  value       = module.edge.route53_name_servers
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront ディストリビューション の *.cloudfront.net ドメイン (動作確認用)"
+  value       = module.edge.cloudfront_domain_name
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS (Route53 経由でない直接アクセス用、動作確認のみ)"
+  value       = module.compute.alb_dns_name
+}
+
+output "ecr_repository_urls" {
+  description = "CI が docker push する先 (GitHub Actions から参照)"
+  value       = module.compute.ecr_repository_urls
+}
+
+output "ecs_cluster_name" {
+  value = module.compute.ecs_cluster_name
+}
+
+output "rds_endpoint" {
+  description = "RDS エンドポイント (app の DATABASE_URL に使う)"
+  value       = module.data.rds_endpoint
+}
+
+output "redis_connection_url" {
+  description = "Redis 接続 URL (app の REDIS_URL に使う)"
+  value       = module.data.redis_connection_url
+}
+
+output "alerts_topic_arn" {
+  description = "追加のサブスクライバー (Slack 等) を足したいときの SNS Topic ARN"
+  value       = module.observability.sns_topic_arn
+}
+
+output "secret_arns" {
+  description = "ECS task definition の secrets 属性や IAM policy で参照"
+  value       = module.secrets.secret_arns
+}

--- a/terraform/environments/stg/outputs.tf
+++ b/terraform/environments/stg/outputs.tf
@@ -37,11 +37,13 @@ output "ecs_cluster_name" {
 output "rds_endpoint" {
   description = "RDS エンドポイント (app の DATABASE_URL に使う)"
   value       = module.data.rds_endpoint
+  sensitive   = true # architect PR #53 MEDIUM: hostname と port を terminal/CI ログに晒さない
 }
 
 output "redis_connection_url" {
   description = "Redis 接続 URL (app の REDIS_URL に使う)"
   value       = module.data.redis_connection_url
+  sensitive   = true # 接続先 host 情報を含むため
 }
 
 output "alerts_topic_arn" {
@@ -52,4 +54,16 @@ output "alerts_topic_arn" {
 output "secret_arns" {
   description = "ECS task definition の secrets 属性や IAM policy で参照"
   value       = module.secrets.secret_arns
+  sensitive   = true # 個別の ARN 自体は公開情報だが、全 Secret の存在リストを平文で出さない
+}
+
+# 二段階 apply で使う ARN (terraform.tfvars に書き戻す)
+output "cloudfront_distribution_arn" {
+  description = "二段階 apply 時に terraform.tfvars の cloudfront_distribution_arn_override に設定"
+  value       = module.edge.cloudfront_distribution_arn
+}
+
+output "acm_alb_arn" {
+  description = "二段階 apply 時に terraform.tfvars の alb_certificate_arn_override に設定"
+  value       = module.edge.acm_alb_arn
 }

--- a/terraform/environments/stg/terraform.tfvars.example
+++ b/terraform/environments/stg/terraform.tfvars.example
@@ -5,13 +5,23 @@
 domain_name = "example.com"
 
 # アラート送信先 (SNS topic subscription 確認メールが届く → 承認リンクをクリック)
-alert_email = "haruna0712rakuten@gmail.com"
+alert_email = "alerts@example.com"
 
 # デフォルト値を上書きしたい場合だけ記述:
 # app_subdomain             = "stg"
+# webhook_subdomain         = "webhook"
 # aws_region                = "ap-northeast-1"
 # rds_instance_class        = "db.t4g.small"  # 本番昇格の準備
 # rds_multi_az              = true
 # rds_skip_final_snapshot   = true            # teardown を頻繁に行う場合
 # redis_node_type           = "cache.t4g.small"
 # enable_vpc_endpoints      = false           # コスト削減 ($35/月)
+
+# ---------- 二段階 apply ----------
+# 初回 apply 時は以下 2 つを**空のまま**にする。
+# edge モジュール作成後に
+#   terraform output -raw cloudfront_distribution_arn
+#   terraform output -raw acm_alb_arn
+# の値をコピペして再 apply する。
+# cloudfront_distribution_arn_override = ""
+# alb_certificate_arn_override         = ""

--- a/terraform/environments/stg/terraform.tfvars.example
+++ b/terraform/environments/stg/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# コピーして terraform.tfvars に保存し、実値を埋める
+# (terraform.tfvars は .gitignore されるので secret を書いても良い)。
+
+# お名前.com で取得した apex ドメイン
+domain_name = "example.com"
+
+# アラート送信先 (SNS topic subscription 確認メールが届く → 承認リンクをクリック)
+alert_email = "haruna0712rakuten@gmail.com"
+
+# デフォルト値を上書きしたい場合だけ記述:
+# app_subdomain             = "stg"
+# aws_region                = "ap-northeast-1"
+# rds_instance_class        = "db.t4g.small"  # 本番昇格の準備
+# rds_multi_az              = true
+# rds_skip_final_snapshot   = true            # teardown を頻繁に行う場合
+# redis_node_type           = "cache.t4g.small"
+# enable_vpc_endpoints      = false           # コスト削減 ($35/月)

--- a/terraform/environments/stg/variables.tf
+++ b/terraform/environments/stg/variables.tf
@@ -1,0 +1,68 @@
+variable "aws_region" {
+  description = "stg の AWS リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "project" {
+  description = "プロジェクト名 (全リソース prefix に使う)"
+  type        = string
+  default     = "sns"
+}
+
+# ---------- DNS ----------
+
+variable "domain_name" {
+  description = "apex ドメイン (お名前.com で取得してある。例: example.com)"
+  type        = string
+}
+
+variable "app_subdomain" {
+  description = "アプリ用サブドメイン (結果: <app_subdomain>.<domain_name>)"
+  type        = string
+  default     = "stg"
+}
+
+# ---------- 通知 ----------
+
+variable "alert_email" {
+  description = "observability モジュールからのアラート送信先メール"
+  type        = string
+}
+
+# ---------- RDS オーバーライド (環境別に調整しやすく) ----------
+
+variable "rds_instance_class" {
+  type    = string
+  default = "db.t4g.micro"
+}
+
+variable "rds_allocated_storage_gb" {
+  type    = number
+  default = 20
+}
+
+variable "rds_multi_az" {
+  type    = bool
+  default = false # stg は Single-AZ
+}
+
+variable "rds_skip_final_snapshot" {
+  type    = bool
+  default = false
+}
+
+# ---------- ElastiCache オーバーライド ----------
+
+variable "redis_node_type" {
+  type    = string
+  default = "cache.t4g.micro"
+}
+
+# ---------- 便利オプション ----------
+
+variable "enable_vpc_endpoints" {
+  description = "VPC Interface Endpoints (ECR/Secrets/Logs/STS) を作るか。月 $35 前後かかるのでオフにもできる。"
+  type        = bool
+  default     = true
+}

--- a/terraform/environments/stg/variables.tf
+++ b/terraform/environments/stg/variables.tf
@@ -59,6 +59,43 @@ variable "redis_node_type" {
   default = "cache.t4g.micro"
 }
 
+# ---------- サブドメイン ----------
+
+variable "webhook_subdomain" {
+  description = "Stripe/GitHub webhook 用サブドメイン (architect PR #53 MEDIUM: ハードコード廃止)。結果: <webhook_subdomain>.<app_subdomain>.<domain_name>"
+  type        = string
+  default     = "webhook"
+}
+
+# ---------- 二段階 apply の override ----------
+#
+# edge モジュール作成前は、storage bucket policy / compute HTTPS listener に
+# 渡す ARN が存在しないため空文字列で bootstrap する。edge 作成後は以下の値を
+# tfvars に書き込んで再 apply すれば main.tf を編集せずに二段階目に進める
+# (architect PR #53 HIGH)。
+#
+# 初回:
+#   terraform apply         # bootstrap、空のまま
+# 二段階目:
+#   terraform output cloudfront_distribution_arn > /tmp/cf.arn
+#   terraform output acm_alb_arn > /tmp/acm.arn
+#   # terraform.tfvars に以下を追記:
+#   cloudfront_distribution_arn_override = "<cf.arn>"
+#   alb_certificate_arn_override         = "<acm.arn>"
+#   terraform apply
+
+variable "cloudfront_distribution_arn_override" {
+  description = "storage の bucket policy に渡す CloudFront distribution ARN。二段階目 apply 時に埋める。"
+  type        = string
+  default     = ""
+}
+
+variable "alb_certificate_arn_override" {
+  description = "compute の ALB HTTPS listener に渡す ACM 証明書 ARN (ap-northeast-1)。二段階目 apply 時に埋める。"
+  type        = string
+  default     = ""
+}
+
 # ---------- 便利オプション ----------
 
 variable "enable_vpc_endpoints" {

--- a/terraform/environments/stg/versions.tf
+++ b/terraform/environments/stg/versions.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+# Default provider: ap-northeast-1 (stg リージョン)
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project     = "sns"
+      Environment = "stg"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# us-east-1 provider alias: edge モジュールが CloudFront 用 ACM 証明書を取得するのに必要
+# (CloudFront は us-east-1 の証明書のみ受け付ける)
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      Project     = "sns"
+      Environment = "stg"
+      ManagedBy   = "terraform"
+    }
+  }
+}


### PR DESCRIPTION
Closes #20

## 概要
Phase 0.5 の 7 モジュール (tf-state / observability / network / storage / secrets / data / compute / edge) を **terraform/environments/stg/main.tf** で結合。`terraform plan` 一発で stg 環境全体の差分が出る状態に。

## 構成
- `versions.tf`: Terraform >= 1.9 / aws ~> 5.60、ap-northeast-1 default + us-east-1 alias (CloudFront ACM 用)
- `backend.tf`: S3 backend (`sns-stg-tf-state` / DynamoDB lock)
- `variables.tf`: domain_name + alert_email 必須、その他 override 可能
- `main.tf`: 7 モジュール呼び出し、依存順に配線
- `outputs.tf`: app_url / webhook_url / route53_name_servers / ecr_repository_urls 等
- `terraform.tfvars.example` + README

## 二段階 apply
`storage.cloudfront_oac_arn` と `compute.alb_certificate_arn` は edge 作成前には埋められないため、初回 apply は空文字列、edge 完了後に埋めて 2 回目の apply で完成させる方針を README に明記。

## .gitignore
Terraform state / tfvars を除外 (terraform.tfvars.example のみ commit)

## サブエージェントレビュー
- [ ] architect (モジュール結合順序 / 循環依存の回避 / 二段階 apply)
- [ ] security-reviewer (default_tags / tfstate 保護)