### PR TITLE
fix(phase-1): pre-deploy CRITICAL/HIGH fixes from post-hoc reviewer audit

### DIFF
--- a/.github/workflows/cd-stg.yml
+++ b/.github/workflows/cd-stg.yml
@@ -127,20 +127,51 @@ jobs:
           role-session-name: gha-cd-stg-migrate-${{ github.run_id }}
 
       # Phase 0.5 では django / celery の task definition がまだ ECS に登録
-      # されていないため、`|| true` でスキップしてもパイプラインは進める。
-      # Phase 1 で aws_ecs_service が作られた後、以下を有効化する:
-      #
-      # - name: Trigger migration task
-      #   run: |
-      #     aws ecs run-task \
-      #       --cluster ${{ vars.ECS_CLUSTER }} \
-      #       --task-definition sns-stg-django-migrate \
-      #       --launch-type FARGATE \
-      #       --network-configuration "awsvpcConfiguration={subnets=[${{ vars.ECS_PRIVATE_SUBNETS }}],securityGroups=[${{ vars.ECS_SECURITY_GROUP }}]}" \
-      #       --wait
-      - name: Placeholder — migration not yet wired
+      # F1-2 (security-reviewer Phase 1 CRITICAL): placeholder を本実装に置換。
+      # ECS task definition `sns-stg-django-migrate` (terraform 側で定義) を
+      # `run-task` で起動して migration を流す。タスクが定義されていない環境
+      # では `vars.ECS_MIGRATE_TASK_DEFINITION` 未設定で skip する (新規 stg /
+      # 復旧フェーズ用)。
+      - name: Run Django migrations on ECS
+        if: vars.ECS_MIGRATE_TASK_DEFINITION != '' && vars.ECS_PRIVATE_SUBNETS != '' && vars.ECS_SECURITY_GROUP != ''
+        env:
+          CLUSTER: ${{ vars.ECS_CLUSTER }}
+          TASK_DEF: ${{ vars.ECS_MIGRATE_TASK_DEFINITION }}
+          SUBNETS: ${{ vars.ECS_PRIVATE_SUBNETS }}
+          SECGROUP: ${{ vars.ECS_SECURITY_GROUP }}
+          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
         run: |
-          echo "::warning::Phase 0.5: migration step is a placeholder until Phase 1 wires aws_ecs_service"
+          set -euo pipefail
+          # 直近の image tag を環境変数として container override で渡す。
+          # 同一 task definition の中で migrate コンテナだけが該当する。
+          task_arn=$(aws ecs run-task \
+            --cluster "$CLUSTER" \
+            --task-definition "$TASK_DEF" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECGROUP],assignPublicIp=DISABLED}" \
+            --overrides "{\"containerOverrides\":[{\"name\":\"django\",\"environment\":[{\"name\":\"IMAGE_TAG\",\"value\":\"$IMAGE_TAG\"}]}]}" \
+            --query 'tasks[0].taskArn' \
+            --output text)
+          echo "Migration task: $task_arn"
+          aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$task_arn"
+          # exit code を取得してジョブ成否に反映
+          exit_code=$(aws ecs describe-tasks \
+            --cluster "$CLUSTER" \
+            --tasks "$task_arn" \
+            --query 'tasks[0].containers[0].exitCode' \
+            --output text)
+          if [ "$exit_code" != "0" ]; then
+            echo "::error::Migration task exited with code $exit_code"
+            aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$task_arn" \
+              --query 'tasks[0].stoppedReason' --output text
+            exit 1
+          fi
+          echo "Migration completed successfully"
+
+      - name: Skip migration (ECS migrate task definition not configured)
+        if: vars.ECS_MIGRATE_TASK_DEFINITION == ''
+        run: |
+          echo "::warning::ECS_MIGRATE_TASK_DEFINITION が未設定のため migration を skip。stg 初回 apply 後に GitHub Variables に登録すること。"
 
   # -----------------------------------------------------------------------
   # 3. ECS サービス更新 (Rolling Update)
@@ -157,22 +188,41 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: gha-cd-stg-deploy-${{ github.run_id }}
 
-      # Phase 0.5 時点では aws_ecs_service が未定義。Phase 1 で追加される
-      # サービスに対して下記のような update-service を実行する。
-      - name: Placeholder — services not yet wired
+      # F1-2: ECS service rolling update を本実装。
+      # 対象 service 一覧は env var `ECS_SERVICES` (カンマ区切り) で指定。
+      # 例: "sns-stg-django,sns-stg-next,sns-stg-daphne,sns-stg-celery-worker,sns-stg-celery-beat"
+      - name: Force new deployment on ECS services
+        if: vars.ECS_CLUSTER != '' && vars.ECS_SERVICES != ''
+        env:
+          CLUSTER: ${{ vars.ECS_CLUSTER }}
+          SERVICES: ${{ vars.ECS_SERVICES }}
         run: |
-          echo "::warning::Phase 0.5: ECS service rolling update is a placeholder until Phase 1 defines aws_ecs_service for django/next/daphne/celery-worker/celery-beat"
+          set -euo pipefail
+          IFS=',' read -ra SERVICE_LIST <<< "$SERVICES"
+          for svc in "${SERVICE_LIST[@]}"; do
+            svc="${svc// /}"  # trim spaces
+            [ -z "$svc" ] && continue
+            echo "Triggering rolling update on service: $svc"
+            aws ecs update-service \
+              --cluster "$CLUSTER" \
+              --service "$svc" \
+              --force-new-deployment \
+              --no-cli-pager > /dev/null
+          done
+          # Rolling update が steady state に到達するまで wait (最大 10 分)。
+          # 5 サービス並列で wait しても AWS CLI が直列処理するので体感 5-8 min。
+          for svc in "${SERVICE_LIST[@]}"; do
+            svc="${svc// /}"
+            [ -z "$svc" ] && continue
+            echo "Waiting for $svc to be stable..."
+            aws ecs wait services-stable --cluster "$CLUSTER" --services "$svc"
+            echo "$svc is stable"
+          done
 
-      # 有効化する時のテンプレ:
-      # - name: Force new deployment
-      #   run: |
-      #     for service in django next daphne celery-worker celery-beat; do
-      #       aws ecs update-service \
-      #         --cluster ${{ vars.ECS_CLUSTER }} \
-      #         --service "sns-stg-$service" \
-      #         --force-new-deployment \
-      #         --no-cli-pager
-      #     done
+      - name: Skip deploy (ECS services not configured)
+        if: vars.ECS_CLUSTER == '' || vars.ECS_SERVICES == ''
+        run: |
+          echo "::warning::ECS_CLUSTER または ECS_SERVICES が未設定のためデプロイを skip。stg 初回 apply 後に GitHub Variables に登録すること。"
 
   # -----------------------------------------------------------------------
   # 4. Smoke test
@@ -182,13 +232,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
+      # F1-2: continue-on-error を削除して smoke 失敗で job を fail させる。
+      # SMOKE_URL 未設定の場合は明示的に skip する step を別建てにし、設定漏れと
+      # 実行失敗を CI 上で区別できるようにする。
       - name: curl /api/health/
-        # TODO(Phase1): `continue-on-error: true` を外して smoke 失敗で job を
-        # 落とすこと。Phase 0.5 では SMOKE_URL 未設定 + ECS サービス未配線で
-        # 常時失敗するので warning 止まりにしている。追跡 Issue: Phase 1 着手
-        # 時の `[P1-XX] Harden cd-stg.yml smoke test` で対応。
         if: vars.SMOKE_URL != ''
         run: |
+          set -euo pipefail
           url="${{ vars.SMOKE_URL }}/api/health/"
           echo "Hitting $url"
           for i in 1 2 3 4 5; do
@@ -201,7 +251,11 @@ jobs:
           done
           echo "::error::Health check failed after 5 attempts"
           exit 1
-        continue-on-error: true
+
+      - name: Skip smoke test (SMOKE_URL not configured)
+        if: vars.SMOKE_URL == ''
+        run: |
+          echo "::warning::SMOKE_URL が未設定のため smoke を skip。stg 初回 apply + DNS 委任完了後に GitHub Variables に登録すること。"
       - name: Smoke test skipped notice
         if: vars.SMOKE_URL == ''
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,9 @@ repos:
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: check-json
-        exclude: ^client/cache/
+        # devcontainer.json は JSONC (JSON with Comments) 仕様で // コメントが
+        # 公式に許容されている。check-json は plain JSON しか parse できないので除外。
+        exclude: ^(client/cache/|\.devcontainer/devcontainer\.json$)
       - id: check-toml
       - id: check-added-large-files
         args: [--maxkb=500]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -180,7 +180,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 377
+        "line_number": 404
       }
     ],
     "docs/operations/email-auth.md": [
@@ -221,9 +221,9 @@
         "filename": "terraform/modules/secrets/main.tf",
         "hashed_secret": "f0211d35e5600a3e66afc79c5dfee563b2b6e60e",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 54
       }
     ]
   },
-  "generated_at": "2026-04-24T15:42:42Z"
+  "generated_at": "2026-04-29T01:02:38Z"
 }

--- a/apps/common/cookie_auth.py
+++ b/apps/common/cookie_auth.py
@@ -85,8 +85,17 @@ class CookieAuthentication(JWTAuthentication):
             validated_token = self.get_validated_token(raw_token)
             user = self.get_user(validated_token)
         except TokenError as e:
-            logger.error("Token validation error: %s", e)
-            return None
+            # security-reviewer Phase 1 post-hoc HIGH:
+            # `return None` だと DRF からは「認証情報なし」扱いになり、`AnonymousUser`
+            # としてリクエストが素通りしてしまう。期限切れ / 改竄 / 鍵ローテ後の旧
+            # トークンを「素通り」させると、IsAuthenticated が無い endpoint で
+            # 認証バイパスの温床になる。401 を返すように `AuthenticationFailed` を投げる。
+            #
+            # NOTE: ヘッダ / Cookie に「トークンが含まれていない」ケース (raw_token=None)
+            # はこの分岐に到達せず上で `return None` する。ここで弾くのは「トークンは
+            # あるが invalid」のケースのみ。
+            logger.warning("token_invalid", extra={"reason": str(e)})
+            raise exceptions.AuthenticationFailed("Invalid or expired token.") from e
 
         if from_cookie:
             # Cookie 経由でしか JWT が届かないケースに限り CSRF を enforcement する。

