### PR TITLE
feat(terraform/edge): add WAFv2 web ACL on CloudFront with managed rules + rate limit

### DIFF
--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -153,6 +153,9 @@ module "edge" {
 
   media_bucket_regional_domain  = module.storage.bucket_regional_domains["media"]
   static_bucket_regional_domain = module.storage.bucket_regional_domains["static"]
+
+  enable_waf              = var.enable_waf
+  waf_rate_limit_per_5min = var.waf_rate_limit_per_5min
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/environments/stg/variables.tf
+++ b/terraform/environments/stg/variables.tf
@@ -115,3 +115,17 @@ variable "enable_vpc_endpoints" {
   type        = bool
   default     = true
 }
+
+# ---------- WAF (CloudFront 前段) ----------
+
+variable "enable_waf" {
+  description = "CloudFront に WAFv2 を紐付けるか。stg で負荷試験を回す時だけ false にしてテスト後に戻す。"
+  type        = bool
+  default     = true
+}
+
+variable "waf_rate_limit_per_5min" {
+  description = "WAF rate-based rule の閾値 (1 IP あたり 5 分間のリクエスト数)。デフォルト 2000。"
+  type        = number
+  default     = 2000
+}

--- a/terraform/modules/edge/main.tf
+++ b/terraform/modules/edge/main.tf
@@ -178,6 +178,10 @@ resource "aws_cloudfront_distribution" "this" {
   aliases             = [local.app_fqdn]
   http_version        = "http2and3"
 
+  # WAFv2 web ACL (CLOUDFRONT scope は us-east-1 のみ作成可)。
+  # var.enable_waf = false の時は null を渡して紐付けを外す (負荷試験時のみ)。
+  web_acl_id = var.enable_waf ? aws_wafv2_web_acl.cloudfront[0].arn : null
+
   # -------- Origins --------
   origin {
     origin_id   = "alb"
@@ -337,4 +341,129 @@ resource "aws_route53_record" "webhook" {
     zone_id                = var.alb_zone_id
     evaluate_target_health = true
   }
+}
+
+# ---------------------------------------------------------------------------
+# WAFv2 web ACL (CLOUDFRONT scope)
+#
+# CLOUDFRONT scope の web ACL は us-east-1 のみで作成可能。`provider = aws.us_east_1`
+# を明示する。
+#
+# ルール構成:
+#   priority 1: AWSManagedRulesCommonRuleSet     (OWASP 系の汎用シグネチャ)
+#   priority 2: AWSManagedRulesKnownBadInputsRuleSet (既知の悪意ある入力)
+#   priority 3: AWSManagedRulesAmazonIpReputationList (脅威 IP リスト)
+#   priority 10: rate-based rule                 (1 IP あたり 5 分間で var.waf_rate_limit_per_5min まで)
+#
+# 監視:
+#   各ルールの sampled_requests_enabled = true で AWS Console 側のサンプル閲覧を有効化。
+#   metric_name は `${local.prefix}-cf-<rule>` で CloudWatch にエクスポート。
+# ---------------------------------------------------------------------------
+resource "aws_wafv2_web_acl" "cloudfront" {
+  count    = var.enable_waf ? 1 : 0
+  provider = aws.us_east_1
+
+  name        = "${local.prefix}-cloudfront"
+  description = "WAF for ${local.prefix} CloudFront distribution"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.prefix}-cf-common"
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.prefix}-cf-bad-inputs"
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 3
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.prefix}-cf-ip-rep"
+    }
+  }
+
+  rule {
+    name     = "RateLimitPerIp"
+    priority = 10
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.waf_rate_limit_per_5min
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.prefix}-cf-rate-limit"
+    }
+  }
+
+  visibility_config {
+    sampled_requests_enabled   = true
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.prefix}-cloudfront-acl"
+  }
+
+  tags = merge(local.default_tags, { Name = "${local.prefix}-cloudfront-waf" })
 }

--- a/terraform/modules/edge/outputs.tf
+++ b/terraform/modules/edge/outputs.tf
@@ -31,7 +31,7 @@ output "cloudfront_distribution_arn" {
     `AWS:SourceArn` 条件に渡す (OAC 推奨パターン、architect PR #52 MEDIUM:
     旧 `cloudfront_oac_arn` はリネームした)。
   EOT
-  value = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.this.id}"
+  value       = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.this.id}"
 }
 
 # 旧 output 名との後方互換 (storage モジュールがまだ `cloudfront_oac_arn` 参照)
