### PR TITLE
feat(terraform/data): encrypt Redis with TLS + at-rest + AUTH via replication_group

### DIFF
--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -77,7 +77,8 @@ module "data" {
   rds_deletion_protection          = var.rds_deletion_protection
   final_snapshot_identifier_suffix = var.final_snapshot_identifier_suffix
 
-  redis_node_type = var.redis_node_type
+  redis_node_type  = var.redis_node_type
+  redis_auth_token = module.secrets.redis_auth_token_value
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/data/main.tf
+++ b/terraform/modules/data/main.tf
@@ -191,21 +191,42 @@ resource "aws_elasticache_parameter_group" "redis7" {
   tags = local.default_tags
 }
 
-resource "aws_elasticache_cluster" "this" {
-  cluster_id           = "${local.prefix}-redis"
-  engine               = "redis"
-  engine_version       = var.redis_engine_version
-  node_type            = var.redis_node_type
-  num_cache_nodes      = var.redis_num_cache_nodes
+# Redis は cluster ではなく replication_group を使う。Single-node でも
+# replication_group は起動できる (num_node_groups=1, replicas_per_node_group=0)。
+# その代わり以下の prod 必須機能が常に有効化できる:
+#   - transit_encryption_enabled (TLS): セッション/Celery payload を VPC 内で暗号化
+#   - at_rest_encryption_enabled: ノード退役時の物理ディスクからの読み出しを防ぐ
+#   - auth_token: SG 突破時の最後の防衛線。secrets モジュールから sensitive で受け取る
+#   - automatic_failover_enabled: 後で replicas を増やすだけで切替可能
+# stg/prod を同じモジュールで賄え、prod 化時は replicas を増やすだけで済む。
+resource "aws_elasticache_replication_group" "this" {
+  replication_group_id = "${local.prefix}-redis"
+  description          = "Redis 7 for ${var.environment} (Channels + Celery + cache)"
+
+  engine         = "redis"
+  engine_version = var.redis_engine_version
+  node_type      = var.redis_node_type
+
+  num_node_groups         = var.redis_num_node_groups
+  replicas_per_node_group = var.redis_replicas_per_node_group
+
   parameter_group_name = aws_elasticache_parameter_group.redis7.name
   port                 = 6379
 
   subnet_group_name  = aws_elasticache_subnet_group.this.name
   security_group_ids = [var.redis_security_group_id]
 
-  # stg は AUTH token 無効 (SG で十分守る)。prod では
-  # replication group + transit encryption + at-rest encryption + auth_token が推奨で、
-  # 別モジュール (data_replication) で提供する前提。
+  # 暗号化と AUTH は常に有効。defense-in-depth で SG だけに依存しない。
+  transit_encryption_enabled = true
+  at_rest_encryption_enabled = true
+  auth_token                 = var.redis_auth_token
+  auth_token_update_strategy = "ROTATE"
+
+  # replicas が 1 以上なら failover/Multi-AZ を有効化。
+  # 0 (stg default) では AWS 側が拒否するので明示的に false。
+  automatic_failover_enabled = var.redis_replicas_per_node_group >= 1
+  multi_az_enabled           = var.redis_replicas_per_node_group >= 1
+
   snapshot_retention_limit   = 0 # stg は snapshot なし (Redis は壊れても再作成で OK)
   apply_immediately          = false
   auto_minor_version_upgrade = true

--- a/terraform/modules/data/outputs.tf
+++ b/terraform/modules/data/outputs.tf
@@ -34,19 +34,31 @@ output "rds_arn" {
 }
 
 output "redis_id" {
-  value = aws_elasticache_cluster.this.id
+  value = aws_elasticache_replication_group.this.id
 }
 
 output "redis_primary_endpoint" {
-  description = "Redis primary endpoint (Single-node なので cluster_address とほぼ同じ)"
-  value       = aws_elasticache_cluster.this.cache_nodes[0].address
+  description = "Redis primary endpoint (writes 用)。replication_group の primary endpoint。"
+  value       = aws_elasticache_replication_group.this.primary_endpoint_address
+}
+
+output "redis_reader_endpoint" {
+  description = "Redis reader endpoint (replicas へのラウンドロビン)。replicas が 0 なら primary と同じ挙動。"
+  value       = aws_elasticache_replication_group.this.reader_endpoint_address
 }
 
 output "redis_port" {
-  value = aws_elasticache_cluster.this.port
+  value = aws_elasticache_replication_group.this.port
 }
 
 output "redis_connection_url" {
-  description = "Django settings / Celery に渡す REDIS_URL"
-  value       = "redis://${aws_elasticache_cluster.this.cache_nodes[0].address}:${aws_elasticache_cluster.this.port}/0"
+  description = <<-EOT
+    Django settings / Celery に渡す REDIS_URL。
+    rediss:// (TLS) + AUTH token 埋め込み。sensitive。
+    アプリ側で SecretsManager から auth-token を fetch して
+    redis://primary_endpoint:port/0 + ssl=True を組み立てる方が
+    本来は望ましいが、stg は簡略化のためここで完成形を返す。
+  EOT
+  value       = "rediss://:${var.redis_auth_token}@${aws_elasticache_replication_group.this.primary_endpoint_address}:${aws_elasticache_replication_group.this.port}/0"
+  sensitive   = true
 }

--- a/terraform/modules/data/variables.tf
+++ b/terraform/modules/data/variables.tf
@@ -154,10 +154,32 @@ variable "redis_node_type" {
   default     = "cache.t4g.micro"
 }
 
-variable "redis_num_cache_nodes" {
-  description = "stg は Single-node の 1。prod は replication group で 2+ (別モジュールで拡張)"
+variable "redis_replicas_per_node_group" {
+  description = "シャードあたりの read replica 数。stg は 0 (Single-AZ コスト優先)、prod は 1+ で Multi-AZ failover を有効化推奨。"
+  type        = number
+  default     = 0
+}
+
+variable "redis_num_node_groups" {
+  description = "シャード数。1 で cluster mode disabled。Phase 3+ で水平分割が必要になったら増やす。"
   type        = number
   default     = 1
+}
+
+variable "redis_auth_token" {
+  description = <<-EOT
+    Redis AUTH token (sensitive)。secrets モジュールの redis_auth_token_value を渡す。
+    transit_encryption_enabled = true を有効化する以上、空文字列は許容しない
+    (validation で強制)。手動ローテートは aws elasticache modify-replication-group で
+    `--auth-token-update-strategy ROTATE` を指定する運用。
+  EOT
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.redis_auth_token) >= 16 && length(var.redis_auth_token) <= 128
+    error_message = "Redis AUTH token は 16-128 文字必須 (ElastiCache 制約)。"
+  }
 }
 
 variable "tags" {

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -35,17 +35,21 @@ locals {
   generated_secrets = {
     "django/secret-key"  = { description = "Django SECRET_KEY", length = 64, special = true }
     "django/db-password" = { description = "RDS master password", length = 40, special = false } # RDS の制約で記号制限あり
+    # ElastiCache Redis AUTH token。長さ 16-128 文字、特殊文字制約あり
+    # (NG: / @ " whitespace)。英数字のみで生成して安全側に倒す。
+    # data モジュールが transit_encryption_enabled = true を強制するため必須。
+    "redis/auth-token" = { description = "ElastiCache Redis AUTH token", length = 64, special = false }
   }
 
   # Placeholder グループ: terraform は枠だけ作る
   placeholder_secrets = {
-    "sentry/dsn"             = "Sentry Django/Celery DSN (https://...@sentry.io/...)"
-    "mailgun/api-key"        = "Mailgun API key (Phase 1 以降で利用)"
-    "mailgun/signing-key"    = "Mailgun webhook signing key"
-    "stripe/secret-key"      = "Stripe Secret Key (sk_test_... / sk_live_...)"
-    "stripe/webhook-secret"  = "Stripe webhook signing secret (whsec_...)"
-    "openai/api-key"         = "OpenAI API key (Phase 7 Bot 要約)"
-    "anthropic/api-key"      = "Anthropic API key (Phase 8 記事下書き AI)"
+    "sentry/dsn"            = "Sentry Django/Celery DSN (https://...@sentry.io/...)"
+    "mailgun/api-key"       = "Mailgun API key (Phase 1 以降で利用)"
+    "mailgun/signing-key"   = "Mailgun webhook signing key"
+    "stripe/secret-key"     = "Stripe Secret Key (sk_test_... / sk_live_...)"
+    "stripe/webhook-secret" = "Stripe webhook signing secret (whsec_...)"
+    "openai/api-key"        = "OpenAI API key (Phase 7 Bot 要約)"
+    "anthropic/api-key"     = "Anthropic API key (Phase 8 記事下書き AI)"
   }
 }
 

--- a/terraform/modules/secrets/outputs.tf
+++ b/terraform/modules/secrets/outputs.tf
@@ -29,3 +29,14 @@ output "db_password_value" {
   value       = var.generate_random_values ? random_password.generated["django/db-password"].result : null
   sensitive   = true
 }
+
+output "redis_auth_token_arn" {
+  description = "Redis AUTH token の ARN。アプリ側 (Django/Celery) が起動時に SecretsManager から fetch する。"
+  value       = aws_secretsmanager_secret.generated["redis/auth-token"].arn
+}
+
+output "redis_auth_token_value" {
+  description = "Redis AUTH token の現在値。data モジュールへ初回 apply 時に渡す用途で sensitive。"
+  value       = var.generate_random_values ? random_password.generated["redis/auth-token"].result : null
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

review-top **#1** from the post-#171/#172/#173/#174 architect re-review.

The previous \`aws_elasticache_cluster\` ran **plaintext**: no transit encryption, no at-rest encryption, no AUTH token. SG was the only protective layer for Django Channels session state, Celery job payloads, and SNS feed cache crossing the VPC. The inline comment had punted hardening to a separate prod-only module, but **stg is the test bed for prod**, so the hardened path was never exercised end-to-end.

## Approach

Switch to \`aws_elasticache_replication_group\` so a single module covers both:
- **stg**: Single-AZ, \`replicas_per_node_group = 0\` (cost-optimized)
- **prod**: Multi-AZ, \`replicas_per_node_group = 1+\` (failover)

Replication groups always allow encryption + AUTH, so we flip them on unconditionally:

| Setting | Value |
|---|---|
| \`transit_encryption_enabled\` | \`true\` |
| \`at_rest_encryption_enabled\` | \`true\` (AWS-managed \`aws/elasticache\` KMS) |
| \`auth_token\` | from secrets (16+ chars, validated) |
| \`auth_token_update_strategy\` | \`ROTATE\` (online rotation) |
| \`automatic_failover_enabled\` | derived: \`replicas ≥ 1\` |
| \`multi_az_enabled\` | derived: \`replicas ≥ 1\` |

## Secrets

\`secrets\` module now auto-generates \`redis/auth-token\` (64 chars, alphanumeric only — Redis AUTH bans \`/ @ \" whitespace\`). New outputs:

- \`redis_auth_token_arn\` — for app IAM policies
- \`redis_auth_token_value\` (sensitive) — passed into \`data\` module on apply

\`data\` module enforces \`length(auth_token) ∈ [16, 128]\`. Empty strings are rejected at plan time.

## Output changes

| Output | Before | After |
|---|---|---|
| \`redis_id\` | cluster_id | replication_group_id |
| \`redis_port\` | unchanged | unchanged |
| \`redis_primary_endpoint\` | \`cache_nodes[0].address\` | \`primary_endpoint_address\` |
| \`redis_reader_endpoint\` | (new) | \`reader_endpoint_address\` (falls back to primary when replicas=0) |
| \`redis_connection_url\` | \`redis://host:port/0\` | \`rediss://:<auth>@host:port/0\` (sensitive) |

## Application impact

Django/Celery \`REDIS_URL\` must use \`rediss://\` scheme and present AUTH. The connection URL is composed inside the module, so apps just consume \`module.data.redis_connection_url\`. A future improvement is to have the app fetch AUTH from SecretsManager at runtime — deferred to a separate PR to keep this one focused on the infra change.

## Migration impact

This is a **destroy-and-recreate** for the Redis cluster (replication_group is a different resource type). stg has no production data and no Redis state to preserve, so this is acceptable. There is no prod environment yet, so no prod cutover is needed.

## Test plan

- [ ] \`terraform plan\` shows: replication_group + parameter_group recreate, secret \`redis/auth-token\` created
- [ ] \`terraform apply\` succeeds end-to-end (Redis takes ~5-7 min for replication_group provision)
- [ ] App-side smoke test: Django Channels connects via \`rediss://\` with AUTH, Celery worker accepts/processes a sample task
- [ ] \`terraform destroy\` cleans up cleanly

## References

- ElastiCache encryption docs: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html
- AUTH token requirements: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html