### PR TITLE
fix(terraform): unblock terraform plan against AWS (2 pre-existing bugs)

### DIFF
--- a/terraform/modules/data/main.tf
+++ b/terraform/modules/data/main.tf
@@ -157,7 +157,11 @@ resource "aws_elasticache_subnet_group" "this" {
 }
 
 resource "aws_elasticache_parameter_group" "redis7" {
-  name_prefix = "${local.prefix}-redis7-"
+  # NOTE: aws_elasticache_parameter_group は `name_prefix` をサポートしない
+  # (aws_db_parameter_group とは仕様が異なる。AWS provider 5.x で確認)。
+  # 固定 `name` を使い、parameter 値変更で再作成が必要な時は
+  # create_before_destroy + 別名を経由する 2 段 apply で対応する。
+  name        = "${local.prefix}-redis7"
   family      = "redis7"
   description = "Redis 7 parameters for stg (Channels layer + Celery broker + cache)"
 

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -223,7 +223,9 @@ resource "aws_security_group" "ecs" {
     from_port   = 0
     to_port     = 0
     cidr_blocks = ["0.0.0.0/0"]
-    description = "Outbound to RDS / Redis / VPC Endpoints / fck-nat -> Internet"
+    # NOTE: AWS Security Group description は `[0-9A-Za-z_ .:/()#,@\[\]+=&;{}!$*-]` のみ。
+    # `>` は弾かれるため矢印ではなく `then` で接続する。
+    description = "Outbound to RDS / Redis / VPC Endpoints / fck-nat then Internet"
   }
 
   tags = merge(local.default_tags, { Name = "${local.prefix}-ecs-sg" })


### PR DESCRIPTION
## Summary

Two tiny pre-existing bugs that prevented \`terraform plan\` from completing against the real AWS API. Both surfaced on the first real plan attempt for stg (Phase 0.5 #28 was always pending, so these were never caught in CI either).

## Bug 1: \`aws_elasticache_parameter_group\` does not support \`name_prefix\`

\`aws_db_parameter_group\` accepts \`name_prefix\` but \`aws_elasticache_parameter_group\` only accepts \`name\` (AWS provider 5.x). Code change:

\`\`\`diff
 resource \"aws_elasticache_parameter_group\" \"redis7\" {
-  name_prefix = \"\${local.prefix}-redis7-\"
+  name        = \"\${local.prefix}-redis7\"
\`\`\`

## Bug 2: SG description regex rejects \`>\`

AWS validates Security Group descriptions against \`[0-9A-Za-z_ .:/()#,@\\\\[\\\\]+=&;{}!$*-]*\`. Our ECS SG had \`fck-nat -> Internet\` which contains \`>\` (not in the allowed set).

\`\`\`diff
-    description = \"Outbound to RDS / Redis / VPC Endpoints / fck-nat -> Internet\"
+    description = \"Outbound to RDS / Redis / VPC Endpoints / fck-nat then Internet\"
\`\`\`

Both fixes carry explanatory \`NOTE:\` comments so they don't get reintroduced.

## Verification

\`terraform plan\` now reaches the observability module instead of failing at schema/regex gate. There is a separate, structural issue in observability (\`count = var.X == \"\" ? 0 : 1\` where \`var.X\` is computed at apply time) which will be addressed in a follow-up PR.

## Why these never triggered before

- Phase 0.5 #28 (\"stg 初回デプロイ\") was always pending → no real \`terraform apply\` had ever run
- CI only does \`terraform fmt -check\` (warning-only at the moment per F-17) and validate, neither of which catches schema-level errors against AWS
- The bugs were planted in P0.5-07 (initial module composition) and went undetected for months