### PR TITLE
[feature][backend] /timeline/* に cursor pagination 追加 (Closes #200)

### DIFF
--- a/apps/timeline/cursor.py
+++ b/apps/timeline/cursor.py
@@ -1,0 +1,44 @@
+"""Cursor pagination helper for timeline endpoints (Issue #200).
+
+Phase 2 段階の cursor は Tweet ID 単独 (base64 url-safe エンコード) で十分。
+クライアント側は不透明な文字列として扱い、サーバ側だけが decode する。
+
+将来 (created_at, id) のタプルが必要になったら ``encode_cursor`` /
+``decode_cursor`` の入出力を Pydantic / dataclass に拡張する。
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Cursor:
+    """ID-only cursor. SPEC §5.4 でのカーソル方式の最小実装."""
+
+    id: int
+
+
+def encode_cursor(tweet_id: int) -> str:
+    """``tweet_id`` を url-safe base64 で encode する.
+
+    数値そのままだと簡単に URL から推測できるが、これは「順序情報の隠蔽」
+    ではなく「不透明性によりクライアントが ID 順を前提にしないため」の
+    シリアライゼーション。セキュリティ目的の暗号化ではない。
+    """
+    raw = str(tweet_id).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_cursor(token: str | None) -> Cursor | None:
+    """``token`` を ``Cursor`` に戻す. 不正値は ``None`` を返す."""
+    if not token:
+        return None
+    try:
+        # 末尾 padding を補完して decode
+        padding = "=" * (-len(token) % 4)
+        raw = base64.urlsafe_b64decode((token + padding).encode("ascii"))
+        return Cursor(id=int(raw.decode("utf-8")))
+    except (ValueError, TypeError):
+        return None

--- a/apps/timeline/tests/test_cursor.py
+++ b/apps/timeline/tests/test_cursor.py
@@ -1,0 +1,28 @@
+"""Tests for cursor encoding helpers (#200)."""
+
+from __future__ import annotations
+
+from apps.timeline.cursor import Cursor, decode_cursor, encode_cursor
+
+
+class TestEncodeDecode:
+    def test_round_trip(self):
+        for tid in (1, 42, 1_000_000, 2**31 - 1):
+            assert decode_cursor(encode_cursor(tid)) == Cursor(id=tid)
+
+    def test_decode_returns_none_for_empty(self):
+        assert decode_cursor("") is None
+        assert decode_cursor(None) is None
+
+    def test_decode_returns_none_for_garbage(self):
+        assert decode_cursor("not-base64-!!@@") is None
+        assert decode_cursor("aGVsbG8=") is None  # decodes to "hello", non-int
+
+    def test_encoded_cursor_is_url_safe(self):
+        token = encode_cursor(123_456_789)
+        # base64 url-safe character class only
+        assert all(c.isalnum() or c in "-_" for c in token)
+
+    def test_encoded_cursor_strips_padding(self):
+        token = encode_cursor(7)
+        assert "=" not in token

--- a/apps/timeline/views.py
+++ b/apps/timeline/views.py
@@ -1,4 +1,4 @@
-"""Timeline API views (P2-08 / GitHub #183)."""
+"""Timeline API views (P2-08 / GitHub #183, cursor pagination #200)."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.timeline.cursor import decode_cursor, encode_cursor
 from apps.timeline.services import (
     build_explore_tl,
     get_or_build_home_tl,
@@ -23,8 +24,32 @@ from apps.tweets.serializers import TweetListSerializer
 logger = logging.getLogger(__name__)
 
 
+def _parse_limit(request: Request, default: int = 20, cap: int = 100) -> int:
+    try:
+        return max(1, min(int(request.query_params.get("limit", default)), cap))
+    except (TypeError, ValueError):
+        return default
+
+
+def _slice_with_cursor(
+    tweets: list[Tweet], cursor_id: int | None, limit: int
+) -> tuple[list[Tweet], str | None, bool]:
+    """Apply cursor + limit to an in-memory tweet list.
+
+    Returns ``(page, next_cursor, has_more)``. The cursor is exclusive — the
+    tweet whose pk equals ``cursor_id`` is skipped before slicing ``limit``.
+    """
+    if cursor_id is not None:
+        idx = next((i for i, t in enumerate(tweets) if t.pk == cursor_id), -1)
+        tweets = tweets[idx + 1 :] if idx >= 0 else tweets
+    page = tweets[:limit]
+    has_more = len(tweets) > limit
+    next_cursor = encode_cursor(page[-1].pk) if has_more and page else None
+    return page, next_cursor, has_more
+
+
 class HomeTimelineView(APIView):
-    """GET /api/v1/timeline/home/
+    """GET /api/v1/timeline/home/?cursor=...&limit=N
 
     アルゴリズム TL (フォロー 70% + 全体 30%)、Redis キャッシュ、認証必須。
     """
@@ -32,31 +57,39 @@ class HomeTimelineView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request: Request) -> Response:
-        try:
-            limit = max(1, min(int(request.query_params.get("limit", 20)), 100))
-        except (TypeError, ValueError):
-            limit = 20
+        limit = _parse_limit(request)
+        cursor = decode_cursor(request.query_params.get("cursor"))
 
-        tweets, cache_hit = get_or_build_home_tl(request.user, limit=limit)
+        # Cache はカーソル境界を含めない一括取得 → views 側で slice する。
+        # 将来 cursor を service レイヤに渡す場合はこの slice を services に
+        # 寄せるが、本 PR は最小変更で互換維持。limit*5 は次ページ分の余裕。
+        full, cache_hit = get_or_build_home_tl(request.user, limit=limit * 5)
+        page, next_cursor, has_more = _slice_with_cursor(full, cursor.id if cursor else None, limit)
 
-        # メトリクス用ログ (Phase 2 完成時に CloudWatch 統合)
         logger.info(
             "tl_home_get",
             extra={
                 "event": "timeline.home.get",
                 "user_id": request.user.pk,
                 "cache_hit": cache_hit,
-                "result_count": len(tweets),
+                "result_count": len(page),
+                "has_cursor": cursor is not None,
             },
         )
 
-        # TweetListSerializer は P1-08 のものを再利用 (author / images / tags 含む)
-        data = TweetListSerializer(tweets, many=True, context={"request": request}).data
-        return Response({"results": data, "cache_hit": cache_hit})
+        data = TweetListSerializer(page, many=True, context={"request": request}).data
+        return Response(
+            {
+                "results": data,
+                "cache_hit": cache_hit,
+                "next_cursor": next_cursor,
+                "has_more": has_more,
+            }
+        )
 
 
 class FollowingTimelineView(APIView):
-    """GET /api/v1/timeline/following/
+    """GET /api/v1/timeline/following/?cursor=...&limit=N
 
     フォロー中タブ: 時系列のみ、24h 以内のフォロイーのツイート。認証必須。
     """
@@ -64,10 +97,8 @@ class FollowingTimelineView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request: Request) -> Response:
-        try:
-            limit = max(1, min(int(request.query_params.get("limit", 20)), 100))
-        except (TypeError, ValueError):
-            limit = 20
+        limit = _parse_limit(request)
+        cursor = decode_cursor(request.query_params.get("cursor"))
 
         cutoff = timezone.now() - timedelta(hours=24)
         qs: QuerySet[Tweet] = (
@@ -77,14 +108,23 @@ class FollowingTimelineView(APIView):
                 created_at__gte=cutoff,
             )
             .exclude(author=request.user)
-            .order_by("-created_at")[:limit]
+            .order_by("-created_at", "-id")
         )
-        data = TweetListSerializer(list(qs), many=True, context={"request": request}).data
-        return Response({"results": data})
+        if cursor is not None:
+            qs = qs.filter(id__lt=cursor.id)
+
+        # +1 件多めに取って has_more を判定する古典的パターン。
+        rows = list(qs[: limit + 1])
+        has_more = len(rows) > limit
+        page = rows[:limit]
+        next_cursor = encode_cursor(page[-1].pk) if has_more and page else None
+
+        data = TweetListSerializer(page, many=True, context={"request": request}).data
+        return Response({"results": data, "next_cursor": next_cursor, "has_more": has_more})
 
 
 class ExploreTimelineView(APIView):
-    """GET /api/v1/timeline/explore/
+    """GET /api/v1/timeline/explore/?cursor=...&limit=N
 
     未ログイン閲覧可。reaction 数上位 24h。auth 時は viewer の双方向 Block で除外。
     """
@@ -92,12 +132,12 @@ class ExploreTimelineView(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request: Request) -> Response:
-        try:
-            limit = max(1, min(int(request.query_params.get("limit", 20)), 100))
-        except (TypeError, ValueError):
-            limit = 20
+        limit = _parse_limit(request)
+        cursor = decode_cursor(request.query_params.get("cursor"))
 
         viewer = None if isinstance(request.user, AnonymousUser) else request.user
-        tweets = build_explore_tl(viewer=viewer, limit=limit)
-        data = TweetListSerializer(tweets, many=True, context={"request": request}).data
-        return Response({"results": data})
+        full = build_explore_tl(viewer=viewer, limit=limit * 5)
+        page, next_cursor, has_more = _slice_with_cursor(full, cursor.id if cursor else None, limit)
+
+        data = TweetListSerializer(page, many=True, context={"request": request}).data
+        return Response({"results": data, "next_cursor": next_cursor, "has_more": has_more})


### PR DESCRIPTION
Closes #200

P2-13 (#186) で limit-incremental 暫定実装した部分を、SPEC §5.4 通りの cursor 方式に拡張。

## 変更

### 新規
- \`apps/timeline/cursor.py\` — Tweet ID 単独 cursor (url-safe base64) helper、不正値は silent decode → None
- \`apps/timeline/tests/test_cursor.py\` — 5 件 (round-trip / 空 / 不正値 / url-safe / padding 除去)

### views.py 拡張
- HomeTimelineView / ExploreTimelineView — cache list を views 側で cursor exclusive slice
- FollowingTimelineView — \`id__lt\` で QuerySet フィルタ、+1 件多めに取って \`has_more\` 判定

## 下位互換

cursor 未指定なら従来通り先頭 limit 件。クライアント (HomeFeed) は次 PR で cursor 化。

## マージ判断

CLAUDE.md §4.1.1 ブロッカー条件非該当 → CI 緑なら auto-merge。