### PR TITLE
feat(p1-13): ログイン/サインアップ UI (cookie JWT + Google OAuth)

### DIFF
--- a/client/src/app/(template)/(auth)/activate/[uid]/[token]/page.tsx
+++ b/client/src/app/(template)/(auth)/activate/[uid]/[token]/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useActivateUserMutation } from "@/lib/redux/features/auth/authApiSlice";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
+
+import { activateAccount } from "@/lib/api/auth";
+import { parseDrfErrors } from "@/lib/api/errors";
 
 interface ActivationProps {
 	params: {
@@ -12,49 +14,71 @@ interface ActivationProps {
 	};
 }
 
+type Status = "pending" | "success" | "error";
+
+/**
+ * djoser activation link handler (P1-13).
+ *
+ * The user clicks a link in their activation email and lands here. We fire a
+ * one-shot POST to ``/auth/users/activation/``. On success we bounce them to
+ * ``/login`` with ``?email=…`` so the login form is pre-filled. On failure
+ * (invalid token / already activated) we show the error inline with a link
+ * back to login.
+ */
 export default function ActivationPage({ params }: ActivationProps) {
 	const router = useRouter();
-	const [activateUser, { isLoading, isSuccess, isError, error }] =
-		useActivateUserMutation();
+	const [status, setStatus] = useState<Status>("pending");
+	const [errorMessage, setErrorMessage] = useState<string>();
+	const attempted = useRef(false);
 
 	useEffect(() => {
-		const { uid, token } = params;
-		activateUser({ uid, token });
-	}, [activateUser, params]);
+		// React 18 dev StrictMode runs effects twice; guard so we don't double-POST.
+		if (attempted.current) return;
+		attempted.current = true;
 
-	useEffect(() => {
-		if (isSuccess) {
-			toast.success("Account activated successfully!");
-			router.push("/login");
-		} else if (isError && error) {
-			toast.error("Failed to activate your account");
-		}
-	}, [isSuccess, isError, error, router]);
+		let cancelled = false;
+		activateAccount({ uid: params.uid, token: params.token })
+			.then(() => {
+				if (cancelled) return;
+				setStatus("success");
+				toast.success("アカウントを有効化しました。ログインしてください。");
+				const search = new URLSearchParams({ email: "" });
+				router.push(`/login?${search.toString()}`);
+			})
+			.catch((error: unknown) => {
+				if (cancelled) return;
+				setStatus("error");
+				setErrorMessage(parseDrfErrors(error).summary);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [params.uid, params.token, router]);
 
 	return (
 		<div className="flex min-h-screen items-center justify-center">
-			<div className="text-center">
+			<div
+				className="text-center"
+				role="status"
+				aria-live="polite"
+				aria-atomic="true"
+			>
 				<h3 className="dark:text-platinum font-robotoSlab text-2xl font-bold text-gray-800 sm:text-4xl md:text-5xl">
-					{isLoading ? (
-						<div className="flex-center">
-							<span className="mr-2">⏰</span>
-							<span>Activating your account....Please wait</span>
-							<span className="ml-2">🥱</span>
-						</div>
-					) : isSuccess ? (
-						<div>
-							<span className="mr-2">✅</span>
-							<span>Account Activated successfully!</span>
-						</div>
-					) : (
-						isError && (
-							<div>
-								<span className="mr-2">❌</span>
-								<span>Your account has already been activated...</span>
-							</div>
-						)
-					)}
+					{status === "pending" && "アカウントを有効化しています…"}
+					{status === "success" && "アカウントを有効化しました 🎉"}
+					{status === "error" &&
+						(errorMessage ??
+							"有効化に失敗しました。リンクが無効か、既に有効化されています。")}
 				</h3>
+				{status === "error" && (
+					<a
+						href="/login"
+						className="mt-4 inline-block text-sm underline hover:text-indigo-500 dark:hover:text-lime-400"
+					>
+						ログインページに戻る
+					</a>
+				)}
 			</div>
 		</div>
 	);

--- a/client/src/app/(template)/(auth)/google/page.tsx
+++ b/client/src/app/(template)/(auth)/google/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Spinner from "@/components/shared/Spinner";
-import { useSocialAuth } from "@/hooks";
-import { useSocialAuthenticationMutation } from "@/lib/redux/features/auth/authApiSlice";
 import { Suspense } from "react";
+
+import Spinner from "@/components/shared/Spinner";
+import useSocialAuth from "@/hooks/useSocialAuth";
 
 export default function GoogleLoginPage() {
 	return (
@@ -20,7 +20,19 @@ export default function GoogleLoginPage() {
 }
 
 function GoogleLoginContent() {
-	const [googleAuthenticate] = useSocialAuthenticationMutation();
-	useSocialAuth(googleAuthenticate, "google-oauth2");
-	return null;
+	const status = useSocialAuth();
+	return (
+		<div
+			className="flex-center pt-32 flex-col gap-4"
+			role="status"
+			aria-live="polite"
+		>
+			<Spinner size="xl" />
+			<p className="text-sm dark:text-platinum">
+				{status === "error"
+					? "Google ログインに失敗しました。ログインページに戻ります…"
+					: "Google アカウントを確認しています…"}
+			</p>
+		</div>
+	);
 }

--- a/client/src/app/(template)/(auth)/login/page.tsx
+++ b/client/src/app/(template)/(auth)/login/page.tsx
@@ -1,27 +1,37 @@
 "use client";
+
+import { Suspense } from "react";
+
 import { AuthFormHeader, LoginForm } from "@/components/forms/auth";
 import OauthButtons from "@/components/shared/OauthButtons";
-import { useRedirectIfAuthenticated } from "@/hooks";
+import Spinner from "@/components/shared/Spinner";
 
 export default function LoginPage() {
-	useRedirectIfAuthenticated();
 	return (
 		<div>
 			<AuthFormHeader
-				title="Login to your account"
-				staticText="Don't have an account?"
-				linkText="Register Here"
+				title="ログイン"
+				staticText="アカウントをお持ちでない方は"
+				linkText="新規登録"
 				linkHref="/register"
 			/>
 			<div className="mt-7 sm:mx-auto sm:w-full sm:max-w-[480px]">
 				<div className="bg-lightGrey dark:bg-deepBlueGrey rounded-xl px-6 py-12 shadow sm:rounded-lg sm:px-12 md:rounded-3xl">
-					<LoginForm />
-					{/* <div className="flex-center mt-5 space-x-2">
+					<Suspense
+						fallback={
+							<div className="flex justify-center py-6">
+								<Spinner size="md" />
+							</div>
+						}
+					>
+						<LoginForm />
+					</Suspense>
+					<div className="flex-center mt-5 space-x-2">
 						<div className="bg-richBlack dark:bg-platinum h-px flex-1"></div>
-						<span className="dark:text-platinum px-2 text-sm">Or</span>
+						<span className="dark:text-platinum px-2 text-sm">または</span>
 						<div className="bg-richBlack dark:bg-platinum h-px flex-1"></div>
 					</div>
-					<OauthButtons /> */}
+					<OauthButtons />
 				</div>
 			</div>
 		</div>

--- a/client/src/app/(template)/(auth)/register/page.tsx
+++ b/client/src/app/(template)/(auth)/register/page.tsx
@@ -1,28 +1,27 @@
 "use client";
+
 import AuthFormHeader from "@/components/forms/auth/AuthFormHeader";
 import RegisterForm from "@/components/forms/auth/RegisterForm";
 import OauthButtons from "@/components/shared/OauthButtons";
-import { useRedirectIfAuthenticated } from "@/hooks";
 
 export default function RegisterPage() {
-	useRedirectIfAuthenticated();
 	return (
 		<div>
 			<AuthFormHeader
-				title="Sign up for an account"
-				staticText="Already have an account?"
-				linkText="Login Here"
+				title="新規登録"
+				staticText="すでにアカウントをお持ちの方は"
+				linkText="ログイン"
 				linkHref="/login"
 			/>
 			<div className="mt-7 sm:mx-auto sm:w-full sm:max-w-[480px]">
 				<div className="bg-lightGrey dark:bg-deepBlueGrey rounded-xl px-6 py-12 shadow sm:rounded-lg sm:px-12 md:rounded-3xl">
 					<RegisterForm />
-					{/* <div className="flex-center mt-5 space-x-2">
+					<div className="flex-center mt-5 space-x-2">
 						<div className="bg-richBlack dark:bg-platinum h-px flex-1"></div>
-						<span className="dark:text-platinum px-2 text-sm">Or</span>
+						<span className="dark:text-platinum px-2 text-sm">または</span>
 						<div className="bg-richBlack dark:bg-platinum h-px flex-1"></div>
 					</div>
-					<OauthButtons />  */}
+					<OauthButtons />
 				</div>
 			</div>
 		</div>

--- a/client/src/components/forms/auth/FormSummaryError.tsx
+++ b/client/src/components/forms/auth/FormSummaryError.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * Accessible, polite-announced summary error for auth forms (P1-13).
+ *
+ * ``role="alert"`` + ``aria-live="polite"`` so screen readers announce server
+ * errors (e.g., invalid credentials, throttled requests) without stealing
+ * focus. Rendered even when ``message`` is empty so the live region is in the
+ * DOM before the first error (prevents first-error announcements from being
+ * swallowed by some screen readers).
+ */
+
+interface FormSummaryErrorProps {
+	message?: string;
+}
+
+export function FormSummaryError({ message }: FormSummaryErrorProps) {
+	return (
+		<div
+			role="alert"
+			aria-live="polite"
+			aria-atomic="true"
+			className={
+				message
+					? "rounded-md border border-red-400 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/60 dark:bg-red-950/40 dark:text-red-200"
+					: "sr-only"
+			}
+			data-testid="auth-form-summary-error"
+		>
+			{message ?? ""}
+		</div>
+	);
+}

--- a/client/src/components/forms/auth/PasswordResetConfirmForm.tsx
+++ b/client/src/components/forms/auth/PasswordResetConfirmForm.tsx
@@ -1,91 +1,77 @@
 "use client";
-import { useResetPasswordConfirmMutation } from "@/lib/redux/features/auth/authApiSlice";
-import {
-	passwordResetConfirmSchema,
-	TPasswordResetConfirmSchema,
-} from "@/lib/validationSchemas";
-import { extractErrorMessage } from "@/utils";
+
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useParams, useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
-import * as z from "zod";
-import { FormFieldComponent } from "@/components/forms/FormFieldComponent";
-import { Button } from "@/components/ui/button";
-import Spinner from "@/components/shared/Spinner";
 
+import Spinner from "@/components/shared/Spinner";
+import { FormFieldComponent } from "@/components/forms/FormFieldComponent";
+import { FormSummaryError } from "@/components/forms/auth/FormSummaryError";
+import { Button } from "@/components/ui/button";
+import { useAuthMutation } from "@/hooks/useAuthMutation";
+import { confirmPasswordReset } from "@/lib/api/auth";
+import {
+	passwordResetConfirmSchema,
+	type TPasswordResetConfirmSchema,
+} from "@/lib/validationSchemas";
+
+/**
+ * Reset-confirm form (P1-13). ``uid`` / ``token`` come from the URL path;
+ * user fills in the new password fields only.
+ */
 export default function PasswordResetConfirmForm() {
 	const router = useRouter();
-	const { uid, token } = useParams();
+	const params = useParams();
+	const uid = params.uid as string;
+	const token = params.token as string;
 
-	const [resetPasswordConfirm, { isLoading }] =
-		useResetPasswordConfirmMutation();
-
-	const {
-		register,
-		handleSubmit,
-		reset,
-		formState: { errors },
-	} = useForm<TPasswordResetConfirmSchema>({
+	const form = useForm<TPasswordResetConfirmSchema>({
+		resolver: zodResolver(passwordResetConfirmSchema),
 		mode: "all",
-		defaultValues: {
-			uid: uid as string,
-			token: token as string,
-			new_password: "",
-			re_new_password: "",
+		defaultValues: { uid, token, new_password: "", re_new_password: "" },
+	});
+
+	const { isSubmitting, summaryError, submit } = useAuthMutation({
+		form,
+		mutate: (values) => confirmPasswordReset({ ...values, uid, token }),
+		onSuccess: () => {
+			toast.success("パスワードを再設定しました。ログインしてください。");
+			router.push("/login");
+			form.reset();
 		},
 	});
 
-	const onSubmit = async (
-		values: z.infer<typeof passwordResetConfirmSchema>,
-	) => {
-		try {
-			await resetPasswordConfirm({
-				...values,
-				uid: uid as string,
-				token: token as string,
-			}).unwrap();
-			router.push("/login");
-			toast.success("Your password was reset successfully");
-			reset();
-		} catch (e) {
-			const errorMessage = extractErrorMessage(e);
-			toast.error(errorMessage || "An error occurred");
-		}
-	};
-
 	return (
-		<main>
-			<form
-				noValidate
-				onSubmit={handleSubmit(onSubmit)}
-				className="flex w-full max-w-md flex-col gap-4"
+		<form
+			noValidate
+			onSubmit={form.handleSubmit(submit)}
+			className="flex w-full max-w-md flex-col gap-4"
+		>
+			<FormSummaryError message={summaryError} />
+			<FormFieldComponent
+				label="新しいパスワード"
+				name="new_password"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="8文字以上"
+				isPassword
+			/>
+			<FormFieldComponent
+				label="新しいパスワード (確認)"
+				name="re_new_password"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="もう一度入力"
+				isPassword
+			/>
+			<Button
+				type="submit"
+				className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
+				disabled={isSubmitting}
 			>
-				<FormFieldComponent
-					label="New Password"
-					name="new_password"
-					register={register}
-					errors={errors}
-					placeholder="New Password"
-					isPassword={true}
-				/>
-
-				<FormFieldComponent
-					label="Confirm Password"
-					name="re_new_password"
-					register={register}
-					errors={errors}
-					placeholder="Confirm New Password"
-					isPassword={true}
-				/>
-				<Button
-					type="submit"
-					className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-					disabled={isLoading}
-				>
-					{isLoading ? <Spinner size="sm" /> : `Confirm New Password`}
-				</Button>
-			</form>
-		</main>
+				{isSubmitting ? <Spinner size="sm" /> : "パスワードを再設定"}
+			</Button>
+		</form>
 	);
 }

--- a/client/src/components/forms/auth/PasswordResetRequestForm.tsx
+++ b/client/src/components/forms/auth/PasswordResetRequestForm.tsx
@@ -1,71 +1,67 @@
 "use client";
-import * as z from "zod";
+
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useResetPasswordRequestMutation } from "@/lib/redux/features/auth/authApiSlice";
+import { MailIcon } from "lucide-react";
 import { useForm } from "react-hook-form";
+import { toast } from "react-toastify";
+
+import Spinner from "@/components/shared/Spinner";
+import { FormFieldComponent } from "@/components/forms/FormFieldComponent";
+import { FormSummaryError } from "@/components/forms/auth/FormSummaryError";
+import { Button } from "@/components/ui/button";
+import { useAuthMutation } from "@/hooks/useAuthMutation";
+import { requestPasswordReset } from "@/lib/api/auth";
 import {
 	passwordResetRequestSchema,
-	TPasswordResetRequestSchema,
+	type TPasswordResetRequestSchema,
 } from "@/lib/validationSchemas";
-import { extractErrorMessage } from "@/utils";
-import { toast } from "react-toastify";
-import { FormFieldComponent } from "@/components/forms/FormFieldComponent";
-import { MailIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import Spinner from "@/components/shared/Spinner";
 
+/**
+ * Request-a-reset-link form (P1-13). djoser ``/auth/users/reset_password/``
+ * always returns 204 (ignores whether the email exists) to avoid user
+ * enumeration, so we show a generic success message.
+ */
 export default function PasswordResetRequestForm() {
-	const [resetPasswordRequest, { isLoading }] =
-		useResetPasswordRequestMutation();
-
-	const {
-		register,
-		handleSubmit,
-		reset,
-		formState: { errors },
-	} = useForm<TPasswordResetRequestSchema>({
+	const form = useForm<TPasswordResetRequestSchema>({
 		resolver: zodResolver(passwordResetRequestSchema),
 		mode: "all",
-		defaultValues: {
-			email: "",
+		defaultValues: { email: "" },
+	});
+
+	const { isSubmitting, summaryError, submit } = useAuthMutation({
+		form,
+		mutate: (values) => requestPasswordReset(values),
+		onSuccess: () => {
+			toast.success(
+				"入力されたメールアドレスに、パスワード再設定のリンクを送信しました。",
+			);
+			form.reset();
 		},
 	});
 
-	const onSubmit = async (
-		values: z.infer<typeof passwordResetRequestSchema>,
-	) => {
-		try {
-			await resetPasswordRequest(values).unwrap();
-			toast.success("Request sent, check your email for the reset link");
-			reset();
-		} catch (e) {
-			const errorMessage = extractErrorMessage(e);
-			toast.error(errorMessage || "An error occurred");
-		}
-	};
 	return (
-		<main>
-			<form
-				noValidate
-				onSubmit={handleSubmit(onSubmit)}
-				className="flex w-full max-w-md flex-col gap-4"
+		<form
+			noValidate
+			onSubmit={form.handleSubmit(submit)}
+			className="flex w-full max-w-md flex-col gap-4"
+		>
+			<FormSummaryError message={summaryError} />
+			<FormFieldComponent
+				label="メールアドレス"
+				name="email"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="you@example.com"
+				type="email"
+				startIcon={<MailIcon className="dark:text-babyPowder size-8" />}
+			/>
+			<Button
+				type="submit"
+				className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
+				disabled={isSubmitting}
 			>
-				<FormFieldComponent
-					label="Email Address"
-					name="email"
-					register={register}
-					errors={errors}
-					placeholder="Email Address"
-					startIcon={<MailIcon className="dark:text-babyPowder size-8" />}
-				/>
-				<Button
-					type="submit"
-					className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-					disabled={isLoading}
-				>
-					{isLoading ? <Spinner size="sm" /> : `Request Password Reset`}
-				</Button>
-			</form>
-		</main>
+				{isSubmitting ? <Spinner size="sm" /> : "再設定リンクを送信"}
+			</Button>
+		</form>
 	);
 }

--- a/client/src/components/forms/auth/RegisterForm.tsx
+++ b/client/src/components/forms/auth/RegisterForm.tsx
@@ -1,30 +1,31 @@
 "use client";
-import * as z from "zod";
+
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Contact2Icon, MailIcon, UserCheck2 } from "lucide-react";
-import { useRegisterUserMutation } from "@/lib/redux/features/auth/authApiSlice";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
+import { toast } from "react-toastify";
+
+import Spinner from "@/components/shared/Spinner";
+import { FormFieldComponent } from "@/components/forms/FormFieldComponent";
+import { FormSummaryError } from "@/components/forms/auth/FormSummaryError";
+import { Button } from "@/components/ui/button";
+import { useAuthMutation } from "@/hooks/useAuthMutation";
+import { registerAccount } from "@/lib/api/auth";
 import {
 	registerUserSchema,
-	TRregisterUserSchema,
+	type TRegisterUserSchema,
 } from "@/lib/validationSchemas";
-import { extractErrorMessage } from "@/utils";
-import { toast } from "react-toastify";
-import { FormFieldComponent } from "@/components/forms/FormFieldComponent";
-import { Button } from "@/components/ui/button";
-import Spinner from "@/components/shared/Spinner";
 
+/**
+ * Sign-up form (P1-13). Posts to djoser ``/auth/users/`` which sends the
+ * activation mail; the actual ``/login`` redirect is deferred until the user
+ * clicks the activation link.
+ */
 export default function RegisterForm() {
-	const [registerUser, { isLoading }] = useRegisterUserMutation();
 	const router = useRouter();
 
-	const {
-		register,
-		handleSubmit,
-		reset,
-		formState: { errors },
-	} = useForm<TRregisterUserSchema>({
+	const form = useForm<TRegisterUserSchema>({
 		resolver: zodResolver(registerUserSchema),
 		mode: "all",
 		defaultValues: {
@@ -34,91 +35,124 @@ export default function RegisterForm() {
 			email: "",
 			password: "",
 			re_password: "",
+			terms: false as unknown as true,
 		},
 	});
 
-	const onSubmit = async (values: z.infer<typeof registerUserSchema>) => {
-		try {
-			await registerUser(values).unwrap();
+	const { isSubmitting, summaryError, submit } = useAuthMutation({
+		form,
+		mutate: async (values) => {
+			// terms はクライアント側だけの validation 用フィールドなので送信しない。
+			const { terms: _terms, ...payload } = values;
+			await registerAccount(payload);
+		},
+		onSuccess: (values) => {
 			toast.success(
-				"An Email with an activation link has been sent to your email address. Please check your email and activate your account.",
+				"確認メールを送信しました。メールに記載されたリンクからアカウントを有効化してください。",
 			);
-			router.push("/login");
-			reset();
-		} catch (e) {
-			const errorMessage = extractErrorMessage(e);
-			toast.error(errorMessage || "An error occurred");
-		}
-	};
+			const search = new URLSearchParams({ email: values.email });
+			router.push(`/login?${search.toString()}`);
+		},
+	});
 
 	return (
-		<main>
-			<form
-				noValidate
-				onSubmit={handleSubmit(onSubmit)}
-				className="flex w-full max-w-md flex-col gap-4"
-			>
-				<FormFieldComponent
-					label="Username"
-					name="username"
-					register={register}
-					errors={errors}
-					placeholder="Username"
-					startIcon={<UserCheck2 className="dark:text-babyPowder size-8" />}
-				/>
+		<form
+			noValidate
+			onSubmit={form.handleSubmit(submit)}
+			className="flex w-full max-w-md flex-col gap-4"
+		>
+			<FormSummaryError message={summaryError} />
+			<FormFieldComponent
+				label="ハンドル (@handle)"
+				name="username"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="alice"
+				startIcon={<UserCheck2 className="dark:text-babyPowder size-8" />}
+			/>
+			<FormFieldComponent
+				label="名"
+				name="first_name"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="太郎"
+				startIcon={<Contact2Icon className="dark:text-babyPowder size-8" />}
+			/>
+			<FormFieldComponent
+				label="姓"
+				name="last_name"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="山田"
+				startIcon={<Contact2Icon className="dark:text-babyPowder size-8" />}
+			/>
+			<FormFieldComponent
+				label="メールアドレス"
+				name="email"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="you@example.com"
+				type="email"
+				startIcon={<MailIcon className="dark:text-babyPowder size-8" />}
+			/>
+			<FormFieldComponent
+				label="パスワード"
+				name="password"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="8文字以上"
+				isPassword
+			/>
+			<FormFieldComponent
+				label="パスワード (確認)"
+				name="re_password"
+				register={form.register}
+				errors={form.formState.errors}
+				placeholder="もう一度入力"
+				isPassword
+			/>
 
-				<FormFieldComponent
-					label="First Name"
-					name="first_name"
-					register={register}
-					errors={errors}
-					placeholder="First Name"
-					startIcon={<Contact2Icon className="dark:text-babyPowder size-8" />}
+			<label className="flex items-start gap-2 text-sm">
+				<input
+					type="checkbox"
+					{...form.register("terms")}
+					className="mt-1 size-4"
+					aria-describedby="terms-error"
 				/>
-
-				<FormFieldComponent
-					label="Last Name"
-					name="last_name"
-					register={register}
-					errors={errors}
-					placeholder="Last Name"
-					startIcon={<Contact2Icon className="dark:text-babyPowder size-8" />}
-				/>
-
-				<FormFieldComponent
-					label="Email Address"
-					name="email"
-					register={register}
-					errors={errors}
-					placeholder="Email Address"
-					startIcon={<MailIcon className="dark:text-babyPowder size-8" />}
-				/>
-
-				<FormFieldComponent
-					label="Password"
-					name="password"
-					register={register}
-					errors={errors}
-					placeholder="Password"
-					isPassword={true}
-				/>
-
-				<FormFieldComponent
-					label="Password Confirm"
-					name="re_password"
-					register={register}
-					errors={errors}
-					placeholder="Confirm Password"
-					isPassword={true}
-				/>
-				<Button
-					type="submit"
-					className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-					disabled={isLoading}
+				<span className="dark:text-babyPowder">
+					<a
+						href="/terms"
+						className="underline hover:text-indigo-500 dark:hover:text-lime-400"
+					>
+						利用規約
+					</a>
+					と
+					<a
+						href="/privacy"
+						className="underline hover:text-indigo-500 dark:hover:text-lime-400"
+					>
+						プライバシーポリシー
+					</a>
+					に同意します
+				</span>
+			</label>
+			{form.formState.errors.terms?.message && (
+				<span
+					id="terms-error"
+					className="-mt-3 text-sm text-red-500"
+					role="alert"
 				>
-					{isLoading ? <Spinner size="sm" /> : `Submit`}
-				</Button>
-			</form>
-		</main>
+					{form.formState.errors.terms.message}
+				</span>
+			)}
+
+			<Button
+				type="submit"
+				className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
+				disabled={isSubmitting}
+			>
+				{isSubmitting ? <Spinner size="sm" /> : "アカウント作成"}
+			</Button>
+		</form>
 	);
 }

--- a/client/src/components/shared/OauthButtons.tsx
+++ b/client/src/components/shared/OauthButtons.tsx
@@ -1,13 +1,46 @@
 "use client";
 
-import { UseGoogle } from "@/utils";
-import OauthButton from "./OauthButton";
+import { useState } from "react";
+import { toast } from "react-toastify";
 
+import OauthButton from "./OauthButton";
+import { startGoogleOAuth } from "@/lib/api/auth";
+import { parseDrfErrors } from "@/lib/api/errors";
+
+/**
+ * Social-login buttons (P1-13). The Google handshake is a two-step flow:
+ *
+ * 1. Call ``GET /auth/o/google-oauth2/?redirect_uri=<frontend>/google`` to
+ *    obtain the Google authorization URL.
+ * 2. ``window.location.href`` to that URL. Google bounces back to
+ *    ``/google?state=…&code=…`` where ``useSocialAuth`` exchanges the code
+ *    for a Cookie JWT via ``POST /auth/o/google-oauth2/cookie/``.
+ */
 export default function OauthButtons() {
+	const [isLoading, setIsLoading] = useState(false);
+
+	const onGoogleClick = async () => {
+		if (typeof window === "undefined") return;
+		setIsLoading(true);
+		try {
+			const redirectUri = `${window.location.origin}/google`;
+			const { authorization_url } = await startGoogleOAuth(redirectUri);
+			window.location.href = authorization_url;
+		} catch (error) {
+			const message = parseDrfErrors(error).summary;
+			toast.error(message ?? "Google ログインを開始できませんでした。");
+			setIsLoading(false);
+		}
+	};
+
 	return (
 		<div className="mt-3 flex items-center justify-between gap-2">
-			<OauthButton provider="google" onClick={UseGoogle}>
-				Sign in with Google
+			<OauthButton
+				provider="google"
+				onClick={onGoogleClick}
+				disabled={isLoading}
+			>
+				Google でログイン
 			</OauthButton>
 		</div>
 	);

--- a/client/src/hooks/useAuthMutation.ts
+++ b/client/src/hooks/useAuthMutation.ts
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * Generic hook for posting a form to the Django API via the axios wrapper
+ * (P1-13). Maps DRF errors back into react-hook-form ``setError`` calls and
+ * exposes a summary message for a single aria-live region near the submit
+ * button. Keeps the auth form components small and testable.
+ */
+
+import { useCallback, useState } from "react";
+import type { FieldValues, Path, UseFormReturn } from "react-hook-form";
+import { parseDrfErrors } from "@/lib/api/errors";
+
+export interface UseAuthMutationOptions<TValues extends FieldValues> {
+	form: UseFormReturn<TValues>;
+	mutate: (values: TValues) => Promise<void>;
+	onSuccess?: (values: TValues) => void | Promise<void>;
+}
+
+export interface UseAuthMutationResult<TValues extends FieldValues> {
+	isSubmitting: boolean;
+	summaryError: string | undefined;
+	submit: (values: TValues) => Promise<void>;
+	clearSummary: () => void;
+}
+
+export function useAuthMutation<TValues extends FieldValues>({
+	form,
+	mutate,
+	onSuccess,
+}: UseAuthMutationOptions<TValues>): UseAuthMutationResult<TValues> {
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [summaryError, setSummaryError] = useState<string | undefined>();
+
+	const submit = useCallback(
+		async (values: TValues): Promise<void> => {
+			setIsSubmitting(true);
+			setSummaryError(undefined);
+			try {
+				await mutate(values);
+				await onSuccess?.(values);
+			} catch (error) {
+				const { summary, fields } = parseDrfErrors(error);
+				for (const [name, message] of Object.entries(fields)) {
+					// Only attach field errors for keys the form knows about; unknown
+					// keys (e.g., server-only fields) flow into summary instead.
+					if (name in form.getValues()) {
+						form.setError(name as Path<TValues>, {
+							type: "server",
+							message,
+						});
+					}
+				}
+				setSummaryError(summary);
+			} finally {
+				setIsSubmitting(false);
+			}
+		},
+		[form, mutate, onSuccess],
+	);
+
+	const clearSummary = useCallback(() => setSummaryError(undefined), []);
+
+	return { isSubmitting, summaryError, submit, clearSummary };
+}

--- a/client/src/hooks/useSocialAuth.ts
+++ b/client/src/hooks/useSocialAuth.ts
@@ -1,35 +1,50 @@
-import { setAuth } from "@/lib/redux/features/auth/authSlice";
-import { useAppDispatch } from "@/lib/redux/hooks/typedHooks";
+"use client";
+
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 
-export default function useSocialAuth(authenticate: any, provider: string) {
-	const dispatch = useAppDispatch();
-	const router = useRouter();
-	const searchParams = useSearchParams();
+import { completeGoogleOAuth } from "@/lib/api/auth";
+import { parseDrfErrors } from "@/lib/api/errors";
+import { setAuth } from "@/lib/redux/features/auth/authSlice";
+import { useAppDispatch } from "@/lib/redux/hooks/typedHooks";
 
-	const effectRan = useRef(false);
+export type SocialStatus = "idle" | "processing" | "success" | "error";
+
+/**
+ * Completes a Google OAuth redirect by reading ``state`` + ``code`` from the
+ * URL and exchanging them for a Cookie JWT via ``POST /auth/o/google-oauth2/cookie/``.
+ * Runs once even under React 18 Strict Mode double-invocation.
+ */
+export default function useSocialAuth(): SocialStatus {
+	const router = useRouter();
+	const dispatch = useAppDispatch();
+	const searchParams = useSearchParams();
+	const attempted = useRef(false);
+	const [status, setStatus] = useState<SocialStatus>("idle");
 
 	useEffect(() => {
 		const state = searchParams.get("state");
 		const code = searchParams.get("code");
+		if (!state || !code) return;
+		if (attempted.current) return;
+		attempted.current = true;
 
-		if (state && code && !effectRan.current) {
-			authenticate({ provider, state, code })
-				.unwrap()
-				.then(() => {
-					dispatch(setAuth());
-					toast.success("Logged in successfully");
-					router.push("/welcome");
-				})
-				.catch(() => {
-					toast.error("Login Failed, Try Again!");
-					router.push("/auth/login");
-				});
-		}
-		return () => {
-			effectRan.current = true;
-		};
-	}, [authenticate, dispatch, provider, router, searchParams]);
+		setStatus("processing");
+		completeGoogleOAuth({ state, code })
+			.then(() => {
+				dispatch(setAuth());
+				setStatus("success");
+				toast.success("Google アカウントでログインしました。");
+				router.push("/");
+			})
+			.catch((error: unknown) => {
+				setStatus("error");
+				const message = parseDrfErrors(error).summary;
+				toast.error(message ?? "Google ログインに失敗しました。");
+				router.push("/login");
+			});
+	}, [dispatch, router, searchParams]);
+
+	return status;
 }

--- a/client/src/lib/api/__tests__/auth.test.ts
+++ b/client/src/lib/api/__tests__/auth.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Auth helper tests (P1-13).
+ *
+ * Uses axios-mock-adapter on an isolated client so we exercise the real
+ * request interceptor (CSRF header) and response path.
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+import { createApiClient } from "@/lib/api/client";
+import {
+	activateAccount,
+	completeGoogleOAuth,
+	confirmPasswordReset,
+	login,
+	logout,
+	registerAccount,
+	requestPasswordReset,
+	startGoogleOAuth,
+} from "@/lib/api/auth";
+
+function buildClient() {
+	const client = createApiClient();
+	const mock = new MockAdapter(client);
+	mock.onGet("/auth/csrf/").reply(200, { detail: "CSRF cookie set" });
+	return { client, mock };
+}
+
+describe("auth helpers", () => {
+	it("login POSTs email + password to /auth/cookie/create/ after CSRF bootstrap", async () => {
+		const { client, mock } = buildClient();
+		mock.onPost("/auth/cookie/create/").reply((config) => {
+			expect(JSON.parse(config.data)).toEqual({
+				email: "a@b.com",
+				password: "x",
+			});
+			return [200, { detail: "Login successful" }];
+		});
+
+		await login({ email: "a@b.com", password: "x" }, client);
+		expect(mock.history.get.some((r) => r.url === "/auth/csrf/")).toBe(true);
+		expect(
+			mock.history.post.some((r) => r.url === "/auth/cookie/create/"),
+		).toBe(true);
+	});
+
+	it("logout POSTs to /auth/cookie/logout/", async () => {
+		const { client, mock } = buildClient();
+		mock.onPost("/auth/cookie/logout/").reply(204);
+		await logout(client);
+		expect(
+			mock.history.post.some((r) => r.url === "/auth/cookie/logout/"),
+		).toBe(true);
+	});
+
+	it("registerAccount POSTs to /auth/users/", async () => {
+		const { client, mock } = buildClient();
+		mock.onPost("/auth/users/").reply((config) => {
+			const body = JSON.parse(config.data);
+			expect(body.username).toBe("alice");
+			expect(body.re_password).toBe("secret12");
+			return [201, { id: 1 }];
+		});
+
+		await registerAccount(
+			{
+				email: "a@b.com",
+				username: "alice",
+				first_name: "Alice",
+				last_name: "Liddell",
+				password: "secret12",
+				re_password: "secret12",
+			},
+			client,
+		);
+	});
+
+	it("activateAccount POSTs uid + token to /auth/users/activation/", async () => {
+		const { client, mock } = buildClient();
+		mock.onPost("/auth/users/activation/").reply((config) => {
+			expect(JSON.parse(config.data)).toEqual({ uid: "U", token: "T" });
+			return [204];
+		});
+		await activateAccount({ uid: "U", token: "T" }, client);
+	});
+
+	it("requestPasswordReset + confirmPasswordReset use correct endpoints", async () => {
+		const { client, mock } = buildClient();
+		mock.onPost("/auth/users/reset_password/").reply(204);
+		mock.onPost("/auth/users/reset_password_confirm/").reply((config) => {
+			expect(JSON.parse(config.data).new_password).toBe("newpass12");
+			return [204];
+		});
+
+		await requestPasswordReset({ email: "a@b.com" }, client);
+		await confirmPasswordReset(
+			{
+				uid: "U",
+				token: "T",
+				new_password: "newpass12",
+				re_new_password: "newpass12",
+			},
+			client,
+		);
+	});
+
+	it("startGoogleOAuth GETs the provider URL with redirect_uri query", async () => {
+		const { client, mock } = buildClient();
+		mock.onGet(/\/auth\/o\/google-oauth2\/.*/).reply((config) => {
+			expect(config.url).toContain(
+				"redirect_uri=https%3A%2F%2Fexample.com%2Fgoogle",
+			);
+			return [200, { authorization_url: "https://accounts.google.com/xyz" }];
+		});
+
+		const result = await startGoogleOAuth("https://example.com/google", client);
+		expect(result.authorization_url).toBe("https://accounts.google.com/xyz");
+	});
+
+	it("completeGoogleOAuth POSTs state + code and returns user", async () => {
+		const { client, mock } = buildClient();
+		mock.onPost(/\/auth\/o\/google-oauth2\/cookie\/.*/).reply((config) => {
+			expect(config.url).toContain("state=S");
+			expect(config.url).toContain("code=C");
+			expect(config.headers?.["Content-Type"]).toBe(
+				"application/x-www-form-urlencoded",
+			);
+			return [
+				200,
+				{
+					user: { id: "u1", email: "a@b.com", username: "alice" },
+					detail: "ok",
+				},
+			];
+		});
+
+		const res = await completeGoogleOAuth({ state: "S", code: "C" }, client);
+		expect(res.user.username).toBe("alice");
+	});
+
+	it("login surfaces DRF 401 as thrown AxiosError", async () => {
+		const { client, mock } = buildClient();
+		mock.onPost("/auth/cookie/create/").reply(401, { detail: "no match" });
+		await expect(
+			login({ email: "a@b.com", password: "x" }, client),
+		).rejects.toThrowError();
+	});
+});

--- a/client/src/lib/api/__tests__/errors.test.ts
+++ b/client/src/lib/api/__tests__/errors.test.ts
@@ -1,0 +1,94 @@
+/**
+ * DRF error normalization tests (P1-13).
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseDrfErrors } from "@/lib/api/errors";
+
+function axiosErrorLike(status: number, data: unknown) {
+	return {
+		isAxiosError: true,
+		response: { status, data },
+	};
+}
+
+describe("parseDrfErrors", () => {
+	it("returns top-level detail as summary", () => {
+		const result = parseDrfErrors(
+			axiosErrorLike(401, { detail: "Invalid credentials" }),
+		);
+		expect(result.summary).toBe("Invalid credentials");
+		expect(result.fields).toEqual({});
+	});
+
+	it("returns non_field_errors first element as summary", () => {
+		const result = parseDrfErrors(
+			axiosErrorLike(400, {
+				non_field_errors: ["Passwords do not match", "Second error"],
+			}),
+		);
+		expect(result.summary).toBe("Passwords do not match");
+		expect(result.fields).toEqual({});
+	});
+
+	it("maps per-field errors to fields map", () => {
+		const result = parseDrfErrors(
+			axiosErrorLike(400, {
+				email: ["Enter a valid email"],
+				password: ["Too short", "Second error"],
+			}),
+		);
+		expect(result.fields.email).toBe("Enter a valid email");
+		expect(result.fields.password).toBe("Too short");
+	});
+
+	it("promotes the first field error to summary when no detail/non_field_errors", () => {
+		const result = parseDrfErrors(
+			axiosErrorLike(400, { username: ["Already taken"] }),
+		);
+		expect(result.summary).toBe("Already taken");
+		expect(result.fields.username).toBe("Already taken");
+	});
+
+	it("falls back to generic message for 401 with no body", () => {
+		const result = parseDrfErrors(axiosErrorLike(401, {}));
+		expect(result.summary).toMatch(/正しくありません/);
+	});
+
+	it("falls back to generic message for 500", () => {
+		const result = parseDrfErrors(axiosErrorLike(500, {}));
+		expect(result.summary).toMatch(/サーバーエラー/);
+	});
+
+	it("falls back to network error message when no response", () => {
+		const result = parseDrfErrors({ message: "Network Error" });
+		expect(result.summary).toMatch(/ネットワーク/);
+	});
+
+	it("handles top-level string payload", () => {
+		const result = parseDrfErrors(axiosErrorLike(500, "Internal error"));
+		expect(result.summary).toBe("Internal error");
+		expect(result.fields).toEqual({});
+	});
+
+	it("returns 429 throttle message", () => {
+		const result = parseDrfErrors(axiosErrorLike(429, {}));
+		expect(result.summary).toMatch(/しばらく時間をおいてから/);
+	});
+
+	it("skips empty arrays and keeps first truthy value", () => {
+		const result = parseDrfErrors(
+			axiosErrorLike(400, {
+				email: [],
+				username: ["Invalid"],
+			}),
+		);
+		expect(result.fields.username).toBe("Invalid");
+		expect(result.fields.email).toBeUndefined();
+	});
+
+	it("handles null / undefined error gracefully", () => {
+		expect(parseDrfErrors(null).summary).toBeDefined();
+		expect(parseDrfErrors(undefined).summary).toBeDefined();
+	});
+});

--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -1,0 +1,141 @@
+/**
+ * Auth-related API helpers built on the axios wrapper (P1-13).
+ *
+ * Thin, testable wrappers over djoser + apps.users cookie endpoints so UI
+ * components don't need to remember URLs or orchestrate CSRF bootstrapping.
+ * All functions:
+ *
+ *   - take a pre-configured ``AxiosInstance`` (default: ``api`` singleton).
+ *   - throw the underlying AxiosError so callers can pipe it into
+ *     ``parseDrfErrors`` for setError / toast.
+ *   - call ``ensureCsrfToken`` before unsafe methods so the first POST does
+ *     not 403 on a cold Cookie jar.
+ */
+
+import type { AxiosInstance } from "axios";
+import { api, ensureCsrfToken } from "@/lib/api/client";
+
+export interface LoginPayload {
+	email: string;
+	password: string;
+}
+
+export interface RegisterPayload {
+	email: string;
+	username: string;
+	first_name: string;
+	last_name: string;
+	password: string;
+	re_password: string;
+}
+
+export interface ActivationPayload {
+	uid: string;
+	token: string;
+}
+
+export interface ResetPasswordPayload {
+	email: string;
+}
+
+export interface ResetPasswordConfirmPayload extends ActivationPayload {
+	new_password: string;
+	re_new_password: string;
+}
+
+async function withCsrf<T>(
+	client: AxiosInstance,
+	fn: () => Promise<T>,
+): Promise<T> {
+	await ensureCsrfToken(client);
+	return fn();
+}
+
+export async function login(
+	payload: LoginPayload,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await withCsrf(client, () => client.post("/auth/cookie/create/", payload));
+}
+
+export async function logout(client: AxiosInstance = api): Promise<void> {
+	await withCsrf(client, () => client.post("/auth/cookie/logout/"));
+}
+
+export async function registerAccount(
+	payload: RegisterPayload,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await withCsrf(client, () => client.post("/auth/users/", payload));
+}
+
+export async function activateAccount(
+	payload: ActivationPayload,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await withCsrf(client, () => client.post("/auth/users/activation/", payload));
+}
+
+export async function requestPasswordReset(
+	payload: ResetPasswordPayload,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await withCsrf(client, () =>
+		client.post("/auth/users/reset_password/", payload),
+	);
+}
+
+export async function confirmPasswordReset(
+	payload: ResetPasswordConfirmPayload,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await withCsrf(client, () =>
+		client.post("/auth/users/reset_password_confirm/", payload),
+	);
+}
+
+export interface GoogleOAuthCompletePayload {
+	state: string;
+	code: string;
+}
+
+/**
+ * Complete the Google OAuth handshake. The caller must first send the user to
+ * Google's authorization URL (obtained from ``GET /auth/o/google-oauth2/?redirect_uri=...``)
+ * and then pass the ``state`` + ``code`` returned to the redirect_uri back
+ * here. Returns the authenticated user payload on success.
+ */
+export async function completeGoogleOAuth(
+	{ state, code }: GoogleOAuthCompletePayload,
+	client: AxiosInstance = api,
+): Promise<{ user: { id: string; email: string; username: string } }> {
+	const params = new URLSearchParams({ state, code });
+	const res = await withCsrf(client, () =>
+		client.post<{ user: { id: string; email: string; username: string } }>(
+			`/auth/o/google-oauth2/cookie/?${params.toString()}`,
+			null,
+			{
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+			},
+		),
+	);
+	return res.data;
+}
+
+/**
+ * Fetch the Google authorization URL from djoser. Frontend sets
+ * ``window.location.href`` to the returned URL to begin the handshake.
+ */
+export async function startGoogleOAuth(
+	redirectUri: string,
+	client: AxiosInstance = api,
+): Promise<{ authorization_url: string }> {
+	const params = new URLSearchParams({ redirect_uri: redirectUri });
+	const res = await client.get<{ authorization_url: string }>(
+		`/auth/o/google-oauth2/?${params.toString()}`,
+	);
+	return res.data;
+}

--- a/client/src/lib/api/errors.ts
+++ b/client/src/lib/api/errors.ts
@@ -1,0 +1,118 @@
+/**
+ * DRF / djoser error normalization (P1-13).
+ *
+ * Django REST Framework returns validation errors in several shapes depending
+ * on the endpoint and the serializer field:
+ *
+ *   {"detail": "Invalid credentials"}                        — top-level string
+ *   {"non_field_errors": ["Passwords do not match"]}          — serializer-wide
+ *   {"email": ["Enter a valid email"], "password": ["..."]}   — per field
+ *   {"uid": ["Invalid token"], "token": ["Invalid token"]}    — activation
+ *
+ * This module flattens all three into ``FormErrors`` so react-hook-form can
+ * call ``setError(name, ...)`` in one loop, and exposes a summary string for
+ * toast / aria-live announcements.
+ */
+
+import type { AxiosError } from "axios";
+
+export interface FormErrors {
+	/** Top-level message shown near the submit button. */
+	summary?: string;
+	/** Per-field messages keyed by serializer field name. */
+	fields: Record<string, string>;
+}
+
+const NON_FIELD_KEYS = new Set(["non_field_errors", "detail"]);
+
+/**
+ * Flatten a DRF / djoser error response into ``FormErrors``. Robust against
+ * unknown shapes (returns an empty ``fields`` map with a generic summary).
+ */
+export function parseDrfErrors(error: unknown): FormErrors {
+	const data = extractResponseData(error);
+	const fields: Record<string, string> = {};
+	let summary: string | undefined;
+
+	if (typeof data === "string") {
+		return { summary: data, fields };
+	}
+
+	if (data && typeof data === "object") {
+		for (const [key, value] of Object.entries(data)) {
+			const msg = firstString(value);
+			if (!msg) continue;
+			if (NON_FIELD_KEYS.has(key)) {
+				summary = summary ?? msg;
+			} else {
+				fields[key] = msg;
+			}
+		}
+	}
+
+	if (!summary) {
+		if (Object.keys(fields).length > 0) {
+			// Pick the first field error as the summary so toast / aria-live has
+			// *something* to speak without duplicating what inline errors show.
+			summary = Object.values(fields)[0];
+		} else {
+			summary = fallbackMessageForStatus(extractStatus(error));
+		}
+	}
+
+	return { summary, fields };
+}
+
+function extractResponseData(error: unknown): unknown {
+	if (!error || typeof error !== "object") return error;
+	const axiosLike = error as AxiosError;
+	if (axiosLike.response && "data" in axiosLike.response) {
+		return axiosLike.response.data;
+	}
+	// Fallback to any `.data` property (older shims / fetch wrappers).
+	return (error as { data?: unknown }).data ?? undefined;
+}
+
+function extractStatus(error: unknown): number | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const axiosLike = error as AxiosError;
+	return axiosLike.response?.status;
+}
+
+function firstString(value: unknown): string | undefined {
+	if (typeof value === "string") return value || undefined;
+	if (Array.isArray(value)) {
+		for (const entry of value) {
+			const s = firstString(entry);
+			if (s) return s;
+		}
+	}
+	if (value && typeof value === "object") {
+		for (const entry of Object.values(value)) {
+			const s = firstString(entry);
+			if (s) return s;
+		}
+	}
+	return undefined;
+}
+
+function fallbackMessageForStatus(status: number | undefined): string {
+	switch (status) {
+		case 400:
+			return "入力内容を確認してください。";
+		case 401:
+			return "メールアドレスまたはパスワードが正しくありません。";
+		case 403:
+			return "この操作を行う権限がありません。";
+		case 404:
+			return "リソースが見つかりません。";
+		case 429:
+			return "しばらく時間をおいてから再度お試しください。";
+		case undefined:
+			return "ネットワークエラーが発生しました。接続を確認してください。";
+		default:
+			if (status >= 500)
+				return "サーバーエラーが発生しました。時間をおいて再度お試しください。";
+			return "想定外のエラーが発生しました。";
+	}
+}

--- a/client/src/lib/validationSchemas/RegisterSchema.ts
+++ b/client/src/lib/validationSchemas/RegisterSchema.ts
@@ -1,31 +1,57 @@
 import * as z from "zod";
 
-const usernameRegex = /^[a-zA-Z0-9_@+.-]+$/;
+// SPEC §2.1 + apps/users/validators.py の `validate_handle` と一致させる。
+// - 英数 + `_` のみ
+// - 3〜30 文字
+// - 予約語ブラックリスト
+const HANDLE_PATTERN = /^[a-zA-Z0-9_]{3,30}$/;
+const RESERVED_HANDLES = new Set([
+	"admin",
+	"api",
+	"auth",
+	"help",
+	"me",
+	"null",
+	"root",
+	"settings",
+	"support",
+	"system",
+	"undefined",
+]);
 
 export const registerUserSchema = z
 	.object({
-		username: z.string().regex(usernameRegex, {
-			message: "ユーザー名は英数字、_, @, +, ., - のみ使用できます",
-		}),
+		username: z
+			.string()
+			.trim()
+			.regex(HANDLE_PATTERN, {
+				message:
+					"ハンドルは英数字とアンダースコア、3〜30 文字で入力してください",
+			})
+			.refine((value) => !RESERVED_HANDLES.has(value.toLowerCase()), {
+				message: "このハンドルは使用できません",
+			}),
 		first_name: z
 			.string()
 			.trim()
-			.min(2, { message: "名は2文字以上で入力してください" })
-			.max(50, { message: "名は50文字以内で入力してください" }),
+			.min(1, { message: "名は1文字以上で入力してください" })
+			.max(60, { message: "名は60文字以内で入力してください" }),
 		last_name: z
 			.string()
 			.trim()
-			.min(2, { message: "姓は2文字以上で入力してください" })
-			.max(50, { message: "姓は50文字以内で入力してください" }),
+			.min(1, { message: "姓は1文字以上で入力してください" })
+			.max(60, { message: "姓は60文字以内で入力してください" }),
 		email: z
 			.string()
 			.trim()
 			.email({ message: "有効なメールアドレスを入力してください" }),
 		password: z
 			.string()
-			.min(8, { message: "パスワードは8文字以上で入力してください" }),
-		re_password: z.string().min(8, {
-			message: "確認用パスワードは8文字以上で入力してください",
+			.min(8, { message: "パスワードは8文字以上で入力してください" })
+			.max(128, { message: "パスワードは128文字以内で入力してください" }),
+		re_password: z.string(),
+		terms: z.literal(true, {
+			errorMap: () => ({ message: "利用規約に同意してください" }),
 		}),
 	})
 	.refine((data) => data.password === data.re_password, {
@@ -33,4 +59,8 @@ export const registerUserSchema = z
 		path: ["re_password"],
 	});
 
-export type TRregisterUserSchema = z.infer<typeof registerUserSchema>;
+export type TRegisterUserSchema = z.infer<typeof registerUserSchema>;
+
+// NOTE: previously exported as TRregisterUserSchema (typo). Keep alias to avoid
+// breaking ambient imports until all auth forms migrate to TRegisterUserSchema.
+export type TRregisterUserSchema = TRegisterUserSchema;

--- a/client/src/lib/validationSchemas/index.ts
+++ b/client/src/lib/validationSchemas/index.ts
@@ -8,4 +8,7 @@ export { passwordResetRequestSchema } from "./PasswordResetRequestSchema";
 export type { TPasswordResetRequestSchema } from "./PasswordResetRequestSchema";
 
 export { registerUserSchema } from "./RegisterSchema";
-export type { TRregisterUserSchema } from "./RegisterSchema";
+export type {
+	TRegisterUserSchema,
+	TRregisterUserSchema,
+} from "./RegisterSchema";


### PR DESCRIPTION
## Summary

Closes #122. Stacked on top of #140 (P1-13a axios wrapper). Wires the /login, /register, /activate, /password-reset(-confirm), /google flows to Cookie JWT + CSRF Double Submit (ADR-0003), and removes the broken RTK Query path that skipped CSRF.

- `lib/api/auth.ts` — typed helpers for `/auth/cookie/create/`, `/auth/users/`, `/auth/users/activation/`, `/auth/users/reset_password{,_confirm}/`, `/auth/o/google-oauth2/{,,cookie/}`.
- `lib/api/errors.ts` — `parseDrfErrors` flattens `{detail | non_field_errors | <field>: [...]}` into `{summary, fields}` with Japanese fallbacks per status code (400/401/403/404/429/5xx/network).
- `hooks/useAuthMutation.ts` — generic react-hook-form ↔ DRF bridge that attaches field errors via `setError` and exposes a `summaryError` for an aria-live region.
- `components/forms/auth/FormSummaryError.tsx` — `role="alert"` + `aria-live="polite"` banner, sr-only when empty so first announcement is not swallowed.
- `components/shared/OauthButtons.tsx` — re-enabled on /login and /register; now GETs the Google authorization URL and window.location's to it.
- `useSocialAuth` rewritten to exchange state+code via `/auth/o/google-oauth2/cookie/`.
- `RegisterSchema` tightened to match `apps/users/validators.py#validate_handle` (3-30 chars, `[a-zA-Z0-9_]`, reserved-word blacklist) + terms-of-service checkbox required.

19 new vitest cases (total 44 passing). Coverage: `auth.ts` 100% / `errors.ts` 91% / `client.ts` 95% / `server.ts` 100%.

## Acceptance criteria (Issue #122)

- [x] /login, /register, /activate/[uid]/[token], /password-reset, /password-reset-confirm/[uid]/[token] wired to new endpoints
- [x] zod + react-hook-form validation for every form
- [x] shadcn/ui Form / Input / Button via existing FormFieldComponent
- [x] DRF `{detail, non_field_errors, <field>: [...]}` standardized error handling
- [x] Success redirect to / (login) or /login?email=… (register / password reset)
- [x] Google OAuth button redirects to `/auth/o/google-oauth2/` and exchanges at `/auth/o/google-oauth2/cookie/`
- [x] zod rejects short passwords / invalid handles before the network
- [x] a11y: labels via FormFieldComponent, aria-live summary, terms error linked via aria-describedby
- [ ] Lighthouse a11y 95+ — verify in stg (P1-23)
- [ ] E2E signup → activate → login → `/` — scripted in P1-22 (#124)

## Test plan

- [x] `npm run test` (44 passed)
- [x] `npx tsc --noEmit --pretty false` (green)
- [x] `npm run lint` (only pre-existing Tailwind class-order warnings in unrelated navbar components)
- [ ] Manual signup → activation → login → cookie visible in DevTools — run locally once backend PR merges
- [ ] Lighthouse a11y — run in stg after #125 deploys this build

## Notes

- Existing RTK Query `authApiSlice` is untouched; it targets the legacy `/auth/login/` path and is kept for the time being for backwards compatibility, but new code should go through `lib/api/auth.ts`. Subsequent frontend issues (#117 composer, etc.) will continue that migration.
- `useRedirectIfAuthenticated` calls were removed from /login and /register — the old hook redirected to `/welcome` which no longer exists. A proper auth-gate + redirect-to-TL hook will land with #119 (profile page) / the TL issue in Phase 2.