### PR TITLE
chore(devcontainer): persist /home/node/.config via named volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,6 +63,13 @@
     // 別 PC でこのレポジトリを開いた場合は、その PC で 1 度だけ
     // `aws configure` を打ち直す必要がある (volume はホストごとに独立)。
     "source=claude-code-aws,target=/home/node/.aws,type=volume",
+    // gh CLI の認証情報 (`/home/node/.config/gh/hosts.yml`) を含む XDG config
+    // ディレクトリの永続化。`gh auth login` を一度通せば、devcontainer リビルド
+    // を跨いで認証が残る。`claude-code-aws` と同様、`${devcontainerId}` を含めない
+    // 固定名にして devcontainer.json 編集の影響を受けないようにする。
+    // `/home/node/.config` 全体を載せているのは、将来 gh 以外のツール (op /
+    // direnv 等) が同じディレクトリに設定を書いた時にも自動で永続化されるため。
+    "source=claude-code-config-xdg,target=/home/node/.config,type=volume",
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
   ],
   "containerEnv": {


### PR DESCRIPTION
## Summary

Mount a fixed-name `claude-code-config-xdg` Docker volume at `/home/node/.config` so `gh auth login` (and any other XDG-spec tools) survive devcontainer rebuilds.

```diff
   "mounts": [
     ...
     "source=claude-code-aws,target=/home/node/.aws,type=volume",
+    "source=claude-code-config-xdg,target=/home/node/.config,type=volume",
     ...
   ]
```

## Why a whole-dir mount instead of `/home/node/.config/gh`

If we mount the parent `.config/` instead of just `gh/`, future tools that follow the XDG Base Directory spec (1Password CLI, direnv, fish, gcloud, etc.) automatically inherit the same persistence with no further config edits. There's no real downside — nothing in `~/.config/` is repo-specific, and the Dockerfile doesn't seed `~/.config/` at build time, so the volume just shadows nothing on first start.

## Why a fixed name (no `${devcontainerId}`)

Same rationale as #162: editing `devcontainer.json` should not blow away `gh auth login` work.

## Manual verification after merge

```
Dev Containers: Rebuild Container
gh auth status                         # → ✓ Logged in as haruna0712 (persists)
gh pr list --state open --limit 3      # smoke test
```

## Related

- Builds on #162 (AWS credentials volume)
- Together: AWS CLI, GitHub CLI, and any XDG-config tool all survive rebuilds