### PR TITLE
[fix][security] /u, /tag, /tweet ページに DOMPurify 二重防御適用 (Closes #198)

### DIFF
--- a/client/src/app/(template)/tag/[name]/page.tsx
+++ b/client/src/app/(template)/tag/[name]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
+import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 
 interface TagDetail {
 	name: string;
@@ -122,7 +123,9 @@ export default async function TagPage({ params }: PageProps) {
 										</div>
 										<div
 											className="prose prose-sm dark:prose-invert max-w-none"
-											dangerouslySetInnerHTML={{ __html: t.html }}
+											dangerouslySetInnerHTML={{
+												__html: sanitizeTweetHtml(t.html),
+											}}
 										/>
 										<time
 											dateTime={t.created_at}

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 
 interface PageProps {
 	params: { id: string };
@@ -144,9 +145,9 @@ export default async function TweetDetailPage({ params }: PageProps) {
 
 				<div
 					className="prose prose-sm dark:prose-invert max-w-none"
-					// Server-rendered Markdown via apps/tweets/rendering.render_markdown.
-					// bleach already sanitizes on the backend, so this string is safe.
-					dangerouslySetInnerHTML={{ __html: tweet.html }}
+					// Backend (markdown2 + bleach) sanitizes on write, but client-side
+					// sanitize is a mandatory second layer (SPEC sec CRITICAL #2).
+					dangerouslySetInnerHTML={{ __html: sanitizeTweetHtml(tweet.html) }}
 				/>
 
 				{tweet.images.length > 0 && (

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 
 interface PublicProfile {
 	username: string;
@@ -179,7 +180,9 @@ export default async function ProfilePage({ params }: PageProps) {
 									<a href={`/tweet/${t.id}`} className="block">
 										<div
 											className="prose prose-sm dark:prose-invert max-w-none"
-											dangerouslySetInnerHTML={{ __html: t.html }}
+											dangerouslySetInnerHTML={{
+												__html: sanitizeTweetHtml(t.html),
+											}}
 										/>
 										<time
 											dateTime={t.created_at}

--- a/client/src/lib/sanitize/__tests__/sanitizeTweetHtml.test.ts
+++ b/client/src/lib/sanitize/__tests__/sanitizeTweetHtml.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+// RED: These tests will fail until sanitizeTweetHtml is implemented.
+import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
+
+describe("sanitizeTweetHtml", () => {
+	it("strips <script> tags", () => {
+		const input = '<p>Hello</p><script>alert("xss")</script>';
+		const result = sanitizeTweetHtml(input);
+		expect(result).not.toContain("<script>");
+		expect(result).not.toContain("alert");
+		expect(result).toContain("Hello");
+	});
+
+	it("strips onerror event handler attributes", () => {
+		const input = '<img src="x" onerror="alert(1)">';
+		const result = sanitizeTweetHtml(input);
+		expect(result).not.toContain("onerror");
+	});
+
+	it("strips onclick event handler attributes", () => {
+		const input = '<p onclick="stealCookies()">Click me</p>';
+		const result = sanitizeTweetHtml(input);
+		expect(result).not.toContain("onclick");
+		expect(result).toContain("Click me");
+	});
+
+	it("strips javascript: href links", () => {
+		const input = '<a href="javascript:alert(1)">Click</a>';
+		const result = sanitizeTweetHtml(input);
+		expect(result).not.toContain("javascript:");
+	});
+
+	it("strips <iframe> tags", () => {
+		const input = '<p>Safe</p><iframe src="https://evil.com"></iframe>';
+		const result = sanitizeTweetHtml(input);
+		expect(result).not.toContain("<iframe");
+		expect(result).toContain("Safe");
+	});
+
+	it("strips <style> tags", () => {
+		const input = "<p>Text</p><style>body { display: none }</style>";
+		const result = sanitizeTweetHtml(input);
+		expect(result).not.toContain("<style>");
+		expect(result).toContain("Text");
+	});
+
+	it("preserves safe HTML content (bold, links, lists)", () => {
+		const input =
+			'<p>Hello <strong>world</strong></p><a href="https://example.com">link</a><ul><li>item</li></ul>';
+		const result = sanitizeTweetHtml(input);
+		expect(result).toContain("<strong>world</strong>");
+		expect(result).toContain("https://example.com");
+		expect(result).toContain("<ul>");
+		expect(result).toContain("<li>");
+	});
+});

--- a/client/src/lib/sanitize/sanitizeTweetHtml.ts
+++ b/client/src/lib/sanitize/sanitizeTweetHtml.ts
@@ -1,0 +1,22 @@
+/**
+ * sanitizeTweetHtml — defense-in-depth XSS sanitizer for tweet HTML.
+ *
+ * The backend (markdown2 + bleach) sanitizes on write, but we MUST NOT trust
+ * that blindly: any future leak in the backend pipeline would otherwise reach
+ * the DOM unfiltered. SPEC sec CRITICAL #2 mandates client-side sanitize as a
+ * second layer.
+ *
+ * Used by TweetCard (timeline) and the static tweet/profile/tag pages.
+ */
+
+import DOMPurify from "isomorphic-dompurify";
+
+export function sanitizeTweetHtml(html: string): string {
+	// USE_PROFILES.html keeps the basic safe-HTML allowlist; FORBID_TAGS adds
+	// belt-and-braces removal of `<style>` (CSS exfiltration / display tricks)
+	// since the html profile alone has not consistently stripped it.
+	return DOMPurify.sanitize(html, {
+		USE_PROFILES: { html: true },
+		FORBID_TAGS: ["style"],
+	});
+}

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "html", "lcov"],
-			// Scope coverage to modules that ship tests in this PR (P2-13). As new
+			// Scope coverage to modules that ship tests in this PR (P2-13, #198). As new
 			// modules are added, extend this include list rather than loosening the
 			// global gate.
 			include: [
@@ -21,11 +21,13 @@ export default defineConfig({
 				"src/lib/api/**/*.tsx",
 				"src/components/timeline/**/*.tsx",
 				"src/lib/timeline/**/*.ts",
+				"src/lib/sanitize/**/*.ts",
 			],
 			exclude: [
 				"src/lib/api/**/__tests__/**",
 				"src/components/**/__tests__/**",
 				"src/lib/timeline/**/__tests__/**",
+				"src/lib/sanitize/**/__tests__/**",
 				"**/*.d.ts",
 			],
 			thresholds: {


### PR DESCRIPTION
## 関連 Issue

Closes #198

P2-13 (#186) follow-up。元 PR #202 では TweetCard に DOMPurify 適用済だが、既存ページが残っていた。

## 修正

P2-13 元実装が Revert された主因 = SPEC sec CRITICAL #2 違反 (client-side sanitize 抜け) と同一パターンが 3 ページに残っていたので、共通 sanitize ヘルパで一掃。

### 新規

- \`client/src/lib/sanitize/sanitizeTweetHtml.ts\` — \`isomorphic-dompurify\` ベースの XSS sanitizer
- \`client/src/lib/sanitize/__tests__/sanitizeTweetHtml.test.ts\` — XSS テスト 7 件

### 適用

| ファイル | 修正 |
|---|---|
| \`client/src/app/(template)/u/[handle]/page.tsx\` | \`t.html\` → \`sanitizeTweetHtml(t.html)\` |
| \`client/src/app/(template)/tag/[name]/page.tsx\` | 同上 |
| \`client/src/app/(template)/tweet/[id]/page.tsx\` | 同上、危険コメント (\"safe because backend sanitizes\") も削除 |

### 設定

- \`vitest.config.ts\` の coverage include に \`src/lib/sanitize/\` を追加
- \`USE_PROFILES.html\` だけだと \`<style>\` が消えなかったので \`FORBID_TAGS: [\"style\"]\` を併用

## テスト

- [x] vitest 182/182 PASS (新規 +7)
- [x] tsc クリーン
- [x] lint エラーゼロ
- [x] sanitize ヘルパが \`<script>\`, \`onerror\`, \`onclick\`, \`javascript:\`, \`<iframe>\`, \`<style>\` を除去し、\`<strong>\`, \`<a>\`, \`<ul>\` 等を保持することをテストで検証

## マージ判断 (CLAUDE.md §4.1.1)

ブロッカー条件 **非該当**:
- ✅ CI 緑なら自動マージ可
- ✅ Revert 再投入ではない
- ✅ 認証/課金等の本番影響度高い領域ではない (XSS 対策の追加防御)
- ✅ ~94 行の small PR

CI 緑になり次第、auto-merge します。