### PR TITLE
chore(devcontainer): bundle AWS CLI v2 + open AWS endpoints in firewall

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -98,6 +98,23 @@ RUN ARCH=$(dpkg --print-architecture) && \
   sudo dpkg -i /tmp/gh.deb && \
   rm /tmp/gh.deb
 
+# Install AWS CLI v2 (used for Terraform plan/apply, ECS operations, secret
+# management against the stg/prod AWS account). Pinned per the same convention
+# as gh / act so contributors get the same version. Bumping AWS_CLI_VERSION
+# in devcontainer.json triggers a rebuild on next "Reopen in Container".
+ARG AWS_CLI_VERSION=2.18.0
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "$ARCH" in \
+    amd64) AWS_ARCH=x86_64 ;; \
+    arm64) AWS_ARCH=aarch64 ;; \
+    *) echo "Unsupported architecture for aws-cli: $ARCH" && exit 1 ;; \
+  esac && \
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}-${AWS_CLI_VERSION}.zip" -o /tmp/awscliv2.zip && \
+  unzip -q /tmp/awscliv2.zip -d /tmp/ && \
+  sudo /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli && \
+  rm -rf /tmp/awscliv2.zip /tmp/aws && \
+  aws --version
+
 # Set up non-root user
 USER node
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
       "GIT_DELTA_VERSION": "0.18.2",
       "ACT_VERSION": "0.2.80",
       "GH_VERSION": "2.63.2",
+      "AWS_CLI_VERSION": "2.18.0",
       "ZSH_IN_DOCKER_VERSION": "1.2.0"
     }
   },

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -71,6 +71,41 @@ while read -r cidr; do
     ipset add allowed-domains "$cidr" -exist
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
+# Fetch AWS IP ranges and allow ap-northeast-1 + GLOBAL service endpoints.
+# Required so the bundled `aws` CLI can reach STS / EC2 / S3 / ECS / ECR /
+# IAM / Route53 / CloudFront / etc. for terraform plan/apply and ECS ops.
+# Source: https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html
+#
+# AWS_REGIONS_ALLOWED can be overridden at firewall-init time by setting
+# the env var (comma-separated). Defaults to ap-northeast-1 (this project's
+# stg/prod region) plus GLOBAL (region-less services like IAM / Route53).
+AWS_REGIONS_ALLOWED="${AWS_REGIONS_ALLOWED:-ap-northeast-1,GLOBAL}"
+echo "Fetching AWS IP ranges (regions: ${AWS_REGIONS_ALLOWED})..."
+aws_ranges=""
+for attempt in 1 2 3; do
+    aws_ranges=$(curl -s --retry 2 --connect-timeout 10 https://ip-ranges.amazonaws.com/ip-ranges.json)
+    if [ -n "$aws_ranges" ] && echo "$aws_ranges" | jq -e '.prefixes' >/dev/null 2>&1; then
+        break
+    fi
+    echo "Attempt $attempt failed, retrying..."
+    sleep 2
+done
+if [ -z "$aws_ranges" ]; then
+    echo "WARNING: Failed to fetch AWS IP ranges; aws CLI calls will be blocked"
+else
+    region_filter=$(echo "$AWS_REGIONS_ALLOWED" | tr ',' '\n' | jq -R . | jq -s .)
+    while read -r cidr; do
+        if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+            continue
+        fi
+        ipset add allowed-domains "$cidr" -exist
+    done < <(echo "$aws_ranges" | jq --argjson r "$region_filter" -r \
+        '.prefixes[] | select(.region as $reg | $r | index($reg)) | .ip_prefix' | aggregate -q)
+    aws_count=$(echo "$aws_ranges" | jq --argjson r "$region_filter" \
+        '[.prefixes[] | select(.region as $reg | $r | index($reg))] | length')
+    echo "Added $aws_count AWS prefixes for regions: ${AWS_REGIONS_ALLOWED}"
+fi
+
 # Resolve and add other allowed domains
 for domain in \
     "registry.npmjs.org" \
@@ -155,4 +190,15 @@ if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
     exit 1
 else
     echo "Firewall verification passed - able to reach https://api.github.com as expected"
+fi
+
+# Verify AWS STS reachability (only if AWS CLI is installed and ranges were
+# loaded). STS is region-prefixed; ap-northeast-1 endpoint is the canonical
+# probe target for this project.
+if command -v aws >/dev/null 2>&1; then
+    if curl --connect-timeout 5 -sI https://sts.ap-northeast-1.amazonaws.com >/dev/null 2>&1; then
+        echo "Firewall verification passed - able to reach AWS STS (ap-northeast-1)"
+    else
+        echo "WARNING: aws CLI is installed but STS endpoint is unreachable"
+    fi
 fi


### PR DESCRIPTION
## Summary

Add AWS CLI v2 to the devcontainer image so every contributor (and Claude) gets the same version on rebuild, and allow AWS public IP ranges through the sandbox firewall so the CLI can actually call AWS APIs.

## Changes

- **`.devcontainer/Dockerfile`**: install AWS CLI v2, pinned to ``AWS_CLI_VERSION`` (2.18.0). Same convention as the existing ``GH_VERSION`` / ``ACT_VERSION`` pins; arch detection matches gh/act.
- **`.devcontainer/devcontainer.json`**: surface ``AWS_CLI_VERSION`` as a build arg so bumping the version is a one-line change.
- **`.devcontainer/init-firewall.sh`**: pull `https://ip-ranges.amazonaws.com/ip-ranges.json` (same pattern as GitHub meta) and add prefixes for `ap-northeast-1` + `GLOBAL` to the `allowed-domains` ipset. Configurable via `AWS_REGIONS_ALLOWED`. Adds a non-fatal STS reachability probe at the end.

## Why bundle in the firewall change

The firewall is otherwise restrictive — installing the CLI without opening AWS endpoints would let `aws --version` work but `aws sts get-caller-identity` immediately fail with "Could not connect", which is hostile UX. Bundling means the next "Reopen in Container" leaves the user with a working CLI.

## Verification (after rebuild)

```bash
aws --version                  # → aws-cli/2.18.0 …
aws sts get-caller-identity    # → requires AWS credentials (aws-vault / env vars)
```

## Follow-ups (out of scope)

- Bundle Terraform (1.9.5 to match cd-stg.yml) the same way
- Publish a one-shot helper for ハルナさん to forward short-term AssumeRole credentials into the devcontainer when she wants Claude to run terraform plan/apply

## Notes for reviewers

- AWS IP ranges add ~500-700 prefixes per region. ipset handles this fine.
- Only IPv4 is added; IPv6 prefixes from ip-ranges.json are skipped (the existing ipset is hash:net IPv4-only).
- If `ip-ranges.amazonaws.com` is briefly unreachable at firewall init, the script logs a WARNING and continues (does not fail the container start).