--- a/apps/common/tests/test_cookie_auth.py
+++ b/apps/common/tests/test_cookie_auth.py
@@ -1,0 +1,70 @@
+"""CookieAuthentication tests (Phase 1 post-hoc HIGH fix).
+
+security-reviewer 指摘:
+- 期限切れ / 改ざん / 鍵ローテ後の旧トークンを `return None` で握り潰すと、
+  AnonymousUser として素通り → 認証バイパスの温床になる。
+- 修正後は `AuthenticationFailed` を投げて 401 を返す。
+
+検証観点:
+- Cookie に invalid token がある場合、AuthenticationFailed が投げられる
+- Cookie が無い場合は None (= 認証情報なし) が返る (既存挙動維持)
+- valid な token では (user, token) tuple が返る (既存挙動維持)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.conf import settings
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APIRequestFactory
+from rest_framework_simplejwt.exceptions import TokenError
+
+from apps.common.cookie_auth import CookieAuthentication
+
+
+def test_invalid_token_in_cookie_raises_authentication_failed() -> None:
+    """期限切れ / 改ざん トークンは AuthenticationFailed (401) を投げるべき.
+
+    `return None` だと DRF が AnonymousUser として認証バイパスを許してしまう。
+    """
+    factory = APIRequestFactory()
+    request = factory.get("/api/v1/users/me/")
+    request.COOKIES[settings.COOKIE_NAME] = "this-is-not-a-valid-jwt"
+
+    auth = CookieAuthentication()
+
+    with pytest.raises(AuthenticationFailed):
+        auth.authenticate(request)
+
+
+def test_no_cookie_no_header_returns_none() -> None:
+    """Cookie もヘッダも無い場合は None (認証情報なし扱い)."""
+    factory = APIRequestFactory()
+    request = factory.get("/api/v1/users/me/")
+    # 何も設定しない
+
+    auth = CookieAuthentication()
+    result = auth.authenticate(request)
+    assert result is None
+
+
+def test_token_error_branch_invokes_warning_log() -> None:
+    """TokenError を捕捉した時に warning ログが出ること (監査用)."""
+    factory = APIRequestFactory()
+    request = factory.get("/api/v1/users/me/")
+    request.COOKIES[settings.COOKIE_NAME] = "rubbish"
+
+    auth = CookieAuthentication()
+    # JWTAuthentication.get_validated_token を強制的に TokenError を投げるよう mock
+    with (
+        patch.object(auth, "get_validated_token", side_effect=TokenError("expired")),
+        patch("apps.common.cookie_auth.logger") as mock_logger,
+    ):
+        with pytest.raises(AuthenticationFailed):
+            auth.authenticate(request)
+        mock_logger.warning.assert_called_once()
+        args, kwargs = mock_logger.warning.call_args
+        assert args[0] == "token_invalid"
+        assert kwargs["extra"]["reason"] == "expired"

--- a/apps/users/tests/test_complete_onboarding.py
+++ b/apps/users/tests/test_complete_onboarding.py
@@ -88,9 +88,7 @@ class TestCompleteOnboardingEndpoint:
         user = user_factory(username="onboarding_04")
         api_client.force_authenticate(user=user)
 
-        res = api_client.post(
-            onboarding_url, data={"display_name": "   "}, format="json"
-        )
+        res = api_client.post(onboarding_url, data={"display_name": "   "}, format="json")
 
         assert res.status_code == status.HTTP_400_BAD_REQUEST
         user.refresh_from_db()
@@ -111,9 +109,7 @@ class TestCompleteOnboardingEndpoint:
         assert res.status_code == status.HTTP_400_BAD_REQUEST
         assert "display_name" in res.data or "bio" in res.data
 
-    def test_requires_authentication(
-        self, api_client: APIClient, onboarding_url: str
-    ) -> None:
+    def test_requires_authentication(self, api_client: APIClient, onboarding_url: str) -> None:
         res = api_client.post(onboarding_url, data={"display_name": "x"}, format="json")
         assert res.status_code in (
             status.HTTP_401_UNAUTHORIZED,

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -67,9 +67,7 @@ def set_auth_cookies(
     response.set_cookie(settings.COOKIE_NAME, access_token, **cookie_settings)
 
     if refresh_token:
-        refresh_token_lifetime = settings.SIMPLE_JWT[
-            "REFRESH_TOKEN_LIFETIME"
-        ].total_seconds()
+        refresh_token_lifetime = settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"].total_seconds()
         refresh_cookie_settings = cookie_settings.copy()
         refresh_cookie_settings["max_age"] = refresh_token_lifetime
         response.set_cookie(
@@ -105,6 +103,12 @@ def _delete_auth_cookie(response: Response, name: str) -> None:
 
 
 class CustomTokenObtainPairView(TokenObtainPairView):
+    # F1-7 (security-reviewer Phase 1 HIGH):
+    # 旧互換 /auth/login/ にも LoginRateThrottle (5/min) を適用。
+    # 既定 AnonRateThrottle (200/day) との 14400 倍差を埋めて
+    # ブルートフォース猶予を新フロー (/cookie/create/) と揃える。
+    throttle_classes = [LoginRateThrottle]
+
     def post(self, request: Request, *args, **kwargs) -> Response:
         token_res = super().post(request, *args, **kwargs)
 
@@ -131,6 +135,10 @@ class CustomTokenObtainPairView(TokenObtainPairView):
 
 
 class CustomTokenRefreshView(TokenRefreshView):
+    # F1-7: refresh も同じ scope で抑制 (5/min)。短時間に refresh を連打する操作は
+    # 通常の利用シナリオでは発生しない。
+    throttle_classes = [LoginRateThrottle]
+
     def post(self, request: Request, *args, **kwargs) -> Response:
         refresh_token = request.COOKIES.get("refresh")
 
@@ -158,9 +166,7 @@ class CustomTokenRefreshView(TokenRefreshView):
                 refresh_res.data["message"] = (
                     "Access or refresh tokens not found in refresh response data"
                 )
-                logger.error(
-                    "Access or refresh token not found in refresh response data"
-                )
+                logger.error("Access or refresh token not found in refresh response data")
 
         return refresh_res
 
@@ -188,9 +194,7 @@ class CustomProviderAuthView(ProviderAuthView):
                 provider_res.data["message"] = (
                     "Access or refresh token not found in provider response"
                 )
-                logger.error(
-                    "Access or refresh token not found in provider response data"
-                )
+                logger.error("Access or refresh token not found in provider response data")
 
         return provider_res
 
@@ -282,9 +286,7 @@ class LogoutAPIView(APIView):
                 token = RefreshToken(refresh_token)
                 token.blacklist()
             except TokenError as exc:
-                logger.warning(
-                    "Legacy logout called with invalid refresh token: %s", exc
-                )
+                logger.warning("Legacy logout called with invalid refresh token: %s", exc)
 
         response = Response(status=status.HTTP_204_NO_CONTENT)
         _delete_auth_cookie(response, settings.COOKIE_NAME)
@@ -506,9 +508,7 @@ class CompleteOnboardingView(APIView):
         display_name = serializers.CharField(
             max_length=50, required=True, allow_blank=False, trim_whitespace=True
         )
-        bio = serializers.CharField(
-            max_length=160, required=False, allow_blank=True, default=""
-        )
+        bio = serializers.CharField(max_length=160, required=False, allow_blank=True, default="")
 
     def post(self, request: Request, *args, **kwargs) -> Response:
         serializer = self._Serializer(data=request.data)

--- a/client/e2e/phase1.spec.ts
+++ b/client/e2e/phase1.spec.ts
@@ -15,7 +15,7 @@ test.describe("Phase 1 golden path", () => {
 		const stamp = Date.now();
 		const handle = `e2e_${stamp}`;
 		const email = `${handle}@example.com`;
-		const password = "supersecret12";
+		const password = "supersecret12"; // pragma: allowlist secret
 
 		// 1. Sign up.
 		await page.goto("/register");

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -61,7 +61,7 @@
 				"eslint-plugin-tailwindcss": "^3.14.1",
 				"jsdom": "^25.0.1",
 				"postcss": "^8",
-				"prettier": "^3.2.4",
+				"prettier": "3.3.3",
 				"sharp": "^0.33.2",
 				"tailwindcss": "^3.3.0",
 				"typescript": "^5",
@@ -12403,9 +12403,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-			"integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {

--- a/client/package.json
+++ b/client/package.json
@@ -67,7 +67,7 @@
 		"eslint-plugin-tailwindcss": "^3.14.1",
 		"jsdom": "^25.0.1",
 		"postcss": "^8",
-		"prettier": "^3.2.4",
+		"prettier": "3.3.3",
 		"sharp": "^0.33.2",
 		"tailwindcss": "^3.3.0",
 		"typescript": "^5",

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
+import { stringifyJsonLd } from "@/lib/json-ld";
 
 interface PageProps {
 	params: { id: string };
@@ -112,8 +113,9 @@ export default async function TweetDetailPage({ params }: PageProps) {
 		<main className="mx-auto max-w-2xl px-6 py-10">
 			<script
 				type="application/ld+json"
-				// generateMetadata + schema.org payload; no user input interpolated as HTML.
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+				// security-reviewer Phase 1 CRITICAL: tweet.body はユーザー生成コンテンツで
+				// `</script>` が含まれうるため stringifyJsonLd で </ をエスケープする。
+				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
 			/>
 			<article className="rounded-lg border bg-card p-6 shadow-sm">
 				<header className="mb-4 flex items-center gap-3">

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
+import { stringifyJsonLd } from "@/lib/json-ld";
 
 interface PublicProfile {
 	username: string;
@@ -104,7 +105,10 @@ export default async function ProfilePage({ params }: PageProps) {
 		<main className="mx-auto max-w-3xl px-4 pb-10">
 			<script
 				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+				// security-reviewer Phase 1 CRITICAL: profile.bio / display_name は
+				// ユーザー生成コンテンツで `</script>` が含まれうるため stringifyJsonLd で
+				// </ をエスケープする。
+				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
 			/>
 
 			{profile.header_url && (

--- a/client/src/components/tweets/TweetEditForm.tsx
+++ b/client/src/components/tweets/TweetEditForm.tsx
@@ -124,7 +124,7 @@ export default function TweetEditForm({
 					{charCount} / {TWEET_MAX_CHARS} |{" "}
 					{policy.isEditable
 						? `残り編集回数 ${policy.editsRemaining} / 時間 ${formatMinutes(policy.msRemaining)}`
-						: reasonMessage ?? ""}
+						: (reasonMessage ?? "")}
 				</div>
 			</div>
 

--- a/client/src/lib/__tests__/json-ld.test.ts
+++ b/client/src/lib/__tests__/json-ld.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { stringifyJsonLd } from "@/lib/json-ld";
+
+const LS = " ";
+const PS = " ";
+
+describe("stringifyJsonLd (security-reviewer Phase 1 CRITICAL fix)", () => {
+	it("escapes </script> breakout sequences", () => {
+		const payload = {
+			body: "alert('boom')</script><script>alert('xss')</script>",
+		};
+
+		const out = stringifyJsonLd(payload);
+
+		// </ は <\/ に置換されるため </script> 連鎖が出ない
+		expect(out).not.toContain("</script>");
+		// データそのものは保持されている (parse 可能)
+		const reparsed = JSON.parse(out);
+		expect(reparsed.body).toBe(
+			"alert('boom')</script><script>alert('xss')</script>",
+		);
+	});
+
+	it("escapes U+2028 / U+2029 line separators", () => {
+		const payload = { text: `before${LS}middle${PS}after` };
+		const out = stringifyJsonLd(payload);
+		expect(out).not.toContain(LS);
+		expect(out).not.toContain(PS);
+		expect(out).toContain("\\u2028");
+		expect(out).toContain("\\u2029");
+	});
+
+	it("preserves normal payload bytes for typical schema.org content", () => {
+		const payload = {
+			"@context": "https://schema.org",
+			"@type": "SocialMediaPosting",
+			author: { "@type": "Person", name: "ハルナ" },
+			articleBody: "これはツイート本文",
+		};
+		const out = stringifyJsonLd(payload);
+		const reparsed = JSON.parse(out);
+		expect(reparsed["@type"]).toBe("SocialMediaPosting");
+		expect(reparsed.articleBody).toBe("これはツイート本文");
+	});
+});

--- a/client/src/lib/__tests__/json-ld.test.ts
+++ b/client/src/lib/__tests__/json-ld.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { stringifyJsonLd } from "@/lib/json-ld";
 
-const LS = " ";
-const PS = " ";
+const LS = String.fromCharCode(0x2028);
+const PS = String.fromCharCode(0x2029);
 
 describe("stringifyJsonLd (security-reviewer Phase 1 CRITICAL fix)", () => {
 	it("escapes </script> breakout sequences", () => {

--- a/client/src/lib/api/__tests__/auth.test.ts
+++ b/client/src/lib/api/__tests__/auth.test.ts
@@ -68,8 +68,8 @@ describe("auth helpers", () => {
 				username: "alice",
 				first_name: "Alice",
 				last_name: "Liddell",
-				password: "secret12",
-				re_password: "secret12",
+				password: "secret12", // pragma: allowlist secret
+				re_password: "secret12", // pragma: allowlist secret
 			},
 			client,
 		);
@@ -97,8 +97,8 @@ describe("auth helpers", () => {
 			{
 				uid: "U",
 				token: "T",
-				new_password: "newpass12",
-				re_new_password: "newpass12",
+				new_password: "newpass12", // pragma: allowlist secret
+				re_new_password: "newpass12", // pragma: allowlist secret
 			},
 			client,
 		);

--- a/client/src/lib/api/__tests__/users.test.ts
+++ b/client/src/lib/api/__tests__/users.test.ts
@@ -63,7 +63,10 @@ describe("users API", () => {
 			const body = JSON.parse(config.data);
 			expect(body.display_name).toBe("Alice");
 			expect(body.bio).toBeUndefined();
-			return [200, { id: "u1", display_name: "Alice", needs_onboarding: false }];
+			return [
+				200,
+				{ id: "u1", display_name: "Alice", needs_onboarding: false },
+			];
 		});
 		await completeOnboarding({ display_name: "Alice" }, client);
 	});

--- a/client/src/lib/api/tags.ts
+++ b/client/src/lib/api/tags.ts
@@ -19,5 +19,5 @@ export async function searchTags(
 		{ params: { q: query } },
 	);
 	const data = res.data;
-	return Array.isArray(data) ? data : data.results ?? [];
+	return Array.isArray(data) ? data : (data.results ?? []);
 }

--- a/client/src/lib/json-ld.ts
+++ b/client/src/lib/json-ld.ts
@@ -21,8 +21,9 @@
  * ```
  */
 
-const LINE_SEPARATOR = " ";
-const PARAGRAPH_SEPARATOR = " ";
+// eslint `no-multi-str` 回避のため char code で表現する。
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
 
 /**
  * Serialize a JSON-LD payload to a string that is safe to inline inside

--- a/client/src/lib/json-ld.ts
+++ b/client/src/lib/json-ld.ts
@@ -1,0 +1,38 @@
+/**
+ * JSON-LD safe serialization helpers (security-reviewer Phase 1 post-hoc CRITICAL fix).
+ *
+ * Why: `<script type="application/ld+json">` の内側に
+ * `JSON.stringify(payload)` をそのまま差し込むと、ペイロードの文字列に
+ * `</script>` が含まれた場合にブラウザがそこで script タグを閉じ、後続が
+ * 任意 JS として実行される。ユーザー生成コンテンツ (ツイート本文 / 表示名 等)
+ * を JSON-LD に含める SocialMediaPosting / ProfilePage では実害ありの XSS。
+ *
+ * 対策:
+ * - `</` を `<\/` にエスケープする (JSON 仕様上 `<` は `<` でも代替可)
+ * - 念のため U+2028 / U+2029 (古いパーサで改行扱いされる JS hostile chars)
+ *   もエスケープ
+ *
+ * 使い方:
+ * ```tsx
+ * <script
+ *   type="application/ld+json"
+ *   dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
+ * />
+ * ```
+ */
+
+const LINE_SEPARATOR = " ";
+const PARAGRAPH_SEPARATOR = " ";
+
+/**
+ * Serialize a JSON-LD payload to a string that is safe to inline inside
+ * `<script type="application/ld+json">`.
+ */
+export function stringifyJsonLd(payload: unknown): string {
+	return JSON.stringify(payload)
+		.replace(/<\//g, "<\\/")
+		.split(LINE_SEPARATOR)
+		.join("\\u2028")
+		.split(PARAGRAPH_SEPARATOR)
+		.join("\\u2029");
+}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -273,6 +273,33 @@ if SENTRY_ENVIRONMENT in ("stg", "production") and not COOKIE_SECURE:
         "set env COOKIE_SECURE=True (ADR-0003)."
     )
 
+# F1-5: Django 標準 Cookie の Secure フラグ。CSRF/Session Cookie は本来 SPA + Cookie
+# JWT 構成で session を持たない設計だが、Django admin / djoser が session/CSRF を使う
+# ため必須化する。COOKIE_SECURE と同じ env を共有してフラグの drift を防ぐ。
+CSRF_COOKIE_SECURE = COOKIE_SECURE
+SESSION_COOKIE_SECURE = COOKIE_SECURE
+CSRF_COOKIE_HTTPONLY = False  # CSRF token は JS が読む必要があるので HttpOnly 不可
+CSRF_COOKIE_SAMESITE = "Lax"
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = "Lax"
+
+# F1-6: CORS 設定。Next.js frontend からの cross-origin リクエストを許可。
+# stg/prod では env CORS_ALLOWED_ORIGINS (カンマ区切り) を必須化。
+# local では空のままで django-cors-headers の default 動作 (全 origin 拒否) になるが、
+# DEBUG=True の場合は同一 origin (localhost:3000) 経由が前提なのでこれで OK。
+CORS_ALLOWED_ORIGINS = [
+    o.strip() for o in getenv("CORS_ALLOWED_ORIGINS", "").split(",") if o.strip()
+]
+CORS_ALLOW_CREDENTIALS = True  # HttpOnly Cookie で JWT を送るため必須
+
+if SENTRY_ENVIRONMENT in ("stg", "production") and not CORS_ALLOWED_ORIGINS:
+    from django.core.exceptions import ImproperlyConfigured
+
+    raise ImproperlyConfigured(
+        f"CORS_ALLOWED_ORIGINS must be set in {SENTRY_ENVIRONMENT}. "
+        "Pass a comma-separated list of allowed origins via env."
+    )
+
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (

--- a/docs/operations/phase-1-stg-deploy-runbook.md
+++ b/docs/operations/phase-1-stg-deploy-runbook.md
@@ -60,7 +60,7 @@ git push origin main   # cd-stg ワークフローをトリガー
 - GitHub Actions → `CD stg` ワークフローが走る
 - 各 job が **緑** になっていることを確認
   - build (backend / frontend / nginx すべて push 完了)
-  - migrate (``wait`` モードで完走、exit 0)
+  - migrate (`wait` モードで完走、exit 0)
   - deploy (5 サービスすべて rolling update)
   - smoke-test (`GET /api/health/` が 200)
 
@@ -78,18 +78,18 @@ aws ecs update-service \
 `stg.<domain>` 上で以下のシナリオを順に実施し、すべて想定通りであることを
 確認します:
 
-| # | シナリオ | 期待 |
-|---|---------|------|
-| 1 | `/register` でサインアップ | 「確認メールを送信しました」トースト + `/login?email=...` に遷移 |
-| 2 | メール (Mailgun/SES) を開き activation リンクを踏む | `/activate/...` → `/login` に遷移 |
-| 3 | `/login` で email + password 入力 → ログイン | `/onboarding` に遷移 |
-| 4 | `/onboarding` で表示名 + 自己紹介を入力 → 「はじめる」 | `/` に遷移 |
-| 5 | `/` の Composer でツイート「こんにちは 🎉」を投稿 | トースト「投稿しました」 |
-| 6 | `/u/<handle>` に遷移 | いま投稿したツイートが表示される |
-| 7 | `/tweet/<id>` に遷移 | 本文 + avatar + created_at が表示、OGP タグが `<head>` に出ている |
-| 8 | `/tag/<name>` (存在するタグ) に遷移 | タグに紐づくツイートが見える |
-| 9 | Google OAuth でログイン | `/` に遷移、再ログインできる |
-| 10 | アバター画像アップロード (P1-15) | 5MB 超は reject、300×300 JPEG は WebP で S3 PUT → profile 反映 |
+| #   | シナリオ                                               | 期待                                                              |
+| --- | ------------------------------------------------------ | ----------------------------------------------------------------- |
+| 1   | `/register` でサインアップ                             | 「確認メールを送信しました」トースト + `/login?email=...` に遷移  |
+| 2   | メール (Mailgun/SES) を開き activation リンクを踏む    | `/activate/...` → `/login` に遷移                                 |
+| 3   | `/login` で email + password 入力 → ログイン           | `/onboarding` に遷移                                              |
+| 4   | `/onboarding` で表示名 + 自己紹介を入力 → 「はじめる」 | `/` に遷移                                                        |
+| 5   | `/` の Composer でツイート「こんにちは 🎉」を投稿      | トースト「投稿しました」                                          |
+| 6   | `/u/<handle>` に遷移                                   | いま投稿したツイートが表示される                                  |
+| 7   | `/tweet/<id>` に遷移                                   | 本文 + avatar + created_at が表示、OGP タグが `<head>` に出ている |
+| 8   | `/tag/<name>` (存在するタグ) に遷移                    | タグに紐づくツイートが見える                                      |
+| 9   | Google OAuth でログイン                                | `/` に遷移、再ログインできる                                      |
+| 10  | アバター画像アップロード (P1-15)                       | 5MB 超は reject、300×300 JPEG は WebP で S3 PUT → profile 反映    |
 
 各ステップを完了したらチェックボックスを Issue にコピペして埋めてください。
 

--- a/docs/operations/stg-recovery-runbook.md
+++ b/docs/operations/stg-recovery-runbook.md
@@ -1,0 +1,315 @@
+# stg 環境復旧 runbook (destroy 後の再 apply 手順)
+
+> Generated: 2026-04-29 / 対応: PR #196 merge 後の Phase 1 デプロイ準備
+> 状況: 2026-04-27 に `terraform destroy` 実行 → 11 resources 削除 → 再 apply は
+> Secrets Manager の 7 日 recovery 期間 (〜2026-05-04) で失敗。
+> このランブックは **terraform-search-import** skill ベースの手順。
+
+---
+
+## 0. 前提
+
+- AWS CLI 設定済 (`aws sts get-caller-identity` で確認)
+- Terraform 1.5+ (本リポジトリ pin: `>= 1.5`)
+- `cd terraform/environments/stg/` で実行
+- 現在の AWS account id: `aws sts get-caller-identity --query Account --output text`
+
+---
+
+## 1. AWS 現状把握 (read-only discovery)
+
+destroy 後に何が残っているかを確認する。**何も書き換えないコマンドのみ。**
+
+```bash
+# 環境変数で揃える
+export AWS_REGION=ap-northeast-1
+export PROJECT=sns
+export ENV=stg
+
+echo "=== 1. Secrets Manager (7日 recovery 中シークレット含む) ==="
+aws secretsmanager list-secrets \
+  --include-planned-deletion \
+  --query "SecretList[?starts_with(Name, '${PROJECT}/${ENV}/')].{Name:Name, Deleted:DeletedDate, ScheduledDeletion:ScheduledDeletionDate}" \
+  --output table
+
+echo "=== 2. Route53 hosted zone ==="
+aws route53 list-hosted-zones \
+  --query "HostedZones[?contains(Name, 'YOUR_DOMAIN')].{Id:Id, Name:Name, Records:ResourceRecordSetCount}" \
+  --output table
+# YOUR_DOMAIN は terraform.tfvars の domain_name に置換
+
+echo "=== 3. S3 buckets ==="
+aws s3api list-buckets \
+  --query "Buckets[?starts_with(Name, '${PROJECT}-${ENV}-')].{Name:Name, Created:CreationDate}" \
+  --output table
+
+echo "=== 4. ECR repositories ==="
+aws ecr describe-repositories \
+  --query "repositories[?starts_with(repositoryName, '${PROJECT}-${ENV}-')].{Name:repositoryName, Created:createdAt}" \
+  --output table
+
+echo "=== 5. IAM roles (GitHub OIDC + ECS task) ==="
+aws iam list-roles \
+  --query "Roles[?starts_with(RoleName, '${PROJECT}-${ENV}-')].{Name:RoleName, Created:CreateDate}" \
+  --output table
+
+echo "=== 6. VPC ==="
+aws ec2 describe-vpcs \
+  --filters "Name=tag:Project,Values=${PROJECT}" "Name=tag:Environment,Values=${ENV}" \
+  --query "Vpcs[].{Id:VpcId, Cidr:CidrBlock}" \
+  --output table
+
+echo "=== 7. RDS instances (削除予約も含む) ==="
+aws rds describe-db-instances \
+  --query "DBInstances[?starts_with(DBInstanceIdentifier, '${PROJECT}-${ENV}-')].{Id:DBInstanceIdentifier, Status:DBInstanceStatus, Engine:Engine}" \
+  --output table
+
+echo "=== 8. ElastiCache replication groups ==="
+aws elasticache describe-replication-groups \
+  --query "ReplicationGroups[?starts_with(ReplicationGroupId, '${PROJECT}-${ENV}-')].{Id:ReplicationGroupId, Status:Status}" \
+  --output table
+
+echo "=== 9. CloudFront distributions (destroy で消えにくい) ==="
+aws cloudfront list-distributions \
+  --query "DistributionList.Items[?contains(Comment, '${PROJECT}-${ENV}')].{Id:Id, Domain:DomainName, Status:Status}" \
+  --output table
+
+echo "=== 10. ACM certificates (us-east-1 / ap-northeast-1) ==="
+for region in us-east-1 ap-northeast-1; do
+  aws acm list-certificates --region $region \
+    --query "CertificateSummaryList[?contains(DomainName, 'YOUR_DOMAIN')].{Arn:CertificateArn, Domain:DomainName, Status:Status}" \
+    --output table
+done
+```
+
+**判断基準:**
+- 残存 = terraform import で取り込む候補 (Route53 hosted zone, ECR, IAM/OIDC role, S3 backup bucket, CloudFront など作り直しコストが高いもの)
+- 削除予約 = restore-secret + import / force-delete どちらかを選ぶ
+- 不存在 = terraform apply で新規作成 (VPC, RDS, ElastiCache 等)
+
+---
+
+## 2. Secrets Manager: restore + import 戦略
+
+destroy 後 7 日 recovery 中のシークレットは **2 つの選択肢**:
+
+| Option | 手順 | メリット | デメリット |
+|---|---|---|---|
+| **A: 値を残す** | `restore-secret` + `terraform import` で state に取り込む | 既存の Redis AUTH token / Django SECRET_KEY を維持、サービス再起動不要 | terraform random_password との整合に注意 |
+| **B: 値を新規生成** | `force-delete-without-recovery` で完全削除 → terraform apply で新規 | シンプル、stg なら影響軽微 | Redis を絡めると client が切断 (stg は単体なので OK) |
+
+**stg では Option B (force-delete) を推奨**: シンプルで 7日 recovery を待つ必要なし。Option A は本番 (prod) で必要になる手順として参考。
+
+### Option A: restore + import (詳細)
+
+```bash
+# 2-A-1. リストアップ
+SECRETS=(
+  "${PROJECT}/${ENV}/django/secret-key"
+  "${PROJECT}/${ENV}/django/db-password"
+  "${PROJECT}/${ENV}/django/jwt-signing-key"   # F1-3 で追加
+  "${PROJECT}/${ENV}/redis/auth-token"
+  "${PROJECT}/${ENV}/sentry/dsn"
+  "${PROJECT}/${ENV}/mailgun/api-key"
+  "${PROJECT}/${ENV}/mailgun/signing-key"
+  "${PROJECT}/${ENV}/stripe/secret-key"
+  "${PROJECT}/${ENV}/stripe/webhook-secret"
+  "${PROJECT}/${ENV}/openai/api-key"
+  "${PROJECT}/${ENV}/anthropic/api-key"
+  "${PROJECT}/${ENV}/google/oauth-client-id"      # F1-3 で追加
+  "${PROJECT}/${ENV}/google/oauth-client-secret"  # F1-3 で追加
+)
+
+# 2-A-2. 全件 restore (idempotent: 既に restored なら no-op で成功)
+for s in "${SECRETS[@]}"; do
+  echo "Restoring $s ..."
+  aws secretsmanager restore-secret --secret-id "$s" 2>&1 | tee -a /tmp/restore.log || true
+done
+
+# 2-A-3. terraform import
+# secrets module は path key (例: "django/secret-key") で for_each している。
+# generated グループ (4 個) と placeholder グループ (9 個) で resource address が異なるので注意。
+
+# generated group (terraform が値を put する)
+for key in django/secret-key django/db-password django/jwt-signing-key redis/auth-token; do
+  arn=$(aws secretsmanager describe-secret --secret-id "${PROJECT}/${ENV}/${key}" --query ARN --output text)
+  terraform import "module.secrets.aws_secretsmanager_secret.generated[\"${key}\"]" "$arn"
+done
+
+# placeholder group (terraform は枠だけ作る)
+for key in sentry/dsn mailgun/api-key mailgun/signing-key stripe/secret-key stripe/webhook-secret \
+           openai/api-key anthropic/api-key google/oauth-client-id google/oauth-client-secret; do
+  arn=$(aws secretsmanager describe-secret --secret-id "${PROJECT}/${ENV}/${key}" --query ARN --output text)
+  terraform import "module.secrets.aws_secretsmanager_secret.placeholder[\"${key}\"]" "$arn"
+done
+
+# 2-A-4. terraform plan で差分確認
+terraform plan -out=plan.tfplan
+# 期待される差分:
+# - aws_secretsmanager_secret_version は新しい value で update される (random_password の新値で AWS 側を上書き)
+#   → これを避けたい場合は事前に `aws secretsmanager put-secret-value` で
+#     現在の AWS 側の値を terraform state にも反映させる workaround が必要 (本 runbook では skip)
+```
+
+### Option B: force-delete (推奨)
+
+```bash
+# 7日待たずに完全削除
+for s in "${SECRETS[@]}"; do
+  echo "Force-deleting $s ..."
+  aws secretsmanager delete-secret \
+    --secret-id "$s" \
+    --force-delete-without-recovery 2>&1 | tee -a /tmp/force_delete.log || true
+done
+
+# 完全削除後 30 秒ほど待つ (Secrets Manager の整合性確保)
+sleep 30
+
+# その後 terraform apply で新規作成 (3. のフェーズへ)
+```
+
+---
+
+## 3. terraform apply フロー
+
+destroy 前と異なる点:
+- **services モジュールが新規追加** (PR #196 で導入: ECS task definition + service)
+- **secrets module に新エントリ** (jwt-signing-key, google/oauth-client-{id,secret})
+
+### 3-1. apply (二段階)
+
+P0.5 の deploy runbook 準拠の二段階 apply:
+
+```bash
+cd /workspace/terraform/environments/stg/
+
+# ステージ 1: edge / certificate を作る前 (CloudFront / ACM 以外)
+terraform apply -target='module.network' \
+                -target='module.secrets' \
+                -target='module.data' \
+                -target='module.storage' \
+                -target='module.compute' \
+                -target='module.observability' \
+                -auto-approve
+
+# ステージ 2: edge (ACM 検証 + CloudFront) — DNS 委任完了が前提
+# 委任手順は docs/operations/dns-delegation.md
+terraform apply -target='module.edge' -auto-approve
+
+# ステージ 3: services モジュール (ECS task def / service)
+# compute モジュールの IAM role / ECR / target group がすべて作成済が前提
+terraform apply -target='module.services' -auto-approve
+
+# 最後に全体 apply で残差確認
+terraform apply
+```
+
+### 3-2. apply 後の出力取得
+
+```bash
+# GitHub Variables 設定用の値を取得
+terraform output -raw ecs_services_csv          # → vars.ECS_SERVICES
+terraform output -raw ecs_migrate_task_definition  # → vars.ECS_MIGRATE_TASK_DEFINITION
+terraform output -raw ecs_private_subnets_csv      # → vars.ECS_PRIVATE_SUBNETS
+terraform output -raw ecs_security_group_id        # → vars.ECS_SECURITY_GROUP
+terraform output -raw alb_dns_name                  # 確認用
+```
+
+### 3-3. Secrets Manager に値を put (placeholder のみ)
+
+```bash
+# Sentry DSN (https://...@sentry.io/...)
+aws secretsmanager put-secret-value --secret-id sns/stg/sentry/dsn \
+  --secret-string "https://YOUR_KEY@oXXXXX.ingest.sentry.io/PROJECT_ID"
+
+# Google OAuth (Cloud Console から取得)
+aws secretsmanager put-secret-value --secret-id sns/stg/google/oauth-client-id \
+  --secret-string "XXXXX.apps.googleusercontent.com"
+aws secretsmanager put-secret-value --secret-id sns/stg/google/oauth-client-secret \
+  --secret-string "GOCSPX-XXXXX"
+
+# Mailgun (送信ドメイン用)
+aws secretsmanager put-secret-value --secret-id sns/stg/mailgun/api-key \
+  --secret-string "key-XXXXX"
+aws secretsmanager put-secret-value --secret-id sns/stg/mailgun/signing-key \
+  --secret-string "XXXXX"
+
+# Stripe / OpenAI / Anthropic は Phase 7-8 で利用、stg では空のままで OK
+```
+
+---
+
+## 4. GitHub Variables 登録
+
+Settings → Secrets and variables → Actions → Variables (Repository):
+
+| Name | Value (terraform output から取得) |
+|---|---|
+| `AWS_REGION` | `ap-northeast-1` |
+| `AWS_DEPLOY_ROLE_ARN` | `aws iam list-roles --query "Roles[?contains(RoleName,'github-actions')].Arn" --output text` |
+| `ECR_BACKEND_REPOSITORY` | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-django` |
+| `ECR_FRONTEND_REPOSITORY` | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-next` |
+| `ECR_NGINX_REPOSITORY` | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-nginx` (将来追加用) |
+| `ECS_CLUSTER` | `sns-stg-cluster` |
+| `ECS_SERVICES` | `terraform output -raw ecs_services_csv` |
+| `ECS_MIGRATE_TASK_DEFINITION` | `terraform output -raw ecs_migrate_task_definition` |
+| `ECS_PRIVATE_SUBNETS` | `terraform output -raw ecs_private_subnets_csv` |
+| `ECS_SECURITY_GROUP` | `terraform output -raw ecs_security_group_id` |
+| `SMOKE_URL` | `https://stg.<your-domain>` |
+
+GitHub CLI でまとめて設定:
+
+```bash
+gh variable set AWS_REGION --body "ap-northeast-1"
+gh variable set ECS_CLUSTER --body "sns-stg-cluster"
+gh variable set ECS_SERVICES --body "$(terraform output -raw ecs_services_csv)"
+gh variable set ECS_MIGRATE_TASK_DEFINITION --body "$(terraform output -raw ecs_migrate_task_definition)"
+gh variable set ECS_PRIVATE_SUBNETS --body "$(terraform output -raw ecs_private_subnets_csv)"
+gh variable set ECS_SECURITY_GROUP --body "$(terraform output -raw ecs_security_group_id)"
+gh variable set SMOKE_URL --body "https://stg.YOUR_DOMAIN"
+# AWS_DEPLOY_ROLE_ARN / ECR_* は手動で取得して set
+```
+
+---
+
+## 5. 最終 deploy トリガー
+
+```bash
+# main ブランチに PR #196 を merge
+gh pr merge 196 --squash --delete-branch
+
+# CD stg ワークフローが自動起動 (build → migrate → deploy → smoke)
+gh run watch --exit-status
+```
+
+**期待される job の流れ:**
+1. **build**: Docker image を ECR に push (~5 分)
+2. **migrate**: `aws ecs run-task` で `sns-stg-django-migrate` を起動 → Django migrations を実行 (~2 分)
+3. **deploy**: 4 service を `force-new-deployment` + `services-stable` 待機 (~5-8 分)
+4. **smoke-test**: `curl https://stg.<domain>/api/health/` が 200 (5 retry)
+
+---
+
+## 6. トラブルシュート
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `restore-secret` が `ResourceNotFoundException` | 既に完全削除済 | 何もせず terraform apply で新規作成 |
+| terraform import が `Error: resource address ... does not exist` | for_each キーの quote 忘れ | `terraform import 'module.X.Y.Z["key"]' arn` (シングルクォートで囲む) |
+| ECS task が起動直後に exit | Secrets Manager の値未設定 (Sentry DSN 等) | `aws secretsmanager put-secret-value` で値を入れて service を再起動 |
+| ALB target group が unhealthy | Django container の health check (`/api/health/`) が 503 | RDS migrations 未実行の可能性 → migrate job のログ確認 |
+| `aws ecs wait services-stable` がタイムアウト | image pull 失敗 / health check 失敗 | CloudWatch logs `/ecs/sns-stg/<service>` を確認 |
+
+---
+
+## 7. ロールバック
+
+万一 deploy 後に重大な不具合があれば:
+
+```bash
+# 直前の image tag に戻す (ECR の stg-PREV-SHA を採用)
+gh workflow run cd-stg.yml -f image_tag=stg-<prev-sha>
+
+# または ECS service ごと desired_count=0 で停止
+aws ecs update-service --cluster sns-stg-cluster --service sns-stg-django --desired-count 0
+```

--- a/docs/operations/stg-recovery-runbook.md
+++ b/docs/operations/stg-recovery-runbook.md
@@ -83,6 +83,7 @@ done
 ```
 
 **判断基準:**
+
 - 残存 = terraform import で取り込む候補 (Route53 hosted zone, ECR, IAM/OIDC role, S3 backup bucket, CloudFront など作り直しコストが高いもの)
 - 削除予約 = restore-secret + import / force-delete どちらかを選ぶ
 - 不存在 = terraform apply で新規作成 (VPC, RDS, ElastiCache 等)
@@ -93,10 +94,10 @@ done
 
 destroy 後 7 日 recovery 中のシークレットは **2 つの選択肢**:
 
-| Option | 手順 | メリット | デメリット |
-|---|---|---|---|
-| **A: 値を残す** | `restore-secret` + `terraform import` で state に取り込む | 既存の Redis AUTH token / Django SECRET_KEY を維持、サービス再起動不要 | terraform random_password との整合に注意 |
-| **B: 値を新規生成** | `force-delete-without-recovery` で完全削除 → terraform apply で新規 | シンプル、stg なら影響軽微 | Redis を絡めると client が切断 (stg は単体なので OK) |
+| Option              | 手順                                                                | メリット                                                               | デメリット                                           |
+| ------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------- |
+| **A: 値を残す**     | `restore-secret` + `terraform import` で state に取り込む           | 既存の Redis AUTH token / Django SECRET_KEY を維持、サービス再起動不要 | terraform random_password との整合に注意             |
+| **B: 値を新規生成** | `force-delete-without-recovery` で完全削除 → terraform apply で新規 | シンプル、stg なら影響軽微                                             | Redis を絡めると client が切断 (stg は単体なので OK) |
 
 **stg では Option B (force-delete) を推奨**: シンプルで 7日 recovery を待つ必要なし。Option A は本番 (prod) で必要になる手順として参考。
 
@@ -173,6 +174,7 @@ sleep 30
 ## 3. terraform apply フロー
 
 destroy 前と異なる点:
+
 - **services モジュールが新規追加** (PR #196 で導入: ECS task definition + service)
 - **secrets module に新エントリ** (jwt-signing-key, google/oauth-client-{id,secret})
 
@@ -243,19 +245,19 @@ aws secretsmanager put-secret-value --secret-id sns/stg/mailgun/signing-key \
 
 Settings → Secrets and variables → Actions → Variables (Repository):
 
-| Name | Value (terraform output から取得) |
-|---|---|
-| `AWS_REGION` | `ap-northeast-1` |
-| `AWS_DEPLOY_ROLE_ARN` | `aws iam list-roles --query "Roles[?contains(RoleName,'github-actions')].Arn" --output text` |
-| `ECR_BACKEND_REPOSITORY` | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-django` |
-| `ECR_FRONTEND_REPOSITORY` | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-next` |
-| `ECR_NGINX_REPOSITORY` | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-nginx` (将来追加用) |
-| `ECS_CLUSTER` | `sns-stg-cluster` |
-| `ECS_SERVICES` | `terraform output -raw ecs_services_csv` |
-| `ECS_MIGRATE_TASK_DEFINITION` | `terraform output -raw ecs_migrate_task_definition` |
-| `ECS_PRIVATE_SUBNETS` | `terraform output -raw ecs_private_subnets_csv` |
-| `ECS_SECURITY_GROUP` | `terraform output -raw ecs_security_group_id` |
-| `SMOKE_URL` | `https://stg.<your-domain>` |
+| Name                          | Value (terraform output から取得)                                                            |
+| ----------------------------- | -------------------------------------------------------------------------------------------- |
+| `AWS_REGION`                  | `ap-northeast-1`                                                                             |
+| `AWS_DEPLOY_ROLE_ARN`         | `aws iam list-roles --query "Roles[?contains(RoleName,'github-actions')].Arn" --output text` |
+| `ECR_BACKEND_REPOSITORY`      | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-django`                              |
+| `ECR_FRONTEND_REPOSITORY`     | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-next`                                |
+| `ECR_NGINX_REPOSITORY`        | `<account>.dkr.ecr.ap-northeast-1.amazonaws.com/sns-stg-nginx` (将来追加用)                  |
+| `ECS_CLUSTER`                 | `sns-stg-cluster`                                                                            |
+| `ECS_SERVICES`                | `terraform output -raw ecs_services_csv`                                                     |
+| `ECS_MIGRATE_TASK_DEFINITION` | `terraform output -raw ecs_migrate_task_definition`                                          |
+| `ECS_PRIVATE_SUBNETS`         | `terraform output -raw ecs_private_subnets_csv`                                              |
+| `ECS_SECURITY_GROUP`          | `terraform output -raw ecs_security_group_id`                                                |
+| `SMOKE_URL`                   | `https://stg.<your-domain>`                                                                  |
 
 GitHub CLI でまとめて設定:
 
@@ -283,6 +285,7 @@ gh run watch --exit-status
 ```
 
 **期待される job の流れ:**
+
 1. **build**: Docker image を ECR に push (~5 分)
 2. **migrate**: `aws ecs run-task` で `sns-stg-django-migrate` を起動 → Django migrations を実行 (~2 分)
 3. **deploy**: 4 service を `force-new-deployment` + `services-stable` 待機 (~5-8 分)
@@ -292,13 +295,13 @@ gh run watch --exit-status
 
 ## 6. トラブルシュート
 
-| 症状 | 原因 | 対処 |
-|---|---|---|
-| `restore-secret` が `ResourceNotFoundException` | 既に完全削除済 | 何もせず terraform apply で新規作成 |
-| terraform import が `Error: resource address ... does not exist` | for_each キーの quote 忘れ | `terraform import 'module.X.Y.Z["key"]' arn` (シングルクォートで囲む) |
-| ECS task が起動直後に exit | Secrets Manager の値未設定 (Sentry DSN 等) | `aws secretsmanager put-secret-value` で値を入れて service を再起動 |
-| ALB target group が unhealthy | Django container の health check (`/api/health/`) が 503 | RDS migrations 未実行の可能性 → migrate job のログ確認 |
-| `aws ecs wait services-stable` がタイムアウト | image pull 失敗 / health check 失敗 | CloudWatch logs `/ecs/sns-stg/<service>` を確認 |
+| 症状                                                             | 原因                                                     | 対処                                                                  |
+| ---------------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------- |
+| `restore-secret` が `ResourceNotFoundException`                  | 既に完全削除済                                           | 何もせず terraform apply で新規作成                                   |
+| terraform import が `Error: resource address ... does not exist` | for_each キーの quote 忘れ                               | `terraform import 'module.X.Y.Z["key"]' arn` (シングルクォートで囲む) |
+| ECS task が起動直後に exit                                       | Secrets Manager の値未設定 (Sentry DSN 等)               | `aws secretsmanager put-secret-value` で値を入れて service を再起動   |
+| ALB target group が unhealthy                                    | Django container の health check (`/api/health/`) が 503 | RDS migrations 未実行の可能性 → migrate job のログ確認                |
+| `aws ecs wait services-stable` がタイムアウト                    | image pull 失敗 / health check 失敗                      | CloudWatch logs `/ecs/sns-stg/<service>` を確認                       |
 
 ---
 

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -12,7 +12,7 @@
 
 terraform {
   backend "s3" {
-    bucket         = "sns-stg-tf-state"
+    bucket = "sns-stg-tf-state"
     # key は環境ごとに override (terraform init -backend-config="key=stg/terraform.tfstate")
     key            = "UNSET-override-with-backend-config"
     region         = "ap-northeast-1"

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -160,6 +160,52 @@ module "edge" {
 }
 
 # ---------------------------------------------------------------------------
+# 6.5. ECS Services (Phase 1 stg deployment)
+# ---------------------------------------------------------------------------
+#
+# Phase 1 完了後の stg 起動に必要な ECS task definition + service を追加する。
+# F1-2 で cd-stg.yml の placeholder を本実装に切替えたが、その実装が機能する
+# ために必要な ECS resource をここで作成する。
+#
+# 含まれる: django / next / celery-worker / celery-beat の 4 service +
+#          django-migrate (one-shot task definition)。
+# 含まれない: daphne (Phase 3 DM 実装と同時に追加)。
+
+module "services" {
+  source = "../../modules/services"
+
+  project     = var.project
+  environment = "stg"
+  aws_region  = "ap-northeast-1"
+
+  # compute モジュールから受け取る
+  ecs_cluster_arn              = module.compute.ecs_cluster_arn
+  ecs_task_execution_role_arn  = module.compute.ecs_task_execution_role_arn
+  ecs_task_execution_role_name = module.compute.ecs_task_execution_role_name
+  ecs_task_role_arn            = module.compute.ecs_task_role_arn
+  ecs_task_role_name           = module.compute.ecs_task_role_name
+  ecr_repository_urls          = module.compute.ecr_repository_urls
+  target_group_arns            = module.compute.target_group_arns
+
+  # network モジュールから
+  private_subnet_ids    = module.network.private_subnet_ids
+  ecs_security_group_id = module.network.ecs_security_group_id
+
+  # secrets モジュールから (path → ARN map)
+  secret_arns = module.secrets.secret_arns
+
+  # data モジュールから
+  rds_endpoint       = module.data.rds_endpoint
+  redis_url_template = module.data.redis_connection_url
+
+  # アプリ config
+  domain               = "${var.app_subdomain}.${var.domain_name}"
+  cors_allowed_origins = "https://${var.app_subdomain}.${var.domain_name}"
+
+  tags = local.common_tags
+}
+
+# ---------------------------------------------------------------------------
 # 7. Observability (Log Groups + Alarms + SNS Topic)
 # ---------------------------------------------------------------------------
 

--- a/terraform/environments/stg/outputs.tf
+++ b/terraform/environments/stg/outputs.tf
@@ -67,3 +67,27 @@ output "acm_alb_arn" {
   description = "二段階 apply 時に terraform.tfvars の alb_certificate_arn_override に設定"
   value       = module.edge.acm_alb_arn
 }
+
+# ---------------------------------------------------------------------------
+# cd-stg.yml が GitHub Variables に設定する値 (services モジュール経由)
+# ---------------------------------------------------------------------------
+
+output "ecs_services_csv" {
+  description = "GitHub Variables の ECS_SERVICES に貼る (カンマ区切りで django/next/celery-worker/celery-beat)"
+  value       = module.services.service_names_csv
+}
+
+output "ecs_migrate_task_definition" {
+  description = "GitHub Variables の ECS_MIGRATE_TASK_DEFINITION に貼る (family 名、最新 revision が常に使われる)"
+  value       = module.services.migrate_task_definition_family
+}
+
+output "ecs_private_subnets_csv" {
+  description = "GitHub Variables の ECS_PRIVATE_SUBNETS に貼る"
+  value       = join(",", module.network.private_subnet_ids)
+}
+
+output "ecs_security_group_id" {
+  description = "GitHub Variables の ECS_SECURITY_GROUP に貼る"
+  value       = module.network.ecs_security_group_id
+}

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -42,15 +42,15 @@ locals {
       protocol = "HTTP"
       # F-10: 軽量 /api/healthz route handler を叩く。SSR フルレンダを 30s ごとに
       # 起動しないため ALB 側のコストも Next.js 側の負荷も下がる。
-      health   = "/api/healthz"
-      sticky   = false
+      health = "/api/healthz"
+      sticky = false
     }
     daphne = {
       port     = 8001
       protocol = "HTTP"
       health   = "/ws/health/"
       # WebSocket 再接続を同じタスクに張り付かせるため sticky (ARCHITECTURE §3.4)
-      sticky   = true
+      sticky = true
     }
   }
 }

--- a/terraform/modules/compute/outputs.tf
+++ b/terraform/modules/compute/outputs.tf
@@ -70,5 +70,5 @@ output "service_names" {
     将来 aws_ecs_service を本 module で管理するようになったら、そちらから
     直接参照する。現状は命名規約を先に固定するためマップを出している。
   EOT
-  value = { for svc in var.ecs_services : svc => "${local.prefix}-${svc}" }
+  value       = { for svc in var.ecs_services : svc => "${local.prefix}-${svc}" }
 }

--- a/terraform/modules/github_oidc/main.tf
+++ b/terraform/modules/github_oidc/main.tf
@@ -84,9 +84,9 @@ data "aws_iam_policy_document" "trust" {
 }
 
 resource "aws_iam_role" "github_actions" {
-  name               = "${local.prefix}-github-actions"
-  description        = "Assumed by GitHub Actions via OIDC for stg deploy"
-  assume_role_policy = data.aws_iam_policy_document.trust.json
+  name                 = "${local.prefix}-github-actions"
+  description          = "Assumed by GitHub Actions via OIDC for stg deploy"
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
   max_session_duration = 3600
 
   tags = local.default_tags
@@ -187,9 +187,9 @@ data "aws_iam_policy_document" "ecs_deploy" {
   # 対して PassedToService=ecs-tasks.amazonaws.com で絞る暫定運用
   # (security-reviewer PR #57 HIGH)。
   statement {
-    sid     = "EcsPassRole"
-    effect  = "Allow"
-    actions = ["iam:PassRole"]
+    sid       = "EcsPassRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
     resources = length(var.ecs_task_role_arns) > 0 ? var.ecs_task_role_arns : ["*"]
     condition {
       test     = "StringEquals"

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -39,6 +39,10 @@ locals {
     # (NG: / @ " whitespace)。英数字のみで生成して安全側に倒す。
     # data モジュールが transit_encryption_enabled = true を強制するため必須。
     "redis/auth-token" = { description = "ElastiCache Redis AUTH token", length = 64, special = false }
+    # F1-3: SimpleJWT の SIGNING_KEY。settings.base.py で stg/prod は fail-fast
+    # するため、未設定だと ECS タスクが起動直後に ImproperlyConfigured で落ちる。
+    # 64 文字英数記号で十分な entropy を確保する。
+    "django/jwt-signing-key" = { description = "SimpleJWT signing key (HS256)", length = 64, special = true }
   }
 
   # Placeholder グループ: terraform は枠だけ作る
@@ -50,6 +54,10 @@ locals {
     "stripe/webhook-secret" = "Stripe webhook signing secret (whsec_...)"
     "openai/api-key"        = "OpenAI API key (Phase 7 Bot 要約)"
     "anthropic/api-key"     = "Anthropic API key (Phase 8 記事下書き AI)"
+    # F1-3 (P1-12): Google OAuth client_id / secret。Google Cloud Console から
+    # 取得した値を `aws secretsmanager put-secret-value` で書き込む。
+    "google/oauth-client-id"     = "Google OAuth2 Client ID (from Google Cloud Console)"
+    "google/oauth-client-secret" = "Google OAuth2 Client Secret (from Google Cloud Console)"
   }
 }
 

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -57,7 +57,7 @@ locals {
     # F1-3 (P1-12): Google OAuth client_id / secret。Google Cloud Console から
     # 取得した値を `aws secretsmanager put-secret-value` で書き込む。
     "google/oauth-client-id"     = "Google OAuth2 Client ID (from Google Cloud Console)"
-    "google/oauth-client-secret" = "Google OAuth2 Client Secret (from Google Cloud Console)"
+    "google/oauth-client-secret" = "Google OAuth2 Client Secret (from Google Cloud Console)" # pragma: allowlist secret
   }
 }
 

--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -1,0 +1,403 @@
+#####################################################################
+# ECS Task Definitions + Services for Phase 1 stg deployment.
+#
+# Phase 1 完了後 (PR #196) の stg 起動に必要な最小構成:
+#   - django (Gunicorn, ALB target group=app)
+#   - next   (Next.js SSR, ALB target group=next)
+#   - celery-worker
+#   - celery-beat
+#   - django-migrate (one-shot Fargate task, cd-stg.yml が run-task で起動)
+#
+# Daphne (Channels / DM) は Phase 3 で別途追加。Daphne 用 ALB target group は
+# compute モジュールに既に存在するが、本モジュールでは task def を作らない。
+#
+# 設計方針:
+#   - 1 task = 1 container が原則。Sidecar (xray-agent / log-router 等) は
+#     phase 9 本番昇格時に検討。
+#   - Secrets Manager の秘密は ECS task definition の `secrets` で注入する
+#     (環境変数として container に到達するが、CloudTrail に値が残らない)。
+#   - すべて FARGATE (FARGATE_SPOT は celery-worker のみ将来採用)。
+#####################################################################
+
+locals {
+  prefix = "${var.project}-${var.environment}"
+  common_tags = merge(var.tags, {
+    Module = "services"
+  })
+
+  # 全アプリで共有する非機密 env (CloudWatch metric / logging 用 ARG 含む)
+  common_env = [
+    { name = "DJANGO_SETTINGS_MODULE", value = "config.settings.production" },
+    { name = "SENTRY_ENVIRONMENT", value = var.environment },
+    { name = "DOMAIN", value = var.domain },
+    { name = "AWS_REGION", value = var.aws_region },
+    { name = "POSTGRES_HOST", value = var.rds_endpoint },
+    { name = "POSTGRES_PORT", value = "5432" },
+    { name = "POSTGRES_DB", value = var.rds_database_name },
+    { name = "POSTGRES_USER", value = var.rds_username },
+    { name = "REDIS_URL", value = var.redis_url_template },
+    { name = "CELERY_BROKER_URL", value = var.redis_url_template },
+    { name = "CELERY_RESULT_BACKEND", value = var.redis_url_template },
+    { name = "DJANGO_ADMIN_URL", value = "admin/" },
+    { name = "COOKIE_SECURE", value = "True" },
+    { name = "CORS_ALLOWED_ORIGINS", value = var.cors_allowed_origins },
+    { name = "ALLOWED_HOSTS", value = var.domain },
+  ]
+
+  # Django / Celery 共通の機密注入。ARN を直接 secrets ブロックに渡す。
+  django_secrets = [
+    { name = "DJANGO_SECRET_KEY", valueFrom = var.secret_arns["django/secret-key"] },
+    { name = "SIGNING_KEY", valueFrom = var.secret_arns["django/jwt-signing-key"] },
+    { name = "POSTGRES_PASSWORD", valueFrom = var.secret_arns["django/db-password"] },
+    { name = "REDIS_AUTH_TOKEN", valueFrom = var.secret_arns["redis/auth-token"] },
+    { name = "SENTRY_DSN", valueFrom = var.secret_arns["sentry/dsn"] },
+    { name = "GOOGLE_OAUTH_CLIENT_ID", valueFrom = var.secret_arns["google/oauth-client-id"] },
+    { name = "GOOGLE_OAUTH_CLIENT_SECRET", valueFrom = var.secret_arns["google/oauth-client-secret"] },
+    { name = "MAILGUN_API_KEY", valueFrom = var.secret_arns["mailgun/api-key"] },
+    { name = "MAILGUN_SIGNING_KEY", valueFrom = var.secret_arns["mailgun/signing-key"] },
+  ]
+
+  # Next.js (SSR) は public な NEXT_PUBLIC_* と Sentry DSN だけで十分
+  next_secrets = [
+    { name = "SENTRY_DSN", valueFrom = var.secret_arns["sentry/dsn"] },
+  ]
+}
+
+#####################################################################
+# CloudWatch Log Groups (1 per service)
+#####################################################################
+resource "aws_cloudwatch_log_group" "this" {
+  for_each = toset([
+    "django",
+    "next",
+    "celery-worker",
+    "celery-beat",
+    "django-migrate",
+  ])
+  name              = "/ecs/${local.prefix}/${each.key}"
+  retention_in_days = var.log_retention_days
+  tags              = local.common_tags
+}
+
+#####################################################################
+# IAM: Secrets Manager 読み取り policy を task execution role に attach
+# (アプリ container が secrets ブロック経由で値を取れるようにする)
+#####################################################################
+data "aws_iam_policy_document" "secrets_read" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+    resources = values(var.secret_arns)
+  }
+}
+
+resource "aws_iam_policy" "secrets_read" {
+  name        = "${local.prefix}-ecs-secrets-read"
+  description = "ECS task execution role に attach する Secrets Manager 読み取り権限"
+  policy      = data.aws_iam_policy_document.secrets_read.json
+  tags        = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "exec_secrets" {
+  role       = var.ecs_task_execution_role_name
+  policy_arn = aws_iam_policy.secrets_read.arn
+}
+
+#####################################################################
+# Task Definitions
+#####################################################################
+
+# ---------- django (Gunicorn API) ----------
+resource "aws_ecs_task_definition" "django" {
+  family                   = "${local.prefix}-django"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.django_cpu
+  memory                   = var.django_memory
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "django"
+      image     = "${var.ecr_repository_urls["django"]}:${var.image_tag}"
+      essential = true
+      portMappings = [
+        { containerPort = 8000, protocol = "tcp" }
+      ]
+      environment = local.common_env
+      secrets     = local.django_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this["django"].name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "django"
+        }
+      }
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -fsSL http://localhost:8000/api/health/ || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+# ---------- next (Next.js SSR) ----------
+resource "aws_ecs_task_definition" "next" {
+  family                   = "${local.prefix}-next"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.next_cpu
+  memory                   = var.next_memory
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "next"
+      image     = "${var.ecr_repository_urls["next"]}:${var.image_tag}"
+      essential = true
+      portMappings = [
+        { containerPort = 3000, protocol = "tcp" }
+      ]
+      environment = [
+        { name = "NODE_ENV", value = "production" },
+        { name = "NEXT_PUBLIC_API_BASE_URL", value = "https://${var.domain}/api/v1" },
+        { name = "PORT", value = "3000" },
+      ]
+      secrets = local.next_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this["next"].name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "next"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+# ---------- celery-worker ----------
+resource "aws_ecs_task_definition" "celery_worker" {
+  family                   = "${local.prefix}-celery-worker"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.celery_cpu
+  memory                   = var.celery_memory
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name        = "celery-worker"
+      image       = "${var.ecr_repository_urls["django"]}:${var.image_tag}" # Django image を共有
+      essential   = true
+      command     = ["celery", "-A", "config", "worker", "-l", "INFO"]
+      environment = local.common_env
+      secrets     = local.django_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this["celery-worker"].name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "celery"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+# ---------- celery-beat (must be Single Instance!) ----------
+resource "aws_ecs_task_definition" "celery_beat" {
+  family                   = "${local.prefix}-celery-beat"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.celery_cpu
+  memory                   = var.celery_memory
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name        = "celery-beat"
+      image       = "${var.ecr_repository_urls["django"]}:${var.image_tag}"
+      essential   = true
+      command     = ["celery", "-A", "config", "beat", "-l", "INFO", "--scheduler", "django_celery_beat.schedulers:DatabaseScheduler"]
+      environment = local.common_env
+      secrets     = local.django_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this["celery-beat"].name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "beat"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+# ---------- django-migrate (one-shot, cd-stg.yml run-task) ----------
+resource "aws_ecs_task_definition" "django_migrate" {
+  family                   = "${local.prefix}-django-migrate"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name        = "django"
+      image       = "${var.ecr_repository_urls["django"]}:${var.image_tag}"
+      essential   = true
+      command     = ["python", "manage.py", "migrate", "--noinput"]
+      environment = local.common_env
+      secrets     = local.django_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this["django-migrate"].name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "migrate"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+#####################################################################
+# ECS Services
+#####################################################################
+
+# django (ALB target group=app, port 8000)
+resource "aws_ecs_service" "django" {
+  name             = "${local.prefix}-django"
+  cluster          = var.ecs_cluster_arn
+  task_definition  = aws_ecs_task_definition.django.arn
+  desired_count    = var.django_desired_count
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arns["app"]
+    container_name   = "django"
+    container_port   = 8000
+  }
+
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+
+  # cd-stg.yml が `force-new-deployment` で更新するため、image tag 変更で
+  # terraform plan に毎回差分が出ないよう、task_definition revision の管理は
+  # CD 側に委譲する。`ignore_changes` で revision を terraform 監視外に。
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+
+  tags = local.common_tags
+}
+
+# next (ALB target group=next, port 3000)
+resource "aws_ecs_service" "next" {
+  name             = "${local.prefix}-next"
+  cluster          = var.ecs_cluster_arn
+  task_definition  = aws_ecs_task_definition.next.arn
+  desired_count    = var.next_desired_count
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arns["next"]
+    container_name   = "next"
+    container_port   = 3000
+  }
+
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+
+  tags = local.common_tags
+}
+
+# celery-worker (no ALB)
+resource "aws_ecs_service" "celery_worker" {
+  name             = "${local.prefix}-celery-worker"
+  cluster          = var.ecs_cluster_arn
+  task_definition  = aws_ecs_task_definition.celery_worker.arn
+  desired_count    = 1
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+
+  tags = local.common_tags
+}
+
+# celery-beat (must be 1 task only — duplicates cause double scheduling)
+resource "aws_ecs_service" "celery_beat" {
+  name             = "${local.prefix}-celery-beat"
+  cluster          = var.ecs_cluster_arn
+  task_definition  = aws_ecs_task_definition.celery_beat.arn
+  desired_count    = 1
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+
+  # Beat は重複起動禁止。max=100 で「新タスク開始前に古いタスク停止」を強制。
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+
+  tags = local.common_tags
+}

--- a/terraform/modules/services/outputs.tf
+++ b/terraform/modules/services/outputs.tf
@@ -1,0 +1,30 @@
+output "django_service_name" {
+  value = aws_ecs_service.django.name
+}
+
+output "next_service_name" {
+  value = aws_ecs_service.next.name
+}
+
+output "celery_worker_service_name" {
+  value = aws_ecs_service.celery_worker.name
+}
+
+output "celery_beat_service_name" {
+  value = aws_ecs_service.celery_beat.name
+}
+
+output "service_names_csv" {
+  description = "cd-stg.yml の vars.ECS_SERVICES に貼る用 (カンマ区切り)"
+  value = join(",", [
+    aws_ecs_service.django.name,
+    aws_ecs_service.next.name,
+    aws_ecs_service.celery_worker.name,
+    aws_ecs_service.celery_beat.name,
+  ])
+}
+
+output "migrate_task_definition_family" {
+  description = "cd-stg.yml の vars.ECS_MIGRATE_TASK_DEFINITION に貼る (revision なしの family 形式で常に最新が使われる)"
+  value       = aws_ecs_task_definition.django_migrate.family
+}

--- a/terraform/modules/services/variables.tf
+++ b/terraform/modules/services/variables.tf
@@ -9,143 +9,163 @@ variable "environment" {
 }
 
 variable "aws_region" {
-  type    = string
-  default = "ap-northeast-1"
+  description = "AWS region for ECS cluster and CloudWatch log groups."
+  type        = string
+  default     = "ap-northeast-1"
 }
 
 # ---------- Wired-in module outputs ----------
 
 variable "ecs_cluster_arn" {
-  type = string
+  description = "ARN of the ECS cluster from the compute module."
+  type        = string
 }
 
 variable "ecs_task_execution_role_arn" {
-  type = string
+  description = "ARN of the IAM role assumed by ECS to pull images and read secrets."
+  type        = string
 }
 
 variable "ecs_task_execution_role_name" {
+  description = "Name of the task execution role. Required because we attach a Secrets Manager read policy to it."
   type        = string
-  description = "Secrets Manager 読み取り policy をアタッチするため name も受け取る"
 }
 
 variable "ecs_task_role_arn" {
-  type = string
+  description = "ARN of the IAM role assumed by the application container at runtime (AWS SDK access)."
+  type        = string
 }
 
 variable "ecs_task_role_name" {
-  type = string
+  description = "Name of the task role. Reserved for future runtime IAM policy attachments."
+  type        = string
 }
 
 variable "ecr_repository_urls" {
+  description = "Map of service logical name (django / next) → ECR repository URL produced by the compute module."
   type        = map(string)
-  description = "service 論理名 → ECR URL"
 }
 
 variable "target_group_arns" {
+  description = "Map of ALB target group logical name → ARN. Must contain 'app' (django) and 'next' (Next.js SSR)."
   type        = map(string)
-  description = "ALB target group 論理名 → ARN ('app' / 'next')"
 }
 
 variable "private_subnet_ids" {
-  type = list(string)
+  description = "Private subnet IDs for ECS tasks (Fargate ENI placement)."
+  type        = list(string)
 }
 
 variable "ecs_security_group_id" {
-  type = string
+  description = "Security group attached to ECS tasks. Allows egress to RDS / Redis / Internet via NAT."
+  type        = string
 }
 
 variable "secret_arns" {
+  description = "Map of secret path (e.g., 'django/secret-key') → Secrets Manager ARN. Used in container 'secrets' blocks and IAM policy."
   type        = map(string)
-  description = "secrets module の secret_arns (path形式 'django/secret-key' → ARN)"
 }
 
 # ---------- Application config ----------
 
 variable "rds_endpoint" {
-  type      = string
-  sensitive = true
+  description = "RDS endpoint (host) injected into POSTGRES_HOST. Sensitive to avoid leaking via terraform output."
+  type        = string
+  sensitive   = true
 }
 
 variable "rds_database_name" {
-  type    = string
-  default = "sns"
+  description = "Database name created on RDS for the application."
+  type        = string
+  default     = "sns"
 }
 
 variable "rds_username" {
-  type    = string
-  default = "sns"
+  description = "Database master username for the application's connection string."
+  type        = string
+  default     = "sns"
 }
 
 variable "redis_url_template" {
+  description = "Full rediss:// URL with embedded AUTH token. Source: data module's redis_connection_url output. Sensitive."
   type        = string
   sensitive   = true
-  description = "rediss://:{token}@host:port/0 (data モジュールの redis_url を流用、host:port のみ)"
 }
 
 variable "domain" {
+  description = "Public application domain (e.g., 'stg.example.com'). Used in CORS_ALLOWED_ORIGINS / ALLOWED_HOSTS / NEXT_PUBLIC_API_BASE_URL."
   type        = string
-  description = "アプリ公開ドメイン (例: stg.example.com) - CORS / ALLOWED_HOSTS で使用"
 }
 
 variable "cors_allowed_origins" {
+  description = "Comma-separated origins for django-cors-headers CORS_ALLOWED_ORIGINS (F1-6). Example: 'https://stg.example.com'."
   type        = string
-  description = "CORS_ALLOWED_ORIGINS (カンマ区切り、F1-6)。例: 'https://stg.example.com'"
 }
 
 variable "image_tag" {
+  description = "ECR image tag pinned in task definitions. CD pushes 'stg-{git-sha}', initial apply uses 'stg-latest'."
   type        = string
   default     = "stg-latest"
-  description = "ECR image tag。CD は stg-{git-sha} で push するが、初回 apply 時は stg-latest"
 }
 
 # ---------- Resource sizing ----------
 
 variable "django_cpu" {
-  type    = number
-  default = 512
+  description = "Fargate CPU units for the Django (Gunicorn) task."
+  type        = number
+  default     = 512
 }
 
 variable "django_memory" {
-  type    = number
-  default = 1024
+  description = "Fargate memory (MiB) for the Django task."
+  type        = number
+  default     = 1024
 }
 
 variable "django_desired_count" {
-  type    = number
-  default = 1
+  description = "Desired running count of Django tasks."
+  type        = number
+  default     = 1
 }
 
 variable "next_cpu" {
-  type    = number
-  default = 256
+  description = "Fargate CPU units for the Next.js SSR task."
+  type        = number
+  default     = 256
 }
 
 variable "next_memory" {
-  type    = number
-  default = 512
+  description = "Fargate memory (MiB) for the Next.js SSR task."
+  type        = number
+  default     = 512
 }
 
 variable "next_desired_count" {
-  type    = number
-  default = 1
+  description = "Desired running count of Next.js SSR tasks."
+  type        = number
+  default     = 1
 }
 
 variable "celery_cpu" {
-  type    = number
-  default = 256
+  description = "Fargate CPU units for celery-worker and celery-beat (single value shared)."
+  type        = number
+  default     = 256
 }
 
 variable "celery_memory" {
-  type    = number
-  default = 512
+  description = "Fargate memory (MiB) for celery-worker and celery-beat."
+  type        = number
+  default     = 512
 }
 
 variable "log_retention_days" {
-  type    = number
-  default = 14
+  description = "CloudWatch Logs retention for ECS task log groups."
+  type        = number
+  default     = 14
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Common tags merged into every resource."
+  type        = map(string)
+  default     = {}
 }

--- a/terraform/modules/services/variables.tf
+++ b/terraform/modules/services/variables.tf
@@ -1,0 +1,151 @@
+variable "project" {
+  description = "Project name prefix (e.g., 'sns')"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment short name (e.g., 'stg')"
+  type        = string
+}
+
+variable "aws_region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+# ---------- Wired-in module outputs ----------
+
+variable "ecs_cluster_arn" {
+  type = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  type = string
+}
+
+variable "ecs_task_execution_role_name" {
+  type        = string
+  description = "Secrets Manager 読み取り policy をアタッチするため name も受け取る"
+}
+
+variable "ecs_task_role_arn" {
+  type = string
+}
+
+variable "ecs_task_role_name" {
+  type = string
+}
+
+variable "ecr_repository_urls" {
+  type        = map(string)
+  description = "service 論理名 → ECR URL"
+}
+
+variable "target_group_arns" {
+  type        = map(string)
+  description = "ALB target group 論理名 → ARN ('app' / 'next')"
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "ecs_security_group_id" {
+  type = string
+}
+
+variable "secret_arns" {
+  type        = map(string)
+  description = "secrets module の secret_arns (path形式 'django/secret-key' → ARN)"
+}
+
+# ---------- Application config ----------
+
+variable "rds_endpoint" {
+  type      = string
+  sensitive = true
+}
+
+variable "rds_database_name" {
+  type    = string
+  default = "sns"
+}
+
+variable "rds_username" {
+  type    = string
+  default = "sns"
+}
+
+variable "redis_url_template" {
+  type        = string
+  sensitive   = true
+  description = "rediss://:{token}@host:port/0 (data モジュールの redis_url を流用、host:port のみ)"
+}
+
+variable "domain" {
+  type        = string
+  description = "アプリ公開ドメイン (例: stg.example.com) - CORS / ALLOWED_HOSTS で使用"
+}
+
+variable "cors_allowed_origins" {
+  type        = string
+  description = "CORS_ALLOWED_ORIGINS (カンマ区切り、F1-6)。例: 'https://stg.example.com'"
+}
+
+variable "image_tag" {
+  type        = string
+  default     = "stg-latest"
+  description = "ECR image tag。CD は stg-{git-sha} で push するが、初回 apply 時は stg-latest"
+}
+
+# ---------- Resource sizing ----------
+
+variable "django_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "django_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "django_desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "next_cpu" {
+  type    = number
+  default = 256
+}
+
+variable "next_memory" {
+  type    = number
+  default = 512
+}
+
+variable "next_desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "celery_cpu" {
+  type    = number
+  default = 256
+}
+
+variable "celery_memory" {
+  type    = number
+  default = 512
+}
+
+variable "log_retention_days" {
+  type    = number
+  default = 14
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/modules/services/versions.tf
+++ b/terraform/modules/services/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 完了後 (PR #195 議論中) に並列 reviewer (python / security / database / code) で発見した **CRITICAL 2 + HIGH 5** を stg デプロイ前に修正。

|  | 内容 | 検証 |
|---|---|---|
| F1-1 | JSON-LD XSS (`<script>` 閉じタグ未エスケープ) → `stringifyJsonLd` 共通化 | vitest 3/3 ✅ |
| F1-2 | cd-stg.yml placeholder → ECS run-task / update-service 本実装、smoke continue-on-error 削除 | yaml 構文 ✅ |
| F1-3 | Terraform Secrets に `django/jwt-signing-key` (generated) + `google/oauth-client-{id,secret}` (placeholder) | hcl 構文 ✅ |
| F1-4 | CookieAuthentication TokenError 握り潰し → `AuthenticationFailed` で 401 | pytest 3/3 ✅ |
| F1-5 | CSRF_COOKIE_SECURE / SESSION_COOKIE_SECURE 設定 + stg/prod fail-fast | system check ✅ |
| F1-6 | CORS_ALLOWED_ORIGINS 設定 + stg/prod fail-fast | system check ✅ |
| F1-7 | legacy `/auth/login/` `/auth/refresh/` に LoginRateThrottle (5/min) | system check ✅ |

## ローカル検証
- ✅ \`ruff check .\` clean
- ✅ \`ruff format --check\` clean (touched files)
- ✅ \`pytest apps/common/tests/test_cookie_auth.py\` 3/3
- ✅ \`vitest src/lib/__tests__/json-ld.test.ts\` 3/3
- ✅ \`npx tsc --noEmit\` clean
- ✅ \`npx prettier --check\` clean (touched files)
- ✅ \`python manage.py check\` no issues

## 残課題 (本 PR 対象外)

- **ECS task definition / aws_ecs_service の Terraform 追加** — cd-stg.yml は GitHub Variables (\`ECS_MIGRATE_TASK_DEFINITION\`, \`ECS_SERVICES\`, \`ECS_PRIVATE_SUBNETS\`, \`ECS_SECURITY_GROUP\`) 未設定時に warning skip で degrade する設計。これら variables を埋めるためには task definition / service 定義を terraform で作る必要がある (P1-23 / P0.5-15 の手動デプロイステップ)
- HIGH 残 (本 PR 範囲外): find_similar_tags フルスキャン / TweetImage TOCTOE / Tweet FK index 欠落 — 負荷が低い stg では後回し可、Phase 2 で対応
- MEDIUM: Celery 設定 typo / Swagger 公開 / SSL HSTS 設定 — 別 issue で起票推奨

## Test Plan
- [ ] CI が green になる
- [ ] terraform plan で `django/jwt-signing-key` / `google/oauth-client-*` が新規追加として現れる (destroy 後の re-apply フェーズで確認)
- [ ] 本 PR merge 後に terraform apply → ECS task definition / service 定義 → cd-stg.yml の GitHub Variables を埋める
- [ ] stg で `/api/health/` が 200 を返す
- [ ] stg で意図的に invalid な JWT cookie を送ったとき 401 (AnonymousUser バイパスされない)

## 関連
- Post-hoc reviewer 結果: python-reviewer / security-reviewer / database-reviewer / code-reviewer (Phase 1 main HEAD = 652b278)