### PR TITLE
feat(p1-12a): メール認証フロー + Cookie JWT (create/refresh/logout)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,13 +158,45 @@
         "line_number": 119
       }
     ],
+    "apps/users/tests/test_email_auth_flow.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/users/tests/test_email_auth_flow.py",
+        "hashed_secret": "d869db7fe62fb07c25a0403ecaea55031744b5fb",
+        "is_verified": false,
+        "line_number": 518
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/users/tests/test_email_auth_flow.py",
+        "hashed_secret": "c58144d6ccf5ea1353d1f2bb09988dc25fc8635f",
+        "is_verified": false,
+        "line_number": 575
+      }
+    ],
     "config/settings/base.py": [
       {
         "type": "Secret Keyword",
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 326
+        "line_number": 358
+      }
+    ],
+    "docs/operations/email-auth.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/operations/email-auth.md",
+        "hashed_secret": "9e7b3fde1239f0e960e60b3ca067d595d74d01f5",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/operations/email-auth.md",
+        "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
+        "is_verified": false,
+        "line_number": 188
       }
     ],
     "terraform/modules/github_oidc/main.tf": [
@@ -193,5 +225,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T15:16:15Z"
+  "generated_at": "2026-04-24T01:50:38Z"
 }

--- a/apps/common/cookie_auth.py
+++ b/apps/common/cookie_auth.py
@@ -1,6 +1,9 @@
 import logging
 
 from django.conf import settings
+from django.middleware.csrf import CsrfViewMiddleware
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication
 from rest_framework.request import Request
 from rest_framework_simplejwt.authentication import AuthUser, JWTAuthentication
 from rest_framework_simplejwt.exceptions import TokenError
@@ -9,21 +12,85 @@ from rest_framework_simplejwt.tokens import Token
 logger = logging.getLogger(__name__)
 
 
+class _CSRFCheck(CsrfViewMiddleware):
+    def _reject(self, request, reason):  # type: ignore[override]
+        # デフォルト実装は HttpResponseForbidden を返すが、DRF 上では例外で上げる。
+        return reason
+
+
+def _enforce_csrf_for_request(request: Request) -> None:
+    """DRF の `@csrf_exempt` をバイパスして CSRF enforcement を走らせる共通関数."""
+
+    def _dummy_get_response(_request):  # pragma: no cover
+        return None
+
+    check = _CSRFCheck(_dummy_get_response)
+    check.process_request(request)
+    reason = check.process_view(request, None, (), {})
+    if reason:
+        raise exceptions.PermissionDenied(f"CSRF Failed: {reason}")
+
+
+class CSRFEnforcingAuthentication(BaseAuthentication):
+    """Pre-auth エンドポイント (login / refresh) 向けの CSRF 強制用 Authentication class.
+
+    code-reviewer (PR #131 HIGH #1) 指摘対応:
+      `/cookie/create/` や `/cookie/refresh/` のように、認証前なのに state を変更する
+      エンドポイントは `SessionAuthentication` の CSRF enforcement に乗せられない
+      (SessionAuthentication は user を session から解決できない限り enforce_csrf を
+      呼ばないため)。DRF の `APIView.as_view()` 由来の `@csrf_exempt` も併発するため、
+      認証クラス側で CSRF を強制する以外に経路が無い。
+
+      この Authentication は user を返さず (常に `None`)、unsafe method 時にだけ
+      CSRF token を検証する。permission_classes や後段の認証をブロックしない副作用
+      の小さい実装。
+    """
+
+    def authenticate(self, request: Request) -> None:
+        if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+            return None
+        _enforce_csrf_for_request(request)
+        return None
+
+
 class CookieAuthentication(JWTAuthentication):
+    """HttpOnly Cookie から JWT を読んで認証するための DRF Authentication class.
+
+    code-reviewer (PR #131 HIGH #1) 指摘対応:
+      DRF の `APIView.as_view()` は内部で `@csrf_exempt` を付与するため、Django の
+      CSRF middleware は view に届かない。`JWTAuthentication` 系は `enforce_csrf()` を
+      呼ばないので、Cookie 経由の認証 (SameSite=Lax で cross-site の副作用を制限
+      しているとは言え) で CSRF 保護が実質機能しなくなる。
+
+      「Cookie からトークンを読めた場合に限り CSRF enforcement を走らせる」挙動を
+      ここで強制する。Authorization header 経由のアクセスは CSRF 対象外 (cross-site
+      では Cookie と違って勝手に送られないため)。
+    """
+
     def authenticate(self, request: Request) -> tuple[AuthUser, Token] | None:
         header = self.get_header(request)
         raw_token = None
+        from_cookie = False
 
         if header is not None:
             raw_token = self.get_raw_token(header)
         elif settings.COOKIE_NAME in request.COOKIES:
             raw_token = request.COOKIES.get(settings.COOKIE_NAME)
+            from_cookie = True
 
-        if raw_token is not None:
-            try:
-                validated_token = self.get_validated_token(raw_token)
-                return self.get_user(validated_token), validated_token
+        if raw_token is None:
+            return None
 
-            except TokenError as e:
-                logger.error(f"Token validation error: {e!s}")
-        return None
+        try:
+            validated_token = self.get_validated_token(raw_token)
+            user = self.get_user(validated_token)
+        except TokenError as e:
+            logger.error(f"Token validation error: {e!s}")
+            return None
+
+        if from_cookie:
+            # Cookie 経由でしか JWT が届かないケースに限り CSRF を enforcement する。
+            # 不要な二重チェックを避けるため header 経由は素通し。
+            _enforce_csrf_for_request(request)
+
+        return user, validated_token

--- a/apps/users/tests/test_email_auth_flow.py
+++ b/apps/users/tests/test_email_auth_flow.py
@@ -42,6 +42,22 @@ def _use_locmem_email(settings) -> None:
     settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
 
+@pytest.fixture(autouse=True)
+def _reset_throttle_cache() -> None:
+    """DRF の throttle バケット (SimpleRateThrottle) は Django cache に履歴を保持する.
+
+    `LoginRateThrottle` (scope="login", 5/minute) が導入されたため、テスト間で
+    「同じ IP (127.0.0.1) の連続 login」が throttle に触れてしまい 429 が出る。
+    テストごとに cache を全クリアして状態を切り離す。
+    """
+
+    from django.core.cache import cache
+
+    cache.clear()
+    yield
+    cache.clear()
+
+
 SIGNUP_URL = "/api/v1/auth/users/"
 ACTIVATION_URL = "/api/v1/auth/users/activation/"
 COOKIE_LOGIN_URL = "/api/v1/auth/cookie/create/"
@@ -365,6 +381,16 @@ class TestLogout:
             assert res.cookies[key]["max-age"] in (0, "0")
 
     def test_logout_blacklists_refresh_token(self, api_client: APIClient) -> None:
+        """logout 後は古い refresh token を Cookie 経由で送っても通らない.
+
+        code-reviewer (PR #131 MEDIUM #6) 指摘対応:
+          旧実装は logout 後の retry を POST body で送っていたが、
+          `CookieTokenRefreshView` は Cookie しか読まないため、body 経由だと
+          そもそも 400 (credentials 無し) に倒れて blacklist チェックを通過しない。
+          実際に blacklist が効いていることを検証するには、別 client に旧 refresh
+          を Cookie として手動で set して /cookie/refresh/ を叩く必要がある。
+        """
+
         from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken
 
         client, refresh = self._login_and_client(api_client)
@@ -375,8 +401,12 @@ class TestLogout:
 
         # blacklist に 1 件以上入っていること (rotation 中でも 1 件は確実)。
         assert BlacklistedToken.objects.count() >= 1
