### PR TITLE
feat(p1-03): プロフィール API (/users/me/ + 公開プロフィール /users/<handle>/)

### DIFF
--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -55,11 +55,14 @@ class CustomUserSerializer(UserSerializer):
             "date_joined",
         ]
         # username / email / is_premium は変更不可 (is_premium は Stripe webhook でのみ更新)。
+        # needs_onboarding もクライアント側からは変更不可 — オンボーディング完了判定は
+        # サーバー側 (signal / dedicated endpoint) でのみ更新する (P1-03 review MEDIUM 対応)。
         read_only_fields = [
             "id",
             "email",
             "username",
             "is_premium",
+            "needs_onboarding",
             "date_joined",
         ]
 
@@ -95,4 +98,7 @@ class PublicProfileSerializer(serializers.ModelSerializer):
             "date_joined",
         ]
         # 公開 API はすべて read_only (PATCH は /me/ 経由のみ)。
-        read_only_fields = fields
+        # ``fields`` と同じ list を参照させると、DRF 内部で片方に mutate が走った
+        # ときに他方まで壊れる可能性がある。独立コピーを持たせる
+        # (P1-03 review HIGH 対応)。
+        read_only_fields = list(fields)

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -1,9 +1,15 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import URLValidator
 from djoser.serializers import UserCreateSerializer, UserSerializer
 from rest_framework import serializers
 
 from apps.users.validators import validate_handle
+
+# Serializer レベルで URL のスキームを https に限定する validator。
+# djoser UserSerializer を継承している都合で model validators が拾われないため、
+# extra_kwargs で再注入する (apps/users/models.py の _HTTPS_URL_VALIDATOR と同等)。
+_HTTPS_URL_VALIDATOR = URLValidator(schemes=["https"])
 
 User = get_user_model()
 
@@ -65,6 +71,19 @@ class CustomUserSerializer(UserSerializer):
             "needs_onboarding",
             "date_joined",
         ]
+        # djoser UserSerializer 継承時 model field の URLValidator(schemes=["https"]) が
+        # 自動取り込みされないため、extra_kwargs で各 SNS URL に明示的に再注入する
+        # (security-reviewer #131 既知問題の類似パターン対応)。
+        extra_kwargs = {
+            "github_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+            "x_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+            "zenn_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+            "qiita_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+            "note_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+            "linkedin_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+            "avatar_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+            "header_url": {"validators": [_HTTPS_URL_VALIDATOR]},
+        }
 
 
 class PublicProfileSerializer(serializers.ModelSerializer):

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -23,9 +23,10 @@ class CreateUserSerializer(UserCreateSerializer):
 
 
 class CustomUserSerializer(UserSerializer):
-    """プロフィール表示/更新用。
+    """プロフィール表示/更新用 (self view)。
 
     SPEC §2 に従い username は read_only (= 変更不可) として公開する。
