### PR TITLE
chore(devcontainer): bundle HashiCorp Agent Skills (Terraform plugins)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -205,6 +205,25 @@ RUN CLAUDE_CONFIG_DIR=/home/node/.claude claude mcp add --scope user serena -- \
     CLAUDE_CONFIG_DIR=/home/node/.claude claude mcp add --scope user playwright -- \
     npx -y @playwright/mcp --browser chrome
 
+# Register HashiCorp Agent Skills marketplace + install Terraform-related plugins
+# at user scope. Same lifecycle / volume seeding as the MCP block above.
+#
+# Curated picks for this project:
+#   - terraform-code-generation: HashiCorp HCL style guide + Terraform tests.
+#     Catches anti-patterns like `count = unknown_var ? 0 : 1` early.
+#   - terraform-module-generation: module design + Stacks + monolith refactoring.
+#     Useful as we add aws_ecs_service / Phase 2+ modules.
+#
+# Skipped intentionally:
+#   - terraform-provider-development: we consume the AWS provider, don't author one
+#   - packer-builders / packer-hcp: project does not use Packer
+#
+# To add other plugins at runtime: `/plugin install <name>@hashicorp` from inside
+# Claude Code, or via CLI: `claude plugin install <name>@hashicorp --scope user`.
+RUN CLAUDE_CONFIG_DIR=/home/node/.claude claude plugin marketplace add hashicorp/agent-skills --scope user && \
+    CLAUDE_CONFIG_DIR=/home/node/.claude claude plugin install terraform-code-generation@hashicorp --scope user && \
+    CLAUDE_CONFIG_DIR=/home/node/.claude claude plugin install terraform-module-generation@hashicorp --scope user
+
 # Seed Claude Code user settings with Stop/Notification hooks that emit BEL
 # (paired with VS Code's terminal.integrated.enableBell=true). Goes onto the
 # named volume via seeding on first container start.


### PR DESCRIPTION
## Summary

Auto-install HashiCorp's official Terraform Agent Skills on devcontainer build so style-guide / module-design guidance is available to Claude Code on every fresh container.

## Diff

```diff
+# Register HashiCorp Agent Skills marketplace + install Terraform-related plugins
+RUN CLAUDE_CONFIG_DIR=/home/node/.claude claude plugin marketplace add hashicorp/agent-skills --scope user && \
+    CLAUDE_CONFIG_DIR=/home/node/.claude claude plugin install terraform-code-generation@hashicorp --scope user && \
+    CLAUDE_CONFIG_DIR=/home/node/.claude claude plugin install terraform-module-generation@hashicorp --scope user
```

Sits right after the existing MCP server registration block (serena / context7 / playwright). Same lifecycle, same volume seeding (`/home/node/.claude` → named volume).

## Curated picks

| Plugin | Why |
|---|---|
| `terraform-code-generation` | HCL style guide + Terraform tests. Would have caught the `count = unknown_var ? 0 : 1` anti-pattern in #167. |
| `terraform-module-generation` | Module design + Stacks + monolith refactoring. Relevant as Phase 1 #125 adds aws_ecs_service modules. |

## Intentionally skipped

| Plugin | Reason |
|---|---|
| `terraform-provider-development` | We consume AWS provider, don't author one |
| `packer-builders` | Project does not use Packer |
| `packer-hcp` | Same |

Anyone working in those areas can opt in per-session via `/plugin install <name>@hashicorp`.

## Verified locally

```
$ claude plugin marketplace add hashicorp/agent-skills --scope user
✔ Successfully added marketplace: hashicorp

$ claude plugin install terraform-code-generation@hashicorp --scope user
✔ Successfully installed plugin

$ claude plugin list
❯ terraform-code-generation@hashicorp v1.0.0 ✔ enabled
❯ terraform-module-generation@hashicorp v1.0.0 ✔ enabled
```

## Source

Blog: https://www.hashicorp.com/en/blog/introducing-hashicorp-agent-skills
Repo: https://github.com/hashicorp/agent-skills