### PR TITLE
[chore][security] axios 1.6.7 → 1.15.2 で既知 CVE を解消 (Closes #199)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,7 +23,7 @@
 				"@sentry/nextjs": "^8.26.0",
 				"@stripe/stripe-js": "^4.4.0",
 				"async-mutex": "^0.4.1",
-				"axios": "^1.6.7",
+				"axios": "^1.15.2",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
 				"cookies-next": "^4.1.1",
@@ -5048,14 +5048,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-			"integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.4",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/axios-mock-adapter": {
@@ -5070,6 +5070,15 @@
 			},
 			"peerDependencies": {
 				"axios": ">= 0.17.0"
+			}
+		},
+		"node_modules/axios/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/axobject-query": {

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
 		"@sentry/nextjs": "^8.26.0",
 		"@stripe/stripe-js": "^4.4.0",
 		"async-mutex": "^0.4.1",
-		"axios": "^1.6.7",
+		"axios": "^1.15.2",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"cookies-next": "^4.1.1",


### PR DESCRIPTION
Closes #199

P2-13 (#186) の security-reviewer が指摘した axios の HIGH CVE を解消。

## 変更
- \`axios\` を \`^1.6.7\` → \`^1.15.2\` に更新

## 対象 CVE (axios 1.0-1.14 系)
- SSRF / DoS / credential leakage / proto pollution / NO_PROXY bypass

## 確認
- \`npm audit\` で **axios は HIGH/CRITICAL リストから消えた**
- vitest 239/239 PASS — axios の API 後方互換維持を確認

## 残存 HIGH/CRITICAL（本 PR 範囲外、別 Issue 候補）
- next CRITICAL（Next.js 14.1.4）
- @sentry/nextjs HIGH
- @typescript-eslint 系 HIGH
- glob / minimatch / picomatch / flatted / rollup HIGH

これらは Next.js 14 系のメジャーアップグレードや他依存を伴うので分離。

CLAUDE.md §4.1.1 ブロッカー条件非該当 → CI 緑なら auto-merge。