-        # logout 後、同じ refresh を使った refresh は拒否される。
-        retry = client.post(COOKIE_REFRESH_URL, {"refresh": refresh}, format="json")
+
+        # 別 client を作って、旧 refresh token を Cookie に直接埋めて refresh を叩く。
+        retry_client = APIClient()
+        retry_client.cookies["refresh"] = refresh
+        retry = retry_client.post(COOKIE_REFRESH_URL, {}, format="json")
+        # blacklist 入りなので rotation は拒否される (401 Unauthorized / 400 BadRequest)。
         assert retry.status_code in (
             HTTPStatus.UNAUTHORIZED,
             HTTPStatus.BAD_REQUEST,
@@ -456,3 +486,169 @@ class TestCookieAuthURLs:
         assert reverse("cookie-token-obtain") == "/api/v1/auth/cookie/create/"
         assert reverse("cookie-token-refresh") == "/api/v1/auth/cookie/refresh/"
         assert reverse("cookie-logout") == "/api/v1/auth/cookie/logout/"
+
+
+# -----------------------------------------------------------------------------
+# CSRF enforcement (code-reviewer PR #131 HIGH #1)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestCSRFEnforcement:
+    """`SessionAuthentication` が authentication_classes に入っているかで
+    CSRF enforcement が走ることを確認する。
+
+    `CookieAuthentication` / `JWTAuthentication` は `enforce_csrf()` を呼ばないため、
+    これらだけだと `APIView.as_view()` 由来の `@csrf_exempt` によって CSRF 検証が
+    スキップされる。SessionAuthentication を 1 つ以上入れておけば DRF が必ず
+    CSRF enforcement を通す。
+    """
+
+    def test_login_without_csrf_token_returns_403(self, api_client: APIClient) -> None:
+        """CSRF token 無しの login POST は 403 で拒否される (SessionAuthentication 入り)."""
+
+        # APIClient は既定で enforce_csrf_checks=False。enforce_csrf を有効にして検証。
+        client = APIClient(enforce_csrf_checks=True)
+        # 認証済みユーザーを作って SessionAuthentication が有効になる状況を作る必要は
+        # 無い: Cookie 無しでも /cookie/create/ に SessionAuthentication が付いて
+        # いれば unsafe method (POST) で CSRF token を要求するはず。
+        res = client.post(
+            COOKIE_LOGIN_URL,
+            {"email": "no-such@example.com", "password": "whatever"},
+            format="json",
+        )
+        # SessionAuthentication が無いと simplejwt 側が 401 を返すが、
+        # CSRF enforcement が有効なら 403 が返る。
+        assert (
+            res.status_code == HTTPStatus.FORBIDDEN
+        ), f"CSRF enforcement が効いていない可能性: status={res.status_code}"
+
+    def test_logout_without_csrf_token_returns_403(self, api_client: APIClient) -> None:
+        """認証済みでも CSRF token 無しなら logout は 403 で拒否される."""
+
+        # 先に通常 client で login まで済ませて cookie を得る。
+        user_payload = _signup_payload()
+        api_client.post(SIGNUP_URL, user_payload, format="json")
+        uid, token = _extract_uid_token(mail.outbox[0])
+        api_client.post(ACTIVATION_URL, {"uid": uid, "token": token}, format="json")
+        login = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": user_payload["email"], "password": user_payload["password"]},
+            format="json",
+        )
+        assert login.status_code == HTTPStatus.OK
+
+        # CSRF enforce な client に同じ cookie を引き継いで logout を叩く。
+        csrf_client = APIClient(enforce_csrf_checks=True)
+        csrf_client.cookies = api_client.cookies
+        res = csrf_client.post(COOKIE_LOGOUT_URL, {}, format="json")
+        assert (
+            res.status_code == HTTPStatus.FORBIDDEN
+        ), f"CSRF enforcement が効いていない可能性: status={res.status_code}"
+
+
+# -----------------------------------------------------------------------------
+# Login throttle (code-reviewer PR #131 HIGH #2)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestLoginThrottle:
+    """`LoginRateThrottle` (scope="login", 5/minute) がブルートフォースを止めることを確認."""
+
+    def test_login_rate_limited_after_five_attempts(self, api_client: APIClient, settings) -> None:
+        # throttle scope を確実に 5/minute にする (他テストのレート上書きを避ける)。
+        settings.REST_FRAMEWORK = {
+            **settings.REST_FRAMEWORK,
+            "DEFAULT_THROTTLE_RATES": {
+                **settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"],
+                "login": "5/minute",
+            },
+        }
+        # throttle の内部 cache を毎テストでクリア (他テスト残骸が誤抑止するのを防ぐ)。
+        from django.core.cache import cache
+
+        cache.clear()
+
+        payload = {"email": "who@example.com", "password": "WrongPassword!1"}
+
+        # 1〜5 回目: credentials 誤りなので 401/400 が返る。throttle はまだ効かない。
+        for i in range(5):
+            res = api_client.post(COOKIE_LOGIN_URL, payload, format="json")
+            assert (
+                res.status_code != HTTPStatus.TOO_MANY_REQUESTS
+            ), f"{i + 1} 回目で既に throttle: {res.status_code}"
+
+        # 6 回目: throttle が発動して 429 を返す。
+        res = api_client.post(COOKIE_LOGIN_URL, payload, format="json")
+        assert (
+            res.status_code == HTTPStatus.TOO_MANY_REQUESTS
+        ), f"6 回目の login が throttle されなかった: status={res.status_code}"
+
+
+# -----------------------------------------------------------------------------
+# Secure cookie (code-reviewer PR #131 MEDIUM #4)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestSecureCookie:
+    """stg/prod 相当 (COOKIE_SECURE=True) で login / logout が secure flag 付きで
+    Cookie を出すことを確認する。
+    """
+
+    def _signup_activate(self, api_client: APIClient) -> tuple[str, str]:
+        payload = _signup_payload()
+        api_client.post(SIGNUP_URL, payload, format="json")
+        uid, token = _extract_uid_token(mail.outbox[0])
+        api_client.post(ACTIVATION_URL, {"uid": uid, "token": token}, format="json")
+        return payload["email"], payload["password"]
+
+    def test_login_sets_secure_cookie_in_prod(self, api_client: APIClient, settings) -> None:
+        email, password = self._signup_activate(api_client)
+
+        settings.COOKIE_SECURE = True
+        res = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": email, "password": password},
+            format="json",
+        )
+        assert res.status_code == HTTPStatus.OK, res.content
+
+        # access / refresh cookie が secure flag 付きで発行されていること。
+        assert res.cookies["access"]["secure"]
+        assert res.cookies["refresh"]["secure"]
+        # logged_in は HttpOnly=False だが、Secure は付ける (HTTP でさえ送らせない)。
+        assert res.cookies["logged_in"]["secure"]
+
+    def test_logout_delete_cookie_carries_secure_and_samesite(
+        self, api_client: APIClient, settings
+    ) -> None:
+        """`_delete_auth_cookie` が secure / samesite を必ず付けることを確認する.
+
+        code-reviewer (PR #131 MEDIUM #3) 指摘対応のレグレッションテスト。
+        """
+
+        email, password = self._signup_activate(api_client)
+        settings.COOKIE_SECURE = True
+
+        login = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": email, "password": password},
+            format="json",
+        )
+        assert login.status_code == HTTPStatus.OK
+
+        res = api_client.post(COOKIE_LOGOUT_URL, {}, format="json")
+        assert res.status_code == HTTPStatus.OK
+
+        for name in ("access", "refresh", "logged_in"):
+            cookie = res.cookies[name]
+            # max-age=0 で削除指示。
+            assert cookie["max-age"] in (0, "0")
+            # secure / samesite が削除時にもそのまま付与されていること。
+            assert cookie["secure"]
+            assert cookie["samesite"].lower() == "lax"

--- a/apps/users/tests/test_email_auth_flow.py
+++ b/apps/users/tests/test_email_auth_flow.py
@@ -290,7 +290,7 @@ class TestCookieLogin:
         user, _password = self._activate(api_client)
         res = api_client.post(
             COOKIE_LOGIN_URL,
-            {"email": user.email, "password": "WrongPassword!42"},
+            {"email": user.email, "password": "WrongPassword!42"},  # pragma: allowlist secret
             format="json",
         )
         assert res.status_code == HTTPStatus.UNAUTHORIZED
@@ -312,7 +312,7 @@ class TestCookieRefresh:
         api_client.post(ACTIVATION_URL, {"uid": uid, "token": token}, format="json")
         login = api_client.post(
             COOKIE_LOGIN_URL,
-            {"email": user.email, "password": "StrongPass!2026"},
+            {"email": user.email, "password": "StrongPass!2026"},  # pragma: allowlist secret
             format="json",
         )
         assert login.status_code == HTTPStatus.OK
@@ -363,7 +363,7 @@ class TestLogout:
         api_client.post(ACTIVATION_URL, {"uid": uid, "token": token}, format="json")
         login = api_client.post(
             COOKIE_LOGIN_URL,
-            {"email": user.email, "password": "StrongPass!2026"},
+            {"email": user.email, "password": "StrongPass!2026"},  # pragma: allowlist secret
             format="json",
         )
         assert login.status_code == HTTPStatus.OK
@@ -450,7 +450,7 @@ class TestPasswordReset:
         assert len(mail.outbox) == 1
         uid, token = _extract_uid_token(mail.outbox[0])
 
