### PR TITLE
[feature][timeline] サイドバー (TrendingTags + WhoToFollow) MVP (Closes #189)

### DIFF
--- a/client/src/components/sidebar/RightSidebar.tsx
+++ b/client/src/components/sidebar/RightSidebar.tsx
@@ -1,0 +1,26 @@
+/**
+ * RightSidebar — desktop right rail with TrendingTags + WhoToFollow.
+ *
+ * MVP scope (P2-17 / Issue #189):
+ *   - Visible only at lg+ (≥1024px). Tablet shows nothing; the mobile
+ *     end-of-feed collapse (SPEC §16.3) ships as a follow-up.
+ */
+
+import TrendingTags from "@/components/sidebar/TrendingTags";
+import WhoToFollow from "@/components/sidebar/WhoToFollow";
+
+interface RightSidebarProps {
+	isAuthenticated: boolean;
+}
+
+export default function RightSidebar({ isAuthenticated }: RightSidebarProps) {
+	return (
+		<aside
+			aria-label="サイドバー"
+			className="hidden lg:block w-80 shrink-0 space-y-4 px-4 py-6"
+		>
+			<TrendingTags />
+			<WhoToFollow isAuthenticated={isAuthenticated} />
+		</aside>
+	);
+}

--- a/client/src/components/sidebar/TrendingTags.tsx
+++ b/client/src/components/sidebar/TrendingTags.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * TrendingTags — right-rail panel listing the top trending tags.
+ *
+ * MVP scope (P2-17 / Issue #189):
+ *   - One-shot fetch on mount; polling/refresh deferred to a follow-up.
+ *   - Skeleton → data | empty | error fallback.
+ *   - Up to 10 items, each linking to /tag/<name>.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { fetchTrendingTags, type TrendingTag } from "@/lib/api/trending";
+
+const SKELETON_ROWS = 5;
+const MAX_ITEMS = 10;
+
+type LoadState = "loading" | "ready" | "error";
+
+export default function TrendingTags() {
+	const [tags, setTags] = useState<TrendingTag[]>([]);
+	const [state, setState] = useState<LoadState>("loading");
+
+	useEffect(() => {
+		let cancelled = false;
+		fetchTrendingTags()
+			.then((data) => {
+				if (cancelled) return;
+				setTags(data.slice(0, MAX_ITEMS));
+				setState("ready");
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setState("error");
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return (
+		<section
+			aria-labelledby="sidebar-trending-heading"
+			className="rounded-lg border border-border bg-card p-4"
+		>
+			<h2
+				id="sidebar-trending-heading"
+				className="mb-3 text-sm font-semibold text-foreground"
+			>
+				トレンドタグ
+			</h2>
+
+			{state === "loading" && (
+				<ul className="space-y-2">
+					{Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+						<li
+							key={i}
+							role="listitem"
+							aria-busy="true"
+							className="h-6 w-full animate-pulse rounded bg-muted"
+						/>
+					))}
+				</ul>
+			)}
+
+			{state === "error" && (
+				<p className="text-sm text-muted-foreground">
+					トレンドの取得に失敗しました
+				</p>
+			)}
+
+			{state === "ready" && tags.length === 0 && (
+				<p className="text-sm text-muted-foreground">
+					トレンドはまだ集計中です
+				</p>
+			)}
+
+			{state === "ready" && tags.length > 0 && (
+				<ul className="flex flex-col gap-1">
+					{tags.map((tag) => (
+						<li key={tag.name}>
+							<Link
+								href={`/tag/${tag.name}`}
+								className="flex items-center justify-between rounded px-2 py-1.5 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							>
+								<span className="flex items-center gap-2">
+									<span className="text-xs font-bold text-lime-600 dark:text-lime-400 w-6">
+										#{tag.rank}
+									</span>
+									{tag.emoji && <span aria-hidden="true">{tag.emoji}</span>}
+									<span className="text-sm text-foreground">
+										{tag.display_name}
+									</span>
+								</span>
+								<span className="text-xs text-muted-foreground">
+									{tag.uses}
+								</span>
+							</Link>
+						</li>
+					))}
+				</ul>
+			)}
+		</section>
+	);
+}

--- a/client/src/components/sidebar/WhoToFollow.tsx
+++ b/client/src/components/sidebar/WhoToFollow.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * WhoToFollow — right-rail recommendation panel.
+ *
+ * MVP scope (P2-17 / Issue #189):
+ *   - Auth state determines endpoint: /users/recommended/ vs /users/popular/.
+ *   - Reason chip (e.g. "同じタグを投稿") only shown for personalised
+ *     authenticated results.
+ *   - Follow button is rendered as an aria-disabled placeholder; the actual
+ *     follow action is wired up in P2-15 once the follow API is integrated.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import {
+	fetchPopularUsers,
+	fetchRecommendedUsers,
+	type SidebarUser,
+} from "@/lib/api/trending";
+
+const SKELETON_ROWS = 3;
+const LIMIT = 5;
+
+type LoadState = "loading" | "ready" | "error";
+
+interface WhoToFollowProps {
+	isAuthenticated: boolean;
+}
+
+export default function WhoToFollow({ isAuthenticated }: WhoToFollowProps) {
+	const [users, setUsers] = useState<SidebarUser[]>([]);
+	const [state, setState] = useState<LoadState>("loading");
+
+	useEffect(() => {
+		let cancelled = false;
+		const fetcher = isAuthenticated
+			? () => fetchRecommendedUsers(LIMIT)
+			: () => fetchPopularUsers(LIMIT);
+		fetcher()
+			.then((data) => {
+				if (cancelled) return;
+				setUsers(data);
+				setState("ready");
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setState("error");
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [isAuthenticated]);
+
+	return (
+		<section
+			aria-labelledby="sidebar-wtf-heading"
+			className="rounded-lg border border-border bg-card p-4"
+		>
+			<h2
+				id="sidebar-wtf-heading"
+				className="mb-3 text-sm font-semibold text-foreground"
+			>
+				おすすめユーザー
+			</h2>
+
+			{state === "loading" && (
+				<ul className="space-y-3">
+					{Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+						<li
+							key={i}
+							role="listitem"
+							aria-busy="true"
+							className="flex items-center gap-3"
+						>
+							<div className="size-10 shrink-0 animate-pulse rounded-full bg-muted" />
+							<div className="flex-1 space-y-1.5">
+								<div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+								<div className="h-2 w-1/3 animate-pulse rounded bg-muted" />
+							</div>
+						</li>
+					))}
+				</ul>
+			)}
+
+			{state === "error" && (
+				<p className="text-sm text-muted-foreground">
+					おすすめの取得に失敗しました
+				</p>
+			)}
+
+			{state === "ready" && users.length === 0 && (
+				<p className="text-sm text-muted-foreground">
+					おすすめユーザーがいません
+				</p>
+			)}
+
+			{state === "ready" && users.length > 0 && (
+				<ul className="flex flex-col gap-3">
+					{users.map((user) => (
+						<li key={user.handle} className="flex items-center gap-3">
+							{user.avatar_url ? (
+								<img
+									src={user.avatar_url}
+									alt=""
+									aria-hidden="true"
+									className="size-10 shrink-0 rounded-full object-cover"
+								/>
+							) : (
+								<div
+									aria-hidden="true"
+									className="size-10 shrink-0 rounded-full bg-muted"
+								/>
+							)}
+							<div className="min-w-0 flex-1">
+								<Link
+									href={`/u/${user.handle}`}
+									className="block truncate text-sm font-semibold text-foreground hover:underline"
+								>
+									{user.display_name}
+								</Link>
+								<span className="block truncate text-xs text-muted-foreground">
+									@{user.handle}
+								</span>
+								{isAuthenticated && user.reason && (
+									<span className="mt-1 inline-block rounded-full bg-lime-500/10 px-2 py-0.5 text-xs text-lime-700 dark:text-lime-400">
+										{user.reason}
+									</span>
+								)}
+							</div>
+							<button
+								type="button"
+								aria-label={`${user.display_name} をフォロー`}
+								aria-disabled="true"
+								title="この機能はまもなく追加されます"
+								className="rounded-full border border-border px-3 py-1 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							>
+								フォロー
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+		</section>
+	);
+}

--- a/client/src/components/sidebar/__tests__/RightSidebar.test.tsx
+++ b/client/src/components/sidebar/__tests__/RightSidebar.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Tests for RightSidebar container (P2-17 / Issue #189).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import RightSidebar from "@/components/sidebar/RightSidebar";
+
+vi.mock("@/components/sidebar/TrendingTags", () => ({
+	default: () => <div data-testid="trending">trending stub</div>,
+}));
+vi.mock("@/components/sidebar/WhoToFollow", () => ({
+	default: ({ isAuthenticated }: { isAuthenticated: boolean }) => (
+		<div data-testid="wtf">wtf {isAuthenticated ? "auth" : "anon"}</div>
+	),
+}));
+
+describe("RightSidebar", () => {
+	it("renders TrendingTags and WhoToFollow", () => {
+		render(<RightSidebar isAuthenticated={true} />);
+		expect(screen.getByTestId("trending")).toBeInTheDocument();
+		expect(screen.getByTestId("wtf")).toBeInTheDocument();
+	});
+
+	it("forwards isAuthenticated to WhoToFollow", () => {
+		render(<RightSidebar isAuthenticated={false} />);
+		expect(screen.getByTestId("wtf")).toHaveTextContent("anon");
+	});
+
+	it("is hidden below 1024px (lg breakpoint) via Tailwind hidden lg:block", () => {
+		const { container } = render(<RightSidebar isAuthenticated={false} />);
+		const aside = container.querySelector("aside");
+		expect(aside).toBeTruthy();
+		expect(aside?.className).toMatch(/hidden/);
+		expect(aside?.className).toMatch(/lg:block/);
+	});
+
+	it("uses an <aside> landmark with aria-label", () => {
+		const { container } = render(<RightSidebar isAuthenticated={true} />);
+		const aside = container.querySelector("aside");
+		expect(aside?.getAttribute("aria-label")).toBe("サイドバー");
+	});
+});

--- a/client/src/components/sidebar/__tests__/TrendingTags.test.tsx
+++ b/client/src/components/sidebar/__tests__/TrendingTags.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for TrendingTags (P2-17 / Issue #189).
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TrendingTags from "@/components/sidebar/TrendingTags";
+import { fetchTrendingTags } from "@/lib/api/trending";
+
+vi.mock("@/lib/api/trending", () => ({
+	fetchTrendingTags: vi.fn(),
+}));
+
+const SAMPLE = [
+	{ rank: 1, name: "python", display_name: "Python", uses: 100, emoji: "🐍" },
+	{ rank: 2, name: "rust", display_name: "Rust", uses: 80 },
+];
+
+describe("TrendingTags", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("shows skeleton placeholders before data resolves", () => {
+		vi.mocked(fetchTrendingTags).mockImplementation(
+			() => new Promise(() => {}),
+		);
+		render(<TrendingTags />);
+		expect(
+			screen.getAllByRole("listitem", { busy: true }).length,
+		).toBeGreaterThan(0);
+	});
+
+	it("renders trending tags after fetch resolves", async () => {
+		vi.mocked(fetchTrendingTags).mockResolvedValue(SAMPLE);
+		render(<TrendingTags />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Python")).toBeInTheDocument();
+		});
+		expect(screen.getByText("Rust")).toBeInTheDocument();
+		expect(screen.getByText("100")).toBeInTheDocument();
+	});
+
+	it("links each tag to /tag/<name>", async () => {
+		vi.mocked(fetchTrendingTags).mockResolvedValue(SAMPLE);
+		render(<TrendingTags />);
+		const link = await screen.findByRole("link", { name: /Python/ });
+		expect(link).toHaveAttribute("href", "/tag/python");
+	});
+
+	it("shows empty-state message when no tags", async () => {
+		vi.mocked(fetchTrendingTags).mockResolvedValue([]);
+		render(<TrendingTags />);
+		await waitFor(() => {
+			expect(screen.getByText(/トレンドはまだ集計中/)).toBeInTheDocument();
+		});
+	});
+
+	it("shows error fallback when fetch throws", async () => {
+		vi.mocked(fetchTrendingTags).mockRejectedValue(new Error("500"));
+		render(<TrendingTags />);
+		await waitFor(() => {
+			expect(screen.getByText(/取得に失敗/)).toBeInTheDocument();
+		});
+	});
+});

--- a/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
+++ b/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for WhoToFollow (P2-17 / Issue #189).
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WhoToFollow from "@/components/sidebar/WhoToFollow";
+import { fetchPopularUsers, fetchRecommendedUsers } from "@/lib/api/trending";
+
+vi.mock("@/lib/api/trending", () => ({
+	fetchRecommendedUsers: vi.fn(),
+	fetchPopularUsers: vi.fn(),
+}));
+
+const SAMPLE = [
+	{
+		handle: "alice",
+		display_name: "Alice",
+		avatar_url: "https://example.com/a.png",
+		bio: "Engineer",
+		is_following: false,
+		reason: "人気のユーザー",
+	},
+];
+
+describe("WhoToFollow", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("calls fetchRecommendedUsers when authenticated", async () => {
+		vi.mocked(fetchRecommendedUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={true} />);
+		await waitFor(() => {
+			expect(fetchRecommendedUsers).toHaveBeenCalledWith(5);
+		});
+		expect(fetchPopularUsers).not.toHaveBeenCalled();
+	});
+
+	it("calls fetchPopularUsers when unauthenticated", async () => {
+		vi.mocked(fetchPopularUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={false} />);
+		await waitFor(() => {
+			expect(fetchPopularUsers).toHaveBeenCalledWith(5);
+		});
+		expect(fetchRecommendedUsers).not.toHaveBeenCalled();
+	});
+
+	it("renders user info after fetch resolves", async () => {
+		vi.mocked(fetchRecommendedUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={true} />);
+		await screen.findByText("Alice");
+		expect(screen.getByText("@alice")).toBeInTheDocument();
+	});
+
+	it("hides reason chip when unauthenticated (no personalization)", async () => {
+		vi.mocked(fetchPopularUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={false} />);
+		await screen.findByText("Alice");
+		expect(screen.queryByText("人気のユーザー")).not.toBeInTheDocument();
+	});
+
+	it("shows reason chip when authenticated", async () => {
+		vi.mocked(fetchRecommendedUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={true} />);
+		await screen.findByText("人気のユーザー");
+	});
+
+	it("renders follow button as aria-disabled placeholder (P2-15 wires action)", async () => {
+		vi.mocked(fetchRecommendedUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={true} />);
+		const btn = await screen.findByRole("button", { name: /フォロー/ });
+		expect(btn.getAttribute("aria-disabled")).toBe("true");
+	});
+
+	it("shows empty-state when no users", async () => {
+		vi.mocked(fetchRecommendedUsers).mockResolvedValue([]);
+		render(<WhoToFollow isAuthenticated={true} />);
+		await waitFor(() => {
+			expect(
+				screen.getByText(/おすすめユーザーがいません/),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("shows error fallback on fetch failure", async () => {
+		vi.mocked(fetchRecommendedUsers).mockRejectedValue(new Error("500"));
+		render(<WhoToFollow isAuthenticated={true} />);
+		await waitFor(() => {
+			expect(screen.getByText(/取得に失敗/)).toBeInTheDocument();
+		});
+	});
+});

--- a/client/src/lib/api/__tests__/trending.test.ts
+++ b/client/src/lib/api/__tests__/trending.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for trending/sidebar API helpers (P2-17 / Issue #189).
+ * TDD RED phase — these tests should FAIL before implementation.
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+import { createApiClient } from "@/lib/api/client";
+import {
+	fetchTrendingTags,
+	fetchRecommendedUsers,
+	fetchPopularUsers,
+	type TrendingTag,
+	type SidebarUser,
+} from "@/lib/api/trending";
+
+function stub() {
+	const client = createApiClient();
+	const mock = new MockAdapter(client);
+	return { client, mock };
+}
+
+const SAMPLE_TAG: TrendingTag = {
+	rank: 1,
+	name: "python",
+	display_name: "Python",
+	uses: 1234,
+	emoji: "🐍",
+};
+
+const SAMPLE_USER: SidebarUser = {
+	handle: "alice",
+	display_name: "Alice",
+	avatar_url: "https://example.com/alice.png",
+	bio: "Software Engineer",
+	is_following: false,
+	reason: "人気のユーザー",
+};
+
+// ----- fetchTrendingTags -----
+
+describe("fetchTrendingTags", () => {
+	it("GETs /tags/trending/ and returns TrendingTag array", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/tags/trending/").reply(200, [SAMPLE_TAG]);
+
+		const tags = await fetchTrendingTags(client);
+		expect(tags).toHaveLength(1);
+		expect(tags[0]!.rank).toBe(1);
+		expect(tags[0]!.name).toBe("python");
+		expect(tags[0]!.uses).toBe(1234);
+	});
+
+	it("returns results array when response is paginated {results:[...]}", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/tags/trending/").reply(200, { results: [SAMPLE_TAG] });
+
+		const tags = await fetchTrendingTags(client);
+		expect(tags).toHaveLength(1);
+		expect(tags[0]!.name).toBe("python");
+	});
+
+	it("returns empty array when response is empty array", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/tags/trending/").reply(200, []);
+
+		const tags = await fetchTrendingTags(client);
+		expect(tags).toEqual([]);
+	});
+
+	it("throws on network error", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/tags/trending/").networkError();
+
+		await expect(fetchTrendingTags(client)).rejects.toThrow();
+	});
+
+	it("throws on 500 server error", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/tags/trending/").reply(500, { detail: "Server Error" });
+
+		await expect(fetchTrendingTags(client)).rejects.toThrow();
+	});
+});
+
+// ----- fetchRecommendedUsers (auth) -----
+
+describe("fetchRecommendedUsers", () => {
+	it("GETs /users/recommended/ with limit param", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/recommended/").reply((config) => {
+			expect(config.params).toEqual({ limit: 5 });
+			return [200, [SAMPLE_USER]];
+		});
+
+		const users = await fetchRecommendedUsers(5, client);
+		expect(users).toHaveLength(1);
+		expect(users[0]!.handle).toBe("alice");
+	});
+
+	it("returns results array when paginated", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/recommended/").reply(200, { results: [SAMPLE_USER] });
+
+		const users = await fetchRecommendedUsers(5, client);
+		expect(users).toHaveLength(1);
+	});
+
+	it("returns empty array on empty response", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/recommended/").reply(200, []);
+
+		const users = await fetchRecommendedUsers(5, client);
+		expect(users).toEqual([]);
+	});
+
+	it("throws on 401 unauthorized", async () => {
+		const { client, mock } = stub();
+		// Disable refresh retry for this test — reply 401 to both the original
+		// and the refresh endpoint
+		mock.onPost("/auth/cookie/refresh/").reply(401);
+		mock.onGet("/users/recommended/").reply(401, { detail: "Unauthorized" });
+
+		await expect(fetchRecommendedUsers(5, client)).rejects.toThrow();
+	});
+
+	it("throws on network error", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/recommended/").networkError();
+
+		await expect(fetchRecommendedUsers(5, client)).rejects.toThrow();
+	});
+});
+
+// ----- fetchPopularUsers (unauth) -----
+
+describe("fetchPopularUsers", () => {
+	it("GETs /users/popular/ with limit param", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/popular/").reply((config) => {
+			expect(config.params).toEqual({ limit: 5 });
+			return [200, [SAMPLE_USER]];
+		});
+
+		const users = await fetchPopularUsers(5, client);
+		expect(users).toHaveLength(1);
+		expect(users[0]!.handle).toBe("alice");
+	});
+
+	it("returns results array when paginated", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/popular/").reply(200, { results: [SAMPLE_USER] });
+
+		const users = await fetchPopularUsers(5, client);
+		expect(users).toHaveLength(1);
+	});
+
+	it("returns empty array on empty response", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/popular/").reply(200, []);
+
+		const users = await fetchPopularUsers(5, client);
+		expect(users).toEqual([]);
+	});
+
+	it("throws on network error", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/popular/").networkError();
+
+		await expect(fetchPopularUsers(5, client)).rejects.toThrow();
+	});
+});

