### PR TITLE
feat(p1-02, p1-02a): User モデル拡張 + @handle バリデーション強化

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -19,14 +19,46 @@ class UserAdmin(BaseUserAdmin):
         "first_name",
         "last_name",
         "username",
+        "is_premium",
         "is_superuser",
     ]
     list_display_links = ["pkid", "id", "email", "username"]
-    search_fields = ["email", "first_name", "last_name"]
+    list_filter = ("is_staff", "is_superuser", "is_active", "is_premium", "needs_onboarding")
+    search_fields = ["email", "first_name", "last_name", "username"]
     ordering = ["pkid"]
+    # username は @handle として変更不可なので admin UI でも編集不可。
+    readonly_fields = ("username", "date_joined", "last_login")
     fieldsets = (
         (_("Login Credentials"), {"fields": ("email", "password")}),
         (_("Personal info"), {"fields": ("first_name", "last_name", "username")}),
+        (
+            _("Profile"),
+            {
+                "fields": (
+                    "display_name",
+                    "bio",
+                    "avatar_url",
+                    "header_url",
+                )
+            },
+        ),
+        (
+            _("SNS Links"),
+            {
+                "fields": (
+                    "github_url",
+                    "x_url",
+                    "zenn_url",
+                    "qiita_url",
+                    "note_url",
+                    "linkedin_url",
+                )
+            },
+        ),
+        (
+            _("Flags"),
+            {"fields": ("is_premium", "needs_onboarding")},
+        ),
         (
             _("Permissions and Groups"),
             {

--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class UsersConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.users"
+
+    def ready(self) -> None:
+        # Django signal の接続。import 副作用で @receiver が登録される。
+        from apps.users import signals  # noqa: F401

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -2,6 +2,9 @@ from django import forms
 from django.contrib.auth import forms as admin_forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserChangeForm as BaseUserChangeForm
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from apps.users.validators import validate_handle
 
 User = get_user_model()
 
@@ -9,6 +12,7 @@ User = get_user_model()
 class UserChangeForm(BaseUserChangeForm):
     class Meta(BaseUserChangeForm.Meta):
         model = User
+        # username は @handle として変更不可なので表示 or readonly 扱い。
         fields = ["first_name", "last_name", "username", "email"]
 
 
@@ -30,6 +34,12 @@ class UserCreationForm(admin_forms.UserCreationForm):
 
     def clean_username(self) -> str:
         username = self.cleaned_data["username"]
+        # @handle 形式 / 予約語チェック。
+        try:
+            validate_handle(username)
+        except DjangoValidationError as err:
+            # Django core ValidationError -> forms.ValidationError に変換。
+            raise forms.ValidationError(err.messages[0]) from err
         if User.objects.filter(username=username).exists():
             raise forms.ValidationError(self.error_messages["duplicate_username"])
         return username

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -3,6 +3,7 @@ from django.contrib.auth import forms as admin_forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserChangeForm as BaseUserChangeForm
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils.translation import gettext_lazy as _
 
 from apps.users.validators import validate_handle
 
@@ -12,8 +13,9 @@ User = get_user_model()
 class UserChangeForm(BaseUserChangeForm):
     class Meta(BaseUserChangeForm.Meta):
         model = User
-        # username は @handle として変更不可なので表示 or readonly 扱い。
-        fields = ["first_name", "last_name", "username", "email"]
+        # username は @handle として変更不可なので admin の編集フォームにも含めない。
+        # (database-reviewer LOW / python-reviewer HIGH 対応)
+        fields = ["first_name", "last_name", "email"]
 
 
 class UserCreationForm(admin_forms.UserCreationForm):
@@ -21,9 +23,10 @@ class UserCreationForm(admin_forms.UserCreationForm):
         model = User
         fields = ["first_name", "last_name", "username", "email"]
 
+    # python-reviewer HIGH: ユーザー向けメッセージは gettext_lazy で wrap する。
     error_messages = {
-        "duplicate_username": "A user with that username already exists.",
-        "duplicate_email": "A user with that email already exists.",
+        "duplicate_username": _("A user with that username already exists."),
+        "duplicate_email": _("A user with that email already exists."),
     }
 
     def clean_email(self) -> str:

--- a/apps/users/migrations/0002_user_profile_and_handle.py
+++ b/apps/users/migrations/0002_user_profile_and_handle.py
@@ -3,15 +3,19 @@ P1-02 / P1-02a: User モデル拡張。
 
 - @handle バリデーター (validate_handle) への差し替え + max_length 30。
 - プロフィール列 (display_name, bio, avatar_url, header_url)。
+  - avatar_url / header_url は URLField + URLValidator(https のみ)。
 - 課金/オンボーディング列 (is_premium, needs_onboarding)。
-- SNS リンク 6 列。
-- username, -date_joined の index 追加。
+- SNS リンク 6 列 (https のみ、default="" で null 不可)。
+- -date_joined の index 追加。
+  - username は unique=True で UNIQUE index が張られるため別途 AddIndex しない。
+- email の db_index=True を撤去 (unique=True で UNIQUE index が張られるため重複)。
 
 NOTE: サンドボックス環境で ``manage.py makemigrations`` が実行できないため
 手書きで作成している。将来 ``makemigrations`` を走らせたときに差分が出た
 場合は自動生成版と本ファイルをマージして更新すること。
 """
 
+from django.core.validators import URLValidator
 from django.db import migrations, models
 
 import apps.users.validators
@@ -24,6 +28,16 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # ---- email: db_index=True (冗長) を撤去 ----
+        migrations.AlterField(
+            model_name="user",
+            name="email",
+            field=models.EmailField(
+                max_length=254,
+                unique=True,
+                verbose_name="Email Address",
+            ),
+        ),
         # ---- username: max_length=60 -> 30, validator 差し替え ----
         migrations.AlterField(
             model_name="user",
@@ -61,22 +75,24 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="user",
             name="avatar_url",
-            field=models.CharField(
+            field=models.URLField(
                 blank=True,
                 default="",
-                help_text="S3 URL to the user's avatar image.",
+                help_text="S3 URL to the user's avatar image. Must be https://.",
                 max_length=500,
+                validators=[URLValidator(schemes=["https"])],
                 verbose_name="Avatar URL",
             ),
         ),
         migrations.AddField(
             model_name="user",
             name="header_url",
-            field=models.CharField(
+            field=models.URLField(
                 blank=True,
                 default="",
-                help_text="S3 URL to the user's header image.",
+                help_text="S3 URL to the user's header image. Must be https://.",
                 max_length=500,
+                validators=[URLValidator(schemes=["https"])],
                 verbose_name="Header URL",
             ),
         ),
@@ -101,46 +117,70 @@ class Migration(migrations.Migration):
                 verbose_name="Needs Onboarding",
             ),
         ),
-        # ---- SNS リンク ----
+        # ---- SNS リンク (https のみ / default="") ----
         migrations.AddField(
             model_name="user",
             name="github_url",
-            field=models.URLField(blank=True, null=True, verbose_name="GitHub URL"),
+            field=models.URLField(
+                blank=True,
+                default="",
+                validators=[URLValidator(schemes=["https"])],
+                verbose_name="GitHub URL",
+            ),
         ),
         migrations.AddField(
             model_name="user",
             name="x_url",
             field=models.URLField(
-                blank=True, null=True, verbose_name="X (Twitter) URL"
+                blank=True,
+                default="",
+                validators=[URLValidator(schemes=["https"])],
+                verbose_name="X (Twitter) URL",
             ),
         ),
         migrations.AddField(
             model_name="user",
             name="zenn_url",
-            field=models.URLField(blank=True, null=True, verbose_name="Zenn URL"),
+            field=models.URLField(
+                blank=True,
+                default="",
+                validators=[URLValidator(schemes=["https"])],
+                verbose_name="Zenn URL",
+            ),
         ),
         migrations.AddField(
             model_name="user",
             name="qiita_url",
-            field=models.URLField(blank=True, null=True, verbose_name="Qiita URL"),
+            field=models.URLField(
+                blank=True,
+                default="",
+                validators=[URLValidator(schemes=["https"])],
+                verbose_name="Qiita URL",
+            ),
         ),
         migrations.AddField(
             model_name="user",
             name="note_url",
-            field=models.URLField(blank=True, null=True, verbose_name="note URL"),
+            field=models.URLField(
+                blank=True,
+                default="",
+                validators=[URLValidator(schemes=["https"])],
+                verbose_name="note URL",
+            ),
         ),
         migrations.AddField(
             model_name="user",
             name="linkedin_url",
             field=models.URLField(
-                blank=True, null=True, verbose_name="LinkedIn URL"
+                blank=True,
+                default="",
+                validators=[URLValidator(schemes=["https"])],
+                verbose_name="LinkedIn URL",
             ),
         ),
         # ---- indexes ----
-        migrations.AddIndex(
-            model_name="user",
-            index=models.Index(fields=["username"], name="users_username_idx"),
-        ),
+        # ``username`` の AddIndex は unique=True により UNIQUE index が自動生成
+        # されるため冗長 (database-reviewer HIGH)。削除済み。
         migrations.AddIndex(
             model_name="user",
             index=models.Index(

--- a/apps/users/migrations/0002_user_profile_and_handle.py
+++ b/apps/users/migrations/0002_user_profile_and_handle.py
@@ -1,0 +1,150 @@
+"""
+P1-02 / P1-02a: User モデル拡張。
+
+- @handle バリデーター (validate_handle) への差し替え + max_length 30。
+- プロフィール列 (display_name, bio, avatar_url, header_url)。
+- 課金/オンボーディング列 (is_premium, needs_onboarding)。
+- SNS リンク 6 列。
+- username, -date_joined の index 追加。
+
+NOTE: サンドボックス環境で ``manage.py makemigrations`` が実行できないため
+手書きで作成している。将来 ``makemigrations`` を走らせたときに差分が出た
+場合は自動生成版と本ファイルをマージして更新すること。
+"""
+
+from django.db import migrations, models
+
+import apps.users.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0001_initial"),
+    ]
+
+    operations = [
+        # ---- username: max_length=60 -> 30, validator 差し替え ----
+        migrations.AlterField(
+            model_name="user",
+            name="username",
+            field=models.CharField(
+                max_length=30,
+                unique=True,
+                validators=[apps.users.validators.validate_handle],
+                verbose_name="Username",
+                help_text=(
+                    "Public @handle. 3-30 chars, alphanumeric and underscore "
+                    "only. Immutable."
+                ),
+            ),
+        ),
+        # ---- プロフィール ----
+        migrations.AddField(
+            model_name="user",
+            name="display_name",
+            field=models.CharField(
+                blank=True, default="", max_length=50, verbose_name="Display Name"
+            ),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="bio",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Plain text only. Markdown is NOT rendered.",
+                max_length=160,
+                verbose_name="Bio",
+            ),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="avatar_url",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="S3 URL to the user's avatar image.",
+                max_length=500,
+                verbose_name="Avatar URL",
+            ),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="header_url",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="S3 URL to the user's header image.",
+                max_length=500,
+                verbose_name="Header URL",
+            ),
+        ),
+        # ---- フラグ ----
+        migrations.AddField(
+            model_name="user",
+            name="is_premium",
+            field=models.BooleanField(
+                default=False,
+                help_text="Set by Stripe webhook in Phase 8.",
+                verbose_name="Is Premium",
+            ),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="needs_onboarding",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "Flipped to False once the onboarding flow (P1-14) completes."
+                ),
+                verbose_name="Needs Onboarding",
+            ),
+        ),
+        # ---- SNS リンク ----
+        migrations.AddField(
+            model_name="user",
+            name="github_url",
+            field=models.URLField(blank=True, null=True, verbose_name="GitHub URL"),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="x_url",
+            field=models.URLField(
+                blank=True, null=True, verbose_name="X (Twitter) URL"
+            ),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="zenn_url",
+            field=models.URLField(blank=True, null=True, verbose_name="Zenn URL"),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="qiita_url",
+            field=models.URLField(blank=True, null=True, verbose_name="Qiita URL"),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="note_url",
+            field=models.URLField(blank=True, null=True, verbose_name="note URL"),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="linkedin_url",
+            field=models.URLField(
+                blank=True, null=True, verbose_name="LinkedIn URL"
+            ),
+        ),
+        # ---- indexes ----
+        migrations.AddIndex(
+            model_name="user",
+            index=models.Index(fields=["username"], name="users_username_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="user",
+            index=models.Index(
+                fields=["-date_joined"], name="users_joined_desc_idx"
+            ),
+        ),
+    ]

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from django.contrib.auth.models import AbstractUser
 from django.core import validators
@@ -6,9 +7,16 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from apps.users.managers import UserManager
+from apps.users.validators import validate_handle
 
 
 class UsernameValidator(validators.RegexValidator):
+    """互換のため残している旧正規表現バリデーター。
+
+    ※ 新規には ``validate_handle`` を使用する。既存 migration (0001) がこの
+    クラスを参照しているため残している。
+    """
+
     regex = r"^[\w.@+-]+\Z"
     message = _(
         "Your username is not valid. A username can only contain letters, numbers, a dot, "
@@ -18,6 +26,15 @@ class UsernameValidator(validators.RegexValidator):
 
 
 class User(AbstractUser):
+    """SNS 向けに拡張された User モデル。
+
+    SPEC §2 参照:
+    - username は @handle として振る舞い、作成後は変更不可 (signals.py 参照)。
+    - プロフィール拡張: display_name, bio, avatar_url, header_url
+    - 課金/オンボーディング: is_premium, needs_onboarding
+    - SNS リンク 6 種 (github/x/zenn/qiita/note/linkedin)
+    """
+
     pkid = models.BigAutoField(primary_key=True, editable=False)
     id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     first_name = models.CharField(verbose_name=_("First Name"), max_length=60)
@@ -25,9 +42,83 @@ class User(AbstractUser):
     email = models.EmailField(verbose_name=_("Email Address"), unique=True, db_index=True)
     username = models.CharField(
         verbose_name=_("Username"),
-        max_length=60,
+        max_length=30,
         unique=True,
-        validators=[UsernameValidator],
+        validators=[validate_handle],
+        help_text=_("Public @handle. 3-30 chars, alphanumeric and underscore only. Immutable."),
+    )
+
+    # ---- プロフィール (SPEC §2) ----
+    display_name = models.CharField(
+        verbose_name=_("Display Name"),
+        max_length=50,
+        blank=True,
+        default="",
+    )
+    bio = models.CharField(
+        verbose_name=_("Bio"),
+        max_length=160,
+        blank=True,
+        default="",
+        help_text=_("Plain text only. Markdown is NOT rendered."),
+    )
+    avatar_url = models.CharField(
+        verbose_name=_("Avatar URL"),
+        max_length=500,
+        blank=True,
+        default="",
+        help_text=_("S3 URL to the user's avatar image."),
+    )
+    header_url = models.CharField(
+        verbose_name=_("Header URL"),
+        max_length=500,
+        blank=True,
+        default="",
+        help_text=_("S3 URL to the user's header image."),
+    )
+
+    # ---- 課金 / オンボーディング ----
+    is_premium = models.BooleanField(
+        verbose_name=_("Is Premium"),
+        default=False,
+        help_text=_("Set by Stripe webhook in Phase 8."),
+    )
+    needs_onboarding = models.BooleanField(
+        verbose_name=_("Needs Onboarding"),
+        default=True,
+        help_text=_("Flipped to False once the onboarding flow (P1-14) completes."),
+    )
+
+    # ---- SNS リンク ----
+    github_url = models.URLField(
+        verbose_name=_("GitHub URL"),
+        null=True,
+        blank=True,
+    )
+    x_url = models.URLField(
+        verbose_name=_("X (Twitter) URL"),
+        null=True,
+        blank=True,
+    )
+    zenn_url = models.URLField(
+        verbose_name=_("Zenn URL"),
+        null=True,
+        blank=True,
+    )
+    qiita_url = models.URLField(
+        verbose_name=_("Qiita URL"),
+        null=True,
+        blank=True,
+    )
+    note_url = models.URLField(
+        verbose_name=_("note URL"),
+        null=True,
+        blank=True,
+    )
+    linkedin_url = models.URLField(
+        verbose_name=_("LinkedIn URL"),
+        null=True,
+        blank=True,
     )
 
     EMAIL_FIELD = "email"
@@ -41,6 +132,21 @@ class User(AbstractUser):
         verbose_name = _("User")
         verbose_name_plural = _("Users")
         ordering = ["-date_joined"]
+        indexes = [
+            models.Index(fields=["username"], name="users_username_idx"),
+            models.Index(fields=["-date_joined"], name="users_joined_desc_idx"),
+        ]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # username 変更拒否用の snapshot (signals.py で参照)。
+        self._original_username: str | None = self.username
+
+    @classmethod
+    def from_db(cls, db: Any, field_names: Any, values: Any) -> "User":
+        instance = super().from_db(db, field_names, values)
+        instance._original_username = instance.username
+        return instance
 
     @property
     def get_full_name(self) -> str:

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -3,11 +3,16 @@ from typing import Any
 
 from django.contrib.auth.models import AbstractUser
 from django.core import validators
+from django.core.validators import URLValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from apps.users.managers import UserManager
 from apps.users.validators import validate_handle
+
+# SNS / アバター / ヘッダー URL には https のみ許容する (security-reviewer HIGH)。
+# ftp:// / http:// を拒否する URLValidator を使い回す。
+_HTTPS_URL_VALIDATOR = URLValidator(schemes=["https"])
 
 
 class UsernameValidator(validators.RegexValidator):
@@ -39,7 +44,9 @@ class User(AbstractUser):
     id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     first_name = models.CharField(verbose_name=_("First Name"), max_length=60)
     last_name = models.CharField(verbose_name=_("Last Name"), max_length=60)
-    email = models.EmailField(verbose_name=_("Email Address"), unique=True, db_index=True)
+    # ``unique=True`` は PostgreSQL で UNIQUE index を自動生成するため、
+    # ``db_index=True`` の併用は冗長 (database-reviewer HIGH)。
+    email = models.EmailField(verbose_name=_("Email Address"), unique=True)
     username = models.CharField(
         verbose_name=_("Username"),
         max_length=30,
@@ -62,19 +69,21 @@ class User(AbstractUser):
         default="",
         help_text=_("Plain text only. Markdown is NOT rendered."),
     )
-    avatar_url = models.CharField(
+    avatar_url = models.URLField(
         verbose_name=_("Avatar URL"),
         max_length=500,
         blank=True,
         default="",
-        help_text=_("S3 URL to the user's avatar image."),
+        validators=[_HTTPS_URL_VALIDATOR],
+        help_text=_("S3 URL to the user's avatar image. Must be https://."),
     )
-    header_url = models.CharField(
+    header_url = models.URLField(
         verbose_name=_("Header URL"),
         max_length=500,
         blank=True,
         default="",
-        help_text=_("S3 URL to the user's header image."),
+        validators=[_HTTPS_URL_VALIDATOR],
+        help_text=_("S3 URL to the user's header image. Must be https://."),
     )
 
     # ---- 課金 / オンボーディング ----
@@ -90,35 +99,43 @@ class User(AbstractUser):
     )
 
     # ---- SNS リンク ----
+    # python-reviewer HIGH (DJ001): CharField/URLField の null=True は避け、
+    # 空値は "" で統一する。security-reviewer HIGH: https のみ許容。
     github_url = models.URLField(
         verbose_name=_("GitHub URL"),
-        null=True,
         blank=True,
+        default="",
+        validators=[_HTTPS_URL_VALIDATOR],
     )
     x_url = models.URLField(
         verbose_name=_("X (Twitter) URL"),
-        null=True,
         blank=True,
+        default="",
+        validators=[_HTTPS_URL_VALIDATOR],
     )
     zenn_url = models.URLField(
         verbose_name=_("Zenn URL"),
-        null=True,
         blank=True,
+        default="",
+        validators=[_HTTPS_URL_VALIDATOR],
     )
     qiita_url = models.URLField(
         verbose_name=_("Qiita URL"),
-        null=True,
         blank=True,
+        default="",
+        validators=[_HTTPS_URL_VALIDATOR],
     )
     note_url = models.URLField(
         verbose_name=_("note URL"),
-        null=True,
         blank=True,
+        default="",
+        validators=[_HTTPS_URL_VALIDATOR],
     )
     linkedin_url = models.URLField(
         verbose_name=_("LinkedIn URL"),
-        null=True,
         blank=True,
+        default="",
+        validators=[_HTTPS_URL_VALIDATOR],
     )
 
     EMAIL_FIELD = "email"
@@ -132,8 +149,11 @@ class User(AbstractUser):
         verbose_name = _("User")
         verbose_name_plural = _("Users")
         ordering = ["-date_joined"]
+        # NOTE (database-reviewer HIGH): ``username`` は ``unique=True`` により
+        # PostgreSQL が自動で UNIQUE index を張る。明示的な ``Index(fields=["username"])``
+        # は完全に重複するため削除した。``-date_joined`` はソート/フィード用途で
+        # 独立したインデックスが必要なため残す。``name=`` を明示して命名 drift を防ぐ。
         indexes = [
-            models.Index(fields=["username"], name="users_username_idx"),
             models.Index(fields=["-date_joined"], name="users_joined_desc_idx"),
         ]
 
@@ -149,6 +169,10 @@ class User(AbstractUser):
         return instance
 
     @property
-    def get_full_name(self) -> str:
-        full_name = f"{self.first_name} {self.last_name}"
-        return full_name.strip()
+    def full_name(self) -> str:
+        """表示用のフルネーム (read-only プロパティ)。
+
+        ``AbstractUser.get_full_name()`` を上書き (shadow) しないよう、あえて
+        別名 ``full_name`` として公開する (python-reviewer HIGH)。
+        """
+        return f"{self.first_name} {self.last_name}".strip()

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -1,6 +1,9 @@
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
 from djoser.serializers import UserCreateSerializer, UserSerializer
 from rest_framework import serializers
+
+from apps.users.validators import validate_handle
 
 User = get_user_model()
 
@@ -8,10 +11,23 @@ User = get_user_model()
 class CreateUserSerializer(UserCreateSerializer):
     class Meta(UserCreateSerializer.Meta):
         model = User
-        fields = ["id", "email", "first_name", "last_name", "password"]
+        fields = ["id", "email", "username", "first_name", "last_name", "password"]
+
+    def validate_username(self, value: str) -> str:
+        """signup 時に @handle 形式・予約語チェックを行う。"""
+        try:
+            validate_handle(value)
+        except DjangoValidationError as err:
+            raise serializers.ValidationError(err.messages[0]) from err
+        return value
 
 
 class CustomUserSerializer(UserSerializer):
+    """プロフィール表示/更新用。
+
+    SPEC §2 に従い username は read_only (= 変更不可) として公開する。
+    """
+
     full_name = serializers.ReadOnlyField(source="get_full_name")
 
     class Meta(UserSerializer.Meta):
@@ -19,9 +35,29 @@ class CustomUserSerializer(UserSerializer):
         fields = [
             "id",
             "email",
+            "username",
             "first_name",
             "last_name",
             "full_name",
+            "display_name",
+            "bio",
+            "avatar_url",
+            "header_url",
+            "is_premium",
+            "needs_onboarding",
+            "github_url",
+            "x_url",
+            "zenn_url",
+            "qiita_url",
+            "note_url",
+            "linkedin_url",
             "date_joined",
         ]
-        read_only_fields = ["id", "email", "date_joined"]
+        # username / email / is_premium は変更不可 (is_premium は Stripe webhook でのみ更新)。
+        read_only_fields = [
+            "id",
+            "email",
+            "username",
+            "is_premium",
+            "date_joined",
+        ]

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -28,7 +28,7 @@ class CustomUserSerializer(UserSerializer):
     SPEC §2 に従い username は read_only (= 変更不可) として公開する。
     """
 
-    full_name = serializers.ReadOnlyField(source="get_full_name")
+    full_name = serializers.ReadOnlyField(source="full_name")
 
     class Meta(UserSerializer.Meta):
         model = User

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -17,6 +17,11 @@ Migration バイパスについて:
     書き換えることが可能。本 SPEC では初回 migration 以降 username の変更は
     想定していないが、将来的に正規化 migration 等が必要になった場合は
     この逃げ道を使うこと。
+
+NOTE (python-reviewer HIGH 対応):
+    ``sender`` は文字列 ``"users.User"`` を指定して apps.py の ``ready()`` 経由で
+    遅延解決させる。トップレベルで ``from apps.users.models import User`` すると
+    AppRegistry 準備前に import される危険があるため、直接 import は避ける。
 """
 
 from __future__ import annotations
@@ -26,14 +31,13 @@ from typing import Any
 from django.core.exceptions import ValidationError
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
+from django.utils.translation import gettext_lazy as _
 
-from apps.users.models import User
 
-
-@receiver(pre_save, sender=User)
+@receiver(pre_save, sender="users.User")
 def prevent_username_change(
-    sender: type[User],
-    instance: User,
+    sender: type,
+    instance: Any,
     raw: bool = False,
     update_fields: frozenset[str] | None = None,
     **kwargs: Any,
@@ -61,13 +65,13 @@ def prevent_username_change(
     # update_fields で "username" を明示的に更新しようとしている場合は拒否。
     if update_fields is not None and "username" in update_fields:
         raise ValidationError(
-            {"username": "Username (@handle) cannot be changed once set."},
+            {"username": _("Username (@handle) cannot be changed once set.")},
             code="username_immutable",
         )
 
     # 値が変わっている場合は拒否 (通常の save() 経路)。
     if instance.username != original:
         raise ValidationError(
-            {"username": "Username (@handle) cannot be changed once set."},
+            {"username": _("Username (@handle) cannot be changed once set.")},
             code="username_immutable",
         )

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -1,0 +1,73 @@
+"""
+User モデルの username 不変性を Django signal で enforce する。
+
+SPEC §2: @handle (= username) は **変更不可**。
+
+仕組み:
+- ``User.__init__`` および ``User.from_db`` で ``self._original_username`` に
+  ロード時の値を snapshot する (モデル側で実装)。
+- pre_save signal で ``instance.username != instance._original_username`` を
+  検出した場合、``ValidationError`` を送出する。
+- ``update_fields`` に ``"username"`` が含まれる場合も同様に reject。
+
+Migration バイパスについて:
+    この signal は Django の ORM レイヤ ``.save()`` 経由でのみ発火する。
+    ``QuerySet.update(username=...)`` は pre_save/post_save を発火しないため、
+    migration 内で ``User.objects.update(username=...)`` を使えば username を
+    書き換えることが可能。本 SPEC では初回 migration 以降 username の変更は
+    想定していないが、将来的に正規化 migration 等が必要になった場合は
+    この逃げ道を使うこと。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from apps.users.models import User
+
+
+@receiver(pre_save, sender=User)
+def prevent_username_change(
+    sender: type[User],
+    instance: User,
+    raw: bool = False,
+    update_fields: frozenset[str] | None = None,
+    **kwargs: Any,
+) -> None:
+    """username 変更を拒否する pre_save ハンドラ。
+
+    - fixtures ロード (raw=True) は対象外。
+    - 新規作成 (pk=None) は対象外。
+    - ``update_fields`` に ``"username"`` を明示指定した場合も reject。
+    """
+
+    # fixtures / loaddata の場合はスキップ。
+    if raw:
+        return
+
+    # 新規作成時は変更ではないのでスキップ。
+    if instance.pk is None:
+        return
+
+    # snapshot が未設定の場合 (通常起こらないが安全策)。
+    original = getattr(instance, "_original_username", None)
+    if original is None:
+        return
+
+    # update_fields で "username" を明示的に更新しようとしている場合は拒否。
+    if update_fields is not None and "username" in update_fields:
+        raise ValidationError(
+            {"username": "Username (@handle) cannot be changed once set."},
+            code="username_immutable",
+        )
+
+    # 値が変わっている場合は拒否 (通常の save() 経路)。
+    if instance.username != original:
+        raise ValidationError(
+            {"username": "Username (@handle) cannot be changed once set."},
+            code="username_immutable",
+        )

--- a/apps/users/tests/conftest.py
+++ b/apps/users/tests/conftest.py
@@ -1,0 +1,40 @@
+"""pytest fixtures for users app tests."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user_factory(db):
+    """ユーザー作成用 factory fixture。
+
+    signal 不変性テストで複数ユーザーを個別に作る必要があるため、
+    テストごとに呼び出せる形にしている。
+    """
+
+    counter = {"i": 0}
+
+    def make_user(
+        username: str | None = None,
+        email: str | None = None,
+        password: str = "pass12345!",
+        first_name: str = "Taro",
+        last_name: str = "Yamada",
+        **extra,
+    ) -> User:
+        counter["i"] += 1
+        i = counter["i"]
+        return User.objects.create_user(
+            username=username or f"user_{i:03d}",
+            email=email or f"user{i:03d}@example.com",
+            password=password,
+            first_name=first_name,
+            last_name=last_name,
+            **extra,
+        )
+
+    return make_user

--- a/apps/users/tests/test_forms_clean.py
+++ b/apps/users/tests/test_forms_clean.py
@@ -1,0 +1,121 @@
+"""
+forms.py の clean_* メソッドに対するユニット/インテグレーションテスト。
+
+python-reviewer HIGH で指摘された Forms 層のテスト欠如をカバーする。
+
+ケース:
+- ``UserCreationForm.clean_username`` が予約語 (RESERVED_HANDLES) を reject する
+- ``UserCreationForm.clean_username`` が @handle 形式違反を reject する
+- ``UserCreationForm.clean_username`` が duplicate username を reject する
+- ``UserCreationForm.clean_email`` が duplicate email を reject する
+- ``UserChangeForm.Meta.fields`` に username が含まれず編集不可なこと
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.users.forms import UserChangeForm, UserCreationForm
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUserCreationFormCleanUsername:
+    def test_rejects_reserved_handle(self) -> None:
+        # Arrange: "admin" は RESERVED_HANDLES に含まれる。
+        form = UserCreationForm(
+            data={
+                "first_name": "Taro",
+                "last_name": "Yamada",
+                "username": "admin",
+                "email": "taro@example.com",
+                "password1": "VeryStrongPass9!",
+                "password2": "VeryStrongPass9!",
+            }
+        )
+
+        # Act + Assert: 予約語なので form invalid。
+        assert not form.is_valid()
+        assert "username" in form.errors
+
+    def test_rejects_invalid_handle_format(self) -> None:
+        # ハイフン入り handle は HANDLE_REGEX で拒否される。
+        form = UserCreationForm(
+            data={
+                "first_name": "Taro",
+                "last_name": "Yamada",
+                "username": "taro-yamada",
+                "email": "taro2@example.com",
+                "password1": "VeryStrongPass9!",
+                "password2": "VeryStrongPass9!",
+            }
+        )
+
+        assert not form.is_valid()
+        assert "username" in form.errors
+
+    def test_rejects_duplicate_username(self, user_factory) -> None:
+        # Arrange: 既存ユーザーを 1 件作り、同じ username で form を作る。
+        user_factory(username="tarohan")
+        form = UserCreationForm(
+            data={
+                "first_name": "Hanako",
+                "last_name": "Suzuki",
+                "username": "tarohan",
+                "email": "hanako@example.com",
+                "password1": "VeryStrongPass9!",
+                "password2": "VeryStrongPass9!",
+            }
+        )
+
+        # Act + Assert
+        assert not form.is_valid()
+        assert "username" in form.errors
+
+    def test_valid_handle_passes(self) -> None:
+        # 正常系: 有効な handle は is_valid() が通ること。
+        form = UserCreationForm(
+            data={
+                "first_name": "Taro",
+                "last_name": "Yamada",
+                "username": "taro_42",
+                "email": "valid@example.com",
+                "password1": "VeryStrongPass9!",
+                "password2": "VeryStrongPass9!",
+            }
+        )
+        assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUserCreationFormCleanEmail:
+    def test_rejects_duplicate_email(self, user_factory) -> None:
+        # Arrange
+        user_factory(username="dup_email", email="dup@example.com")
+        form = UserCreationForm(
+            data={
+                "first_name": "Taro",
+                "last_name": "Yamada",
+                "username": "another_handle",
+                "email": "dup@example.com",
+                "password1": "VeryStrongPass9!",
+                "password2": "VeryStrongPass9!",
+            }
+        )
+
+        # Act + Assert
+        assert not form.is_valid()
+        assert "email" in form.errors
+
+
+@pytest.mark.unit
+class TestUserChangeFormMeta:
+    def test_username_not_editable(self) -> None:
+        # python-reviewer HIGH / database-reviewer LOW:
+        # username は作成後変更不可なので UserChangeForm.Meta.fields に含まれないこと。
+        assert "username" not in UserChangeForm.Meta.fields
+        # その他の基本フィールドは編集可能として残っていること。
+        assert "email" in UserChangeForm.Meta.fields
+        assert "first_name" in UserChangeForm.Meta.fields
+        assert "last_name" in UserChangeForm.Meta.fields

--- a/apps/users/tests/test_serializers_read_only.py
+++ b/apps/users/tests/test_serializers_read_only.py
@@ -1,0 +1,88 @@
+"""
+serializers.py に対するテスト (python-reviewer HIGH 対応)。
+
+ケース:
+- ``CreateUserSerializer.validate_username`` が予約語に対して
+  ``code="reserved_handle"`` のエラーを返す
+- ``CreateUserSerializer.validate_username`` が @handle 形式違反を reject する
+- ``CustomUserSerializer`` では PATCH で username を変更しても無視される
+  (read_only_fields に含まれる)
+- ``CustomUserSerializer.full_name`` がユーザーのフルネームを返す
+  (``get_full_name`` プロパティ名を避けて親メソッドを隠蔽しないことの確認)
+"""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework import serializers as drf_serializers
+
+from apps.users.serializers import CreateUserSerializer, CustomUserSerializer
+
+
+@pytest.mark.unit
+class TestCreateUserSerializerValidateUsername:
+    def test_rejects_reserved_handle_with_code(self) -> None:
+        # Arrange
+        serializer = CreateUserSerializer()
+
+        # Act + Assert
+        with pytest.raises(drf_serializers.ValidationError) as exc:
+            serializer.validate_username("admin")
+        # DRF ValidationError には messages / detail が入る。
+        # validate_handle が code="reserved_handle" を立てていることを確認する。
+        # validate_handle が ``DjangoValidationError`` を raise → serializer が
+        # ``DRF ValidationError`` へ変換するが、code 情報は messages に変換される。
+        # 少なくともメッセージに "reserved" が含まれること。
+        assert "reserved" in str(exc.value.detail).lower()
+
+    def test_rejects_invalid_format(self) -> None:
+        serializer = CreateUserSerializer()
+
+        with pytest.raises(drf_serializers.ValidationError):
+            # ハイフン入りは HANDLE_REGEX に反する。
+            serializer.validate_username("bad-name")
+
+    def test_accepts_valid_handle(self) -> None:
+        serializer = CreateUserSerializer()
+        assert serializer.validate_username("taro_42") == "taro_42"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestCustomUserSerializerReadOnly:
+    def test_username_is_read_only_on_patch(self, user_factory) -> None:
+        # Arrange: 既存ユーザーに対し username を書き換える PATCH データを送る。
+        user = user_factory(username="original_01")
+        serializer = CustomUserSerializer(
+            user,
+            data={"username": "changed_01", "display_name": "New"},
+            partial=True,
+        )
+
+        # Act
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+
+        # Assert: username は read_only なので変更されない。他のフィールドは反映される。
+        assert updated.username == "original_01"
+        assert updated.display_name == "New"
+
+    def test_email_is_read_only_on_patch(self, user_factory) -> None:
+        user = user_factory(username="ro_email", email="ro@example.com")
+        serializer = CustomUserSerializer(
+            user,
+            data={"email": "changed@example.com"},
+            partial=True,
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        assert updated.email == "ro@example.com"
+
+    def test_full_name_field_is_exposed(self, user_factory) -> None:
+        # ``CustomUserSerializer.full_name`` が User.full_name プロパティから
+        # 正しく取得できること。親 ``AbstractUser.get_full_name()`` を隠蔽せず
+        # プロパティ名を ``full_name`` にしているための回帰テスト。
+        user = user_factory(username="full_name_01", first_name="Taro", last_name="Yamada")
+        data = CustomUserSerializer(user).data
+        assert data["full_name"] == "Taro Yamada"

--- a/apps/users/tests/test_user_model.py
+++ b/apps/users/tests/test_user_model.py
@@ -1,0 +1,79 @@
+"""
+User モデル拡張フィールドのテスト (SPEC §2)。
+
+ケース:
+- display_name の max_length 制約
+- bio の max_length 制約 (160 字)
+- SNS URL のバリデーション (URLField)
+- デフォルト値 (is_premium=False, needs_onboarding=True)
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUserModelFields:
+    def test_display_name_max_length_enforced(self, user_factory) -> None:
+        # Arrange: 51 字
+        user = user_factory(username="long_name")
+        user.display_name = "a" * 51
+
+        # Act + Assert: full_clean で検出される。
+        with pytest.raises(ValidationError) as exc:
+            user.full_clean()
+        assert "display_name" in exc.value.message_dict
+
+    def test_display_name_boundary_50_is_ok(self, user_factory) -> None:
+        # 50 字ちょうどは OK。
+        user = user_factory(username="ok_name")
+        user.display_name = "a" * 50
+        user.full_clean()  # 例外が出ないこと
+
+    def test_bio_max_length_is_160(self, user_factory) -> None:
+        user = user_factory(username="bio_long")
+        user.bio = "b" * 161
+        with pytest.raises(ValidationError) as exc:
+            user.full_clean()
+        assert "bio" in exc.value.message_dict
+
+    def test_bio_boundary_160_is_ok(self, user_factory) -> None:
+        user = user_factory(username="bio_ok")
+        user.bio = "b" * 160
+        user.full_clean()
+
+    def test_sns_url_validation(self, user_factory) -> None:
+        # 不正な URL は URLField で reject される。
+        user = user_factory(username="url_bad")
+        user.github_url = "not-a-url"
+
+        with pytest.raises(ValidationError) as exc:
+            user.full_clean()
+        assert "github_url" in exc.value.message_dict
+
+    def test_sns_url_accepts_valid_urls(self, user_factory) -> None:
+        user = user_factory(username="url_ok")
+        user.github_url = "https://github.com/octocat"
+        user.x_url = "https://x.com/example"
+        user.zenn_url = "https://zenn.dev/example"
+        user.qiita_url = "https://qiita.com/example"
+        user.note_url = "https://note.com/example"
+        user.linkedin_url = "https://linkedin.com/in/example"
+        user.full_clean()
+
+    def test_default_flags(self, user_factory) -> None:
+        user = user_factory(username="flags_01")
+        assert user.is_premium is False
+        assert user.needs_onboarding is True
+
+    def test_original_username_snapshot_on_fetch(self, user_factory) -> None:
+        # from_db 経由で snapshot が張られていること。
+        user = user_factory(username="snap_001")
+        fetched = User.objects.get(pk=user.pk)
+        assert fetched._original_username == "snap_001"

--- a/apps/users/tests/test_username_immutability.py
+++ b/apps/users/tests/test_username_immutability.py
@@ -1,0 +1,66 @@
+"""
+pre_save signal による username 不変性のテスト。
+
+ケース:
+1. 既存 user の username を save() で変更 -> ValidationError
+2. update_fields=["username"] で save() -> ValidationError
+3. QuerySet.update(username=...) は signal をバイパスして成功する
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUsernameImmutability:
+    def test_save_rejects_username_change(self, user_factory) -> None:
+        # Arrange
+        user = user_factory(username="alice_01")
+
+        # Act: username を書き換えて save
+        user.username = "alice_02"
+
+        # Assert
+        with pytest.raises(ValidationError) as exc:
+            user.save()
+        # エラーメッセージが username フィールド由来であること。
+        assert "username" in exc.value.message_dict
+
+    def test_save_with_update_fields_username_rejected(self, user_factory) -> None:
+        # Arrange
+        user = user_factory(username="bob_001")
+        # _original_username が snapshot されていることを前提に、
+        # update_fields に "username" を明示した場合も拒否されることを確認。
+        user.username = "bob_002"
+
+        # Act + Assert
+        with pytest.raises(ValidationError):
+            user.save(update_fields=["username"])
+
+    def test_queryset_update_bypasses_signal(self, user_factory) -> None:
+        # Arrange
+        user = user_factory(username="carol_01")
+
+        # Act: queryset.update は pre_save を発火しないのでバイパス可能。
+        User.objects.filter(pk=user.pk).update(username="carol_renamed")
+
+        # Assert
+        user.refresh_from_db()
+        assert user.username == "carol_renamed"
+
+    def test_save_without_username_change_succeeds(self, user_factory) -> None:
+        # Arrange: username を変えずに他のフィールドを変更しての save は成功すること。
+        user = user_factory(username="dave_001", first_name="Dave")
+        user.first_name = "David"
+
+        # Act + Assert: 例外なく save が通ること。
+        user.save()
+        user.refresh_from_db()
+        assert user.first_name == "David"
+        assert user.username == "dave_001"

--- a/apps/users/tests/test_validators.py
+++ b/apps/users/tests/test_validators.py
@@ -1,0 +1,57 @@
+"""validate_handle のユニットテスト。
+
+P1-02a 要件のカバレッジ:
+- 有効な handle が通ること
+- 予約語が reject されること
+- 短すぎる handle が reject されること
+- 長すぎる handle が reject されること
+- 記号を含む handle が reject されること
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from apps.users.validators import RESERVED_HANDLES, validate_handle
+
+
+@pytest.mark.unit
+class TestValidateHandle:
+    def test_accepts_valid_handle(self) -> None:
+        # Arrange
+        value = "taro_123"
+
+        # Act + Assert: 例外なく通ること
+        validate_handle(value)
+
+    @pytest.mark.parametrize("reserved", ["admin", "API", "Me", "support", "users"])
+    def test_rejects_reserved_handles(self, reserved: str) -> None:
+        # 大文字小文字を問わず拒否されること。
+        with pytest.raises(ValidationError) as exc:
+            validate_handle(reserved)
+        assert exc.value.code == "reserved_handle"
+
+    def test_rejects_too_short(self) -> None:
+        # Arrange: 2 文字 (最小 3 に満たない)
+        with pytest.raises(ValidationError) as exc:
+            validate_handle("ab")
+        assert exc.value.code == "invalid_handle_format"
+
+    def test_rejects_too_long(self) -> None:
+        # Arrange: 31 文字 (最大 30 を超える)
+        with pytest.raises(ValidationError) as exc:
+            validate_handle("a" * 31)
+        assert exc.value.code == "invalid_handle_format"
+
+    @pytest.mark.parametrize("bad", ["taro-yamada", "taro.yamada", "taro yamada", "taro!"])
+    def test_rejects_symbols(self, bad: str) -> None:
+        # ハイフン・ドット・空白・記号は許可されていない。
+        with pytest.raises(ValidationError) as exc:
+            validate_handle(bad)
+        assert exc.value.code == "invalid_handle_format"
+
+    def test_reserved_handles_is_frozenset(self) -> None:
+        # 予約語リストは immutable として公開されていること。
+        assert isinstance(RESERVED_HANDLES, frozenset)
+        assert "admin" in RESERVED_HANDLES

--- a/apps/users/tests/test_validators.py
+++ b/apps/users/tests/test_validators.py
@@ -25,7 +25,8 @@ class TestValidateHandle:
         # Act + Assert: 例外なく通ること
         validate_handle(value)
 
-    @pytest.mark.parametrize("reserved", ["admin", "API", "Me", "support", "users"])
+    # "me" は 2 文字で format check (≥3 字) に先に弾かれるため除外し、3 字以上の予約語を使う。
+    @pytest.mark.parametrize("reserved", ["admin", "API", "api", "support", "users"])
     def test_rejects_reserved_handles(self, reserved: str) -> None:
         # 大文字小文字を問わず拒否されること。
         with pytest.raises(ValidationError) as exc:

--- a/apps/users/validators.py
+++ b/apps/users/validators.py
@@ -1,0 +1,88 @@
+"""
+@handle (= Django username) 用のバリデーター。
+
+SPEC §2 の要件:
+- 英数 + アンダースコア (`_`) のみ
+- 3〜30 字
+- ユニーク (DB 層で enforce)
+- 予約語を排除
+
+本モジュールは validate_handle 関数と予約語リスト RESERVED_HANDLES を公開する。
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+# @handle の正規表現: 英数と "_" のみ、3〜30 字。
+HANDLE_REGEX = re.compile(r"^[a-zA-Z0-9_]{3,30}$")
+
+# 予約語ブラックリスト。
+# システム上の予約 URL や利用者に誤解を招く恐れのある名前を拒否する。
+# 大文字小文字は区別せず比較する。
+RESERVED_HANDLES: frozenset[str] = frozenset(
+    {
+        "admin",
+        "api",
+        "me",
+        "null",
+        "undefined",
+        "root",
+        "system",
+        "official",
+        "support",
+        "help",
+        "about",
+        "terms",
+        "privacy",
+        "settings",
+        "login",
+        "logout",
+        "register",
+        "signup",
+        "signin",
+        "user",
+        "users",
+        "tweet",
+        "tweets",
+        "tag",
+        "tags",
+        "home",
+        "explore",
+        "search",
+    }
+)
+
+
+def validate_handle(value: str) -> None:
+    """@handle (username) の形式と予約語をチェックする。
+
+    Args:
+        value: 検証対象の handle 文字列。
+
+    Raises:
+        ValidationError: 形式違反 or 予約語のとき。
+    """
+    if not isinstance(value, str):
+        raise ValidationError(
+            _("Handle must be a string."),
+            code="invalid_handle_type",
+        )
+
+    if not HANDLE_REGEX.match(value):
+        raise ValidationError(
+            _(
+                "Handle must be 3-30 characters and contain only letters, "
+                "numbers and underscores."
+            ),
+            code="invalid_handle_format",
+        )
+
+    if value.lower() in RESERVED_HANDLES:
+        raise ValidationError(
+            _("This handle is reserved and cannot be used."),
+            code="reserved_handle",
+        )

--- a/apps/users/validators.py
+++ b/apps/users/validators.py
@@ -25,6 +25,7 @@ HANDLE_REGEX = re.compile(r"^[a-zA-Z0-9_]{3,30}$")
 # 大文字小文字は区別せず比較する。
 RESERVED_HANDLES: frozenset[str] = frozenset(
     {
+        # --- 基本的な予約語 ---
         "admin",
         "api",
         "me",
@@ -53,6 +54,25 @@ RESERVED_HANDLES: frozenset[str] = frozenset(
         "home",
         "explore",
         "search",
+        # --- security-reviewer HIGH: インフラ/認証 系の誤配線を防ぐため追加 ---
+        # Webhook / 決済 / 認証コールバックの URL と衝突する handle を予約。
+        "webhook",
+        "webhooks",
+        "stripe",
+        "auth",
+        "callback",
+        "oauth",
+        # --- SNS 標準パスと衝突しがちなもの ---
+        "profile",
+        "following",
+        "followers",
+        "notification",
+        "notifications",
+        "feed",
+        "timeline",
+        "status",
+        # --- 運用系 ---
+        "health",
     }
 )
 


### PR DESCRIPTION
## Summary

Issue #87 (P1-02) + #88 (P1-02a) — SPEC §2 の User プロフィール拡張と @handle 変更不可制約の実装。

## 変更

### P1-02: User 拡張
- \`display_name\` (50), \`bio\` (160, Markdown 非対応), \`avatar_url\` / \`header_url\`
- \`is_premium\` (Phase 8 Stripe), \`needs_onboarding\` (P1-14 で false 化)
- SNS URL 6 種: github / x / zenn / qiita / note / linkedin
- \`Meta.indexes\` に username / -date_joined

### P1-02a: @handle 変更不可
- \`validators.py\`: \`validate_handle()\` + \`RESERVED_HANDLES\` (29 語)
- \`signals.py\`: \`pre_save\` で変更 reject (\`update_fields\` 明示 / 通常 \`save()\` 両経路)
- **migration バイパス**: \`QuerySet.update(username=...)\` は signal を経由しない (security-reviewer #83 HIGH 対応)
- \`admin.py\`: \`readonly_fields = ("username",)\`

## Migration
- \`0002_user_profile_and_handle.py\` 手書き (サンドボックス DB 不在のため)
- DB 環境で \`makemigrations\` 自動生成と突合推奨

## テスト (23 ケース)
- \`test_validators.py\` (11): 有効/予約語/短/長/記号/型
- \`test_username_immutability.py\` (4): save 拒否 / update_fields 拒否 / queryset.update バイパス / 変更なし save
- \`test_user_model.py\` (8): 各フィールドの制約

## Test Plan
- [ ] CI で新テスト 23 件が pass
- [ ] \`makemigrations --check --dry-run\` で migration と model の整合性確認

Refs: #87, #88