### PR TITLE
feat(p1-06): タグ検索 API + タグ詳細 + 新規提案 (近似チェック付き)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -180,7 +180,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 368
+        "line_number": 373
       }
     ],
     "docs/operations/email-auth.md": [
@@ -225,5 +225,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-24T02:03:20Z"
+  "generated_at": "2026-04-24T15:21:36Z"
 }

--- a/apps/tags/serializers.py
+++ b/apps/tags/serializers.py
@@ -1,0 +1,107 @@
+"""Serializers for the tags app (P1-06, Issue #92).
+
+SPEC §4 準拠:
+    - 一覧 / 検索: ``TagListSerializer`` (name, display_name, usage_count)
+    - 詳細: ``TagDetailSerializer`` (+ description, related_tags)
+    - 新規提案 (POST): ``TagCreateSerializer``
+        * ``name`` は ``validate_tag_name`` で format / length チェック
+        * 小文字正規化し、既存の approved タグと編集距離比較は view 側で実施
+
+未承認タグ (``is_approved=False``) は ``Tag.objects`` (= ApprovedTagManager) の時点で
+自動的に除外される。related_tags も同じマネージャ経由で取るため、
+「未承認タグが関連タグとして露出する」事故は起きない。
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers
+
+from apps.tags.models import Tag
+from apps.tags.validators import validate_tag_name
+
+# 関連タグとして返却する最大件数 (SPEC §4, 初期実装)。
+# 将来 usage_count 帯 or co-occurrence を使った推薦に差し替える予定。
+RELATED_TAGS_LIMIT = 5
+
+
+class TagListSerializer(serializers.ModelSerializer):
+    """タグ一覧 / インクリメンタルサーチ用の軽量表現.
+
+    P1-16 コンポーザーが ``?q=<prefix>`` で高頻度に叩くため、
+    必要最小限のフィールドだけを返す。
+    """
+
+    class Meta:
+        model = Tag
+        fields = ["name", "display_name", "usage_count"]
+        read_only_fields = fields
+
+
+class TagDetailSerializer(serializers.ModelSerializer):
+    """タグ詳細.
+
+    ``related_tags`` は初期実装として「自タグ以外を usage_count 降順で最大 5 件」
+    を返す。``Tag.objects`` (ApprovedTagManager) に乗っているため
+    is_approved=False のタグは混ざらない。
+    """
+
+    related_tags = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Tag
+        fields = [
+            "name",
+            "display_name",
+            "description",
+            "usage_count",
+            "related_tags",
+        ]
+        read_only_fields = fields
+
+    def get_related_tags(self, obj: Tag) -> list[dict[str, object]]:
+        """同じ approved タグ群から関連候補を最大 5 件返す.
+
+        - ``Tag.objects`` は ApprovedTagManager により is_approved=True のみ。
+        - 自タグ自身は除外する。
+        - ordering は Meta の ``-usage_count, name`` を使うだけで十分。
+        """
+        queryset = (
+            Tag.objects.exclude(pk=obj.pk)
+            .only("name", "display_name", "usage_count")
+            .order_by("-usage_count", "name")[:RELATED_TAGS_LIMIT]
+        )
+        return TagListSerializer(queryset, many=True).data
+
+
+class TagCreateSerializer(serializers.Serializer):
+    """タグ新規提案 (POST /api/v1/tags/propose/).
+
+    - ``name``: 小文字正規化 + ``validate_tag_name`` で format / length チェック
+    - ``display_name``: 未指定なら ``name.capitalize()`` を採用
+
+    重複 / 近似候補の検出は view 側で ``find_similar_tags`` により行う。
+    Serializer 自体は入力フォーマットの検証だけに責務を絞る。
+    """
+
+    name = serializers.CharField(max_length=50)
+    display_name = serializers.CharField(max_length=50, required=False, allow_blank=False)
+
+    def validate_name(self, value: str) -> str:
+        """小文字化 + フォーマット検証を適用する.
+
+        ``validate_tag_name`` は Django の ``ValidationError`` を上げるため、
+        DRF 層での ``serializers.ValidationError`` に詰め替える。
+        """
+        normalized = (value or "").strip().lower()
+        try:
+            validate_tag_name(normalized)
+        except DjangoValidationError as err:
+            raise serializers.ValidationError(err.messages[0]) from err
+        return normalized
+
+    def validate(self, attrs: dict[str, str]) -> dict[str, str]:
+        """display_name 未指定時に name.capitalize() をデフォルトとして採用する."""
+        if not attrs.get("display_name"):
+            attrs["display_name"] = attrs["name"].capitalize()
+        return attrs

--- a/apps/tags/serializers.py
+++ b/apps/tags/serializers.py
@@ -101,7 +101,26 @@ class TagCreateSerializer(serializers.Serializer):
         return normalized
 
     def validate(self, attrs: dict[str, str]) -> dict[str, str]:
-        """display_name 未指定時に name.capitalize() をデフォルトとして採用する."""
+        """display_name 未指定時に name.capitalize() をデフォルトとして採用する.
+
+        code-reviewer (PR #135 MEDIUM #4) 指摘: 引数の dict を mutate せず、
+        新しい dict を返して不変性を保つ (共通 coding-style.md の方針に沿う)。
+        """
         if not attrs.get("display_name"):
-            attrs["display_name"] = attrs["name"].capitalize()
+            return {**attrs, "display_name": attrs["name"].capitalize()}
         return attrs
+
+
+class TagCreateResponseSerializer(serializers.ModelSerializer):
+    """タグ新規提案 (POST) の 201 応答用 serializer.
+
+    code-reviewer (PR #135 HIGH #3) 指摘:
+        view 側で dict をハードコードして返すとフィールド構成が serializer と
+        二重管理になり、API Schema との乖離を招く。応答を serializer に寄せて
+        フィールド定義の単一情報源を保つ。
+    """
+
+    class Meta:
+        model = Tag
+        fields = ["name", "display_name", "usage_count", "is_approved"]
+        read_only_fields = fields

--- a/apps/tags/tests/test_views.py
+++ b/apps/tags/tests/test_views.py
@@ -1,0 +1,449 @@
+"""Views test for the tags app (P1-06, Issue #92, SPEC §4).
+
+対象エンドポイント:
+    GET  /api/v1/tags/               -- 一覧 + インクリメンタルサーチ
+    POST /api/v1/tags/propose/       -- 新規タグ提案 (認証必須)
+    GET  /api/v1/tags/<name>/        -- 詳細
+
+方針:
+    - 未承認タグ (is_approved=False) を含む seed を用意して、ApprovedTagManager が
+      公開 API から情報漏洩させないことを回帰テストできるようにする。
+    - ``force_authenticate`` で CSRF / JWT を経由せず直接 user を注入し、
+      ビジネスロジックに集中する。CSRF の実装はテストクライアント側で
+      ``enforce_csrf_checks=True`` のときのみ検証する。
+    - AAA (Arrange-Act-Assert) パターン。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.tags.models import Tag
+
+User = get_user_model()
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def tag_factory(db):
+    """Tag 作成用 factory fixture.
+
+    ``is_approved`` のデフォルトは True (P1-06 の検索 API は承認済タグだけが対象)。
+    未承認タグを作るテストでは明示的に False を渡す。
+    """
+
+    counter = {"i": 0}
+
+    def make_tag(
+        name: str | None = None,
+        display_name: str | None = None,
+        *,
+        usage_count: int = 0,
+        is_approved: bool = True,
+        description: str = "",
+        created_by: User | None = None,
+    ) -> Tag:
+        counter["i"] += 1
+        i = counter["i"]
+        tag_name = name or f"tag-{i:03d}"
+        return Tag.all_objects.create(
+            name=tag_name,
+            display_name=display_name or tag_name.capitalize(),
+            usage_count=usage_count,
+            is_approved=is_approved,
+            description=description,
+            created_by=created_by,
+        )
+
+    return make_tag
+
+
+@pytest.fixture
+def user_factory(db):
+    """ユーザー作成用 factory fixture (タグ提案テスト用)."""
+
+    counter = {"i": 0}
+
+    def make_user(**extra) -> User:
+        counter["i"] += 1
+        i = counter["i"]
+        return User.objects.create_user(
+            username=extra.pop("username", f"proposer_{i:03d}"),
+            email=extra.pop("email", f"proposer{i:03d}@example.com"),
+            password=extra.pop("password", "pass12345!"),
+            first_name=extra.pop("first_name", "Taro"),
+            last_name=extra.pop("last_name", "Yamada"),
+            **extra,
+        )
+
+    return make_user
+
+
+@pytest.fixture
+def list_url() -> str:
+    return reverse("tags-list")
+
+
+@pytest.fixture
+def propose_url() -> str:
+    return reverse("tags-propose")
+
+
+def detail_url(name: str) -> str:
+    return reverse("tags-detail", kwargs={"name": name})
+
+
+# =============================================================================
+# GET /api/v1/tags/
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestTagListView:
+    def test_anonymous_can_list(self, api_client: APIClient, tag_factory, list_url: str) -> None:
+        """未ログインでも 200 で一覧を取得できる."""
+        # Arrange
+        tag_factory(name="python", display_name="Python")
+
+        # Act
+        res = api_client.get(list_url)
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert "results" in data
+        assert len(data["results"]) == 1
+        assert data["results"][0]["name"] == "python"
+        assert data["results"][0]["display_name"] == "Python"
+        assert "usage_count" in data["results"][0]
+
+    def test_unapproved_tags_are_hidden(
+        self, api_client: APIClient, tag_factory, list_url: str
+    ) -> None:
+        """is_approved=False のタグは検索結果に出ない (SPEC §4)."""
+        # Arrange
+        tag_factory(name="python", is_approved=True)
+        tag_factory(name="hidden-tag", is_approved=False)
+
+        # Act
+        res = api_client.get(list_url)
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        names = [r["name"] for r in res.json()["results"]]
+        assert "python" in names
+        assert "hidden-tag" not in names
+
+    def test_ordering_by_usage_count_desc(
+        self, api_client: APIClient, tag_factory, list_url: str
+    ) -> None:
+        """人気順 (usage_count DESC, name ASC) で並ぶ."""
+        # Arrange
+        tag_factory(name="python", usage_count=100)
+        tag_factory(name="rust", usage_count=5)
+        tag_factory(name="typescript", usage_count=50)
+
+        # Act
+        res = api_client.get(list_url)
+
+        # Assert
+        names = [r["name"] for r in res.json()["results"]]
+        assert names == ["python", "typescript", "rust"]
+
+    def test_search_by_prefix(self, api_client: APIClient, tag_factory, list_url: str) -> None:
+        """``?q=py`` で name prefix ヒットする."""
+        # Arrange
+        tag_factory(name="python", display_name="Python")
+        tag_factory(name="pytorch", display_name="PyTorch")
+        tag_factory(name="rust", display_name="Rust")
+
+        # Act: 大文字でも動く (istartswith)
+        res = api_client.get(list_url, {"q": "Py"})
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        names = sorted(r["name"] for r in res.json()["results"])
+        assert names == ["python", "pytorch"]
+
+    def test_search_matches_display_name_contains(
+        self, api_client: APIClient, tag_factory, list_url: str
+    ) -> None:
+        """display_name の部分一致でもヒットする (icontains)."""
+        # Arrange
+        tag_factory(name="nextjs", display_name="Next.js")
+        tag_factory(name="rust", display_name="Rust")
+
+        # Act: "next" は name だけでなく display_name 側でも検索される
+        res = api_client.get(list_url, {"q": "next"})
+
+        # Assert
+        names = [r["name"] for r in res.json()["results"]]
+        assert names == ["nextjs"]
+
+    def test_pagination_default_page_size(
+        self, api_client: APIClient, tag_factory, list_url: str
+    ) -> None:
+        """DRF 既定の PageNumberPagination (PAGE_SIZE=10) が効く."""
+        # Arrange: 12 件作成 (> page_size=10)
+        for i in range(12):
+            tag_factory(name=f"tag-{i:02d}", usage_count=100 - i)
+
+        # Act
+        res = api_client.get(list_url)
+
+        # Assert
+        data = res.json()
+        assert data["count"] == 12
+        assert len(data["results"]) == 10
+        assert data["next"] is not None
+        assert data["previous"] is None
+
+    def test_empty_result(self, api_client: APIClient, list_url: str) -> None:
+        """Tag が 0 件でも 200 + results=[] を返す."""
+        # Act
+        res = api_client.get(list_url)
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert data["count"] == 0
+        assert data["results"] == []
+
+
+# =============================================================================
+# GET /api/v1/tags/<name>/
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestTagDetailView:
+    def test_anonymous_can_retrieve(self, api_client: APIClient, tag_factory) -> None:
+        """未ログインでも 200 で詳細取得できる."""
+        # Arrange
+        tag_factory(
+            name="python",
+            display_name="Python",
+            description="General-purpose language.",
+            usage_count=42,
+        )
+
+        # Act: 大文字 URL も iexact で引ける
+        res = api_client.get(detail_url("Python"))
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert data["name"] == "python"
+        assert data["display_name"] == "Python"
+        assert data["description"] == "General-purpose language."
+        assert data["usage_count"] == 42
+        assert "related_tags" in data
+
+    def test_not_found_for_unknown(self, api_client: APIClient) -> None:
+        """存在しない name で 404."""
+        # Act
+        res = api_client.get(detail_url("nonexistent"))
+
+        # Assert
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unapproved_returns_404(self, api_client: APIClient, tag_factory) -> None:
+        """is_approved=False は存在隠蔽で 404."""
+        # Arrange
+        tag_factory(name="hidden", is_approved=False)
+
+        # Act
+        res = api_client.get(detail_url("hidden"))
+
+        # Assert
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_related_tags_returned(self, api_client: APIClient, tag_factory) -> None:
+        """related_tags は自タグ以外の approved タグから最大 5 件返す."""
+        # Arrange: 本体 + 6 件の関連候補 + 1 件の未承認タグ
+        tag_factory(name="python", usage_count=100)
+        for i in range(6):
+            tag_factory(name=f"related-{i:02d}", usage_count=50 - i, is_approved=True)
+        tag_factory(name="unapproved", is_approved=False)
+
+        # Act
+        res = api_client.get(detail_url("python"))
+
+        # Assert: 関連タグ 5 件で cap、自タグと未承認タグは含まれない
+        data = res.json()
+        related_names = [t["name"] for t in data["related_tags"]]
+        assert len(related_names) == 5
+        assert "python" not in related_names
+        assert "unapproved" not in related_names
+        # usage_count 降順
+        usage_counts = [t["usage_count"] for t in data["related_tags"]]
+        assert usage_counts == sorted(usage_counts, reverse=True)
+
+
+# =============================================================================
+# POST /api/v1/tags/propose/
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestTagProposeView:
+    def test_unauthenticated_returns_401(self, api_client: APIClient, propose_url: str) -> None:
+        """未ログインは 401 を返す."""
+        # Act
+        res = api_client.post(
+            propose_url,
+            data={"name": "newtag", "display_name": "NewTag"},
+            format="json",
+        )
+
+        # Assert
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_similar_existing_returns_409(
+        self,
+        api_client: APIClient,
+        user_factory,
+        tag_factory,
+        propose_url: str,
+    ) -> None:
+        """既存 approved タグに編集距離 2 以下で近いと 409 + similar_tags."""
+        # Arrange: 既存 "python" に対し "pythn" を提案 (距離 1)
+        tag_factory(name="python", display_name="Python")
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.post(
+            propose_url,
+            data={"name": "pythn", "display_name": "Pythn"},
+            format="json",
+        )
+
+        # Assert
+        assert res.status_code == status.HTTP_409_CONFLICT
+        data = res.json()
+        assert "similar_tags" in data
+        assert any(s["name"] == "python" for s in data["similar_tags"])
+        # DB にも作成されていない
+        assert not Tag.all_objects.filter(name="pythn").exists()
+
+    def test_create_success_is_unapproved(
+        self,
+        api_client: APIClient,
+        user_factory,
+        propose_url: str,
+    ) -> None:
+        """近似なしなら 201 + is_approved=False で作成される (search には載らない)."""
+        # Arrange
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.post(
+            propose_url,
+            data={"name": "brand-new-tag", "display_name": "Brand New"},
+            format="json",
+        )
+
+        # Assert
+        assert res.status_code == status.HTTP_201_CREATED
+        data = res.json()
+        assert data["name"] == "brand-new-tag"
+        assert data["display_name"] == "Brand New"
+        assert data["is_approved"] is False
+
+        tag = Tag.all_objects.get(name="brand-new-tag")
+        assert tag.is_approved is False
+        assert tag.created_by == user
+        # ApprovedTagManager からは除外される
+        assert not Tag.objects.filter(name="brand-new-tag").exists()
+
+    def test_invalid_name_returns_400(
+        self,
+        api_client: APIClient,
+        user_factory,
+        propose_url: str,
+    ) -> None:
+        """SPEC §4 の許容文字以外 (例: 空白 / マルチバイト) は 400."""
+        # Arrange
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        # Act: スペース含みは validate_tag_name が拒否する
+        res = api_client.post(
+            propose_url,
+            data={"name": "invalid name", "display_name": "Invalid"},
+            format="json",
+        )
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        data = res.json()
+        assert "name" in data
+
+    def test_display_name_defaults_to_capitalized_name(
+        self,
+        api_client: APIClient,
+        user_factory,
+        propose_url: str,
+    ) -> None:
+        """display_name 省略時は name.capitalize() が入る."""
+        # Arrange
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.post(
+            propose_url,
+            data={"name": "kotlin"},
+            format="json",
+        )
+
+        # Assert
+        assert res.status_code == status.HTTP_201_CREATED
+        assert res.json()["display_name"] == "Kotlin"
+        tag = Tag.all_objects.get(name="kotlin")
+        assert tag.display_name == "Kotlin"
+
+    def test_csrf_enforced_without_token(
+        self,
+        user_factory,
+        propose_url: str,
+    ) -> None:
+        """CSRF を有効にしたクライアントで、Cookie 経由の JWT のみで POST すると 403.
+
+        ``force_authenticate`` は DRF の authentication_classes を全スキップしてしまい
+        ``CSRFEnforcingAuthentication`` / ``CookieAuthentication`` の CSRF 強制を
+        観測できないため、ここでは rest_framework_simplejwt の ``RefreshToken`` で
+        実 JWT を発行し、HttpOnly Cookie にセットして ``CookieAuthentication`` を
+        本来の経路で走らせる (apps/users/tests/test_email_auth_flow.py と同方針)。
+        """
+        from django.conf import settings
+        from rest_framework_simplejwt.tokens import RefreshToken
+
+        # Arrange: 本物の access token を cookie にセットする
+        csrf_client = APIClient(enforce_csrf_checks=True)
+        user = user_factory()
+        refresh = RefreshToken.for_user(user)
+        csrf_client.cookies[settings.COOKIE_NAME] = str(refresh.access_token)
+
+        # Act: CSRF token を付けずに Cookie 経由で POST
+        res = csrf_client.post(
+            propose_url,
+            data={"name": "some-tag", "display_name": "Some"},
+            format="json",
+        )
+
+        # Assert: CookieAuthentication が from_cookie=True と判定し CSRF を強制 → 403
+        assert res.status_code == status.HTTP_403_FORBIDDEN

--- a/apps/tags/tests/test_views.py
+++ b/apps/tags/tests/test_views.py
@@ -218,6 +218,27 @@ class TestTagListView:
         assert data["count"] == 0
         assert data["results"] == []
 
+    def test_empty_q_returns_all_approved(
+        self, api_client: APIClient, tag_factory, list_url: str
+    ) -> None:
+        """``?q=`` (空文字) は絞り込みせず approved 全件を返す.
+
+        code-reviewer (PR #135 MEDIUM #6) 指摘: 空文字 q の挙動を回帰テスト化。
+        """
+        # Arrange: approved 2 件 + unapproved 1 件
+        tag_factory(name="python", is_approved=True)
+        tag_factory(name="rust", is_approved=True)
+        tag_factory(name="hidden", is_approved=False)
+
+        # Act
+        res = api_client.get(list_url, {"q": ""})
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        names = sorted(r["name"] for r in res.json()["results"])
+        # approved 全件が返り、unapproved は混ざらない
+        assert names == ["python", "rust"]
+
 
 # =============================================================================
 # GET /api/v1/tags/<name>/
@@ -415,6 +436,27 @@ class TestTagProposeView:
         assert res.json()["display_name"] == "Kotlin"
         tag = Tag.all_objects.get(name="kotlin")
         assert tag.display_name == "Kotlin"
+
+    def test_get_propose_returns_405(
+        self,
+        api_client: APIClient,
+        user_factory,
+        propose_url: str,
+    ) -> None:
+        """``GET /api/v1/tags/propose/`` は副作用のある POST 専用なので 405.
+
+        code-reviewer (PR #135 MEDIUM #6) 指摘: ``http_method_names`` で弾いている
+        挙動を回帰テスト化する。
+        """
+        # Arrange: 認証済みでも動作が変わらないことを確認したいので force_authenticate
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        # Act
+        res = api_client.get(propose_url)
+
+        # Assert
+        assert res.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     def test_csrf_enforced_without_token(
         self,

--- a/apps/tags/urls.py
+++ b/apps/tags/urls.py
@@ -12,11 +12,13 @@ SPEC §4:
 
 from __future__ import annotations
 
-from django.urls import URLPattern, URLResolver, path
+from django.urls import URLPattern, path
 
 from apps.tags.views import TagDetailView, TagListView, TagProposeView
 
-urlpatterns: list[URLPattern | URLResolver] = [
+# ``include()`` を使っていないため URLResolver は登場しない。
+# code-reviewer (PR #135 LOW) 指摘で未使用 import を削除。
+urlpatterns: list[URLPattern] = [
     path("", TagListView.as_view(), name="tags-list"),
     path("propose/", TagProposeView.as_view(), name="tags-propose"),
     path("<str:name>/", TagDetailView.as_view(), name="tags-detail"),

--- a/apps/tags/urls.py
+++ b/apps/tags/urls.py
@@ -1,5 +1,23 @@
-from django.urls import URLPattern, URLResolver
+"""URL patterns for the tags app (P1-06, Issue #92).
 
-# URL patterns are added in the phase that implements this feature.
-# See docs/ROADMAP.md for ownership.
-urlpatterns: list[URLPattern | URLResolver] = []
+SPEC §4:
+    GET  /api/v1/tags/               -- タグ一覧 + インクリメンタルサーチ
+    POST /api/v1/tags/propose/       -- タグ新規提案 (認証必須 + CSRF)
+    GET  /api/v1/tags/<name>/        -- タグ詳細
+
+順序注意:
+    ``<str:name>/`` を先に置くと ``propose/`` が name="propose" の
+    タグ詳細として解決されてしまうため、必ず ``propose/`` を先に登録する。
+"""
+
+from __future__ import annotations
+
+from django.urls import URLPattern, URLResolver, path
+
+from apps.tags.views import TagDetailView, TagListView, TagProposeView
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("", TagListView.as_view(), name="tags-list"),
+    path("propose/", TagProposeView.as_view(), name="tags-propose"),
+    path("<str:name>/", TagDetailView.as_view(), name="tags-detail"),
+]

--- a/apps/tags/views.py
+++ b/apps/tags/views.py
@@ -21,16 +21,32 @@ from rest_framework.parsers import JSONParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
 
 from apps.common.cookie_auth import CookieAuthentication, CSRFEnforcingAuthentication
 from apps.tags.models import Tag
 from apps.tags.serializers import (
+    TagCreateResponseSerializer,
     TagCreateSerializer,
     TagDetailSerializer,
     TagListSerializer,
 )
-from apps.tags.validators import find_similar_tags
+from apps.tags.validators import MAX_TAG_LENGTH, find_similar_tags
+
+
+class TagProposeThrottle(UserRateThrottle):
+    """``POST /api/v1/tags/propose/`` 専用のレート制限.
+
+    code-reviewer (PR #135 HIGH #2) 指摘:
+        ``find_similar_tags`` は全 approved タグに対して Levenshtein 距離を
+        Python 側で計算するため、認証済みユーザーの既定 throttle (500/day) だけでは
+        攻撃者が短時間に大量 POST して DB / CPU を消費させる余地が残る。
+        `tag_propose` scope を切って 20/hour に絞り、提案 API 単独で
+        ブルートフォース的な近似検索を抑止する。
+    """
+
+    scope = "tag_propose"
 
 
 class TagListView(ListAPIView):
@@ -56,6 +72,12 @@ class TagListView(ListAPIView):
         queryset = Tag.objects.all()
         q = self.request.query_params.get("q", "").strip()
         if q:
+            # code-reviewer (PR #135 MEDIUM #7) 指摘:
+            #   validators.find_similar_tags 側は呼ばれないが、ORM 側の LIKE も
+            #   ``q`` が極端に長いと遅くなるため、タグ名の最大長で切り詰めて
+            #   DoS 的な入力を無害化する。タグ名は MAX_TAG_LENGTH を超えては
+            #   ヒットし得ないのでセマンティクスも変わらない。
+            q = q[:MAX_TAG_LENGTH]
             # name は小文字保存なので istartswith と startswith は等価だが、
             # 大文字入力でも引けるよう istartswith を使う。
             # display_name は大小混在なので icontains で部分一致にする。
@@ -74,7 +96,10 @@ class TagDetailView(RetrieveAPIView):
     serializer_class = TagDetailSerializer
     permission_classes = [AllowAny]
     authentication_classes: list = []
-    # URL kwarg 名は ``name``。
+    # URL kwarg 名は ``name``。``get_object`` を override しているので
+    # ``lookup_field`` は実際には使われないが、code-reviewer (PR #135 MEDIUM #5)
+    # 指摘どおり「どの column で引いているか」を一目で分かるよう明示する。
+    lookup_field = "name"
     lookup_url_kwarg = "name"
 
     def get_queryset(self) -> QuerySet[Tag]:
@@ -118,6 +143,10 @@ class TagProposeView(APIView):
     # 2 番目に置くことで「Cookie 無し POST でも CSRF を強制しつつ、401 を返す」挙動にする。
     authentication_classes = [CookieAuthentication, CSRFEnforcingAuthentication]
     permission_classes = [IsAuthenticated]
+    # code-reviewer (PR #135 HIGH #2) 指摘: find_similar_tags を Python 側で
+    # 全 approved タグに対し回すため、既定 throttle (user: 500/day) だけでは
+    # 短時間の大量 POST に弱い。専用 scope (20/hour) で抑止する。
+    throttle_classes = [TagProposeThrottle]
     parser_classes = [JSONParser]
     # 他メソッドは 405 で弾く (副作用のある POST だけを受け付ける意図を明示する)。
     http_method_names = ["post", "head", "options"]
@@ -160,12 +189,9 @@ class TagProposeView(APIView):
             is_approved=False,
         )
 
+        # code-reviewer (PR #135 HIGH #3) 指摘: 201 応答も serializer 経由にして
+        # フィールドの単一情報源を保つ (API Schema との乖離を防止)。
         return Response(
-            {
-                "name": tag.name,
-                "display_name": tag.display_name,
-                "usage_count": tag.usage_count,
-                "is_approved": tag.is_approved,
-            },
+            TagCreateResponseSerializer(tag).data,
             status=status.HTTP_201_CREATED,
         )

--- a/apps/tags/views.py
+++ b/apps/tags/views.py
@@ -1,5 +1,171 @@
-"""Views for the tags app.
+"""Views for the tags app (P1-06, Issue #92).
 
-Views are added in the phase that owns this feature.
-See docs/ROADMAP.md for ownership.
+SPEC §4 に沿って 3 つのエンドポイントを提供する:
+
+    GET  /api/v1/tags/               -- タグ一覧 + インクリメンタルサーチ (AllowAny)
+    GET  /api/v1/tags/<name>/        -- タグ詳細 (AllowAny)
+    POST /api/v1/tags/propose/       -- タグ新規提案 (IsAuthenticated + CSRF)
+
+未承認タグ (is_approved=False) は ``Tag.objects`` (= ApprovedTagManager) で
+自動的に除外される。POST で新規作成されるタグも ``is_approved=False`` 起点のため、
+モデレータが承認するまで search / detail には現れない。
 """
+
+from __future__ import annotations
+
+from django.db.models import Q, QuerySet
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.common.cookie_auth import CookieAuthentication, CSRFEnforcingAuthentication
+from apps.tags.models import Tag
+from apps.tags.serializers import (
+    TagCreateSerializer,
+    TagDetailSerializer,
+    TagListSerializer,
+)
+from apps.tags.validators import find_similar_tags
+
+
+class TagListView(ListAPIView):
+    """タグ一覧 + インクリメンタルサーチ.
+
+    SPEC §4:
+        - ``?q=<prefix>`` で name の前方一致 + display_name の部分一致を検索
+        - 結果は Meta の ``-usage_count, name`` (人気順 → name 昇順) に従う
+        - 未承認タグは ``Tag.objects`` (ApprovedTagManager) の時点で除外
+        - ページネーションは DRF 既定 (PageNumberPagination, PAGE_SIZE=10)
+
+    権限: AllowAny (未ログインでも閲覧可能)
+    """
+
+    serializer_class = TagListSerializer
+    permission_classes = [AllowAny]
+    # DEFAULT_AUTHENTICATION_CLASSES が Cookie/JWT を拾う挙動になっているが、
+    # AllowAny なので expired cookie 等で 401 を返さないよう明示的に空にする。
+    authentication_classes: list = []
+
+    def get_queryset(self) -> QuerySet[Tag]:
+        """``?q=<prefix>`` で絞り込む. 空なら全件 (Manager が approved のみに絞り込む)."""
+        queryset = Tag.objects.all()
+        q = self.request.query_params.get("q", "").strip()
+        if q:
+            # name は小文字保存なので istartswith と startswith は等価だが、
+            # 大文字入力でも引けるよう istartswith を使う。
+            # display_name は大小混在なので icontains で部分一致にする。
+            queryset = queryset.filter(Q(name__istartswith=q) | Q(display_name__icontains=q))
+        return queryset
+
+
+class TagDetailView(RetrieveAPIView):
+    """タグ詳細 (``GET /api/v1/tags/<name>/``).
+
+    - lookup は ``name__iexact`` で大文字小文字を無視。
+    - 未承認タグは ``Tag.objects`` が除外するので 404 になる。
+    - 権限: AllowAny。
+    """
+
+    serializer_class = TagDetailSerializer
+    permission_classes = [AllowAny]
+    authentication_classes: list = []
+    # URL kwarg 名は ``name``。
+    lookup_url_kwarg = "name"
+
+    def get_queryset(self) -> QuerySet[Tag]:
+        return Tag.objects.all()
+
+    def get_object(self) -> Tag:
+        """name の大文字小文字を無視して解決する.
+
+        DRF 標準の ``get_object()`` は ``filter(**{lookup_field: value})`` と
+        完全一致で引くため、``name__iexact`` を使うにはここで override する。
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+        name = self.kwargs[self.lookup_url_kwarg]
+        obj = get_object_or_404(queryset, name__iexact=name)
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+
+class TagProposeView(APIView):
+    """タグ新規提案 (``POST /api/v1/tags/propose/``).
+
+    SPEC §4:
+        1. ``validate_tag_name`` で format / length チェック (serializer 内)
+        2. ``find_similar_tags`` で編集距離 2 以下の既存 approved タグを検索
+        3. 近似タグが 1 件以上あれば 409 Conflict + ``similar_tags`` を返す
+           (ユーザーが既存タグの選択に誘導されるようにする)
+        4. 近似なしなら ``is_approved=False`` で Tag を作成し、201 を返す
+
+    権限: IsAuthenticated + CSRF (Cookie 経由認証時).
+    """
+
+    # Cookie 経由の認証と、Cookie が無くても CSRF トークンを強制するための pre-auth
+    # を組み合わせる (apps/users/views.py の LogoutView と同方針)。
+    #
+    # 注意: DRF の ``get_authenticate_header()`` は先頭 authenticator から
+    # ``authenticate_header()`` を引いて 401 の WWW-Authenticate を組み立てる。
+    # CSRFEnforcingAuthentication を先頭に置くと header が空になり、未認証時に
+    # 403 が返ってしまう (LogoutView とは異なり、ここは未ログインユーザーも
+    # 叩きうるエンドポイントなので 401 をきちんと返したい)。
+    # そのため CookieAuthentication を先頭に置き、CSRFEnforcingAuthentication は
+    # 2 番目に置くことで「Cookie 無し POST でも CSRF を強制しつつ、401 を返す」挙動にする。
+    authentication_classes = [CookieAuthentication, CSRFEnforcingAuthentication]
+    permission_classes = [IsAuthenticated]
+    parser_classes = [JSONParser]
+    # 他メソッドは 405 で弾く (副作用のある POST だけを受け付ける意図を明示する)。
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        serializer = TagCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        name = serializer.validated_data["name"]
+        display_name = serializer.validated_data["display_name"]
+
+        # 既存 approved タグとの編集距離チェック. 完全一致 (distance=0) も含めて
+        # 返却することで、クライアントが「同名既存タグ」のケースと「似ているタグ」の
+        # ケースを区別せずに選択候補として提示できる。
+        similar = find_similar_tags(name)
+        if similar:
+            return Response(
+                {
+                    "detail": "A similar tag already exists.",
+                    "similar_tags": [
+                        {
+                            "name": s.name,
+                            "display_name": s.display_name,
+                            "distance": s.distance,
+                        }
+                        for s in similar
+                    ],
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        # 承認済み群と被らないのでここで新規作成する. is_approved=False を起点とし、
+        # モデレータ承認まで search / detail からは見えない。
+        # all_objects を使って ApprovedTagManager の filter を回避する
+        # (そうしないと直後の refresh_from_db で自分が見えなくなる)。
+        tag = Tag.all_objects.create(
+            name=name,
+            display_name=display_name,
+            created_by=request.user,
+            is_approved=False,
+        )
+
+        return Response(
+            {
+                "name": tag.name,
+                "display_name": tag.display_name,
+                "usage_count": tag.usage_count,
+                "is_approved": tag.is_approved,
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -309,6 +309,11 @@ REST_FRAMEWORK = {
         # code-reviewer (PR #131 HIGH #2) 指摘: login ブルートフォース対策。
         # apps.users.views.LoginRateThrottle が scope="login" で参照する。
         "login": "5/minute",
+        # code-reviewer (PR #135 HIGH #2) 指摘: タグ新規提案は find_similar_tags で
+        # 全 approved タグを Python 側で走査するため、既定 user レート (500/day) より
+        # 厳しい scope="tag_propose" を用意し DoS 的な連投を抑制する。
+        # apps.tags.views.TagProposeThrottle が参照する。
+        "tag_propose": "20/hour",
     },
 }
 
@@ -437,30 +442,38 @@ AWS_S3_OBJECT_PARAMETERS = {
 _use_s3 = bool(AWS_STORAGE_BUCKET_NAME)
 STORAGES = {
     "default": {
-        "BACKEND": "storages.backends.s3.S3Storage"
-        if _use_s3
-        else "django.core.files.storage.FileSystemStorage",
-        "OPTIONS": {
-            "bucket_name": AWS_STORAGE_BUCKET_NAME,
-            "custom_domain": getenv("AWS_S3_CUSTOM_DOMAIN", "") or None,
-            "location": "media",
-        }
-        if _use_s3
-        else {},
+        "BACKEND": (
+            "storages.backends.s3.S3Storage"
+            if _use_s3
+            else "django.core.files.storage.FileSystemStorage"
+        ),
+        "OPTIONS": (
+            {
+                "bucket_name": AWS_STORAGE_BUCKET_NAME,
+                "custom_domain": getenv("AWS_S3_CUSTOM_DOMAIN", "") or None,
+                "location": "media",
+            }
+            if _use_s3
+            else {}
+        ),
     },
     "staticfiles": {
         # static は CloudFront + S3 (別バケット) から配信。Phase 0.5-08 の
         # sns-stg-static に collectstatic で push。ローカルは FS に fallback。
-        "BACKEND": "storages.backends.s3.S3Storage"
-        if _use_s3
-        else "django.contrib.staticfiles.storage.StaticFilesStorage",
-        "OPTIONS": {
-            "bucket_name": getenv("AWS_STATIC_BUCKET_NAME", ""),
-            "custom_domain": getenv("AWS_S3_STATIC_CUSTOM_DOMAIN", "") or None,
-            "location": "static",
-        }
-        if _use_s3 and getenv("AWS_STATIC_BUCKET_NAME")
-        else {},
+        "BACKEND": (
+            "storages.backends.s3.S3Storage"
+            if _use_s3
+            else "django.contrib.staticfiles.storage.StaticFilesStorage"
+        ),
+        "OPTIONS": (
+            {
+                "bucket_name": getenv("AWS_STATIC_BUCKET_NAME", ""),
+                "custom_domain": getenv("AWS_S3_STATIC_CUSTOM_DOMAIN", "") or None,
+                "location": "static",
+            }
+            if _use_s3 and getenv("AWS_STATIC_BUCKET_NAME")
+            else {}
+        ),
     },
 }
 


### PR DESCRIPTION
## Summary

Issue #92 — タグ API 3 エンドポイント。

## URL
- \`GET /api/v1/tags/\` — 一覧 (prefix 検索 + pagination, AllowAny, is_approved=True のみ)
- \`GET /api/v1/tags/<name>/\` — 詳細 (name__iexact, related_tags, AllowAny)
- \`POST /api/v1/tags/propose/\` — 新規タグ提案 (IsAuthenticated + CSRF)
  - 既存近似タグがあれば 409 + \`{similar_tags: [...]}\`
  - 新規作成時は \`is_approved=False\` で作られ、モデレータ承認待ち

## テスト (17 件)
- TestTagListView 7: anonymous / 未承認除外 / ordering / prefix / pagination
- TestTagDetailView 4: iexact lookup / 404 / related_tags
- TestTagProposeView 6: 401 / 409 similar / 201 / 400 / default display_name / CSRF

Refs: #92