### PR TITLE
chore(devcontainer): persist /home/node/.aws via named volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,6 +57,12 @@
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    // AWS credentials の永続化用 named volume。`${devcontainerId}` を意図的に
+    // 含めず固定名にしているため、devcontainer.json を編集してリビルドしても
+    // `aws configure` で入れた IAM access key / secret は保持される。
+    // 別 PC でこのレポジトリを開いた場合は、その PC で 1 度だけ
+    // `aws configure` を打ち直す必要がある (volume はホストごとに独立)。
+    "source=claude-code-aws,target=/home/node/.aws,type=volume",
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
   ],
   "containerEnv": {


### PR DESCRIPTION
## Summary

Mount a Docker named volume at `/home/node/.aws` so `aws configure` settings persist across container restarts and rebuilds — no need to re-enter the IAM access key every time the devcontainer is rebuilt.

```diff
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=claude-code-aws,target=/home/node/.aws,type=volume",
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
   ],
```

## Why a fixed volume name (no `${devcontainerId}`)

The other two volumes scope themselves to the devcontainer config hash so configuration drift triggers a clean reset. For AWS credentials we want the opposite: editing `devcontainer.json` should not blow away `aws configure` work. Fixed name `claude-code-aws` survives all settings changes.

## Per-host vs cross-host

- Same machine, multiple devcontainer rebuilds → credentials persist ✅
- Different machine opening the same repo → that machine starts with an empty volume; one-time `aws configure` is needed there
- Intentional — IAM access keys should not auto-flow between machines

## Manual steps after merge

```
Dev Containers: Rebuild Container       # picks up the new mount
aws configure                            # one-shot input of access key, secret, region, output
aws sts get-caller-identity              # smoke test
```

## Notes

- Replaces mistargeted anthropics/claude-code#53482 (closed; same content).
- Follow-up worth doing: same treatment for `/home/node/.config/gh` so `gh auth login` survives rebuilds too.