### PR TITLE
[F-10] feat(ui): add /api/healthz route handler for ALB next tg

### DIFF
--- a/client/src/app/api/healthz/route.ts
+++ b/client/src/app/api/healthz/route.ts
@@ -1,0 +1,29 @@
+// Lightweight Next.js health check (F-10).
+//
+// ALB target group "next" の health_check.path がこのエンドポイントを叩く。
+// 従来は "/" を叩いていたが、SSR フルレンダがコストになるため 1 KB 未満の
+// JSON レスポンスに差し替えた。body は version / env / time の最小限。
+//
+// architect PR #51 MEDIUM の指摘反映。Phase 1 Week 0 (F-10) で着手。
+import { NextResponse } from "next/server";
+
+// Route Handler をキャッシュさせない (ALB が 30s ごとに叩くので毎回最新を返す)
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      version: process.env.NEXT_PUBLIC_SENTRY_RELEASE ?? "unknown",
+      environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? "local",
+      time: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    },
+  );
+}

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -40,7 +40,9 @@ locals {
     next = {
       port     = 3000
       protocol = "HTTP"
-      health   = "/"
+      # F-10: 軽量 /api/healthz route handler を叩く。SSR フルレンダを 30s ごとに
+      # 起動しないため ALB 側のコストも Next.js 側の負荷も下がる。
+      health   = "/api/healthz"
       sticky   = false
     }
     daphne = {
@@ -195,9 +197,7 @@ resource "aws_lb_target_group" "this" {
 
   # architect PR #51 MEDIUM: matcher を "200" に絞り、リダイレクトを
   # 健全状態と誤認しないようにする。
-  # TODO(Phase1): Next.js 側で軽量な /api/healthz route handler を用意し、
-  # next target group の health path を / から /api/healthz に差し替える。
-  # 現状 / は SSR をフルレンダするので 30s 間隔でコストが嵩む。
+  # F-10 で next tg の health path を "/" -> "/api/healthz" に差し替え済み。
   health_check {
     path                = each.value.health
     interval            = 30


### PR DESCRIPTION
Closes #71 (F-10)

## 概要
Phase 1 Week 0 タスク。Next.js の ALB next tg health check を "/" から "/api/healthz" に切替。

## 変更
- `client/src/app/api/healthz/route.ts` (新規): Route Handler で 200 + JSON
  - dynamic="force-dynamic", runtime="nodejs"
  - Cache-Control: no-store, max-age=0
  - payload: status / version / environment / time
- `terraform/modules/compute/main.tf`: next tg health path を "/" → "/api/healthz" に差し替え、古い TODO コメントも更新

## 効果
- SSR "/" を 30s 毎にフルレンダするコスト削減
- Phase 1 の認証 middleware が入っても health check が重くならない

## サブエージェントレビュー
- [ ] typescript-reviewer
- [ ] architect (target group 設定)