--- a/client/src/lib/api/trending.ts
+++ b/client/src/lib/api/trending.ts
@@ -1,0 +1,67 @@
+/**
+ * Sidebar API helpers (P2-17 / Issue #189).
+ *
+ * Trending tags + Who-to-follow user lists feed the right-rail sidebar.
+ * Endpoints accept either a plain array or a paginated `{ results: [...] }`
+ * envelope, so consumers stay agnostic.
+ */
+
+import type { AxiosInstance } from "axios";
+import { api } from "@/lib/api/client";
+
+export interface TrendingTag {
+	rank: number;
+	name: string;
+	display_name: string;
+	uses: number;
+	emoji?: string;
+}
+
+export interface SidebarUser {
+	handle: string;
+	display_name: string;
+	avatar_url?: string;
+	bio?: string;
+	is_following?: boolean;
+	reason?: string;
+}
+
+interface MaybePaginated<T> {
+	results?: T[];
+}
+
+function unwrap<T>(data: T[] | MaybePaginated<T>): T[] {
+	if (Array.isArray(data)) return data;
+	return data.results ?? [];
+}
+
+export async function fetchTrendingTags(
+	client: AxiosInstance = api,
+): Promise<TrendingTag[]> {
+	const res = await client.get<TrendingTag[] | MaybePaginated<TrendingTag>>(
+		"/tags/trending/",
+	);
+	return unwrap(res.data);
+}
+
+export async function fetchRecommendedUsers(
+	limit: number,
+	client: AxiosInstance = api,
+): Promise<SidebarUser[]> {
+	const res = await client.get<SidebarUser[] | MaybePaginated<SidebarUser>>(
+		"/users/recommended/",
+		{ params: { limit } },
+	);
+	return unwrap(res.data);
+}
+
+export async function fetchPopularUsers(
+	limit: number,
+	client: AxiosInstance = api,
+): Promise<SidebarUser[]> {
+	const res = await client.get<SidebarUser[] | MaybePaginated<SidebarUser>>(
+		"/users/popular/",
+		{ params: { limit } },
+	);
+	return unwrap(res.data);
+}

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -13,15 +13,16 @@ export default defineConfig({
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "html", "lcov"],
-			// Scope coverage to modules that ship tests in this PR (P2-13, #198). As new
-			// modules are added, extend this include list rather than loosening the
-			// global gate.
+			// Scope coverage to modules that ship tests in this PR (P2-13 / #198 /
+			// P2-17). As new modules are added, extend this include list rather
+			// than loosening the global gate.
 			include: [
 				"src/lib/api/**/*.ts",
 				"src/lib/api/**/*.tsx",
 				"src/components/timeline/**/*.tsx",
 				"src/lib/timeline/**/*.ts",
 				"src/lib/sanitize/**/*.ts",
+				"src/components/sidebar/**/*.tsx",
 			],
 			exclude: [
 				"src/lib/api/**/__tests__/**",


### PR DESCRIPTION
## 関連 Issue

Closes #189 (P2-17)

## 実装内容 (MVP)

SPEC §16.3 の右ペインサイドバーを実装。lg (≥1024px) で常時表示、tablet/mobile では非表示。

### 新規ファイル

- \`client/src/lib/api/trending.ts\` — 3 つのヘルパー (\`fetchTrendingTags\`, \`fetchRecommendedUsers\`, \`fetchPopularUsers\`)。plain array と \`{ results: [...] }\` ペイロード両対応
- \`client/src/components/sidebar/TrendingTags.tsx\` — \`/tags/trending/\` で上位 10 件、skeleton/empty/error fallback
- \`client/src/components/sidebar/WhoToFollow.tsx\` — auth で \`/users/recommended/\` 、unauth で \`/users/popular/\`、reason chip は personalised 時のみ
- \`client/src/components/sidebar/RightSidebar.tsx\` — \`<aside aria-label=\"サイドバー\">\` ランドマーク

### スコープ外（follow-up に切り出し済み or 別 Issue 候補）

- 5 分ポーリング / TanStack Query cache invalidation
- フォローボタンの楽観更新 → P2-15 で動作配線（本 PR は \`aria-disabled\` placeholder）
- モバイル末尾折りたたみ表示

## テスト

- vitest 206/206 PASS（+24 件: TrendingTags 5 / WhoToFollow 8 / RightSidebar 4 / trending api 14 既存）
- tsc クリーン / lint エラーゼロ

## マージ判断

CLAUDE.md §4.1.1 ブロッカー条件に該当なし → CI 緑なら auto-merge。