### PR TITLE
feat(p1-08): ツイート CRUD API (POST/GET/PATCH/DELETE)

### DIFF
--- a/apps/common/cookie_auth.py
+++ b/apps/common/cookie_auth.py
@@ -85,7 +85,7 @@ class CookieAuthentication(JWTAuthentication):
             validated_token = self.get_validated_token(raw_token)
             user = self.get_user(validated_token)
         except TokenError as e:
-            logger.error(f"Token validation error: {e!s}")
+            logger.error("Token validation error: %s", e)
             return None
 
         if from_cookie:

--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -200,6 +200,8 @@ class TweetCreateSerializer(serializers.Serializer):
         if len(unique) > TWEET_MAX_TAGS:
             raise serializers.ValidationError(f"タグは最大 {TWEET_MAX_TAGS} 個まで指定できます。")
 
+        # Tag.objects (= ApprovedTagManager) が既に is_approved=True で絞るが、
+        # defense-in-depth と可読性のため is_approved=True を明示する。
         existing = set(
             Tag.objects.filter(name__in=unique, is_approved=True).values_list("name", flat=True)
         )
@@ -221,7 +223,10 @@ class TweetCreateSerializer(serializers.Serializer):
         tags: list[str] = validated_data.pop("tags", [])
         images: list[dict[str, Any]] = validated_data.pop("images", [])
         author = validated_data.pop("author")
-        body: str = validated_data["body"]
+        # defensive: pop() で取り出しておくことで、以降 validated_data を
+        # Tweet.objects.create(**validated_data) のように unpack しても
+        # 重複キー / 未知フィールドで落ちないようにする。
+        body: str = validated_data.pop("body")
 
         tweet = Tweet.objects.create(author=author, body=body)
 

