### PR TITLE
chore(devcontainer): bundle Terraform 1.9.5 + open HashiCorp endpoints

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -115,6 +115,23 @@ RUN ARCH=$(dpkg --print-architecture) && \
   rm -rf /tmp/awscliv2.zip /tmp/aws && \
   aws --version
 
+# Install Terraform (matches the version used by .github/workflows/cd-stg.yml
+# so local plan output matches CI output exactly). Bump TERRAFORM_VERSION in
+# devcontainer.json to upgrade; keep in sync with cd-stg.yml.
+ARG TERRAFORM_VERSION=1.9.5
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "$ARCH" in \
+    amd64) TF_ARCH=amd64 ;; \
+    arm64) TF_ARCH=arm64 ;; \
+    *) echo "Unsupported architecture for terraform: $ARCH" && exit 1 ;; \
+  esac && \
+  curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TF_ARCH}.zip" -o /tmp/terraform.zip && \
+  unzip -q /tmp/terraform.zip -d /tmp/ && \
+  sudo mv /tmp/terraform /usr/local/bin/terraform && \
+  sudo chmod +x /usr/local/bin/terraform && \
+  rm /tmp/terraform.zip && \
+  terraform version
+
 # Set up non-root user
 USER node
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
       "ACT_VERSION": "0.2.80",
       "GH_VERSION": "2.63.2",
       "AWS_CLI_VERSION": "2.18.0",
+      "TERRAFORM_VERSION": "1.9.5",
       "ZSH_IN_DOCKER_VERSION": "1.2.0"
     }
   },

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -124,7 +124,10 @@ for domain in \
     "pkg-containers.githubusercontent.com" \
     "objects.githubusercontent.com" \
     "pypi.org" \
-    "files.pythonhosted.org"; do
+    "files.pythonhosted.org" \
+    "releases.hashicorp.com" \
+    "registry.terraform.io" \
+    "checkpoint-api.hashicorp.com"; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then


### PR DESCRIPTION
## Summary

Add Terraform 1.9.5 to the devcontainer image so `terraform init / plan / apply` works from inside the sandbox, and whitelist the three HashiCorp endpoints Terraform needs in the firewall.

## Diff

```diff
# Dockerfile — new install block, mirrors the AWS CLI pattern
+ARG TERRAFORM_VERSION=1.9.5
+RUN ARCH=$(dpkg --print-architecture) && \
+  case "$ARCH" in amd64) TF_ARCH=amd64 ;; arm64) TF_ARCH=arm64 ;; esac && \
+  curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TF_ARCH}.zip" -o /tmp/terraform.zip && \
+  unzip -q /tmp/terraform.zip -d /tmp/ && sudo mv /tmp/terraform /usr/local/bin/terraform && \
+  sudo chmod +x /usr/local/bin/terraform && rm /tmp/terraform.zip && terraform version

# devcontainer.json — surface the version as a build arg
+      "TERRAFORM_VERSION": "1.9.5",

# init-firewall.sh — allow the three HashiCorp domains
+    "releases.hashicorp.com" \
+    "registry.terraform.io" \
+    "checkpoint-api.hashicorp.com" \
```

## Why pin to 1.9.5

Matches `.github/workflows/cd-stg.yml`. Local `terraform plan` output then matches CI's plan output exactly — no provider lock drift, no surprise behavior differences.

## What this enables

Combined with #161 (AWS CLI + AWS endpoints), #162 (`~/.aws` volume) and #163 (`~/.config` volume):

```bash
$ aws sts get-caller-identity        # already works after #162 + aws configure
$ terraform version                  # now works
$ cd terraform/environments/stg
$ terraform init                     # provider download via registry.terraform.io
$ terraform plan                     # AWS API calls work via the existing allow-list
```

This unblocks me running the Phase 1 stg deploy runbook (#160) directly instead of asking ハルナさん to run every terraform command manually.

## What this does NOT do

- Does not run any terraform command automatically
- Does not provide AWS credentials (those come from `aws configure` per #162)
- Does not change any IAM permissions or AWS resources

## Verification (after rebuild)

```
Dev Containers: Rebuild Container
terraform version            # → Terraform v1.9.5 on linux_<arch>
cd terraform/environments/stg && terraform init -backend=false  # provider download
```

## Related

- Builds on #161 (AWS CLI + firewall AWS allow-list)
- Builds on #162 (~/.aws named volume)
- Builds on #163 (~/.config named volume so gh auth survives rebuilds)