### PR TITLE
fix(devcontainer): pre-create /home/node/.aws and .config with node ownership

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,9 +66,26 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 # Set `DEVCONTAINER` environment variable to help with orientation
 ENV DEVCONTAINER=true
 
-# Create workspace and config directories and set permissions
-RUN mkdir -p /workspace /home/node/.claude && \
-  chown -R node:node /workspace /home/node/.claude
+# Create workspace and config directories and set permissions.
+#
+# `/home/node/.aws` (#162) and `/home/node/.config` (#163) are mounted as named
+# volumes at container start. Docker's behavior for an EMPTY named volume is to
+# seed it from the image's directory at the mount point, including ownership.
+# By pre-creating these directories with `node:node` ownership here, the first
+# `aws configure` / `gh auth login` on a freshly-built devcontainer (any host)
+# can write without "permission denied" errors. Without this seeding, Docker
+# defaults the volume's root inode to `root:root` and the `node` user is locked
+# out — see PR #16x for the regression report.
+RUN mkdir -p \
+  /workspace \
+  /home/node/.claude \
+  /home/node/.aws \
+  /home/node/.config && \
+  chown -R node:node \
+  /workspace \
+  /home/node/.claude \
+  /home/node/.aws \
+  /home/node/.config
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary

Fix a regression introduced by #162 + #163 where freshly-built devcontainers fail with `permission denied` on the first `aws configure` / `gh auth login` because the named volumes get Docker's default `root:root` ownership at the mount point.

## Root cause

Docker named volumes work like this: when an EMPTY named volume is mounted on top of a directory in the image, Docker copies the image directory's contents into the volume — INCLUDING ownership and permissions. If the image directory doesn't exist at the mount point, Docker creates it as `root:root`, and that ownership sticks to the volume forever (until manually `chown`d).

The Dockerfile already used this seeding trick for `/home/node/.claude`:

```dockerfile
RUN mkdir -p /workspace /home/node/.claude && \
  chown -R node:node /workspace /home/node/.claude
```

When #162 added `claude-code-aws → /home/node/.aws` and #163 added `claude-code-config-xdg → /home/node/.config`, neither directory was added to this seed line. So on first start, Docker defaults the mount points to `root:root` and the `node` user is locked out.

## Fix

Add `/home/node/.aws` and `/home/node/.config` to the existing mkdir+chown block. One-line conceptual change; expanded for readability with a comment explaining why this matters.

## Verification

On any host with no existing `claude-code-aws` / `claude-code-config-xdg` volume (i.e., first-time clone, or after `docker volume rm`):

```bash
Dev Containers: Rebuild Container
ls -ld /home/node/.aws /home/node/.config   # → drwxr-xr-x ... node node
gh auth login                                # → writes to ~/.config/gh/hosts.yml
aws configure                                # → writes to ~/.aws/credentials
```

The current devcontainer (where I'm running from) was hand-fixed via:

```bash
docker run --rm \
  -v claude-code-aws:/aws -v claude-code-config-xdg:/config \
  alpine sh -c "chown -R 1000:1000 /aws /config"
```

That manual fix is per-host and does NOT propagate. This PR is the IaC-correct fix that does propagate.

## Why this matters

ハルナさん explicitly asked for "別 PC でこのレポジトリを開いても同じ環境になる" behavior. Without this PR, every new PC would hit the same permission denied error.