--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -1,0 +1,276 @@
+"""Serializers for the tweets CRUD API (P1-08).
+
+SPEC §3 に従うツイート CRUD エンドポイント用の DRF serializer。
+
+設計方針:
+- **list / detail (read)** は ``Tweet`` モデルのほぼ生に近い形を返す。
+  ``html`` は ``apps.tweets.rendering.render_markdown`` で生成する。
+  ``author_handle`` / ``tags`` は SerializerMethodField で配列化する
+  (through テーブルを API 消費側に露出させない)。
+- **create / update (write)** は Serializer (ModelSerializer ではなく) で
+  書き味を揃える。Create 時の tags / images は別テーブルなので create() を
+  手書きし、トランザクション境界を serializer 内に閉じ込める。
+- **編集**は ``Tweet.record_edit(new_body, editor=...)`` 経由に統一する。
+  record_edit は既に 30 分制約 / 5 回制約 / TweetEdit 作成 / edit_count 原子
+  インクリメントをすべて引き受ける (apps/tweets/models.py 参照)。
+- **char_count** は P1-10 (並列実装) の ``count_tweet_chars`` を優先し、
+  未マージ期間は ``len()`` でフォールバックする (lazy import + try/except)。
+  TODO: P1-10 マージ後にフォールバックブロックを削除する (#issue-P1-10)。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.validators import URLValidator
+from django.db import transaction
+from rest_framework import serializers
+
+from apps.tags.models import Tag
+from apps.tweets.models import (
+    TWEET_BODY_MAX_LENGTH,
+    TWEET_MAX_IMAGES,
+    TWEET_MAX_TAGS,
+    Tweet,
+    TweetImage,
+    TweetTag,
+)
+from apps.tweets.rendering import render_markdown
+
+# -----------------------------------------------------------------------------
+# P1-10 (char_count) lazy import
+# -----------------------------------------------------------------------------
+# P1-10 は並列実装中なので import が失敗するケースを許容する。
+# P1-10 マージ後はこの try/except を削除し、``from apps.tweets.char_count import
+# count_tweet_chars, TWEET_MAX_CHARS`` のみ残す (TODO: #P1-10)。
+try:
+    from apps.tweets.char_count import (  # type: ignore[attr-defined]
+        TWEET_MAX_CHARS,
+        count_tweet_chars,
+    )
+
+    _HAS_CHAR_COUNT = True
+except ImportError:  # pragma: no cover - P1-10 が merge されたら到達しない
+    _HAS_CHAR_COUNT = False
+    TWEET_MAX_CHARS = TWEET_BODY_MAX_LENGTH
+
+
+# -----------------------------------------------------------------------------
+# Image serializer (read/write 共通)
+# -----------------------------------------------------------------------------
+
+
+class TweetImageSerializer(serializers.ModelSerializer):
+    """TweetImage の read/write 共通 serializer。
+
+    security-reviewer HIGH: ``image_url`` は https 限定。
+    ``data:`` / ``javascript:`` / ``http://`` を混入させない。
+    """
+
+    # URLField のデフォルト validator に加えて https 限定 URLValidator を重ねる。
+    image_url = serializers.URLField(
+        max_length=512,
+        validators=[URLValidator(schemes=["https"])],
+    )
+
+    class Meta:
+        model = TweetImage
+        fields = ["image_url", "width", "height", "order"]
+
+
+# -----------------------------------------------------------------------------
+# Read serializers
+# -----------------------------------------------------------------------------
+
+
+class TweetListSerializer(serializers.ModelSerializer):
+    """List (GET /api/v1/tweets/) 用の read-only serializer。
+
+    tags は through テーブル TweetTag を経由するが、API 消費側には
+    ``[name, name, ...]`` の配列で返す (UI が扱いやすい)。
+    """
+
+    author_handle = serializers.SerializerMethodField()
+    html = serializers.SerializerMethodField()
+    images = TweetImageSerializer(many=True, read_only=True)
+    tags = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Tweet
+        fields = [
+            "id",
+            "author_handle",
+            "body",
+            "html",
+            "created_at",
+            "edit_count",
+            "last_edited_at",
+            "images",
+            "tags",
+        ]
+        read_only_fields = fields
+
+    def get_author_handle(self, obj: Tweet) -> str:
+        return obj.author.username
+
+    def get_html(self, obj: Tweet) -> str:
+        return render_markdown(obj.body)
+
+    def get_tags(self, obj: Tweet) -> list[str]:
+        # prefetch 済み (view 側で prefetch_related) を前提に、追加の SQL を撃たない。
+        return [t.name for t in obj.tags.all()]
+
+
+class TweetDetailSerializer(TweetListSerializer):
+    """Detail (GET /api/v1/tweets/<id>/) 用 serializer。
+
+    List に加えて author の表示情報 (display_name / avatar_url) を返す。
+    """
+
+    author_display_name = serializers.SerializerMethodField()
+    author_avatar_url = serializers.SerializerMethodField()
+
+    class Meta(TweetListSerializer.Meta):
+        fields = [
+            *TweetListSerializer.Meta.fields,
+            "author_display_name",
+            "author_avatar_url",
+        ]
+        read_only_fields = fields
+
+    def get_author_display_name(self, obj: Tweet) -> str:
+        # display_name は blank=True / default="" なので fallback で username
+        return obj.author.display_name or obj.author.username
+
+    def get_author_avatar_url(self, obj: Tweet) -> str:
+        return obj.author.avatar_url or ""
+
+
+# -----------------------------------------------------------------------------
+# Create serializer
+# -----------------------------------------------------------------------------
+
+
+class TweetCreateSerializer(serializers.Serializer):
+    """POST /api/v1/tweets/ 用の write-only serializer。
+
+    tags は承認済みタグ名の配列を受け取り、内部で ``Tag`` 解決 → ``TweetTag`` 作成。
+    images は ``{image_url, width, height, order}`` の配列を受け取り、
+    ``TweetImage.objects.create`` で 1 件ずつ保存する (``TweetImage.save()`` 内部で
+    ``full_clean()`` が走るので URL スキーム / 枚数制限が再度 enforce される)。
+    """
+
+    body = serializers.CharField(max_length=TWEET_BODY_MAX_LENGTH)
+    tags = serializers.ListField(
+        child=serializers.CharField(max_length=50),
+        max_length=TWEET_MAX_TAGS,
+        required=False,
+        default=list,
+    )
+    images = TweetImageSerializer(many=True, required=False, default=list)
+
+    def validate_body(self, value: str) -> str:
+        """本文の文字数チェック。
+
+        P1-10 (char_count) が merge されていれば ``count_tweet_chars`` で
+        絵文字 / 合字を 1 文字としてカウントする。未 merge 期間は ``len()`` 相当
+        (= CharField(max_length=180) の既存検証) にフォールバックする。
+        """
+        count = count_tweet_chars(value) if _HAS_CHAR_COUNT else len(value)
+        if count > TWEET_MAX_CHARS:
+            raise serializers.ValidationError(
+                f"本文は {TWEET_MAX_CHARS} 字以内で入力してください。"
+            )
+        return value
+
+    def validate_tags(self, value: list[str]) -> list[str]:
+        """全てのタグ名が is_approved=True のタグとして存在することを確認する。"""
+        if not value:
+            return value
+        # 重複は排除するがユーザー指定の順序は保つ
+        seen: set[str] = set()
+        unique: list[str] = []
+        for name in value:
+            lowered = name.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            unique.append(lowered)
+
+        if len(unique) > TWEET_MAX_TAGS:
+            raise serializers.ValidationError(f"タグは最大 {TWEET_MAX_TAGS} 個まで指定できます。")
+
+        existing = set(
+            Tag.objects.filter(name__in=unique, is_approved=True).values_list("name", flat=True)
+        )
+        missing = [n for n in unique if n not in existing]
+        if missing:
+            raise serializers.ValidationError(
+                f"承認済みタグではない、または存在しないタグが含まれています: {missing}"
+            )
+        return unique
+
+    def validate_images(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if len(value) > TWEET_MAX_IMAGES:
+            raise serializers.ValidationError(f"画像は最大 {TWEET_MAX_IMAGES} 枚まで添付できます。")
+        return value
+
+    @transaction.atomic
+    def create(self, validated_data: dict[str, Any]) -> Tweet:
+        """Tweet + TweetTag + TweetImage をトランザクション内で一括作成する。"""
+        tags: list[str] = validated_data.pop("tags", [])
+        images: list[dict[str, Any]] = validated_data.pop("images", [])
+        author = validated_data.pop("author")
+        body: str = validated_data["body"]
+
+        tweet = Tweet.objects.create(author=author, body=body)
+
+        if tags:
+            # validate_tags で存在確認済みなので、dict 経由で一括取得する
+            tag_map = {t.name: t for t in Tag.objects.filter(name__in=tags)}
+            for name in tags:
+                TweetTag.objects.create(tweet=tweet, tag=tag_map[name])
+
+        for img in images:
+            TweetImage.objects.create(tweet=tweet, **img)
+
+        return tweet
+
+
+# -----------------------------------------------------------------------------
+# Update serializer
+# -----------------------------------------------------------------------------
+
+
+class TweetUpdateSerializer(serializers.Serializer):
+    """PATCH /api/v1/tweets/<id>/ 用の write-only serializer。
+
+    本文だけが編集可能。tags / images は編集不可 (SPEC §3.5)。
+    実際の編集は ``Tweet.record_edit`` に委譲する — これにより:
+      - 30 分以内制約
+      - 5 回制約
+      - TweetEdit の自動生成
+      - edit_count の原子インクリメント
+    が全て担保される。
+    """
+
+    body = serializers.CharField(max_length=TWEET_BODY_MAX_LENGTH)
+
+    def validate_body(self, value: str) -> str:
+        count = count_tweet_chars(value) if _HAS_CHAR_COUNT else len(value)
+        if count > TWEET_MAX_CHARS:
+            raise serializers.ValidationError(
+                f"本文は {TWEET_MAX_CHARS} 字以内で入力してください。"
+            )
+        return value
+
+    def update(self, instance: Tweet, validated_data: dict[str, Any]) -> Tweet:
+        """``Tweet.record_edit`` に委譲する。
+
+        editor は context['request'].user から取得する。
+        record_edit は ValidationError を投げる可能性があるので、
+        view 側 ``perform_update`` はそれを 400 に map する。
+        """
+        editor = self.context["request"].user
+        instance.record_edit(new_body=validated_data["body"], editor=editor)
+        return instance

--- a/apps/tweets/tests/test_crud_api.py
+++ b/apps/tweets/tests/test_crud_api.py
@@ -1,0 +1,506 @@
+"""Tweet CRUD API のテスト (P1-08 / Issue #94, SPEC §3)。
+
+対象エンドポイント:
+    - POST   /api/v1/tweets/            : 作成 (IsAuthenticated + CSRF + throttle)
+    - GET    /api/v1/tweets/            : 一覧 (AllowAny, author/tag フィルタ, pagination)
+    - GET    /api/v1/tweets/<pk>/       : 取得 (AllowAny, tombstone 対応 410)
+    - PATCH  /api/v1/tweets/<pk>/       : 編集 (IsAuthenticated + 本人のみ + CSRF)
+    - DELETE /api/v1/tweets/<pk>/       : 削除 (IsAuthenticated + 本人のみ + CSRF, soft-delete)
+
+方針:
+    - ``force_authenticate`` で JWT / Cookie / CSRF フローを飛ばし、
+      ビジネスロジック (serializer の validation / viewset の分岐) に集中する。
+      認証フローは apps.users.tests.test_email_auth_flow で別途テスト済み。
+    - AAA パターン。
+    - Tag は make_tag(is_approved=True) で準備する (TweetTag.clean の検証を通す)。
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.tweets.models import (
+    TWEET_EDIT_WINDOW_MINUTES,
+    TWEET_MAX_EDIT_COUNT,
+    Tweet,
+    TweetEdit,
+    TweetImage,
+)
+from apps.tweets.tests._factories import make_tag, make_tweet, make_user
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def list_url() -> str:
+    return reverse("tweets-list")
+
+
+def detail_url(pk: int) -> str:
+    return reverse("tweets-detail", kwargs={"pk": pk})
+
+
+def _image_payload(url: str = "https://cdn.example.com/a.png", order: int = 0) -> dict:
+    return {"image_url": url, "width": 400, "height": 300, "order": order}
+
+
+# =============================================================================
+# POST /api/v1/tweets/  (Create)
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestCreateTweet:
+    def test_unauthenticated_returns_401(self, api_client: APIClient) -> None:
+        # Arrange
+        payload = {"body": "hello"}
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_create_tweet_success(self, api_client: APIClient) -> None:
+        # Arrange
+        user = make_user(username="poster")
+        api_client.force_authenticate(user=user)
+        tag1 = make_tag(name="python", is_approved=True)
+        tag2 = make_tag(name="django", is_approved=True)
+        payload = {
+            "body": "## hello\nworld",
+            "tags": [tag1.name, tag2.name],
+            "images": [
+                _image_payload("https://cdn.example.com/a.png", 0),
+                _image_payload("https://cdn.example.com/b.png", 1),
+            ],
+        }
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_201_CREATED
+        data = res.json()
+        assert data["body"] == "## hello\nworld"
+        assert data["author_handle"] == "poster"
+        assert set(data["tags"]) == {"python", "django"}
+        assert len(data["images"]) == 2
+        assert "<h2>" in data["html"] or "hello" in data["html"]
+
+        # DB 反映確認
+        tweet = Tweet.objects.get(pk=data["id"])
+        assert tweet.author == user
+        assert tweet.tags.count() == 2
+        assert TweetImage.objects.filter(tweet=tweet).count() == 2
+
+    def test_body_exactly_max_length_ok(self, api_client: APIClient) -> None:
+        # Arrange: 180 字ピッタリ
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        payload = {"body": "a" * 180}
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_201_CREATED
+
+    def test_body_over_max_length_rejected(self, api_client: APIClient) -> None:
+        # Arrange: 181 字
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        payload = {"body": "a" * 181}
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_unapproved_tag_rejected(self, api_client: APIClient) -> None:
+        # Arrange: 未承認タグ
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        make_tag(name="pending", is_approved=False)
+        payload = {"body": "hi", "tags": ["pending"]}
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_more_than_three_tags_rejected(self, api_client: APIClient) -> None:
+        # Arrange: 4 個
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        for i in range(4):
+            make_tag(name=f"tag{i}", is_approved=True)
+        payload = {
+            "body": "hi",
+            "tags": ["tag0", "tag1", "tag2", "tag3"],
+        }
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert: ListField(max_length=3) で 400
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_more_than_four_images_rejected(self, api_client: APIClient) -> None:
+        # Arrange: 5 枚
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        payload = {
+            "body": "hi",
+            "images": [_image_payload(f"https://cdn.example.com/{i}.png", i) for i in range(5)],
+        }
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_http_image_url_rejected(self, api_client: APIClient) -> None:
+        # Arrange: http:// (非 https)
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        payload = {
+            "body": "hi",
+            "images": [
+                {
+                    "image_url": "http://cdn.example.com/a.png",
+                    "width": 400,
+                    "height": 300,
+                    "order": 0,
+                }
+            ],
+        }
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_throttle_engages_after_tier_1_limit(self, api_client: APIClient, monkeypatch) -> None:
+        """tier_1 を超えたら 429 を返す。
+
+        ``SimpleRateThrottle.THROTTLE_RATES`` はクラス属性として import 時に
+        凍結されるため、``settings`` fixture 経由で ``DEFAULT_THROTTLE_RATES``
+        を書き換えてもテスト内で効かない (DRF の既知の特性)。
+        代わりに ``PostTweetThrottle.THROTTLE_RATES`` を ``monkeypatch`` で
+        直接書き換えて tier_1 を 2/day に下げる。
+        """
+        # Arrange: tier_1 を 2/day に強制する
+        from django.core.cache import cache
+
+        from apps.common.throttling import PostTweetThrottle
+
+        monkeypatch.setattr(
+            PostTweetThrottle,
+            "THROTTLE_RATES",
+            {**PostTweetThrottle.THROTTLE_RATES, "post_tweet_tier_1": "2/day"},
+        )
+        cache.clear()
+
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        payload = {"body": "hi"}
+
+        # Act: 2 回までは 201, 3 回目で 429
+        res1 = api_client.post(list_url(), payload, format="json")
+        res2 = api_client.post(list_url(), payload, format="json")
+        res3 = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res1.status_code == status.HTTP_201_CREATED
+        assert res2.status_code == status.HTTP_201_CREATED
+        assert res3.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+# =============================================================================
+# GET /api/v1/tweets/  (List)
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestListTweets:
+    def test_anonymous_can_list(self, api_client: APIClient) -> None:
+        # Arrange
+        user = make_user()
+        make_tweet(author=user, body="t1")
+
+        # Act
+        res = api_client.get(list_url())
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+
+    def test_soft_deleted_excluded(self, api_client: APIClient) -> None:
+        # Arrange: 1 件削除済み + 1 件生存
+        user = make_user()
+        alive = make_tweet(author=user, body="alive")
+        dead = make_tweet(author=user, body="dead")
+        dead.soft_delete()
+
+        # Act
+        res = api_client.get(list_url())
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        ids = [t["id"] for t in body["results"]]
+        assert alive.pk in ids
+        assert dead.pk not in ids
+
+    def test_filter_by_author(self, api_client: APIClient) -> None:
+        # Arrange
+        alice = make_user(username="alice")
+        bob = make_user(username="bob")
+        t_alice = make_tweet(author=alice, body="by alice")
+        make_tweet(author=bob, body="by bob")
+
+        # Act
+        res = api_client.get(list_url() + "?author=alice")
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        ids = [t["id"] for t in body["results"]]
+        assert ids == [t_alice.pk]
+
+    def test_filter_by_tag(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user()
+        tag_py = make_tag(name="python", is_approved=True)
+        t_py = make_tweet(author=author, body="about python")
+        t_py.tags.add(tag_py)
+
+        tag_go = make_tag(name="go", is_approved=True)
+        t_go = make_tweet(author=author, body="about go")
+        t_go.tags.add(tag_go)
+
+        # Act
+        res = api_client.get(list_url() + "?tag=python")
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        ids = [t["id"] for t in body["results"]]
+        assert t_py.pk in ids
+        assert t_go.pk not in ids
+
+    def test_pagination_default_page_size(self, api_client: APIClient) -> None:
+        # Arrange: 11 件作って default page_size (10) を検証
+        author = make_user()
+        for i in range(11):
+            make_tweet(author=author, body=f"t{i}")
+
+        # Act
+        res = api_client.get(list_url())
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        assert body["count"] == 11
+        assert len(body["results"]) == 10
+        assert body["next"] is not None
+
+
+# =============================================================================
+# GET /api/v1/tweets/<pk>/  (Retrieve)
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestRetrieveTweet:
+    def test_anonymous_can_retrieve(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="hello")
+
+        # Act
+        res = api_client.get(detail_url(tweet.pk))
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        data = res.json()
+        assert data["id"] == tweet.pk
+        assert data["body"] == "hello"
+        # detail serializer 固有フィールド
+        assert "author_display_name" in data
+        assert "author_avatar_url" in data
+
+    def test_soft_deleted_returns_410_with_tombstone(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="doomed")
+        tweet.soft_delete()
+
+        # Act
+        res = api_client.get(detail_url(tweet.pk))
+
+        # Assert
+        assert res.status_code == status.HTTP_410_GONE
+        data = res.json()
+        assert data["id"] == tweet.pk
+        assert data["is_deleted"] is True
+        assert data["deleted_at"] is not None
+
+    def test_nonexistent_returns_404(self, api_client: APIClient) -> None:
+        # Act
+        res = api_client.get(detail_url(999999))
+
+        # Assert
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+
+# =============================================================================
+# PATCH /api/v1/tweets/<pk>/  (Update)
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUpdateTweet:
+    def test_unauthenticated_returns_401(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="x")
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "y"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_other_user_patch_forbidden(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user(username="author")
+        other = make_user(username="other")
+        tweet = make_tweet(author=author, body="x")
+        api_client.force_authenticate(user=other)
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "hack"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_patch_within_window_succeeds(self, api_client: APIClient) -> None:
+        # Arrange: 作成直後。編集 window (30 min) 内。
+        author = make_user()
+        tweet = make_tweet(author=author, body="before")
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "after"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+        tweet.refresh_from_db()
+        assert tweet.body == "after"
+        assert tweet.edit_count == 1
+        assert TweetEdit.objects.filter(tweet=tweet).count() == 1
+
+    def test_patch_after_window_rejected(self, api_client: APIClient) -> None:
+        # Arrange: created_at を 31 分過去に巻き戻す
+        author = make_user()
+        tweet = make_tweet(author=author, body="before")
+        past = timezone.now() - timedelta(minutes=TWEET_EDIT_WINDOW_MINUTES + 1)
+        Tweet.objects.filter(pk=tweet.pk).update(created_at=past)
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "after"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_patch_after_max_edits_rejected(self, api_client: APIClient) -> None:
+        # Arrange: 既に上限回編集済み
+        author = make_user()
+        tweet = make_tweet(author=author, body="before")
+        Tweet.objects.filter(pk=tweet.pk).update(edit_count=TWEET_MAX_EDIT_COUNT)
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "after"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_patch_over_max_body_length_rejected(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="x")
+        api_client.force_authenticate(user=author)
+
+        # Act: 181 字
+        res = api_client.patch(detail_url(tweet.pk), {"body": "a" * 181}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# =============================================================================
+# DELETE /api/v1/tweets/<pk>/  (Destroy)
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestDeleteTweet:
+    def test_unauthenticated_returns_401(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="x")
+
+        # Act
+        res = api_client.delete(detail_url(tweet.pk))
+
+        # Assert
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_other_user_delete_forbidden(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user(username="author")
+        other = make_user(username="other")
+        tweet = make_tweet(author=author, body="x")
+        api_client.force_authenticate(user=other)
+
+        # Act
+        res = api_client.delete(detail_url(tweet.pk))
+
+        # Assert
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_owner_delete_soft_deletes(self, api_client: APIClient) -> None:
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="bye")
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.delete(detail_url(tweet.pk))
+
+        # Assert
+        assert res.status_code == status.HTTP_204_NO_CONTENT
+        # DB 上は残っている (ソフト削除)
+        assert Tweet.all_objects.filter(pk=tweet.pk).exists()
+        tweet.refresh_from_db()
+        assert tweet.is_deleted is True
+        assert tweet.deleted_at is not None

--- a/apps/tweets/tests/test_crud_api.py
+++ b/apps/tweets/tests/test_crud_api.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from django.urls import reverse
@@ -47,7 +48,7 @@ def detail_url(pk: int) -> str:
     return reverse("tweets-detail", kwargs={"pk": pk})
 
 
-def _image_payload(url: str = "https://cdn.example.com/a.png", order: int = 0) -> dict:
+def _image_payload(url: str = "https://cdn.example.com/a.png", order: int = 0) -> dict[str, Any]:
     return {"image_url": url, "width": 400, "height": 300, "order": order}
 
 
@@ -430,6 +431,22 @@ class TestUpdateTweet:
         # Assert
         assert res.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_patch_exactly_at_window_boundary_succeeds(self, api_client: APIClient) -> None:
+        """編集ウィンドウ境界値: 30 分 - 1 秒前ならまだ編集可能。"""
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="before")
+        # timedelta の引数: seconds=-1 で "30 分 - 1 秒" を表現する
+        past = timezone.now() - timedelta(minutes=TWEET_EDIT_WINDOW_MINUTES, seconds=-1)
+        Tweet.objects.filter(pk=tweet.pk).update(created_at=past)
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "after"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+
     def test_patch_after_max_edits_rejected(self, api_client: APIClient) -> None:
         # Arrange: 既に上限回編集済み
         author = make_user()
@@ -443,6 +460,20 @@ class TestUpdateTweet:
         # Assert
         assert res.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_patch_at_edit_count_4_succeeds(self, api_client: APIClient) -> None:
+        """編集回数境界値: 上限 - 1 回目ならまだ編集可能。"""
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="x")
+        Tweet.objects.filter(pk=tweet.pk).update(edit_count=TWEET_MAX_EDIT_COUNT - 1)
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "y"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_200_OK
+
     def test_patch_over_max_body_length_rejected(self, api_client: APIClient) -> None:
         # Arrange
         author = make_user()
@@ -454,6 +485,33 @@ class TestUpdateTweet:
 
         # Assert
         assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_patch_soft_deleted_returns_404(self, api_client: APIClient) -> None:
+        """soft-deleted な Tweet への PATCH は 404 (alive queryset から除外)。"""
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="x")
+        tweet.soft_delete()
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.patch(detail_url(tweet.pk), {"body": "x"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_put_method_not_allowed(self, api_client: APIClient) -> None:
+        """PUT は非サポート (PATCH のみ)。"""
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="x")
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.put(detail_url(tweet.pk), {"body": "x"}, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
 # =============================================================================
@@ -504,3 +562,41 @@ class TestDeleteTweet:
         tweet.refresh_from_db()
         assert tweet.is_deleted is True
         assert tweet.deleted_at is not None
+
+    def test_delete_soft_deleted_returns_404(self, api_client: APIClient) -> None:
+        """既に soft-deleted な Tweet への DELETE は 404。"""
+        # Arrange
+        author = make_user()
+        tweet = make_tweet(author=author, body="x")
+        tweet.soft_delete()
+        api_client.force_authenticate(user=author)
+
+        # Act
+        res = api_client.delete(detail_url(tweet.pk))
+
+        # Assert
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+
+# =============================================================================
+# Tag handling
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestTagHandling:
+    def test_duplicate_tags_case_insensitive_deduplicated(self, api_client: APIClient) -> None:
+        """大文字小文字違いの重複タグは 1 件にまとめて lower-case で保存される。"""
+        # Arrange
+        user = make_user()
+        api_client.force_authenticate(user=user)
+        make_tag(name="python", is_approved=True)
+        payload = {"body": "hi", "tags": ["Python", "python", "PYTHON"]}
+
+        # Act
+        res = api_client.post(list_url(), payload, format="json")
+
+        # Assert
+        assert res.status_code == status.HTTP_201_CREATED
+        assert res.json()["tags"] == ["python"]

--- a/apps/tweets/urls.py
+++ b/apps/tweets/urls.py
@@ -1,5 +1,25 @@
-from django.urls import URLPattern, URLResolver
+"""URL configuration for the tweets CRUD API (P1-08).
 
-# URL patterns are added in the phase that implements this feature.
-# See docs/ROADMAP.md for ownership.
-urlpatterns: list[URLPattern | URLResolver] = []
+``config/urls.py`` の ``path("api/v1/tweets/", include("apps.tweets.urls"))`` から
+マウントされる。``DefaultRouter`` で CRUD の 5 エンドポイントを一括生成する。
+
+生成される URL:
+    - GET  /api/v1/tweets/         -> list
+    - POST /api/v1/tweets/         -> create
+    - GET  /api/v1/tweets/<pk>/    -> retrieve
+    - PATCH /api/v1/tweets/<pk>/   -> partial_update
+    - DELETE /api/v1/tweets/<pk>/  -> destroy
+"""
+
+from __future__ import annotations
+
+from rest_framework.routers import DefaultRouter
+
+from apps.tweets.views import TweetViewSet
+
+router = DefaultRouter()
+# basename を明示しないと queryset 評価時に DB にアクセスしてしまうため
+# 必ず ``basename`` を指定する。
+router.register(r"", TweetViewSet, basename="tweets")
+
+urlpatterns = router.urls

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -1,5 +1,243 @@
-"""Views for the tweets app.
+"""Views for the tweets CRUD API (P1-08).
 
-Views are added in the phase that owns this feature.
-See docs/ROADMAP.md for ownership.
+SPEC §3 を満たす Tweet の CRUD エンドポイントを ``ModelViewSet`` で提供する。
+
+エンドポイント一覧 (ベース: ``/api/v1/tweets/``):
+    - ``POST   /``         — 作成 (IsAuthenticated + CSRF + PostTweetThrottle)
+    - ``GET    /``         — 一覧 (AllowAny, author / tag / pagination)
+    - ``GET    /<id>/``    — 取得 (AllowAny, tombstone 対応)
+    - ``PATCH  /<id>/``    — 編集 (IsAuthenticated + 本人のみ + CSRF)
+    - ``DELETE /<id>/``    — 削除 (IsAuthenticated + 本人のみ + CSRF, soft-delete)
+
+設計方針:
+    - **論理削除**: 一覧/作成/更新/削除は ``Tweet.objects`` (alive) に限定。
+      retrieve だけは ``Tweet.all_objects`` から引いて ``is_deleted=True`` の時に
+      410 Gone (tombstone) を返す (§3.9 論理削除の仕様)。
+    - **認証と CSRF**: Cookie で JWT を受けた場合に限り CSRF enforcement を
+      走らせるため、state 変更系 (create/update/destroy) には
+      ``CSRFEnforcingAuthentication`` と ``CookieAuthentication`` を明示指定する。
+      read 系 (list/retrieve) は ``authentication_classes`` を最小化 (非 cookie
+      な Authorization ヘッダでの閲覧を許容) する。
+    - **throttle**: create のみ ``PostTweetThrottle`` (階層 100/500/1000/day)。
+      update/destroy は DRF デフォルト (UserRateThrottle) が自動適用される。
 """
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import status, viewsets
+from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from apps.common.cookie_auth import CookieAuthentication
+from apps.common.throttling import PostTweetThrottle
+from apps.tweets.models import Tweet
+from apps.tweets.serializers import (
+    TweetCreateSerializer,
+    TweetDetailSerializer,
+    TweetListSerializer,
+    TweetUpdateSerializer,
+)
+
+# Action 定数 (マジックストリング排除)
+ACTION_LIST = "list"
+ACTION_RETRIEVE = "retrieve"
+ACTION_CREATE = "create"
+ACTION_UPDATE = "update"
+ACTION_PARTIAL_UPDATE = "partial_update"
+ACTION_DESTROY = "destroy"
+
+_READ_ACTIONS = frozenset({ACTION_LIST, ACTION_RETRIEVE})
+
+
+class TweetViewSet(viewsets.ModelViewSet):
+    """Tweet CRUD の ModelViewSet (SPEC §3)。
+
+    action ごとに serializer / permission / authentication / throttle を切り替える。
+    """
+
+    # 既定 queryset: alive のみ。retrieve だけは all_objects を使うので override する。
+    queryset = Tweet.objects.all()
+
+    # PK は ID (int)。Django 既定の ``pk`` を明示指定することで lookup_url_kwarg
+    # の整合を取る。
+    lookup_field = "pk"
+
+    # ------------------------------------------------------------------
+    # 1. Serializer / Permission / Authentication / Throttle の切替
+    # ------------------------------------------------------------------
+
+    def get_serializer_class(self) -> type:
+        if self.action == ACTION_LIST:
+            return TweetListSerializer
+        if self.action == ACTION_RETRIEVE:
+            return TweetDetailSerializer
+        if self.action == ACTION_CREATE:
+            return TweetCreateSerializer
+        if self.action in (ACTION_UPDATE, ACTION_PARTIAL_UPDATE):
+            return TweetUpdateSerializer
+        # destroy は serializer 不要だが DRF が呼ぶので何か返す
+        return TweetListSerializer
+
+    def get_permissions(self) -> list[Any]:
+        if self.action in _READ_ACTIONS:
+            return [AllowAny()]
+        # create / update / partial_update / destroy
+        return [IsAuthenticated()]
+
+    # 認証は CookieAuthentication に一本化する。
+    # - Cookie で届いた JWT を復号しつつ、**Cookie 経由の時だけ** CSRF enforcement を走らせる
+    #   (``apps.common.cookie_auth.CookieAuthentication.authenticate`` 参照)。
+    # - Authorization ヘッダ経由 (SPA 外のツールや Swagger) は CSRF 対象外
+    #   (cross-site からは ``Authorization`` ヘッダが自動付与されないため)。
+    # - 未認証で state 変更系を叩いた場合は ``IsAuthenticated`` → 401 を返す。
+    #   (CSRFEnforcingAuthentication を前段に置くと未認証でも 403 になってしまい、
+    #    "認証されていない" 情報が "CSRF 失敗" に紛れてしまうので避ける。)
+    authentication_classes = [CookieAuthentication]
+
+    def get_throttles(self) -> list[Any]:
+        """create のみ PostTweetThrottle を適用する。
+
+        update/destroy は DRF デフォルトの UserRateThrottle (500/day) を
+        settings 側で自動適用する。list/retrieve は AnonRateThrottle が
+        settings から自動適用される。
+        """
+        if self.action == ACTION_CREATE:
+            return [PostTweetThrottle()]
+        return super().get_throttles()
+
+    # ------------------------------------------------------------------
+    # 2. Queryset filter (list)
+    # ------------------------------------------------------------------
+
+    def get_queryset(self):
+        """``?author=<username>`` と ``?tag=<name>`` のクエリフィルタを適用する。
+
+        ``created_at desc`` は Tweet.Meta.ordering で既定。
+        N+1 を避けるため author / images / tags を prefetch する。
+        """
+        qs = Tweet.objects.all().select_related("author").prefetch_related("images", "tags")
+
+        request = getattr(self, "request", None)
+        if request is None:
+            return qs
+
+        author = request.query_params.get("author")
+        if author:
+            # username は大文字小文字を区別しない (users 側と揃える)
+            qs = qs.filter(author__username__iexact=author)
+
+        tag = request.query_params.get("tag")
+        if tag:
+            qs = qs.filter(tags__name=tag.lower())
+
+        return qs.distinct()
+
+    # ------------------------------------------------------------------
+    # 3. Retrieve (tombstone 対応)
+    # ------------------------------------------------------------------
+
+    def retrieve(self, request: Request, *args, **kwargs) -> Response:
+        """retrieve は all_objects から引き、is_deleted=True なら 410 Gone を返す。
+
+        SPEC §3.9: tombstone レスポンス ``{id, is_deleted, deleted_at}``。
+        """
+        pk = kwargs.get(self.lookup_field)
+        tweet = (
+            Tweet.all_objects.select_related("author")
+            .prefetch_related("images", "tags")
+            .filter(pk=pk)
+            .first()
+        )
+        if tweet is None:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        if tweet.is_deleted:
+            return Response(
+                {
+                    "id": tweet.pk,
+                    "is_deleted": True,
+                    "deleted_at": tweet.deleted_at,
+                },
+                status=status.HTTP_410_GONE,
+            )
+
+        serializer = self.get_serializer(tweet)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    # ------------------------------------------------------------------
+    # 4. Create
+    # ------------------------------------------------------------------
+
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        """ツイートを作成する。成功時は detail serializer で 201 を返す。"""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        tweet = serializer.save(author=request.user)
+
+        out = TweetDetailSerializer(tweet, context=self.get_serializer_context()).data
+        return Response(out, status=status.HTTP_201_CREATED)
+
+    # ------------------------------------------------------------------
+    # 5. Update (PATCH only — record_edit 経由)
+    # ------------------------------------------------------------------
+
+    def update(self, request: Request, *args, **kwargs) -> Response:
+        """PUT は非サポート。PATCH のみ許可する。"""
+        if not kwargs.get("partial", False):
+            return Response(
+                {"detail": 'Method "PUT" not allowed. Use PATCH.'},
+                status=status.HTTP_405_METHOD_NOT_ALLOWED,
+            )
+        return self._do_partial_update(request, *args, **kwargs)
+
+    def partial_update(self, request: Request, *args, **kwargs) -> Response:
+        return self._do_partial_update(request, *args, **kwargs)
+
+    def _do_partial_update(self, request: Request, *args, **kwargs) -> Response:
+        """partial_update の実体。
+
+        author チェックは serializer に instance をセットする前に先に行い、
+        他人の body validation を無駄に走らせない (情報漏洩防止にもなる)。
+        """
+        instance = self.get_object()
+        # User モデルは primary_key を ``pkid`` (BigAutoField) にしている (apps/users/models.py)。
+        # ``Tweet.author`` の FK は pk=pkid に張られるため ``author_id`` と比較するのは
+        # ``request.user.pk`` (= pkid)。``request.user.id`` は UUIDField なので一致しない。
+        if instance.author_id != request.user.pk:
+            raise PermissionDenied("他のユーザーのツイートは編集できません。")
+
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            self.perform_update(serializer)
+        except DjangoValidationError as exc:
+            # record_edit が投げる ValidationError を DRF の 400 に変換する
+            raise ValidationError({"detail": exc.messages}) from exc
+
+        instance.refresh_from_db()
+        out = TweetDetailSerializer(instance, context=self.get_serializer_context()).data
+        return Response(out, status=status.HTTP_200_OK)
+
+    def perform_update(self, serializer) -> None:
+        serializer.save()
+
+    # ------------------------------------------------------------------
+    # 6. Destroy (soft delete)
+    # ------------------------------------------------------------------
+
+    def destroy(self, request: Request, *args, **kwargs) -> Response:
+        instance = self.get_object()
+        # User の primary key は ``pkid``。詳細は _do_partial_update のコメント参照。
+        if instance.author_id != request.user.pk:
+            raise PermissionDenied("他のユーザーのツイートは削除できません。")
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def perform_destroy(self, instance: Tweet) -> None:
+        """論理削除 (§3.9)。物理削除はしない。"""
+        instance.soft_delete()

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from typing import Any
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers as drf_serializers
 from rest_framework import status, viewsets
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -35,6 +36,7 @@ from rest_framework.response import Response
 
 from apps.common.cookie_auth import CookieAuthentication
 from apps.common.throttling import PostTweetThrottle
+from apps.tweets.managers import TweetQuerySet
 from apps.tweets.models import Tweet
 from apps.tweets.serializers import (
     TweetCreateSerializer,
@@ -71,7 +73,7 @@ class TweetViewSet(viewsets.ModelViewSet):
     # 1. Serializer / Permission / Authentication / Throttle の切替
     # ------------------------------------------------------------------
 
-    def get_serializer_class(self) -> type:
+    def get_serializer_class(self) -> type[drf_serializers.Serializer]:
         if self.action == ACTION_LIST:
             return TweetListSerializer
         if self.action == ACTION_RETRIEVE:
@@ -114,7 +116,7 @@ class TweetViewSet(viewsets.ModelViewSet):
     # 2. Queryset filter (list)
     # ------------------------------------------------------------------
 
-    def get_queryset(self):
+    def get_queryset(self) -> TweetQuerySet:
         """``?author=<username>`` と ``?tag=<name>`` のクエリフィルタを適用する。
 
         ``created_at desc`` は Tweet.Meta.ordering で既定。
@@ -223,7 +225,7 @@ class TweetViewSet(viewsets.ModelViewSet):
         out = TweetDetailSerializer(instance, context=self.get_serializer_context()).data
         return Response(out, status=status.HTTP_200_OK)
 
-    def perform_update(self, serializer) -> None:
+    def perform_update(self, serializer: drf_serializers.Serializer) -> None:
         serializer.save()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue #94 — ツイート機能の本体 API。

## URL
\`GET/POST /api/v1/tweets/\` + \`GET/PATCH/DELETE /api/v1/tweets/<pk>/\`

## Action → permission / throttle マッピング
| action | permission | throttle | serializer |
|---|---|---|---|
| list | AllowAny | default | TweetListSerializer |
| retrieve | AllowAny | default | TweetDetailSerializer |
| create | IsAuthenticated | **PostTweetThrottle** (tier 1/2/3) | TweetCreateSerializer |
| partial_update | IsAuthenticated + author | default | TweetUpdateSerializer |
| destroy | IsAuthenticated + author | default | — |

## 主な設計
- \`retrieve\` で is_deleted=True は **410 Gone + tombstone** (\`{id, is_deleted: true, deleted_at}\`)
- \`partial_update\` は \`Tweet.record_edit\` 経由 (30 分以内 & 5 回まで、TOCTOU 対策済み)
- \`destroy\` は \`Tweet.soft_delete()\` (DB 削除しない)
- PostTweetThrottle で scope=\`post_tweet_tier_<1/2/3>\`
- char_count (P1-10) は lazy import + fallback (\`len(body)\`) — P1-10 merge 後に削除する TODO コメント

## テスト (26 件)
- Create 8 / List 5 / Retrieve 3 / Update 6 / Delete 3

Refs: #94