+    ``GET /api/v1/users/me/`` および ``PATCH /api/v1/users/me/`` で使用する。
     """
 
     full_name = serializers.ReadOnlyField()
@@ -61,3 +62,37 @@ class CustomUserSerializer(UserSerializer):
             "is_premium",
             "date_joined",
         ]
+
+
+class PublicProfileSerializer(serializers.ModelSerializer):
+    """公開プロフィール用 serializer (SPEC §2.2)。
+
+    ``GET /api/v1/users/<handle>/`` で使用。未ログインでも閲覧可能。
+
+    公開する: display_name, bio, avatar_url, header_url, SNS URL 6 種,
+              @handle (username), full_name, date_joined
+    公開しない: id, email, is_premium, needs_onboarding, first_name, last_name
+    (= 内部 flag / PII を漏らさない)
+    """
+
+    full_name = serializers.ReadOnlyField()
+
+    class Meta:
+        model = User
+        fields = [
+            "username",
+            "display_name",
+            "bio",
+            "avatar_url",
+            "header_url",
+            "github_url",
+            "x_url",
+            "zenn_url",
+            "qiita_url",
+            "note_url",
+            "linkedin_url",
+            "full_name",
+            "date_joined",
+        ]
+        # 公開 API はすべて read_only (PATCH は /me/ 経由のみ)。
+        read_only_fields = fields

--- a/apps/users/tests/test_profile_api.py
+++ b/apps/users/tests/test_profile_api.py
@@ -1,0 +1,325 @@
+"""
+プロフィール API (P1-03 / Issue #89) のテスト (SPEC §2)。
+
+対象エンドポイント:
+- GET    /api/v1/users/me/       : 自分の完全プロフィール (認証必須)
+- PATCH  /api/v1/users/me/       : 自分のプロフィール部分更新 (認証必須)
+- GET    /api/v1/users/<handle>/ : 他人の公開プロフィール (認証不要)
+
+方針:
+- ``force_authenticate`` で JWT/Cookie を経由せず直接 request.user を注入する。
+  Cookie ベースのフローは P1-01/P1-12 側で別途テスト済みなので、本テストでは
+  ビジネスロジック (serializer の出し分け / read_only / 404 挙動) に集中する。
+- AAA (Arrange-Act-Assert) パターン。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def me_url() -> str:
+    return reverse("users-me")
+
+
+def public_profile_url(handle: str) -> str:
+    return reverse("users-public-profile", kwargs={"username": handle})
+
+
+# =============================================================================
+# GET/PATCH /api/v1/users/me/
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestMeEndpoint:
+    def test_get_requires_auth(self, api_client: APIClient, me_url: str) -> None:
+        # Arrange: 匿名クライアント。
+        # Act
+        res = api_client.get(me_url)
+
+        # Assert: 認証必須なので 401。
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_get_returns_full_profile(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange: ログイン済みユーザーに全フィールド値を設定。
+        user = user_factory(
+            username="me_user",
+            email="me@example.com",
+            first_name="Taro",
+            last_name="Yamada",
+        )
+        user.display_name = "Taro T."
+        user.bio = "engineer"
+        user.avatar_url = "https://cdn.example.com/a.png"
+        user.github_url = "https://github.com/taro"
+        user.save()
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.get(me_url)
+
+        # Assert: 200 で必須フィールドがすべて含まれる。
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        expected_fields = {
+            "id",
+            "email",
+            "username",
+            "first_name",
+            "last_name",
+            "full_name",
+            "display_name",
+            "bio",
+            "avatar_url",
+            "header_url",
+            "is_premium",
+            "needs_onboarding",
+            "github_url",
+            "x_url",
+            "zenn_url",
+            "qiita_url",
+            "note_url",
+            "linkedin_url",
+            "date_joined",
+        }
+        assert expected_fields <= set(data.keys())
+        assert data["username"] == "me_user"
+        assert data["email"] == "me@example.com"
+        assert data["display_name"] == "Taro T."
+        assert data["bio"] == "engineer"
+        assert data["full_name"] == "Taro Yamada"
+        assert data["github_url"] == "https://github.com/taro"
+
+    def test_patch_updates_bio_and_display_name(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange
+        user = user_factory(username="patcher")
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.patch(
+            me_url,
+            data={"bio": "updated", "display_name": "New Name"},
+            format="json",
+        )
+
+        # Assert: 200 + DB 反映。
+        assert res.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.bio == "updated"
+        assert user.display_name == "New Name"
+
+    def test_patch_username_change_is_ignored(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange: username は read_only。送っても silent drop される (ADR-0003 仕様)。
+        user = user_factory(username="immutable_01")
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.patch(
+            me_url,
+            data={"username": "new_handle_01", "bio": "ok"},
+            format="json",
+        )
+
+        # Assert: 200 だが username は変更されない。bio は反映される。
+        assert res.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.username == "immutable_01"
+        assert user.bio == "ok"
+        # レスポンスも元の username を返す。
+        assert res.json()["username"] == "immutable_01"
+
+    def test_patch_email_change_is_ignored(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange: email も read_only。
+        user = user_factory(username="email_ro", email="orig@example.com")
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.patch(me_url, data={"email": "new@example.com"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.email == "orig@example.com"
+
+    def test_patch_is_premium_change_is_ignored(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange: is_premium はユーザー経由では変更不可 (Stripe webhook 経由のみ)。
+        user = user_factory(username="premium_hack")
+        assert user.is_premium is False
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.patch(me_url, data={"is_premium": True}, format="json")
+
+        # Assert: 200 だが DB は False のまま。
+        assert res.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.is_premium is False
+
+    def test_patch_rejects_invalid_url(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange: SNS URL は https のみ。ftp:// は _HTTPS_URL_VALIDATOR で弾かれる。
+        user = user_factory(username="bad_url")
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.patch(me_url, data={"github_url": "ftp://evil.example.com"}, format="json")
+
+        # Assert: 400 + errors に github_url が含まれる。
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "github_url" in res.json()
+
+    def test_patch_updates_all_sns_urls(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange
+        user = user_factory(username="sns_all")
+        api_client.force_authenticate(user=user)
+        payload = {
+            "github_url": "https://github.com/u",
+            "x_url": "https://x.com/u",
+            "zenn_url": "https://zenn.dev/u",
+            "qiita_url": "https://qiita.com/u",
+            "note_url": "https://note.com/u",
+            "linkedin_url": "https://linkedin.com/in/u",
+        }
+
+        # Act
+        res = api_client.patch(me_url, data=payload, format="json")
+
+        # Assert: 全 URL が DB に反映される。
+        assert res.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        for field, expected in payload.items():
+            assert getattr(user, field) == expected
+
+    def test_patch_requires_auth(self, api_client: APIClient, me_url: str) -> None:
+        # Arrange: 匿名。
+        # Act
+        res = api_client.patch(me_url, data={"bio": "x"}, format="json")
+
+        # Assert: 認証必須。
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# =============================================================================
+# GET /api/v1/users/<handle>/
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestPublicProfileEndpoint:
+    def test_anonymous_can_view_public_profile(self, api_client: APIClient, user_factory) -> None:
+        # Arrange: 匿名クライアント + 既存ユーザー。
+        user = user_factory(username="public_01")
+        user.display_name = "Public One"
+        user.bio = "hello"
+        user.save()
+
+        # Act
+        res = api_client.get(public_profile_url("public_01"))
+
+        # Assert: 認証なしでも 200。
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert data["username"] == "public_01"
+        assert data["display_name"] == "Public One"
+        assert data["bio"] == "hello"
+
+    def test_public_profile_hides_email(self, api_client: APIClient, user_factory) -> None:
+        # Arrange
+        user_factory(username="hide_email", email="secret@example.com")
+
+        # Act
+        res = api_client.get(public_profile_url("hide_email"))
+
+        # Assert: email はレスポンスに含まれない (PII 漏洩防止)。
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert "email" not in data
+
+    def test_public_profile_hides_is_premium(self, api_client: APIClient, user_factory) -> None:
+        # Arrange: プレミアム状態も公開しない (課金情報は内部 flag)。
+        user = user_factory(username="hide_premium")
+        user.is_premium = True
+        user.save()
+
+        # Act
+        res = api_client.get(public_profile_url("hide_premium"))
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert "is_premium" not in data
+        assert "needs_onboarding" not in data
+
+    def test_public_profile_exposes_sns_urls(self, api_client: APIClient, user_factory) -> None:
+        # Arrange
+        user = user_factory(username="sns_public")
+        user.github_url = "https://github.com/x"
+        user.x_url = "https://x.com/x"
+        user.save()
+
+        # Act
+        res = api_client.get(public_profile_url("sns_public"))
+
+        # Assert: SNS URL は公開される。
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert data["github_url"] == "https://github.com/x"
+        assert data["x_url"] == "https://x.com/x"
+
+    def test_nonexistent_handle_returns_404(self, api_client: APIClient) -> None:
+        # Arrange: 何もユーザーを作らない。
+        # Act
+        res = api_client.get(public_profile_url("nobody_here"))
+
+        # Assert: 404。
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_inactive_user_returns_404(self, api_client: APIClient, user_factory) -> None:
+        # Arrange: 非 active ユーザー (退会扱い)。
+        user = user_factory(username="inactive_01")
+        user.is_active = False
+        user.save()
+
+        # Act
+        res = api_client.get(public_profile_url("inactive_01"))
+
+        # Assert: 存在隠蔽のため 404。
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_authenticated_user_can_view_public_profile(
+        self, api_client: APIClient, user_factory
+    ) -> None:
+        # Arrange: ログイン中でも公開プロフィールは普通に見える。
+        viewer = user_factory(username="viewer_01")
+        target = user_factory(username="target_01")
+        target.display_name = "Target"
+        target.save()
+        api_client.force_authenticate(user=viewer)
+
+        # Act
+        res = api_client.get(public_profile_url("target_01"))
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        assert res.json()["username"] == "target_01"
+        assert res.json()["display_name"] == "Target"

--- a/apps/users/tests/test_profile_api.py
+++ b/apps/users/tests/test_profile_api.py
@@ -30,6 +30,26 @@ def public_profile_url(handle: str) -> str:
     return reverse("users-public-profile", kwargs={"username": handle})
 
 
+# 公開プロフィール API が返すべきキーの完全集合。PublicProfileSerializer.Meta.fields と
+# 1:1 で揃えることで「新フィールド追加時に公開テストを通したままうっかり PII を
+# 露出する」ケースを exhaustive に検知する (P1-03 review HIGH 対応)。
+EXPECTED_PUBLIC_KEYS = {
+    "username",
+    "display_name",
+    "bio",
+    "avatar_url",
+    "header_url",
+    "github_url",
+    "x_url",
+    "zenn_url",
+    "qiita_url",
+    "note_url",
+    "linkedin_url",
+    "full_name",
+    "date_joined",
+}
+
+
 # =============================================================================
 # GET/PATCH /api/v1/users/me/
 # =============================================================================
@@ -171,6 +191,25 @@ class TestMeEndpoint:
         user.refresh_from_db()
         assert user.is_premium is False
 
+    def test_patch_needs_onboarding_change_is_ignored(
+        self, api_client: APIClient, user_factory, me_url: str
+    ) -> None:
+        # Arrange: needs_onboarding はクライアント側からは変更不可。オンボーディング完了
+        # 判定はサーバー側 (signal / 専用 endpoint) でのみ更新される
+        # (P1-03 review MEDIUM 対応)。
+        user = user_factory(username="ob_hack")
+        # signup 直後なので True のはず。前提が崩れたら即 detect できるよう assert しておく。
+        assert user.needs_onboarding is True
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.patch(me_url, data={"needs_onboarding": False}, format="json")
+
+        # Assert: 200 で silently drop (DRF 標準挙動) + DB は True のまま。
+        assert res.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.needs_onboarding is True
+
     def test_patch_rejects_invalid_url(
         self, api_client: APIClient, user_factory, me_url: str
     ) -> None:
@@ -250,10 +289,13 @@ class TestPublicProfileEndpoint:
         # Act
         res = api_client.get(public_profile_url("hide_email"))
 
-        # Assert: email はレスポンスに含まれない (PII 漏洩防止)。
+        # Assert: email はレスポンスに含まれない (PII 漏洩防止)。さらにキー集合そのものが
+        # EXPECTED_PUBLIC_KEYS と完全一致することを exhaustive に検証する
+        # (P1-03 review HIGH 対応)。
         assert res.status_code == status.HTTP_200_OK
         data = res.json()
         assert "email" not in data
+        assert set(data.keys()) == EXPECTED_PUBLIC_KEYS
 
     def test_public_profile_hides_is_premium(self, api_client: APIClient, user_factory) -> None:
         # Arrange: プレミアム状態も公開しない (課金情報は内部 flag)。
@@ -323,3 +365,17 @@ class TestPublicProfileEndpoint:
         assert res.status_code == status.HTTP_200_OK
         assert res.json()["username"] == "target_01"
         assert res.json()["display_name"] == "Target"
+
+    def test_public_profile_handle_lookup_is_case_insensitive(
+        self, api_client: APIClient, user_factory
+    ) -> None:
+        # Arrange: validator 側は大文字小文字を保存するが、URL からの参照は
+        # case-insensitive で解決する (P1-03 review MEDIUM 対応)。
+        user_factory(username="CamelCase_User")
+
+        # Act: 全て小文字で URL を叩く。
+        res = api_client.get(public_profile_url("camelcase_user"))
+
+        # Assert: 200 + 保存時の大文字小文字を維持した username を返す。
+        assert res.status_code == status.HTTP_200_OK
+        assert res.json()["username"] == "CamelCase_User"

--- a/apps/users/urls_profile.py
+++ b/apps/users/urls_profile.py
@@ -1,0 +1,22 @@
+"""プロフィール API の URL 定義 (SPEC §2)。
+
+``config/urls.py`` で ``path("api/v1/users/", include("apps.users.urls_profile"))``
+として登録する。既存の ``apps.users.urls`` (= 認証系) と棲み分けるため別ファイルで
+管理する。
+
+ルーティング:
+- ``GET/PATCH /api/v1/users/me/``    → MeView (自分のプロフィール)
+- ``GET       /api/v1/users/<handle>/`` → PublicProfileView (他人の公開プロフィール)
+
+NOTE: ``<str:username>`` は greedy に ``me`` もマッチしてしまうため、``me/`` を
+先に定義して優先させる。
+"""
+
+from django.urls import path
+
+from .views import MeView, PublicProfileView
+
+urlpatterns = [
+    path("me/", MeView.as_view(), name="users-me"),
+    path("<str:username>/", PublicProfileView.as_view(), name="users-public-profile"),
+]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,14 +1,21 @@
 import logging
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from djoser.social.views import ProviderAuthView
 from rest_framework import status
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
+from apps.users.serializers import CustomUserSerializer, PublicProfileSerializer
+
 logger = logging.getLogger(__name__)
+
+User = get_user_model()
 
 
 def set_auth_cookies(
@@ -129,3 +136,47 @@ class LogoutAPIView(APIView):
         response.delete_cookie("refresh")
         response.delete_cookie("logged_in")
         return response
+
+
+class MeView(APIView):
+    """現在ログイン中ユーザーの完全プロフィール (SPEC §2)。
+
+    - ``GET /api/v1/users/me/``: 完全プロフィール返却 (認証必須)
+    - ``PATCH /api/v1/users/me/``: 可変フィールドを部分更新
+
+    CustomUserSerializer の read_only_fields により
+    username / email / is_premium / id / date_joined は PATCH しても
+    silently drop される (DRF 標準挙動)。
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        serializer = CustomUserSerializer(request.user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def patch(self, request: Request, *args, **kwargs) -> Response:
+        serializer = CustomUserSerializer(
+            request.user,
+            data=request.data,
+            partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class PublicProfileView(RetrieveAPIView):
+    """公開プロフィール (SPEC §2.2)。
+
+    ``GET /api/v1/users/<handle>/``: 未ログインでも閲覧可能。
+
+    - ``is_active=False`` のユーザーは 404 として扱う (存在隠蔽)。
+    - lookup は URL の ``username`` (= @handle) で行う。
+    - PublicProfileSerializer で email / is_premium 等の内部 flag を除外する。
+    """
+
+    lookup_field = "username"
+    queryset = User.objects.filter(is_active=True)
+    serializer_class = PublicProfileSerializer
+    permission_classes = [AllowAny]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.shortcuts import get_object_or_404
 from djoser.social.views import ProviderAuthView
 from rest_framework import status
 from rest_framework.generics import RetrieveAPIView
@@ -147,9 +148,13 @@ class MeView(APIView):
     CustomUserSerializer の read_only_fields により
     username / email / is_premium / id / date_joined は PATCH しても
     silently drop される (DRF 標準挙動)。
+
+    ``http_method_names`` を明示することで PUT / POST / DELETE を 405 で弾き、
+    意図しない HTTP メソッドでの副作用を防ぐ (P1-03 review HIGH 対応)。
     """
 
     permission_classes = [IsAuthenticated]
+    http_method_names = ["get", "patch", "head", "options"]
 
     def get(self, request: Request, *args, **kwargs) -> Response:
         serializer = CustomUserSerializer(request.user)
@@ -172,11 +177,34 @@ class PublicProfileView(RetrieveAPIView):
     ``GET /api/v1/users/<handle>/``: 未ログインでも閲覧可能。
 
     - ``is_active=False`` のユーザーは 404 として扱う (存在隠蔽)。
-    - lookup は URL の ``username`` (= @handle) で行う。
+    - lookup は URL の ``username`` (= @handle) で大文字小文字を無視 (``iexact``) する。
+      P1-02 の ``validate_handle`` は大文字小文字を区別しない予約語判定のみで、
+      username 自体は小文字正規化されずに保存されるケースがあるため、
+      URL から参照する際も case-insensitive で解決する (P1-03 review MEDIUM 対応)。
     - PublicProfileSerializer で email / is_premium 等の内部 flag を除外する。
+    - ``queryset`` をクラス属性で持つと Django 起動時に評価された同一 QuerySet が
+      全リクエストで再利用されてしまい、テスト DB のリセットと相性が悪い。
+      ``get_queryset()`` に移してリクエストごとに評価する (P1-03 review HIGH 対応)。
     """
 
-    lookup_field = "username"
-    queryset = User.objects.filter(is_active=True)
     serializer_class = PublicProfileSerializer
     permission_classes = [AllowAny]
+    lookup_field = "username"
+    lookup_url_kwarg = "username"
+    # Django ORM の ``__iexact`` lookup を使うため、DRF の ``lookup_field`` では
+    # 表現できない。代わりに ``get_object()`` を override する。
+
+    def get_queryset(self):
+        return User.objects.filter(is_active=True)
+
+    def get_object(self):
+        """username の大文字小文字を無視して解決する。
+
+        DRF 標準の ``get_object()`` は ``filter(**{lookup_field: value})`` と
+        完全一致で引くため、``username__iexact`` を使うにはここで override する。
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+        username = self.kwargs[self.lookup_url_kwarg]
+        obj = get_object_or_404(queryset, username__iexact=username)
+        self.check_object_permissions(self.request, obj)
+        return obj

--- a/config/urls.py
+++ b/config/urls.py
@@ -32,6 +32,10 @@ urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
     path("api/v1/auth/", include("djoser.urls")),
     path("api/v1/auth/", include("apps.users.urls")),
+    # P1-03 #89: プロフィール API (SPEC §2)。
+    # /api/v1/users/me/ (GET/PATCH) と /api/v1/users/<handle>/ (GET) を提供。
+    # 認証系 (/api/v1/auth/) と分離するため apps.users.urls_profile として別登録。
+    path("api/v1/users/", include("apps.users.urls_profile")),
     # Phase 0 scaffold (P0-04). Each app ships empty urlpatterns until
     # the owning phase adds real endpoints (see docs/ROADMAP.md).
     path("api/v1/tweets/", include("apps.tweets.urls")),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ DJANGO_SETTINGS_MODULE = "config.settings.local"
 python_files = ["tests.py", "test_*.py", "*_tests.py"]
 addopts = "--reuse-db --cov=apps --cov=config --cov-report=term-missing --cov-report=xml"
 testpaths = ["apps", "config"]
+# カスタムマーカー。未登録だと `PytestUnknownMarkWarning` が出て `-W error` 環境で
+# 詰まるため、ここで明示しておく (P1-03 review HIGH 対応)。
+markers = [
+    "unit: unit tests",
+    "integration: integration tests",
+]
 filterwarnings = [
     "ignore::DeprecationWarning:django.*",
     "ignore::DeprecationWarning:rest_framework.*",


### PR DESCRIPTION
## Summary

Issue #89 — SPEC §2 のプロフィール API 実装。

## URL
- \`GET/PATCH /api/v1/users/me/\` — 自分のプロフィール (IsAuthenticated)
- \`GET /api/v1/users/<handle>/\` — 公開プロフィール (AllowAny, inactive は 404)

## 変更
- \`apps/users/serializers.py\`: \`PublicProfileSerializer\` を追加 (email/is_premium/needs_onboarding を公開しない)
- \`apps/users/views.py\`: \`MeView\` / \`PublicProfileView\`
- \`apps/users/urls_profile.py\` 新規: 認証系 URL (\`/api/v1/auth/\`) と分離
- \`config/urls.py\`: \`api/v1/users/\` → \`apps.users.urls_profile\` を include

## テスト (16 件)
- TestMeEndpoint 9 件: 認証要件 / 全 19 フィールド返却 / PATCH 可変 / username/email/is_premium read-only silent drop / ftp:// 拒否 / SNS 6 URL 更新
- TestPublicProfileEndpoint 7 件: 匿名閲覧可 / email・is_premium 非公開 / SNS URL 公開 / 404 / inactive 404

## Test Plan
- [ ] CI の Backend ジョブで 16 テスト pass
- [ ] ruff check / format 通過

Refs: #89