@@ -60,6 +60,11 @@ output "app_fqdn" {
 
 output "webhook_fqdn" {
   value = local.webhook_fqdn
+}
+
+output "waf_web_acl_arn" {
+  description = "CloudFront に紐付けた WAFv2 web ACL ARN。enable_waf = false の時は null。"
+  value       = var.enable_waf ? aws_wafv2_web_acl.cloudfront[0].arn : null
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/modules/edge/variables.tf
+++ b/terraform/modules/edge/variables.tf
@@ -73,6 +73,26 @@ variable "additional_alb_record" {
   default     = false
 }
 
+variable "enable_waf" {
+  description = <<-EOT
+    CloudFront に WAFv2 を紐付けるか。デフォルト true。
+    stg で負荷試験 (k6 / Locust) を回す時だけ false にして、テスト後に true に戻す運用。
+    AWSManagedRulesCommonRuleSet + KnownBadInputs + AmazonIpReputation + 2000 req/5min/IP の rate-based rule を有効化する。
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "waf_rate_limit_per_5min" {
+  description = "rate-based rule の閾値 (1 IP あたり 5 分間のリクエスト数)。デフォルト 2000 = 約 6.7 req/sec/IP。"
+  type        = number
+  default     = 2000
+  validation {
+    condition     = var.waf_rate_limit_per_5min >= 100 && var.waf_rate_limit_per_5min <= 20000000
+    error_message = "AWS WAFv2 rate-based rule の有効レンジは 100 〜 20,000,000。"
+  }
+}
+
 variable "tags" {
   description = "全リソース共通タグ"
   type        = map(string)


### PR DESCRIPTION
## Summary

review-top **#5** from the post-#171/#172/#173/#174 architect re-review.

CloudFront was exposing Django/Next.js to the open internet with **no managed rule set, no IP reputation list, and no rate-based rule**. Combined with the default behavior allowing \`PUT/POST/PATCH/DELETE\` to the ALB origin without any pre-filtering, an attacker could probe \`/api/auth/*\`, the AI-backed endpoints, or the upload paths with zero front-line resistance.

## Approach

Add an \`aws_wafv2_web_acl\` (CLOUDFRONT scope, created in \`us-east-1\` via the existing \`aws.us_east_1\` provider alias) and associate it with the distribution via \`web_acl_id\`.

### Rule set (priority order)

| Pri | Rule | Action |
|---|---|---|
| 1 | \`AWSManagedRulesCommonRuleSet\` | none (rule-level) |
| 2 | \`AWSManagedRulesKnownBadInputsRuleSet\` | none (rule-level) |
| 3 | \`AWSManagedRulesAmazonIpReputationList\` | none (rule-level) |
| 10 | \`RateLimitPerIp\` (rate-based) | \`block\` |

The managed groups use \`override_action { none {} }\` so the vendor rules' own actions (block/count) are honored.

### Defaults

\`\`\`hcl
enable_waf              = true   # off for load tests only
waf_rate_limit_per_5min = 2000   # ~6.7 req/sec/IP averaged
\`\`\`

### Observability hook

Each rule + the ACL itself emits CloudWatch metrics with names prefixed by \`\${prefix}-cf-*\` so dashboards/alarms can be wired in the \`observability\` module later. Sampled requests are enabled for AWS Console inspection.

### Outputs

- \`waf_web_acl_arn\` — null when \`enable_waf = false\`

### stg knobs

Both \`enable_waf\` and \`waf_rate_limit_per_5min\` are exposed at the root so a load test session can flip WAF off:

\`\`\`bash
terraform apply -var=enable_waf=false
# ... run k6/locust ...
terraform apply -var=enable_waf=true
\`\`\`

## Cost note

WAFv2 pricing (us-east-1): \`\$5/month/web ACL + \$1/month/rule + \$0.60/million requests\`. With 4 rules: \~**\$10/month base** for stg, regardless of traffic.

## Test plan

- [ ] \`terraform plan\` shows: 1 \`aws_wafv2_web_acl\` add + 1 \`aws_cloudfront_distribution\` in-place update setting \`web_acl_id\`
- [ ] \`terraform apply\` creates the ACL in \`us-east-1\` and CloudFront accepts the association
- [ ] CloudFront serves traffic normally for the happy path
- [ ] A simple OWASP-style payload (e.g. \`?q=<script>alert(1)</script>\`) is blocked with HTTP 403
- [ ] Rapid-fire \`>2000 req/5min\` from a single IP is blocked
- [ ] \`terraform apply -var=enable_waf=false\` removes the association cleanly

## References

- AWS WAFv2 managed rule groups: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
- Rate-based rule semantics: https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html