### PR TITLE
fix(terraform/network): fck-nat ASG launch template ENI conflict

### DIFF
--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -353,9 +353,25 @@ resource "aws_launch_template" "fcknat" {
   image_id      = local.fck_nat_ami_id
   instance_type = var.fck_nat_instance_type
 
-  network_interfaces {
-    network_interface_id = aws_network_interface.fcknat[0].id
-  }
+  # NOTE: launch template に `network_interfaces.network_interface_id` を
+  # 直接指定すると、AWS は LT の subnet 拘束と ASG `vpc_zone_identifier`
+  # の同時指定を「a network interface may not specify both a network
+  # interface ID and a subnet」で拒否する。そのため LT は SG だけ持たせ、
+  # 事前に作っておいた ENI は AMI 起動後に user-data で **secondary
+  # ENI として attach する** のが fck-nat の公式パターン。ENI を持つこと
+  # で source/dest check の無効化や EIP の事前割り当てを保ったまま、
+  # ASG による self-heal (instance 入れ替わり時に ENI 再アタッチ) が動く。
+  vpc_security_group_ids = [aws_security_group.fcknat.id]
+
+  user_data = base64encode(<<-EOT
+    #!/bin/bash
+    set -euo pipefail
+    cat > /etc/fck-nat.conf <<EOF
+    eni_id=${aws_network_interface.fcknat[0].id}
+    EOF
+    systemctl restart fck-nat.service
+  EOT
+  )
 
   metadata_options {
     http_tokens   = "required" # IMDSv2 必須


### PR DESCRIPTION
## Summary

Plan B apply against AWS hit an `OperationNotPermitted` validation error when the fck-nat ASG tried to launch instances:

> A network interface may not specify both a network interface ID and a subnet

The launch template was specifying both `network_interfaces.network_interface_id` (pointing at the pre-created NAT ENI) AND the ASG was specifying `vpc_zone_identifier` (subnet IDs). AWS rejects this combination.

This is the **fck-nat upstream recommended pattern**, confirmed via the HashiCorp `terraform-style-guide` agent skill installed in #170:

- Drop the `network_interfaces` block from the launch template entirely
- Add `vpc_security_group_ids` to the launch template directly
- Move ENI attachment to user-data — the fck-nat AMI's `fck-nat.service` reads `/etc/fck-nat.conf` for `eni_id` and attaches it as a secondary NIC at boot

## Why this is the right fix

The fck-nat AMI is purpose-built for this attach-at-boot flow. Pre-attaching the ENI in the LT is fighting the AMI. The user-data approach also lets ASG handle multi-AZ subnet placement correctly.

## Test plan

- [ ] `terraform plan` against stg succeeds with no diff besides this LT change
- [ ] `terraform apply` against stg launches the fck-nat ASG successfully (instance reaches healthy)
- [ ] NAT egress from a private-subnet workload works (curl from ECS task hits internet)
- [ ] Instance recovery after termination still works (ASG launches replacement, ENI re-attaches)

## Related

- Discovered during Plan B apply (#166 follow-up, post-merge of #170)
- Reviewed against `hashicorp/agent-skills` Terraform style guide skill