### PR TITLE
[F-11] refactor(ui): exclude components-demo from production bundle

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,7 +1,18 @@
 import { withSentryConfig } from "@sentry/nextjs";
 
+const isDevelopment = process.env.NODE_ENV === "development";
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // F-11: dev-only ページをバンドル含む/含まないで切り替える。
+  // `dev.tsx` / `dev.ts` 拡張子は development ビルドだけ pageExtensions に含める。
+  // production build では `page.dev.tsx` 等の dev-only ページ/ルートハンドラは
+  // そもそも Next.js の page discovery 対象外になるため、bundle にも含まれない。
+  // 詳細: https://nextjs.org/docs/app/api-reference/next-config-js/pageExtensions
+  pageExtensions: isDevelopment
+    ? ["dev.tsx", "dev.ts", "tsx", "ts", "jsx", "js"]
+    : ["tsx", "ts", "jsx", "js"],
+};
 
 // Sentry webpack plugin options. DSN やプロジェクト設定は env 経由。
 // See: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/

--- a/client/src/app/components-demo/page.dev.tsx
+++ b/client/src/app/components-demo/page.dev.tsx
@@ -1,11 +1,14 @@
 /**
  * Dev-only visual smoke test for shadcn/ui core components.
  *
- * Available at /components-demo. Intentionally returns `notFound()`
- * outside of development so the route disappears from stg/prod bundles
- * once `NODE_ENV=production`. Having a Storybook replacement here
- * (per docs/issues/phase-0.md P0-09) keeps the token swap at Phase 10
- * cheap to verify visually.
+ * **F-11 で page.tsx → page.dev.tsx にリネーム**。
+ * next.config.mjs の pageExtensions が development ビルドの時だけ `dev.tsx`
+ * を含めるよう設定されているため、production build ではこのファイル自体が
+ * Next.js の page discovery 対象外になり、bundle にも含まれない。
+ *
+ * 参考: https://nextjs.org/docs/app/api-reference/next-config-js/pageExtensions
+ *
+ * ランタイムでの `notFound()` 分岐はもう不要だが、多層防御として残す。
  */
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";


### PR DESCRIPTION
Closes #72 (F-11)

## 概要
a11y-architect PR #41 MEDIUM 指摘対応。Phase 1 Week 0 の 5 分タスク。

## 変更
- `client/next.config.mjs`: `pageExtensions` を NODE_ENV で切替
  - dev: `["dev.tsx", "dev.ts", "tsx", ...]`
  - prod: `["tsx", "ts", "jsx", "js"]`
- `page.tsx` → `page.dev.tsx` にリネーム
  - production build では Next.js の page discovery 対象外 → bundle にも含まれない
- コード内 `notFound()` ガードは多層防御として残す

## 参考
- [Next.js pageExtensions](https://nextjs.org/docs/app/api-reference/next-config-js/pageExtensions)

## サブエージェントレビュー
- [ ] typescript-reviewer (pageExtensions の妥当性)