### PR TITLE
fix(terraform/data): repeatable RDS teardown via snapshot suffix + stg deletion_protection

### DIFF
--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -70,10 +70,12 @@ module "data" {
 
   db_master_password = module.secrets.db_password_value
 
-  rds_instance_class       = var.rds_instance_class
-  rds_allocated_storage_gb = var.rds_allocated_storage_gb
-  rds_multi_az             = var.rds_multi_az
-  rds_skip_final_snapshot  = var.rds_skip_final_snapshot
+  rds_instance_class               = var.rds_instance_class
+  rds_allocated_storage_gb         = var.rds_allocated_storage_gb
+  rds_multi_az                     = var.rds_multi_az
+  rds_skip_final_snapshot          = var.rds_skip_final_snapshot
+  rds_deletion_protection          = var.rds_deletion_protection
+  final_snapshot_identifier_suffix = var.final_snapshot_identifier_suffix
 
   redis_node_type = var.redis_node_type
 }

--- a/terraform/environments/stg/variables.tf
+++ b/terraform/environments/stg/variables.tf
@@ -52,6 +52,18 @@ variable "rds_skip_final_snapshot" {
   default = false
 }
 
+variable "rds_deletion_protection" {
+  description = "RDS の deletion_protection。stg は teardown を頻繁にやるので default false。prod は true で上書き必須。"
+  type        = bool
+  default     = false
+}
+
+variable "final_snapshot_identifier_suffix" {
+  description = "RDS final snapshot 名の suffix。teardown を複数回行う前に `-var=final_snapshot_identifier_suffix=$(date +%Y%m%d%H%M%S)` を渡す。"
+  type        = string
+  default     = ""
+}
+
 # ---------- ElastiCache オーバーライド ----------
 
 variable "redis_node_type" {

--- a/terraform/modules/data/main.tf
+++ b/terraform/modules/data/main.tf
@@ -81,15 +81,15 @@ resource "aws_db_parameter_group" "postgres15" {
 resource "aws_db_instance" "this" {
   identifier = "${local.prefix}-postgres"
 
-  engine                 = "postgres"
-  engine_version         = var.rds_engine_version
-  instance_class         = var.rds_instance_class
-  allocated_storage      = var.rds_allocated_storage_gb
-  max_allocated_storage  = var.rds_max_allocated_storage_gb > 0 ? var.rds_max_allocated_storage_gb : null
-  storage_type           = "gp3"
-  iops                   = var.rds_storage_iops
-  storage_throughput     = var.rds_storage_throughput_mbs
-  storage_encrypted      = true
+  engine                = "postgres"
+  engine_version        = var.rds_engine_version
+  instance_class        = var.rds_instance_class
+  allocated_storage     = var.rds_allocated_storage_gb
+  max_allocated_storage = var.rds_max_allocated_storage_gb > 0 ? var.rds_max_allocated_storage_gb : null
+  storage_type          = "gp3"
+  iops                  = var.rds_storage_iops
+  storage_throughput    = var.rds_storage_throughput_mbs
+  storage_encrypted     = true
   # KMS は AWS managed key (aws/rds)。prod で CMK 移行時は kms_key_id を variable 化する。
 
   db_subnet_group_name   = aws_db_subnet_group.this.name
@@ -102,26 +102,29 @@ resource "aws_db_instance" "this" {
   # AWS RDS 側で手動 password 変更した場合、次回 terraform apply で
   # "in-place update" が走るため、lifecycle.ignore_changes でガードする。
 
-  port     = 5432
-  db_name  = "sns"
+  port    = 5432
+  db_name = "sns"
 
-  multi_az                = var.rds_multi_az
-  publicly_accessible     = false
+  multi_az                   = var.rds_multi_az
+  publicly_accessible        = false
   auto_minor_version_upgrade = true
 
   backup_retention_period = var.rds_backup_retention_days
-  backup_window           = "18:00-19:00" # JST 03:00-04:00
+  backup_window           = "18:00-19:00"         # JST 03:00-04:00
   maintenance_window      = "Wed:19:00-Wed:20:00" # JST 水曜 04:00-05:00
 
   deletion_protection = var.rds_deletion_protection
   skip_final_snapshot = var.rds_skip_final_snapshot
-  # final_snapshot_identifier は timestamp() を使わず固定名にする
+  # final_snapshot_identifier は timestamp() を使わず suffix 変数で外から制御する
   # (database-reviewer PR #50 MEDIUM: timestamp() は毎 plan で差分を生む)。
-  # 実行時刻は copy_tags_to_snapshot で引き継いだ tags + AWS 側の作成時刻から追える。
-  # teardown を複数回行う場合は手動で snapshot 名を別にする (e.g. `final_snapshot_identifier`
-  # 変数化は本モジュールでは未対応、必要になれば追加)。
-  final_snapshot_identifier = var.rds_skip_final_snapshot ? null : "${local.prefix}-postgres-final"
-  copy_tags_to_snapshot     = true
+  # apply→destroy を繰り返す環境では `-var=final_snapshot_identifier_suffix=YYYYMMDDhhmmss`
+  # を destroy 直前に渡して `DBSnapshotAlreadyExists` を回避する。
+  final_snapshot_identifier = var.rds_skip_final_snapshot ? null : (
+    var.final_snapshot_identifier_suffix == ""
+    ? "${local.prefix}-postgres-final"
+    : "${local.prefix}-postgres-final-${var.final_snapshot_identifier_suffix}"
+  )
+  copy_tags_to_snapshot = true
 
   performance_insights_enabled          = true
   performance_insights_retention_period = 7 # stg は 7 日、prod は 731 (2 年) を別途指定
@@ -203,8 +206,8 @@ resource "aws_elasticache_cluster" "this" {
   # stg は AUTH token 無効 (SG で十分守る)。prod では
   # replication group + transit encryption + at-rest encryption + auth_token が推奨で、
   # 別モジュール (data_replication) で提供する前提。
-  snapshot_retention_limit = 0 # stg は snapshot なし (Redis は壊れても再作成で OK)
-  apply_immediately        = false
+  snapshot_retention_limit   = 0 # stg は snapshot なし (Redis は壊れても再作成で OK)
+  apply_immediately          = false
   auto_minor_version_upgrade = true
 
   maintenance_window = "thu:19:00-thu:20:00" # JST 木曜 04:00-05:00

--- a/terraform/modules/data/variables.tf
+++ b/terraform/modules/data/variables.tf
@@ -123,6 +123,23 @@ variable "rds_skip_final_snapshot" {
   default     = false
 }
 
+variable "final_snapshot_identifier_suffix" {
+  description = <<-EOT
+    final snapshot identifier に付与する suffix。
+    空の場合は "<project>-<env>-postgres-final"。
+    apply→destroy を複数回繰り返す環境では `DBSnapshotAlreadyExists` を避けるため、
+    destroy 直前に `-var=final_snapshot_identifier_suffix=$(date +%Y%m%d%H%M%S)` を渡す。
+    timestamp() を使わない理由: 毎 plan で差分が出るため (database-reviewer PR #50 MEDIUM)。
+  EOT
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]*$", var.final_snapshot_identifier_suffix))
+    error_message = "final_snapshot_identifier_suffix は英数字とハイフンのみ。"
+  }
+}
+
 # ---------- ElastiCache ----------
 
 variable "redis_engine_version" {


### PR DESCRIPTION
## Summary

Two operational pain points hit during the most-recent \`terraform apply → destroy\` cycle:

1. **\`destroy\` blocked by \`deletion_protection\`** — the \`data\` module defaults \`rds_deletion_protection = true\`, but the stg root module never overrode it. Operator had to flip the flag manually via AWS CLI:
   \`\`\`
   aws rds modify-db-instance --db-instance-identifier sns-stg-postgres \\
     --no-deletion-protection --apply-immediately --region ap-northeast-1
   \`\`\`
2. **\`DBSnapshotAlreadyExists\` on the second apply→destroy cycle** — \`final_snapshot_identifier\` was a fixed string (\`<prefix>-postgres-final\`), so the next destroy with snapshots enabled would fail. The previous comment acknowledged this without fixing it.

## Changes

- \`modules/data/variables.tf\` — add \`final_snapshot_identifier_suffix\` (string, default empty, regex-validated). When set, appended to the identifier so each teardown produces a unique snapshot.
- \`modules/data/main.tf\` — use the suffix in \`final_snapshot_identifier\` with conditional concatenation; updated comment to point operators at \`-var=final_snapshot_identifier_suffix=\$(date +%Y%m%d%H%M%S)\`. Avoids \`timestamp()\` per database-reviewer PR #50 MEDIUM (would diff every plan).
- \`environments/stg/variables.tf\` — expose \`rds_deletion_protection\` (default \`false\` for stg) and \`final_snapshot_identifier_suffix\`.
- \`environments/stg/main.tf\` — pass both through to the data module.

Prod will get its own root module with \`rds_deletion_protection = true\` when it's stood up. The **module-level default stays \`true\`** so any unconfigured environment errs on the safe side; only stg specifically opts out.

## Operator workflow for stg teardown

\`\`\`bash
terraform destroy -auto-approve \\
  -var=\"final_snapshot_identifier_suffix=\$(date +%Y%m%d%H%M%S)\"
\`\`\`

## Test plan

- [ ] \`terraform plan\` shows in-place update on \`aws_db_instance.this\` (\`deletion_protection: true → false\` for stg)
- [ ] First \`terraform apply\` succeeds
- [ ] \`terraform destroy\` against stg succeeds **without** manually disabling deletion_protection
- [ ] A second \`apply → destroy\` cycle (with snapshot suffix passed) does not collide with the first cycle's snapshot

## References

- Surfaced in re-review post #171/#172 merge
- Companion PR: #173 (ALB log policy principal)