### PR TITLE
[F-02] infra(tf): add alb_logs S3 bucket + wire to compute ALB

### DIFF
--- a/scripts/_parse_issues.py
+++ b/scripts/_parse_issues.py
@@ -15,9 +15,10 @@ def main(issue_file: str) -> int:
     path = Path(issue_file)
     content = path.read_text(encoding="utf-8")
 
-    # `\n---\n` 区切りで Issue ブロックを分割、`## P` で始まるブロックのみ採用
+    # `\n---\n` 区切りで Issue ブロックを分割、`## P` or `## F` で始まるブロックを採用
+    # (F-XX は Phase 横断の followup 用、例: phase-0.5-followups.md)
     blocks = re.split(r"\n---\n+", content)
-    issues = [b for b in blocks if re.search(r"^## P[0-9]", b, re.MULTILINE)]
+    issues = [b for b in blocks if re.search(r"^## (P[0-9]|F-[0-9])", b, re.MULTILINE)]
 
     print(f"📋 {len(issues)} 件の Issue を検出")
 
@@ -25,7 +26,7 @@ def main(issue_file: str) -> int:
     failed: list[tuple[str, str]] = []
 
     for idx, block in enumerate(issues, 1):
-        title_match = re.search(r"^## (P[\d.\-]+[^\n]*)", block, re.MULTILINE)
+        title_match = re.search(r"^## ((?:P|F)[\d.\-]+[^\n]*)", block, re.MULTILINE)
         if not title_match:
             print(f"⚠️  Issue {idx}: タイトル抽出失敗、スキップ")
             continue

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -121,6 +121,10 @@ module "compute" {
 
   alb_idle_timeout_seconds = 3600
   enable_fargate_spot      = true
+
+  # F-02: ALB access logs を storage の専用バケットに書き出す。
+  # prefix は compute モジュール側で "alb/<env>" 固定。
+  alb_access_logs_bucket = module.storage.alb_logs_bucket_id
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -24,10 +24,15 @@ locals {
   )
 
   buckets = {
-    media   = { name = "${local.prefix}-media", purpose = "user-uploaded content (avatars, tweet images, DM attachments)" }
-    static  = { name = "${local.prefix}-static", purpose = "Next.js static assets via CloudFront" }
-    backup  = { name = "${local.prefix}-backup", purpose = "RDS / Meilisearch / app-level backups" }
+    media    = { name = "${local.prefix}-media", purpose = "user-uploaded content (avatars, tweet images, DM attachments)" }
+    static   = { name = "${local.prefix}-static", purpose = "Next.js static assets via CloudFront" }
+    backup   = { name = "${local.prefix}-backup", purpose = "RDS / Meilisearch / app-level backups" }
+    alb_logs = { name = "${local.prefix}-alb-logs", purpose = "ALB access logs (F-02)" }
   }
+
+  # ap-northeast-1 Elastic Load Balancing service account (AWS 公式 account ID)。
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
+  elb_service_account_ap_northeast_1 = "582318560864"
 }
 
 resource "aws_s3_bucket" "this" {
@@ -172,6 +177,68 @@ resource "aws_s3_bucket_lifecycle_configuration" "static" {
       days_after_initiation = 7
     }
   }
+}
+
+# alb_logs: 最長 90 日で削除。ALB の access logs は stg では検証用途で、
+# 長期保持は prod で検討する (F-02)。
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  bucket = aws_s3_bucket.this["alb_logs"].id
+
+  rule {
+    id     = "expire-alb-logs"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 90
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+# ALB の access logs 書き込みを許可する bucket policy (F-02):
+# ELB サービスアカウント (ap-northeast-1 = 582318560864) に s3:PutObject のみ許可。
+# 参考: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
+data "aws_iam_policy_document" "alb_logs_write" {
+  statement {
+    sid     = "AllowELBServiceAccountPutObject"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    # prefix は compute モジュールで alb/<env>/... と指定されるのでワイルドカード
+    resources = ["${aws_s3_bucket.this["alb_logs"].arn}/alb/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.elb_service_account_ap_northeast_1}:root"]
+    }
+  }
+
+  # ELB が ACL "bucket-owner-full-control" を付けて PutObject するケースの許可
+  statement {
+    sid     = "AllowELBLoggingDeliveryAcl"
+    effect  = "Allow"
+    actions = ["s3:GetBucketAcl"]
+
+    resources = [aws_s3_bucket.this["alb_logs"].arn]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  bucket = aws_s3_bucket.this["alb_logs"].id
+  policy = data.aws_iam_policy_document.alb_logs_write.json
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/storage/outputs.tf
+++ b/terraform/modules/storage/outputs.tf
@@ -36,3 +36,13 @@ output "backup_bucket_id" {
 output "backup_bucket_arn" {
   value = aws_s3_bucket.this["backup"].arn
 }
+
+# ALB access logs (F-02): compute モジュールの var.alb_access_logs_bucket に渡す
+output "alb_logs_bucket_id" {
+  description = "ALB access logs を保存する S3 bucket 名 (compute モジュール alb_access_logs_bucket に渡す)"
+  value       = aws_s3_bucket.this["alb_logs"].id
+}
+
+output "alb_logs_bucket_arn" {
+  value = aws_s3_bucket.this["alb_logs"].arn
+}


### PR DESCRIPTION
Closes #63 (F-02)

## 概要
Phase 0.5 followup F-02 の実装。ALB access logs を専用 S3 bucket に保存。

## 変更
### terraform/modules/storage
- `buckets` に `alb_logs = <prefix>-alb-logs` を追加 (共通セキュリティ継承)
- ALB access logs 向け bucket policy (ELB service account `582318560864` に `alb/*` 配下 PutObject のみ許可)
- 90 日 expiration lifecycle (stg、prod は延長検討)
- `alb_logs_bucket_id` / `alb_logs_bucket_arn` output

### terraform/environments/stg/main.tf
- compute モジュールに `alb_access_logs_bucket = module.storage.alb_logs_bucket_id` 配線

## 同梱修正
`scripts/_parse_issues.py` の regex を `^## (P[0-9]|F-[0-9])` に拡張し、F-XX formed followup markdown も発行できるように (今 Round の followup 発行で使用)。

## サブエージェントレビュー
- [ ] security-reviewer (bucket policy / ELB service account)
- [ ] architect (lifecycle / outputs)