### PR TITLE
fix(terraform/storage): remove forbidden chars from S3 bucket tag values

### DIFF
--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -23,11 +23,13 @@ locals {
     var.tags,
   )
 
+  # NOTE: S3 tag values are restricted to letters, numbers, spaces, and the chars
+  # + - = . _ : / @ . Parentheses and commas are NOT allowed and cause InvalidTag.
   buckets = {
-    media    = { name = "${local.prefix}-media", purpose = "user-uploaded content (avatars, tweet images, DM attachments)" }
+    media    = { name = "${local.prefix}-media", purpose = "user-uploaded content - avatars / tweet images / DM attachments" }
     static   = { name = "${local.prefix}-static", purpose = "Next.js static assets via CloudFront" }
     backup   = { name = "${local.prefix}-backup", purpose = "RDS / Meilisearch / app-level backups" }
-    alb_logs = { name = "${local.prefix}-alb-logs", purpose = "ALB access logs (F-02)" }
+    alb_logs = { name = "${local.prefix}-alb-logs", purpose = "ALB access logs - F-02" }
   }
 
   # ap-northeast-1 Elastic Load Balancing service account (AWS 公式 account ID)。


### PR DESCRIPTION
## Summary

Plan B apply against AWS hit `InvalidTag: The TagValue you have provided is invalid` when creating the `media` and `alb_logs` buckets.

S3 tag values only allow letters, numbers, spaces, and `+ - = . _ : / @`. The previous \`purpose\` values used parentheses and commas, both of which S3 rejects (some other AWS services accept them, which is why this only surfaced when S3 itself was being created).

Before:
\`\`\`
media:    \"user-uploaded content (avatars, tweet images, DM attachments)\"
alb_logs: \"ALB access logs (F-02)\"
\`\`\`

After (allowed-chars-only, same meaning):
\`\`\`
media:    \"user-uploaded content - avatars / tweet images / DM attachments\"
alb_logs: \"ALB access logs - F-02\"
\`\`\`

Also added an inline comment in the locals block documenting the S3 tag character constraint so future entries stay safe.

## Test plan

- [ ] \`terraform plan\` shows only the tag value updates on the affected buckets
- [ ] \`terraform apply\` against stg creates all four S3 buckets without InvalidTag

## Related

- Discovered during Plan B apply (sister fix to #171)