### PR TITLE
fix(terraform/storage): ALB log policy GetBucketAcl uses correct principal

### DIFF
--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -223,7 +223,12 @@ data "aws_iam_policy_document" "alb_logs_write" {
     }
   }
 
-  # ELB が ACL "bucket-owner-full-control" を付けて PutObject するケースの許可
+  # ELB が ACL "bucket-owner-full-control" を付けて PutObject するケースの許可。
+  # ap-northeast-1 はレガシーリージョンで、ELB ログ配信は AWS アカウント
+  # principal (582318560864) を使う必要がある。`logdelivery.elasticloadbalancing.amazonaws.com`
+  # service principal は新しいリージョン向けで、ap-northeast-1 では拒否され
+  # access log の有効化が失敗する (F-02 監査ログを失う)。
+  # 参考: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
   statement {
     sid     = "AllowELBLoggingDeliveryAcl"
     effect  = "Allow"
@@ -232,8 +237,8 @@ data "aws_iam_policy_document" "alb_logs_write" {
     resources = [aws_s3_bucket.this["alb_logs"].arn]
 
     principals {
-      type        = "Service"
-      identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.elb_service_account_ap_northeast_1}:root"]
     }
   }
 }


### PR DESCRIPTION
## Summary

The ALB access-logs bucket policy had **mismatched principals** between its two statements:
- `s3:PutObject` → AWS account principal \`arn:aws:iam::582318560864:root\` ✅
- \`s3:GetBucketAcl\` → service principal \`logdelivery.elasticloadbalancing.amazonaws.com\` ❌

\`ap-northeast-1\` is a legacy ELB region and ELB log delivery only works there with the **AWS account principal** for **both** statements. The service principal is reserved for newer regions added after 2022 and is rejected here.

With the split principals, the next \`terraform apply\` would create the bucket fine, but **enabling access logs on the ALB itself would fail** at validation (\`The bucket does not allow ACL access\`) — losing the F-02 audit data this bucket exists to capture.

This was not caught in the prior \`apply → destroy\` cycle because the ALB itself was never reached (Plan B stopped at compute layer; ALB-side log enablement happens in compute module wiring).

## Fix

Aligned both statements to use the same \`elb_service_account_ap_northeast_1\` AWS account principal. Added an inline comment explaining the legacy-region rule so the next reader isn't tempted to \"modernize\" it back to the service principal.

## Test plan

- [ ] \`terraform plan\` against stg shows only the policy diff on \`alb_logs\` bucket
- [ ] \`terraform apply\` creates the bucket and policy successfully
- [ ] Once compute module wires the ALB, \`access_logs.bucket\` enablement succeeds (no \`InvalidConfigurationRequestException\`)
- [ ] After ALB receives traffic, log objects appear under \`alb/<env>/AWSLogs/...\`

## References

- AWS docs: [Bucket permissions for access logs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html)
- Surfaced in re-review post #171/#172 merge