### PR TITLE
fix(devcontainer): allow us-east-1 in firewall (CloudFront API region)

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -77,9 +77,17 @@ done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 # Source: https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html
 #
 # AWS_REGIONS_ALLOWED can be overridden at firewall-init time by setting
-# the env var (comma-separated). Defaults to ap-northeast-1 (this project's
-# stg/prod region) plus GLOBAL (region-less services like IAM / Route53).
-AWS_REGIONS_ALLOWED="${AWS_REGIONS_ALLOWED:-ap-northeast-1,GLOBAL}"
+# the env var (comma-separated). Defaults to:
+#   - ap-northeast-1 (this project's stg/prod region)
+#   - us-east-1      (CloudFront control plane lives here even though
+#                     CloudFront is a "global" service; ACM certs that
+#                     CloudFront consumes also have to be issued in us-east-1)
+#   - GLOBAL         (region-less services like IAM / Route53)
+#
+# Without us-east-1, `terraform plan` against this stack will hang forever
+# on `cloudfront:ListCachePolicies` because the SDK cannot reach the
+# CloudFront API endpoint (which resolves to a us-east-1 IP).
+AWS_REGIONS_ALLOWED="${AWS_REGIONS_ALLOWED:-ap-northeast-1,us-east-1,GLOBAL}"
 echo "Fetching AWS IP ranges (regions: ${AWS_REGIONS_ALLOWED})..."
 aws_ranges=""
 for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary

`terraform plan` against this stack hangs forever on `cloudfront:ListCachePolicies` because the CloudFront control plane (`cloudfront.amazonaws.com`) resolves to a us-east-1 IP and the firewall added in #161 only whitelists `ap-northeast-1` + `GLOBAL`.

Symptom on the actual run:

```
module.edge.data.aws_cloudfront_cache_policy.caching_optimized:
  Still reading... [10m48s elapsed]

$ curl https://cloudfront.amazonaws.com
Could not connect to the endpoint URL

$ dig +short cloudfront.amazonaws.com
44.216.203.15           # us-east-1 AMAZON range
```

## Fix

Add `us-east-1` to the default `AWS_REGIONS_ALLOWED`. ip-ranges.json already enumerates us-east-1 IPs, so the rest of init-firewall.sh needs no change.

us-east-1 is necessary for two AWS gotchas, both of which apply here:

- CloudFront control plane (`cloudfront.amazonaws.com`) lives in us-east-1
- ACM certificates consumed by CloudFront must be issued in us-east-1 (`provider us_east_1` alias in `terraform/environments/stg/main.tf`)

## Verification

```bash
AWS_REGIONS_ALLOWED="ap-northeast-1,us-east-1,GLOBAL" \
  sudo /usr/local/bin/init-firewall.sh
curl -sI https://cloudfront.amazonaws.com   # → 200/30x
cd terraform/environments/stg && terraform plan
```