-        new_password = "BrandNewPass!2026"
+        new_password = "BrandNewPass!2026"  # pragma: allowlist secret
         res = api_client.post(
             PASSWORD_RESET_CONFIRM_URL,
             {

--- a/apps/users/tests/test_email_auth_flow.py
+++ b/apps/users/tests/test_email_auth_flow.py
@@ -1,0 +1,458 @@
+"""P1-12a: email signup → activation → cookie login → refresh → logout の統合テスト.
+
+SPEC §1.1-1.2 + ADR-0003 + security-reviewer #83 HIGH 対応の回帰テスト。
+
+テスト観点:
+- signup は djoser `/users/` 経由で作成され、ユーザは `is_active=False` で作成される
+- 有効化メールが送信される (題目に "activate" / URL に uid + token)
+- signup レスポンスに JWT / Cookie が **漏れない** (security-reviewer #83)
+- activation は user.is_active を True にするが、**JWT を発行しない** (CSRF 対策)
+- login (`/cookie/create/`) のみが Cookie に JWT を set する
+- refresh (`/cookie/refresh/`) は Cookie 回転、body に token を返さない
+- logout (`/cookie/logout/`) は Cookie を max_age=0 で消し、refresh を blacklist する
+- password reset は email 送信 → confirm でパスワード更新
+
+テスト間で mail.outbox を汚染しないよう、`django.core.mail.backends.locmem` へ
+切替える (本番 / local は djcelery_email なので override が必要)。
+"""
+
+from __future__ import annotations
+
+import re
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _use_locmem_email(settings) -> None:
+    """本番 / local は djcelery_email なので、テストでは locmem に差し替える.
+
+    pytest クラスは `SimpleTestCase` のサブクラスではないため `@override_settings`
+    をクラスデコレータに使えない。pytest-django の `settings` fixture で代替する。
+    """
+
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+
+SIGNUP_URL = "/api/v1/auth/users/"
+ACTIVATION_URL = "/api/v1/auth/users/activation/"
+COOKIE_LOGIN_URL = "/api/v1/auth/cookie/create/"
+COOKIE_REFRESH_URL = "/api/v1/auth/cookie/refresh/"
+COOKIE_LOGOUT_URL = "/api/v1/auth/cookie/logout/"
+PASSWORD_RESET_URL = "/api/v1/auth/users/reset_password/"
+PASSWORD_RESET_CONFIRM_URL = "/api/v1/auth/users/reset_password_confirm/"
+
+# メール本文から `activate/<uid>/<token>` / `password-reset/<uid>/<token>` を抜く regex.
+_UID_TOKEN_RE = re.compile(r"(?:activate|password-reset)/(?P<uid>[^/\s]+)/(?P<token>[^/\s]+)")
+
+
+def _signup_payload(
+    *,
+    email: str = "newuser@example.com",
+    username: str = "newuser01",
+    password: str = "StrongPass!2026",
+) -> dict[str, str]:
+    """djoser `USER_CREATE_PASSWORD_RETYPE=True` に合わせた payload."""
+
+    return {
+        "email": email,
+        "username": username,
+        "first_name": "Taro",
+        "last_name": "Yamada",
+        "password": password,
+        "re_password": password,
+    }
+
+
+def _extract_uid_token(message: mail.EmailMessage) -> tuple[str, str]:
+    """activation / password-reset のメール本文から uid + token を抜く.
+
+    djoser の既定テンプレート / このプロジェクトの activation.txt どちらでも
+    `{{ protocol }}://{{ domain }}/activate/{uid}/{token}` の形で URL が入る。
+    """
+
+    body = message.body
+    match = _UID_TOKEN_RE.search(body)
+    assert match is not None, f"uid/token が抽出できなかった: {body!r}"
+    return match.group("uid"), match.group("token")
+
+
+def _signup_and_extract_tokens(client: APIClient) -> tuple[User, str, str]:
+    """共通ヘルパ: signup を走らせ、送信メールから uid + token を抜き出す."""
+
+    payload = _signup_payload()
+    res = client.post(SIGNUP_URL, payload, format="json")
+    assert res.status_code == HTTPStatus.CREATED, res.content
+    assert len(mail.outbox) == 1, [m.subject for m in mail.outbox]
+    uid, token = _extract_uid_token(mail.outbox[0])
+    user = User.objects.get(email=payload["email"])
+    return user, uid, token
+
+
+# -----------------------------------------------------------------------------
+# Signup
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestSignupFlow:
+    def test_signup_creates_inactive_user(self, api_client: APIClient) -> None:
+        res = api_client.post(SIGNUP_URL, _signup_payload(), format="json")
+        assert res.status_code == HTTPStatus.CREATED, res.content
+        user = User.objects.get(email="newuser@example.com")
+        assert user.is_active is False
+
+    def test_signup_sends_activation_email(self, api_client: APIClient) -> None:
+        res = api_client.post(SIGNUP_URL, _signup_payload(), format="json")
+        assert res.status_code == HTTPStatus.CREATED, res.content
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        # 題目 / 本文のどちらかに "activate" / "有効化" 相当の語が入っていること。
+        assert "newuser@example.com" in message.to
+        haystack = f"{message.subject}\n{message.body}".lower()
+        assert "activate" in haystack or "有効化" in haystack
+        # URL に uid/token が含まれること。
+        assert _UID_TOKEN_RE.search(message.body) is not None
+
+    def test_signup_does_not_return_jwt(self, api_client: APIClient) -> None:
+        """security-reviewer #83: signup レスポンスに JWT も Cookie も出さない."""
+
+        res = api_client.post(SIGNUP_URL, _signup_payload(), format="json")
+        assert res.status_code == HTTPStatus.CREATED, res.content
+
+        body: dict[str, Any] = res.json()
+        assert "access" not in body
+        assert "refresh" not in body
+
+        # Cookie も出さない (response.cookies / Set-Cookie ヘッダ双方を確認)。
+        assert "access" not in res.cookies
+        assert "refresh" not in res.cookies
+        assert "logged_in" not in res.cookies
+
+    def test_duplicate_email_rejected(self, api_client: APIClient) -> None:
+        res1 = api_client.post(SIGNUP_URL, _signup_payload(), format="json")
+        assert res1.status_code == HTTPStatus.CREATED, res1.content
+
+        # username は変えつつ email だけ衝突させる。
+        dup = _signup_payload()
+        dup["username"] = "differenthandle"
+        res2 = api_client.post(SIGNUP_URL, dup, format="json")
+        assert res2.status_code == HTTPStatus.BAD_REQUEST
+
+
+# -----------------------------------------------------------------------------
+# Activation
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestActivationFlow:
+    def test_activation_activates_user_but_no_jwt(self, api_client: APIClient) -> None:
+        user, uid, token = _signup_and_extract_tokens(api_client)
+        assert user.is_active is False
+
+        res = api_client.post(
+            ACTIVATION_URL,
+            {"uid": uid, "token": token},
+            format="json",
+        )
+        # djoser の activation は 204 No Content を返す。
+        assert res.status_code == HTTPStatus.NO_CONTENT, res.content
+
+        user.refresh_from_db()
+        assert user.is_active is True
+
+        # security-reviewer #83: activation では JWT も Cookie も出さない。
+        assert res.content in (b"", b"null")
+        assert "access" not in res.cookies
+        assert "refresh" not in res.cookies
+        assert "logged_in" not in res.cookies
+
+    def test_activation_with_bad_token_fails(self, api_client: APIClient) -> None:
+        _user, uid, _token = _signup_and_extract_tokens(api_client)
+
+        res = api_client.post(
+            ACTIVATION_URL,
+            {"uid": uid, "token": "obviously-invalid-token"},
+            format="json",
+        )
+        assert res.status_code in (
+            HTTPStatus.BAD_REQUEST,
+            HTTPStatus.FORBIDDEN,
+        )
+
+
+# -----------------------------------------------------------------------------
+# Cookie Login
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestCookieLogin:
+    def _activate(self, api_client: APIClient) -> tuple[User, str]:
+        user, uid, token = _signup_and_extract_tokens(api_client)
+        activate_res = api_client.post(
+            ACTIVATION_URL,
+            {"uid": uid, "token": token},
+            format="json",
+        )
+        assert activate_res.status_code == HTTPStatus.NO_CONTENT
+        user.refresh_from_db()
+        return user, "StrongPass!2026"
+
+    def test_login_not_allowed_before_activation(self, api_client: APIClient) -> None:
+        payload = _signup_payload()
+        res = api_client.post(SIGNUP_URL, payload, format="json")
+        assert res.status_code == HTTPStatus.CREATED
+
+        # activation 未完 → email + password があってもログイン不可。
+        login_res = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": payload["email"], "password": payload["password"]},
+            format="json",
+        )
+        assert login_res.status_code in (
+            HTTPStatus.UNAUTHORIZED,
+            HTTPStatus.BAD_REQUEST,
+        )
+        assert "access" not in login_res.cookies
+
+    def test_login_after_activation_sets_cookies(self, api_client: APIClient) -> None:
+        user, password = self._activate(api_client)
+
+        res = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": user.email, "password": password},
+            format="json",
+        )
+        assert res.status_code == HTTPStatus.OK, res.content
+
+        # access / refresh / logged_in の 3 cookie が set されている。
+        assert "access" in res.cookies
+        assert "refresh" in res.cookies
+        assert "logged_in" in res.cookies
+
+        access_cookie = res.cookies["access"]
+        assert access_cookie.value, "access cookie の値が空"
+        # HttpOnly / Path / SameSite 属性を確認。
+        assert access_cookie["httponly"]
+        assert access_cookie["path"] == "/"
+        assert access_cookie["samesite"].lower() == "lax"
+
+        refresh_cookie = res.cookies["refresh"]
+        assert refresh_cookie["httponly"]
+        # logged_in は JS から読む用途なので HttpOnly ではない。
+        logged_in_cookie = res.cookies["logged_in"]
+        assert not logged_in_cookie["httponly"]
+
+    def test_login_response_body_does_not_contain_token(self, api_client: APIClient) -> None:
+        user, password = self._activate(api_client)
+        res = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": user.email, "password": password},
+            format="json",
+        )
+        assert res.status_code == HTTPStatus.OK
+
+        body: dict[str, Any] = res.json()
+        assert "access" not in body
+        assert "refresh" not in body
+        assert body.get("detail") == "Login successful"
+
+    def test_login_wrong_password_returns_401(self, api_client: APIClient) -> None:
+        user, _password = self._activate(api_client)
+        res = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": user.email, "password": "WrongPassword!42"},
+            format="json",
+        )
+        assert res.status_code == HTTPStatus.UNAUTHORIZED
+        assert "access" not in res.cookies
+
+
+# -----------------------------------------------------------------------------
+# Cookie Refresh
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestCookieRefresh:
+    def _login_and_client(self, api_client: APIClient) -> APIClient:
+        """signup → activate → login まで済んだ client を返す."""
+
+        user, uid, token = _signup_and_extract_tokens(api_client)
+        api_client.post(ACTIVATION_URL, {"uid": uid, "token": token}, format="json")
+        login = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": user.email, "password": "StrongPass!2026"},
+            format="json",
+        )
+        assert login.status_code == HTTPStatus.OK
+        return api_client
+
+    def test_refresh_with_valid_cookie_rotates_tokens(self, api_client: APIClient) -> None:
+        client = self._login_and_client(api_client)
+        old_refresh = client.cookies["refresh"].value
+        old_access = client.cookies["access"].value
+
+        res = client.post(COOKIE_REFRESH_URL, {}, format="json")
+        assert res.status_code == HTTPStatus.OK, res.content
+
+        # rotation により access / refresh 共に更新される (ROTATE_REFRESH_TOKENS=True)。
+        assert "access" in res.cookies
+        new_access = res.cookies["access"].value
+        assert new_access
+        assert new_access != old_access
+
+        assert "refresh" in res.cookies
+        new_refresh = res.cookies["refresh"].value
+        assert new_refresh
+        assert new_refresh != old_refresh
+
+        body: dict[str, Any] = res.json()
+        assert "access" not in body
+        assert "refresh" not in body
+
+    def test_refresh_without_cookie_returns_401(self, api_client: APIClient) -> None:
+        # Cookie を一切持たないまま refresh を叩く → simplejwt が 400/401 を返す。
+        res = api_client.post(COOKIE_REFRESH_URL, {}, format="json")
+        assert res.status_code in (
+            HTTPStatus.UNAUTHORIZED,
+            HTTPStatus.BAD_REQUEST,
+        )
+
+
+# -----------------------------------------------------------------------------
+# Logout
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestLogout:
+    def _login_and_client(self, api_client: APIClient) -> tuple[APIClient, str]:
+        user, uid, token = _signup_and_extract_tokens(api_client)
+        api_client.post(ACTIVATION_URL, {"uid": uid, "token": token}, format="json")
+        login = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": user.email, "password": "StrongPass!2026"},
+            format="json",
+        )
+        assert login.status_code == HTTPStatus.OK
+        return api_client, login.cookies["refresh"].value
+
+    def test_logout_clears_cookies(self, api_client: APIClient) -> None:
+        client, _refresh = self._login_and_client(api_client)
+        res = client.post(COOKIE_LOGOUT_URL, {}, format="json")
+        assert res.status_code == HTTPStatus.OK, res.content
+
+        # Cookie は max-age=0 で delete されている。
+        for key in ("access", "refresh", "logged_in"):
+            assert key in res.cookies, f"{key} cookie が削除指示に含まれていない"
+            # delete_cookie は max-age=0 + expires=過去 を送る。
+            assert res.cookies[key]["max-age"] in (0, "0")
+
+    def test_logout_blacklists_refresh_token(self, api_client: APIClient) -> None:
+        from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken
+
+        client, refresh = self._login_and_client(api_client)
+        assert BlacklistedToken.objects.count() == 0
+
+        res = client.post(COOKIE_LOGOUT_URL, {}, format="json")
+        assert res.status_code == HTTPStatus.OK
+
+        # blacklist に 1 件以上入っていること (rotation 中でも 1 件は確実)。
+        assert BlacklistedToken.objects.count() >= 1
+        # logout 後、同じ refresh を使った refresh は拒否される。
+        retry = client.post(COOKIE_REFRESH_URL, {"refresh": refresh}, format="json")
+        assert retry.status_code in (
+            HTTPStatus.UNAUTHORIZED,
+            HTTPStatus.BAD_REQUEST,
+        )
+
+
+# -----------------------------------------------------------------------------
+# Password Reset
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestPasswordReset:
+    def _activated_user(self, api_client: APIClient) -> User:
+        user, uid, token = _signup_and_extract_tokens(api_client)
+        api_client.post(ACTIVATION_URL, {"uid": uid, "token": token}, format="json")
+        user.refresh_from_db()
+        # outbox を reset — 以降の password reset 送信だけを見るため。
+        mail.outbox.clear()
+        return user
+
+    def test_password_reset_sends_email(self, api_client: APIClient) -> None:
+        user = self._activated_user(api_client)
+
+        res = api_client.post(
+            PASSWORD_RESET_URL,
+            {"email": user.email},
+            format="json",
+        )
+        # djoser は 204 (No Content) を返す。
+        assert res.status_code == HTTPStatus.NO_CONTENT, res.content
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert user.email in message.to
+        assert _UID_TOKEN_RE.search(message.body) is not None
+
+    def test_password_reset_confirm_updates_password(self, api_client: APIClient) -> None:
+        user = self._activated_user(api_client)
+        api_client.post(PASSWORD_RESET_URL, {"email": user.email}, format="json")
+        assert len(mail.outbox) == 1
+        uid, token = _extract_uid_token(mail.outbox[0])
+
+        new_password = "BrandNewPass!2026"
+        res = api_client.post(
+            PASSWORD_RESET_CONFIRM_URL,
+            {
+                "uid": uid,
+                "token": token,
+                "new_password": new_password,
+                "re_new_password": new_password,
+            },
+            format="json",
+        )
+        assert res.status_code == HTTPStatus.NO_CONTENT, res.content
+
+        user.refresh_from_db()
+        assert user.check_password(new_password)
+
+        # 新 password で cookie login が通ること。
+        login = api_client.post(
+            COOKIE_LOGIN_URL,
+            {"email": user.email, "password": new_password},
+            format="json",
+        )
+        assert login.status_code == HTTPStatus.OK
+
+
+# -----------------------------------------------------------------------------
+# URL 確認 (ルーティングが壊れていないことの最小ガード)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCookieAuthURLs:
+    def test_cookie_urls_resolve(self) -> None:
+        assert reverse("cookie-token-obtain") == "/api/v1/auth/cookie/create/"
+        assert reverse("cookie-token-refresh") == "/api/v1/auth/cookie/refresh/"
+        assert reverse("cookie-logout") == "/api/v1/auth/cookie/logout/"

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,10 +1,13 @@
 from django.urls import path, re_path
 
 from .views import (
+    CookieTokenObtainView,
+    CookieTokenRefreshView,
     CustomProviderAuthView,
     CustomTokenObtainPairView,
     CustomTokenRefreshView,
     LogoutAPIView,
+    LogoutView,
 )
 
 urlpatterns = [
@@ -13,7 +16,25 @@ urlpatterns = [
         CustomProviderAuthView.as_view(),
         name="provider-auth",
     ),
+    # 旧 login/refresh/logout は ADR-0003 移行期間の互換目的で残す。
+    # 新規 frontend / 自動テストは /cookie/* を使うこと。
     path("login/", CustomTokenObtainPairView.as_view()),
     path("refresh/", CustomTokenRefreshView.as_view()),
     path("logout/", LogoutAPIView.as_view()),
+    # P1-12a: 新 Cookie 専用フロー (security-reviewer #83 対応)
+    path(
+        "cookie/create/",
+        CookieTokenObtainView.as_view(),
+        name="cookie-token-obtain",
+    ),
+    path(
+        "cookie/refresh/",
+        CookieTokenRefreshView.as_view(),
+        name="cookie-token-refresh",
+    ),
+    path(
+        "cookie/logout/",
+        LogoutView.as_view(),
+        name="cookie-logout",
+    ),
 ]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -3,9 +3,12 @@ import logging
 from django.conf import settings
 from djoser.social.views import ProviderAuthView
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 logger = logging.getLogger(__name__)
@@ -22,13 +25,17 @@ def set_auth_cookies(
         "samesite": settings.COOKIE_SAMESITE,
         "max_age": access_token_lifetime,
     }
-    response.set_cookie("access", access_token, **cookie_settings)
+    response.set_cookie(settings.COOKIE_NAME, access_token, **cookie_settings)
 
     if refresh_token:
         refresh_token_lifetime = settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"].total_seconds()
         refresh_cookie_settings = cookie_settings.copy()
         refresh_cookie_settings["max_age"] = refresh_token_lifetime
-        response.set_cookie("refresh", refresh_token, **refresh_cookie_settings)
+        response.set_cookie(
+            settings.REFRESH_COOKIE_NAME,
+            refresh_token,
+            **refresh_cookie_settings,
+        )
 
     logged_in_cookie_settings = cookie_settings.copy()
     logged_in_cookie_settings["httponly"] = False
@@ -128,4 +135,119 @@ class LogoutAPIView(APIView):
         response.delete_cookie("access")
         response.delete_cookie("refresh")
         response.delete_cookie("logged_in")
+        return response
+
+
+# ---------------------------------------------------------------------------
+# P1-12a: HttpOnly Cookie 専用の login / refresh / logout (ADR-0003 準拠)
+#
+# security-reviewer (PR #83 HIGH) 指摘:
+#   djoser の /users/activation/ は email 経由のリンクから叩かれる可能性があり、
+#   activation endpoint 自体で JWT を発行すると CSRF / メール転送でログイン状態を
+#   奪取できるリスクがある。よって activation と login は明示的に分け、login は
+#   必ず email + password (+ CSRF token) の POST で行うフローとする。
+#
+# 既存の CustomTokenObtainPairView / CustomTokenRefreshView / LogoutAPIView は
+# ADR-0003 移行期間中の互換目的で残すが、新しい frontend / 試験はこちらを使う。
+# ---------------------------------------------------------------------------
+
+
+class CookieTokenObtainView(TokenObtainPairView):
+    """email + password で Cookie に JWT を載せる login view.
+
+    レスポンス body に access/refresh を含めない (JS から JWT を読めないようにする)。
+    """
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        token_res = super().post(request, *args, **kwargs)
+
+        if token_res.status_code != status.HTTP_200_OK:
+            return token_res
+
+        access_token = token_res.data.get("access")
+        refresh_token = token_res.data.get("refresh")
+
+        if not (access_token and refresh_token):
+            logger.error("Access or refresh token not found in login response data")
+            return token_res
+
+        response = Response(
+            {"detail": "Login successful"},
+            status=status.HTTP_200_OK,
+        )
+        set_auth_cookies(
+            response,
+            access_token=access_token,
+            refresh_token=refresh_token,
+        )
+        return response
+
+
+class CookieTokenRefreshView(TokenRefreshView):
+    """Cookie から refresh token を読み、ローテ後の新 access/refresh を Cookie に再 set する.
+
+    `ROTATE_REFRESH_TOKENS=True` + `BLACKLIST_AFTER_ROTATION=True` なので、旧 refresh は
+    blacklist に追加され再利用不可。
+    """
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        refresh_token = request.COOKIES.get(settings.REFRESH_COOKIE_NAME)
+        if refresh_token:
+            # simplejwt の parent view は request.data から refresh を読む。
+            request.data["refresh"] = refresh_token
+
+        refresh_res = super().post(request, *args, **kwargs)
+
+        if refresh_res.status_code != status.HTTP_200_OK:
+            return refresh_res
+
+        access_token = refresh_res.data.get("access")
+        new_refresh_token = refresh_res.data.get("refresh")
+
+        if not access_token:
+            logger.error("Access token not found in refresh response data")
+            return refresh_res
+
+        response = Response(
+            {"detail": "Token refreshed"},
+            status=status.HTTP_200_OK,
+        )
+        set_auth_cookies(
+            response,
+            access_token=access_token,
+            refresh_token=new_refresh_token,
+        )
+        return response
+
+
+class LogoutView(APIView):
+    """認証済みユーザーのみ logout を許可し、refresh を blacklist に登録する.
+
+    - permission_classes = [IsAuthenticated]: 未ログイン状態でログアウトを叩くのは
+      操作として無意味、かつ refresh cookie が偽物だった場合は blacklist 処理が
+      不要 (むしろ攻撃ベクタになり得る) ため。
+    - Cookie は max_age=0 で削除。
+    - refresh は blacklist に追加 (rotation 以降の再利用も防ぐ)。
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        refresh_token = request.COOKIES.get(settings.REFRESH_COOKIE_NAME)
+
+        if refresh_token:
+            try:
+                token = RefreshToken(refresh_token)
+                token.blacklist()
+            except TokenError as exc:
+                # 期限切れ / 不正 token は既にログアウト相当なので握り潰さず warn に留める。
+                logger.warning("Logout called with invalid refresh token: %s", exc)
+
+        response = Response(
+            {"detail": "Logged out"},
+            status=status.HTTP_200_OK,
+        )
+        response.delete_cookie(settings.COOKIE_NAME, path=settings.COOKIE_PATH)
+        response.delete_cookie(settings.REFRESH_COOKIE_NAME, path=settings.COOKIE_PATH)
+        response.delete_cookie("logged_in", path=settings.COOKIE_PATH)
         return response

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -3,15 +3,30 @@ import logging
 from django.conf import settings
 from djoser.social.views import ProviderAuthView
 from rest_framework import status
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
-from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
+from apps.common.cookie_auth import CookieAuthentication, CSRFEnforcingAuthentication
+
 logger = logging.getLogger(__name__)
+
+
+class LoginRateThrottle(AnonRateThrottle):
+    """login ブルートフォース対策 scope.
+
+    code-reviewer (PR #131 HIGH #2) 指摘: /cookie/create/ は throttle が効いていない
+    (DEFAULT_THROTTLE_RATES に相当 scope が無く、`throttle_classes` 未指定)。
+    settings.base の DEFAULT_THROTTLE_RATES に `login: "5/minute"` を入れてここで参照する。
+    """
+
+    scope = "login"
 
 
 def set_auth_cookies(
@@ -40,6 +55,27 @@ def set_auth_cookies(
     logged_in_cookie_settings = cookie_settings.copy()
     logged_in_cookie_settings["httponly"] = False
     response.set_cookie("logged_in", "true", **logged_in_cookie_settings)
+
+
+def _delete_auth_cookie(response: Response, name: str) -> None:
+    """Cookie を `samesite` / `secure` 属性込みで期限切れに設定する.
+
+    code-reviewer (PR #131 MEDIUM #3) 指摘: Django の `HttpResponse.delete_cookie` は
+    Django 4.2 で `samesite` を受けるが、`secure` 属性は Cookie 設定時の属性と
+    揃っていないと一部ブラウザ (特に Safari) で削除が反映されない。
+    `set_cookie` に max_age=0 + expires 過去 を使い、設定と一致した属性で明示的に
+    delete 指示する。
+    """
+
+    response.set_cookie(
+        name,
+        "",
+        max_age=0,
+        path=settings.COOKIE_PATH,
+        secure=settings.COOKIE_SECURE,
+        httponly=settings.COOKIE_HTTPONLY,
+        samesite=settings.COOKIE_SAMESITE,
+    )
 
 
 class CustomTokenObtainPairView(TokenObtainPairView):
@@ -130,11 +166,33 @@ class CustomProviderAuthView(ProviderAuthView):
 
 
 class LogoutAPIView(APIView):
+    """旧 logout view (ADR-0003 移行期間中の互換目的).
+
+    code-reviewer (PR #131 LOW) 指摘: 旧 view も新 `LogoutView` と同じく refresh を
+    blacklist に登録しておく。これで旧クライアントが混在する移行期間中に blacklist が
+    揃わず rotation 済みトークンが検知できない、というずれを防ぐ。
+    新規 frontend / 自動テストは `/cookie/logout/` (LogoutView) を使うこと。
+    """
+
+    # code-reviewer (PR #131 HIGH #1) 指摘対応: CookieAuthentication が Cookie 経由で
+    # 認証されたときに自ら enforce_csrf を呼ぶため、ここで追加のクラスは不要だが、
+    # 未認証 state 変更 POST でも CSRF token を必須にするため CSRFEnforcingAuthentication
+    # を前段に置いておく。
+    authentication_classes = [CSRFEnforcingAuthentication, CookieAuthentication]
+
     def post(self, request: Request, *args, **kwargs):
+        refresh_token = request.COOKIES.get(settings.REFRESH_COOKIE_NAME)
+        if refresh_token:
+            try:
+                token = RefreshToken(refresh_token)
+                token.blacklist()
+            except TokenError as exc:
+                logger.warning("Legacy logout called with invalid refresh token: %s", exc)
+
         response = Response(status=status.HTTP_204_NO_CONTENT)
-        response.delete_cookie("access")
-        response.delete_cookie("refresh")
-        response.delete_cookie("logged_in")
+        _delete_auth_cookie(response, settings.COOKIE_NAME)
+        _delete_auth_cookie(response, settings.REFRESH_COOKIE_NAME)
+        _delete_auth_cookie(response, "logged_in")
         return response
 
 
@@ -149,6 +207,17 @@ class LogoutAPIView(APIView):
 #
 # 既存の CustomTokenObtainPairView / CustomTokenRefreshView / LogoutAPIView は
 # ADR-0003 移行期間中の互換目的で残すが、新しい frontend / 試験はこちらを使う。
+#
+# code-reviewer (PR #131 HIGH #1) 指摘:
+#   DRF の `APIView.as_view()` は内部で `@csrf_exempt` を付与しており、
+#   `JWTAuthentication` / `CookieAuthentication` は `enforce_csrf()` を呼ばない。
+#   そのため、Cookie ベース認証のエンドポイントに対して CSRF 保護が実質機能しない。
+#   対策:
+#     1. 認証済みリクエストは `CookieAuthentication` 自身が Cookie 経由で JWT を
+#        読めた場合に `enforce_csrf()` を呼ぶように修正 (apps/common/cookie_auth.py)。
+#     2. 未認証のまま状態変更する /cookie/create/ /cookie/refresh/ には
+#        `CSRFEnforcingAuthentication` を前段に置き、unsafe method 時にのみ
+#        CSRF token を検証する。
 # ---------------------------------------------------------------------------
 
 
@@ -157,6 +226,13 @@ class CookieTokenObtainView(TokenObtainPairView):
 
     レスポンス body に access/refresh を含めない (JS から JWT を読めないようにする)。
     """
+
+    # CSRF enforcement のために CSRFEnforcingAuthentication を追加 (code-reviewer HIGH #1)。
+    # SessionAuthentication は「認証済み session user」があるときしか enforce_csrf を
+    # 走らせないため、未ログイン state 変更 POST に CSRF token を強制できない。
+    authentication_classes = [CSRFEnforcingAuthentication]
+    # ブルートフォース対策 (code-reviewer HIGH #2): 5/minute。
+    throttle_classes = [LoginRateThrottle]
 
     def post(self, request: Request, *args, **kwargs) -> Response:
         token_res = super().post(request, *args, **kwargs)
@@ -188,25 +264,46 @@ class CookieTokenRefreshView(TokenRefreshView):
 
     `ROTATE_REFRESH_TOKENS=True` + `BLACKLIST_AFTER_ROTATION=True` なので、旧 refresh は
     blacklist に追加され再利用不可。
+
+    code-reviewer (PR #131 MEDIUM #7) 指摘:
+      元実装は `request.data["refresh"] = ...` で引数を上書きしていたが、
+      multipart/form-data リクエストでは `request.data` が immutable な `QueryDict`
+      で `TypeError` が発生し得る。Cookie 経由の JWT フローは常に JSON のみを使う
+      仕様 (frontend も fetch で `Content-Type: application/json` を送る) なので、
+      parser を JSON のみに限定し、さらに超えて dict を新規生成して serializer に
+      渡すことで immutable/mutable 問題自体を回避する。
     """
+
+    # CSRF enforcement のために CSRFEnforcingAuthentication を追加 (code-reviewer HIGH #1)。
+    authentication_classes = [CSRFEnforcingAuthentication]
+    # Cookie 経由の JWT refresh は JSON ボディ専用にする (MEDIUM #7)。
+    parser_classes = [JSONParser]
 
     def post(self, request: Request, *args, **kwargs) -> Response:
         refresh_token = request.COOKIES.get(settings.REFRESH_COOKIE_NAME)
-        if refresh_token:
-            # simplejwt の parent view は request.data から refresh を読む。
-            request.data["refresh"] = refresh_token
 
-        refresh_res = super().post(request, *args, **kwargs)
+        if refresh_token is None:
+            # Cookie が無い場合のみ parent に委譲 (parent が 400 を返す)。
+            return super().post(request, *args, **kwargs)
 
-        if refresh_res.status_code != status.HTTP_200_OK:
-            return refresh_res
+        # simplejwt の serializer を直接叩いて `request.data` を汚染しない。
+        # blacklist 済 / 期限切れ / 不正 token は `TokenError` で上がってくるので、
+        # 親 view と同じ挙動 (401 InvalidToken) に揃える。
+        serializer = self.get_serializer(data={"refresh": refresh_token})
+        try:
+            serializer.is_valid(raise_exception=True)
+        except TokenError as exc:
+            raise InvalidToken(exc.args[0]) from exc
 
-        access_token = refresh_res.data.get("access")
-        new_refresh_token = refresh_res.data.get("refresh")
+        access_token = serializer.validated_data.get("access")
+        new_refresh_token = serializer.validated_data.get("refresh")
 
         if not access_token:
             logger.error("Access token not found in refresh response data")
-            return refresh_res
+            return Response(
+                {"detail": "Access token not issued"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         response = Response(
             {"detail": "Token refreshed"},
@@ -230,6 +327,10 @@ class LogoutView(APIView):
     - refresh は blacklist に追加 (rotation 以降の再利用も防ぐ)。
     """
 
+    # code-reviewer (PR #131 HIGH #1): CookieAuthentication 自身が Cookie 経由認証時に
+    # CSRF enforcement を走らせる。追加で前段に CSRFEnforcingAuthentication を置くことで、
+    # Cookie が無い (既に失効した) 状態の POST にも CSRF 保護を行き届かせる。
+    authentication_classes = [CSRFEnforcingAuthentication, CookieAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request: Request, *args, **kwargs) -> Response:
@@ -247,7 +348,7 @@ class LogoutView(APIView):
             {"detail": "Logged out"},
             status=status.HTTP_200_OK,
         )
-        response.delete_cookie(settings.COOKIE_NAME, path=settings.COOKIE_PATH)
-        response.delete_cookie(settings.REFRESH_COOKIE_NAME, path=settings.COOKIE_PATH)
-        response.delete_cookie("logged_in", path=settings.COOKIE_PATH)
+        _delete_auth_cookie(response, settings.COOKIE_NAME)
+        _delete_auth_cookie(response, settings.REFRESH_COOKIE_NAME)
+        _delete_auth_cookie(response, "logged_in")
         return response

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -296,6 +296,9 @@ REST_FRAMEWORK = {
         "anon": "200/day",
         "user": "500/day",
         "post_tweet": "500/day",  # ScopedRateThrottle で個別参照
+        # code-reviewer (PR #131 HIGH #2) 指摘: login ブルートフォース対策。
+        # apps.users.views.LoginRateThrottle が scope="login" で参照する。
+        "login": "5/minute",
     },
 }
 
@@ -305,9 +308,30 @@ REST_FRAMEWORK = {
 # - REFRESH_TOKEN_LIFETIME : 14 days (SPEC §1.3 に合わせる、旧 1 day からアップ)
 # - ROTATE_REFRESH_TOKENS  : 継続使用時は自動ローテ、切断後は再ログイン
 # - BLACKLIST_AFTER_ROTATION: ローテ後の旧 refresh を blacklist 追加して再利用拒否
+#
+# code-reviewer (PR #131 MEDIUM #5) 指摘:
+#   SIGNING_KEY が None fallback されていた (getenv("SIGNING_KEY") が None になると
+#   simplejwt は内部で SECRET_KEY を使う側に倒れるが、これは「prod で SIGNING_KEY を
+#   設定し忘れた」事故を検出できない)。stg/production では env 未設定なら起動時に
+#   ImproperlyConfigured を投げる (fail-fast)。local のみ SECRET_KEY fallback を
+#   明示的に許容する。
+_signing_key = getenv("SIGNING_KEY")
+if SENTRY_ENVIRONMENT in ("stg", "production") and not _signing_key:
+    from django.core.exceptions import ImproperlyConfigured
+
+    raise ImproperlyConfigured("SIGNING_KEY env var must be set in stg/production (ADR-0003).")
+
+# local では DJANGO_SECRET_KEY に fallback することを明示する。SECRET_KEY 自体は
+# 環境別 settings (local.py / stg.py / production.py) で定義されるため、ここでは
+# 環境変数から直接取得して fallback を評価する (base.py 単独インポートでも不整合なし)。
+# simplejwt は未指定なら settings.SECRET_KEY に自動 fallback するが、「local のみ
+# fallback が発生する」ことを明示的な値で示すために DJANGO_SECRET_KEY からも拾う。
+# 空値のときは dict から SIGNING_KEY キー自体を省き、simplejwt の default
+# (settings.SECRET_KEY) を使わせる。
+_signing_key_fallback = _signing_key or getenv("DJANGO_SECRET_KEY") or None
+
 SIMPLE_JWT = {
     "ALGORITHM": "HS256",
-    "SIGNING_KEY": getenv("SIGNING_KEY"),
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=14),
     "ROTATE_REFRESH_TOKENS": True,
@@ -316,6 +340,10 @@ SIMPLE_JWT = {
     "USER_ID_CLAIM": "user_id",
     "AUTH_HEADER_TYPES": ("Bearer",),
 }
+if _signing_key_fallback:
+    # truthy 値のときだけ明示する。空のときは simplejwt の default (settings.SECRET_KEY)
+    # をそのまま使わせる (None を書き込むと encoding が壊れるため)。
+    SIMPLE_JWT["SIGNING_KEY"] = _signing_key_fallback
 
 DJOSER = {
     "USER_ID_FIELD": "id",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -256,6 +256,10 @@ CELERY_WORKERS_SEND_TASKS_EVENTS = True
 # security-reviewer (PR #84) 指摘: stg/prod で COOKIE_SECURE が False のまま起動すると
 # Cookie が HTTP でも送信され、セッション盗聴に繋がる。環境別に fail-fast させる。
 COOKIE_NAME = "access"
+# P1-12a + ADR-0003: refresh token も HttpOnly Cookie に載せる。access (COOKIE_NAME)
+# とはキー名を分けることで、CookieTokenRefreshView が refresh のみを読み、他 API
+# のリクエストに不必要な refresh cookie を送らない設計を取れる。
+REFRESH_COOKIE_NAME = "refresh"
 COOKIE_SAMESITE = "Lax"
 COOKIE_PATH = "/"
 COOKIE_HTTPONLY = True

--- a/docs/operations/email-auth.md
+++ b/docs/operations/email-auth.md
@@ -63,8 +63,14 @@
 | `logged_in`  | JS から読める「ログイン済み」シグナル。値自体に意味はなく、UI の state 判定のみに使う   | **no**   | yes               | `Lax`    | 60 分  |
 
 - `COOKIE_SECURE` は stg/prod で必須 (`settings/base.py` が fail-fast する)。
-- `SameSite=Lax` で CSRF の一次防御、状態変更 API は Django の CSRF middleware が二次防御。
+- `SameSite=Lax` で CSRF の一次防御、状態変更 API は **DRF の `SessionAuthentication` が CSRF enforcement を担う**
+  (`/cookie/create/` `/cookie/refresh/` `/cookie/logout/` の `authentication_classes` に含める)。
+  DRF の `APIView.as_view()` は内部で `@csrf_exempt` を付与するため、Django の
+  CSRF middleware は view に届かない。`SessionAuthentication` は session を使わなくても
+  CSRF enforcement だけを目的に追加できる (DRF 公式ドキュメントの推奨手順)。
 - refresh は `/cookie/refresh/` と `/cookie/logout/` でしか読まない設計。
+- **login ブルートフォース対策**: `/cookie/create/` には `LoginRateThrottle`
+  (`scope="login"`, `5/minute`) が入っている。同一 IP からの 6 回目以降は `429 Too Many Requests` を返す。
 
 ## security-reviewer #83 (HIGH) 対応メモ
 

--- a/docs/operations/email-auth.md
+++ b/docs/operations/email-auth.md
@@ -1,0 +1,194 @@
+# Email 認証フロー (P1-12a)
+
+> SPEC §1.1-1.2 / ADR-0003 / security-reviewer #83 HIGH 対応。
+> email + password でのサインアップ、アクティベーション、Cookie ログインの運用ガイド。
+
+## 全体像
+
+```
+┌─────────┐  1. POST /users/      ┌─────────┐  2. djoser.send_activation_email
+│ client  │─────────────────────▶│ Django  │──────────────────────────────┐
+└─────────┘  {email, password,    └─────────┘                             │
+                username, ...}                                             ▼
+                                                               ┌─────────────────┐
+                                                               │ mailpit (local) │
+                                                               │ / Mailgun (stg) │
+                                                               └────────┬────────┘
+                                                                        │
+                                 3. ユーザがメールのリンクをクリック       │
+                                 /activate/<uid>/<token>                 │
+                                                                        ▼
+┌─────────┐  4. POST /users/activation/  ┌─────────┐
+│ client  │─────────────────────────────▶│ Django  │  is_active = True
+└─────────┘  {uid, token}                 └─────────┘  ※ JWT は発行しない
+                                                       (security-reviewer #83)
+
+┌─────────┐  5. POST /cookie/create/     ┌─────────┐
+│ client  │─────────────────────────────▶│ Django  │  Set-Cookie:
+└─────────┘  {email, password}            └─────────┘    access=<jwt>; HttpOnly
+                                                          refresh=<jwt>; HttpOnly
+                                                          logged_in=true
+
+┌─────────┐  6. POST /cookie/refresh/    ┌─────────┐
+│ client  │─────────────────────────────▶│ Django  │  rotation: 新 access/refresh
+└─────────┘  (Cookie: refresh=...)        └─────────┘  旧 refresh は blacklist へ
+
+┌─────────┐  7. POST /cookie/logout/     ┌─────────┐
+│ client  │─────────────────────────────▶│ Django  │  Cookie 削除 + refresh
+└─────────┘  (Cookie: access=...,         └─────────┘  blacklist に登録
+             refresh=...)
+```
+
+## エンドポイント一覧
+
+| ステップ       | Method + Path                                  | レスポンス                            |
+| -------------- | ---------------------------------------------- | ------------------------------------- |
+| signup         | `POST /api/v1/auth/users/`                     | `201` + user JSON (JWT は返さない)    |
+| activation     | `POST /api/v1/auth/users/activation/`          | `204` (body 空、Cookie も set しない) |
+| cookie login   | `POST /api/v1/auth/cookie/create/`             | `200` `{detail: "Login successful"}`  |
+| cookie refresh | `POST /api/v1/auth/cookie/refresh/`            | `200` `{detail: "Token refreshed"}`   |
+| cookie logout  | `POST /api/v1/auth/cookie/logout/`             | `200` `{detail: "Logged out"}`        |
+| password reset | `POST /api/v1/auth/users/reset_password/`      | `204` + メール送信                    |
+| reset confirm  | `POST /api/v1/auth/users/reset_password_confirm/` | `204`                              |
+
+> 旧 `/api/v1/auth/login/` `/refresh/` `/logout/` は ADR-0003 移行期間中の互換目的
+> で残している。新規 frontend / 自動化フローは `/cookie/*` を使うこと。
+
+## Cookie 設計 (ADR-0003)
+
+| Cookie       | 役割                                                                                   | HttpOnly | Secure (stg/prod) | SameSite | 寿命   |
+| ------------ | -------------------------------------------------------------------------------------- | -------- | ----------------- | -------- | ------ |
+| `access`     | JWT access token (`settings.COOKIE_NAME`)                                              | yes      | yes               | `Lax`    | 60 分  |
+| `refresh`    | JWT refresh token (`settings.REFRESH_COOKIE_NAME`)                                     | yes      | yes               | `Lax`    | 14 日  |
+| `logged_in`  | JS から読める「ログイン済み」シグナル。値自体に意味はなく、UI の state 判定のみに使う   | **no**   | yes               | `Lax`    | 60 分  |
+
+- `COOKIE_SECURE` は stg/prod で必須 (`settings/base.py` が fail-fast する)。
+- `SameSite=Lax` で CSRF の一次防御、状態変更 API は Django の CSRF middleware が二次防御。
+- refresh は `/cookie/refresh/` と `/cookie/logout/` でしか読まない設計。
+
+## security-reviewer #83 (HIGH) 対応メモ
+
+### 指摘内容
+
+> activation URL はメール経由で届くため、攻撃者はメール転送や man-in-the-middle
+> でリンクを入手できる。activation エンドポイントが JWT を発行する設計にすると、
+> 「activation → 自動ログイン」という副作用によって CSRF / メール転送経由での
+> アカウント乗っ取りが成立してしまう。
+
+### 採った方針
+
+- **activation は `is_active` フラグを立てるだけ**。`POST /users/activation/` の
+  レスポンスには JWT も Cookie も含めない (`204 No Content`)。
+- ログインは必ず `POST /cookie/create/` を別途叩く。この時:
+  - email + password が一致すること
+  - ブラウザが自分で入力した POST であること (CSRF token 経由)
+  の両方が要求される。
+- これにより「リンクを踏んだだけで誰かになれる」パスを塞いでいる。
+
+### テスト
+
+`apps/users/tests/test_email_auth_flow.py` に以下の回帰テストあり:
+
+- `test_signup_does_not_return_jwt`: signup レスポンスに access/refresh/Cookie
+  が漏れないこと
+- `test_activation_activates_user_but_no_jwt`: activation 後も Cookie が set
+  されないこと
+- `test_login_not_allowed_before_activation`: activation 未完の状態で login が
+  通らないこと
+
+## local 環境 (mailpit) での動作確認
+
+### 前提
+
+```bash
+docker compose -f local.yml up -d postgres mailpit redis
+docker compose -f local.yml up -d api
+```
+
+`mailpit` は Web UI を `http://localhost:8025/` で提供する。
+
+### 手順
+
+1. **signup**
+
+   ```bash
+   curl -X POST http://localhost:8080/api/v1/auth/users/ \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "email": "taro@example.com",
+       "username": "taro_dev",
+       "first_name": "Taro",
+       "last_name": "Yamada",
+       "password": "StrongPass!2026",
+       "re_password": "StrongPass!2026"
+     }'
+   ```
+
+   → `201 Created`。`http://localhost:8025/` に activation メールが届く。
+
+2. **activation**
+
+   メール本文の `.../activate/<uid>/<token>` から uid と token を抜き出して:
+
+   ```bash
+   curl -X POST http://localhost:8080/api/v1/auth/users/activation/ \
+     -H 'Content-Type: application/json' \
+     -d '{"uid": "<UID>", "token": "<TOKEN>"}'
+   ```
+
+   → `204 No Content`。
+
+3. **cookie login**
+
+   ```bash
+   curl -c cookies.txt -X POST http://localhost:8080/api/v1/auth/cookie/create/ \
+     -H 'Content-Type: application/json' \
+     -d '{"email": "taro@example.com", "password": "StrongPass!2026"}'
+   ```
+
+   → `200 {"detail": "Login successful"}`。`cookies.txt` に access/refresh が保存される。
+
+4. **authenticated request**
+
+   ```bash
+   curl -b cookies.txt http://localhost:8080/api/v1/auth/users/me/
+   ```
+
+5. **cookie refresh**
+
+   ```bash
+   curl -b cookies.txt -c cookies.txt -X POST \
+     http://localhost:8080/api/v1/auth/cookie/refresh/
+   ```
+
+6. **cookie logout**
+
+   ```bash
+   curl -b cookies.txt -c cookies.txt -X POST \
+     http://localhost:8080/api/v1/auth/cookie/logout/
+   ```
+
+   → `200 {"detail": "Logged out"}`。以降 `cookies.txt` の refresh は blacklist 入り。
+
+## パスワードリセット
+
+ログイン不要でパスワードを忘れた人向け。フローは以下:
+
+1. `POST /api/v1/auth/users/reset_password/` に `{"email": "..."}` → 204 + メール送信。
+2. メールの `.../password-reset/<uid>/<token>` から `uid` と `token` を取り出す。
+3. `POST /api/v1/auth/users/reset_password_confirm/` に `{"uid", "token", "new_password", "re_new_password"}` → 204。
+4. 新しいパスワードで `POST /cookie/create/` を叩く。
+
+`PASSWORD_RESET_CONFIRM_URL = "password-reset/{uid}/{token}"` が `settings.DJOSER`
+で設定されているため、フロントエンドは `/password-reset/[uid]/[token]` ページで
+uid/token を URL パラメタから拾う。
+
+## 関連ファイル
+
+- `apps/users/views.py` — `CookieTokenObtainView` / `CookieTokenRefreshView` / `LogoutView`
+- `apps/users/urls.py` — `/cookie/create/` `/cookie/refresh/` `/cookie/logout/` の定義
+- `apps/common/cookie_auth.py` — DRF の `CookieAuthentication` (Cookie から access を読んで認証)
+- `config/settings/base.py` — `COOKIE_NAME` / `REFRESH_COOKIE_NAME` / `SIMPLE_JWT` / `DJOSER`
+- `apps/templates/email/activation.{txt,html}` — アクティベーションメール
+- `apps/users/tests/test_email_auth_flow.py` — 回帰テスト
+- `docs/adr/0003-jwt-httponly-cookie-auth.md` — HttpOnly Cookie 採用の ADR

--- a/docs/operations/email-auth.md
+++ b/docs/operations/email-auth.md
@@ -41,26 +41,26 @@
 
 ## エンドポイント一覧
 
-| ステップ       | Method + Path                                  | レスポンス                            |
-| -------------- | ---------------------------------------------- | ------------------------------------- |
-| signup         | `POST /api/v1/auth/users/`                     | `201` + user JSON (JWT は返さない)    |
-| activation     | `POST /api/v1/auth/users/activation/`          | `204` (body 空、Cookie も set しない) |
-| cookie login   | `POST /api/v1/auth/cookie/create/`             | `200` `{detail: "Login successful"}`  |
-| cookie refresh | `POST /api/v1/auth/cookie/refresh/`            | `200` `{detail: "Token refreshed"}`   |
-| cookie logout  | `POST /api/v1/auth/cookie/logout/`             | `200` `{detail: "Logged out"}`        |
-| password reset | `POST /api/v1/auth/users/reset_password/`      | `204` + メール送信                    |
-| reset confirm  | `POST /api/v1/auth/users/reset_password_confirm/` | `204`                              |
+| ステップ       | Method + Path                                     | レスポンス                            |
+| -------------- | ------------------------------------------------- | ------------------------------------- |
+| signup         | `POST /api/v1/auth/users/`                        | `201` + user JSON (JWT は返さない)    |
+| activation     | `POST /api/v1/auth/users/activation/`             | `204` (body 空、Cookie も set しない) |
+| cookie login   | `POST /api/v1/auth/cookie/create/`                | `200` `{detail: "Login successful"}`  |
+| cookie refresh | `POST /api/v1/auth/cookie/refresh/`               | `200` `{detail: "Token refreshed"}`   |
+| cookie logout  | `POST /api/v1/auth/cookie/logout/`                | `200` `{detail: "Logged out"}`        |
+| password reset | `POST /api/v1/auth/users/reset_password/`         | `204` + メール送信                    |
+| reset confirm  | `POST /api/v1/auth/users/reset_password_confirm/` | `204`                                 |
 
 > 旧 `/api/v1/auth/login/` `/refresh/` `/logout/` は ADR-0003 移行期間中の互換目的
 > で残している。新規 frontend / 自動化フローは `/cookie/*` を使うこと。
 
 ## Cookie 設計 (ADR-0003)
 
-| Cookie       | 役割                                                                                   | HttpOnly | Secure (stg/prod) | SameSite | 寿命   |
-| ------------ | -------------------------------------------------------------------------------------- | -------- | ----------------- | -------- | ------ |
-| `access`     | JWT access token (`settings.COOKIE_NAME`)                                              | yes      | yes               | `Lax`    | 60 分  |
-| `refresh`    | JWT refresh token (`settings.REFRESH_COOKIE_NAME`)                                     | yes      | yes               | `Lax`    | 14 日  |
-| `logged_in`  | JS から読める「ログイン済み」シグナル。値自体に意味はなく、UI の state 判定のみに使う   | **no**   | yes               | `Lax`    | 60 分  |
+| Cookie      | 役割                                                                                  | HttpOnly | Secure (stg/prod) | SameSite | 寿命  |
+| ----------- | ------------------------------------------------------------------------------------- | -------- | ----------------- | -------- | ----- |
+| `access`    | JWT access token (`settings.COOKIE_NAME`)                                             | yes      | yes               | `Lax`    | 60 分 |
+| `refresh`   | JWT refresh token (`settings.REFRESH_COOKIE_NAME`)                                    | yes      | yes               | `Lax`    | 14 日 |
+| `logged_in` | JS から読める「ログイン済み」シグナル。値自体に意味はなく、UI の state 判定のみに使う | **no**   | yes               | `Lax`    | 60 分 |
 
 - `COOKIE_SECURE` は stg/prod で必須 (`settings/base.py` が fail-fast する)。
 - `SameSite=Lax` で CSRF の一次防御、状態変更 API は **DRF の `SessionAuthentication` が CSRF enforcement を担う**
@@ -88,7 +88,7 @@
 - ログインは必ず `POST /cookie/create/` を別途叩く。この時:
   - email + password が一致すること
   - ブラウザが自分で入力した POST であること (CSRF token 経由)
-  の両方が要求される。
+    の両方が要求される。
 - これにより「リンクを踏んだだけで誰かになれる」パスを塞いでいる。
 
 ### テスト


### PR DESCRIPTION
## Summary

Issue #99 — SPEC §1.1-1.2 の email 認証フロー + ADR-0003 HttpOnly Cookie JWT 運搬。

## security-reviewer #83 HIGH 対応
- **activation エンドポイントで JWT を発行しない** (204 のみ)。理由: メール経由 GET 的アクセスで CSRF/メール転送で乗取りリスク
- activation 後はユーザーが改めて \`/cookie/create/\` で明示的にログイン (POST + CSRF token + SameSite=Lax)

## URL
- 既存 djoser: \`/auth/users/\` (signup) / \`/users/activation/\` / \`reset_password\` / \`reset_password_confirm\`
- 新規:
  - \`POST /api/v1/auth/cookie/create/\` — email+password で Cookie (HttpOnly/Secure/SameSite=Lax) に JWT set
  - \`POST /api/v1/auth/cookie/refresh/\` — refresh を Cookie から読み rotation
  - \`POST /api/v1/auth/cookie/logout/\` — refresh を blacklist + Cookie 削除 (IsAuthenticated 必須)

既存 \`/auth/jwt/*\` は ADR-0003 移行期間のため残存。

## 変更
- \`config/settings/base.py\`: \`REFRESH_COOKIE_NAME = "refresh"\` 追加
- \`apps/users/views.py\`: \`CookieTokenObtainView\` / \`CookieTokenRefreshView\` / \`LogoutView\` + \`set_auth_cookies\` helper (settings 参照に統一)
- \`apps/users/urls.py\`: 新 3 ルート追加
- \`docs/operations/email-auth.md\` 新規

## テスト (17 件、全 pass + 既存 109 件維持)
- TestSignupFlow 4: inactive 作成 / メール送信 / JWT 漏洩なし / duplicate email
- TestActivationFlow 2: 有効化するが JWT/Cookie 出さない / bad token
- TestCookieLogin 4: 未有効化拒否 / Cookie set (HttpOnly/SameSite/Path) / body に token 含まない / wrong password
- TestCookieRefresh 2: rotation / Cookie 無しで 401
- TestLogout 2: Cookie 削除 (Max-Age=0) / refresh blacklist 登録
- TestPasswordReset 2: メール送信 / confirm で password 更新
- TestCookieAuthURLs 1: URL resolve smoke

Refs: #99