### PR TITLE
[feature][backend] apps/search MVP: キーワード検索 (Closes #205 partial)

### DIFF
--- a/apps/search/services.py
+++ b/apps/search/services.py
@@ -1,0 +1,37 @@
+"""Search services (P2-11 / Issue #205).
+
+MVP: Tweet 本文への単純キーワード検索。
+
+ADR-0002 で pg_bigm + Lindera を仮採用しているので、Postgres 本番では
+``body %% query`` (pg_bigm `%>` 演算子) 相当の N-gram マッチが GIN index で
+動く。Django ORM レベルでは ``body__icontains`` を使い、postgres 上で
+pg_bigm 拡張が `LIKE` 演算子に介入する形で高速化する。
+
+フィルタ演算子 (tag:/from:/since:/until:/type:/has:) は P2-12 (#206) で
+拡張する。本サービスはキーワード単独のシンプル検索のみ。
+"""
+
+from __future__ import annotations
+
+from apps.tweets.models import Tweet
+
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 100
+
+
+def search_tweets(query: str, limit: int = DEFAULT_LIMIT) -> list[Tweet]:
+    """Tweet 本文に ``query`` を含むものを新しい順に返す.
+
+    空文字 / 空白のみのクエリは空リストを返す。``limit`` は上限 ``MAX_LIMIT``
+    でクランプする。
+    """
+    cleaned = (query or "").strip()
+    if not cleaned:
+        return []
+
+    capped = max(1, min(limit, MAX_LIMIT))
+    return list(
+        Tweet.objects.select_related("author")
+        .filter(body__icontains=cleaned)
+        .order_by("-created_at", "-id")[:capped]
+    )

--- a/apps/search/tests/test_services.py
+++ b/apps/search/tests/test_services.py
@@ -1,0 +1,57 @@
+"""Tests for search services (P2-11 / Issue #205)."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.search.services import MAX_LIMIT, search_tweets
+from apps.tweets.models import Tweet
+
+User = get_user_model()
+
+
+@pytest.fixture
+def author(db):
+    return User.objects.create_user(username="alice", email="alice@example.com", password="x")
+
+
+@pytest.fixture
+def tweets(author):
+    return [
+        Tweet.objects.create(author=author, body="python is fun"),
+        Tweet.objects.create(author=author, body="rust is safe"),
+        Tweet.objects.create(author=author, body="python and rust"),
+    ]
+
+
+class TestSearchTweets:
+    def test_returns_empty_for_blank_query(self, db):
+        assert search_tweets("") == []
+        assert search_tweets("   ") == []
+        assert search_tweets(None) == []  # type: ignore[arg-type]
+
+    def test_returns_only_matching_tweets(self, tweets):
+        results = search_tweets("python")
+        bodies = [t.body for t in results]
+        assert "python is fun" in bodies
+        assert "python and rust" in bodies
+        assert "rust is safe" not in bodies
+
+    def test_is_case_insensitive(self, tweets):
+        results = search_tweets("PYTHON")
+        assert len(results) == 2
+
+    def test_orders_by_newest_first(self, tweets):
+        results = search_tweets("python")
+        # Created newer-last in fixture → expect reversed creation order.
+        assert results[0].pk > results[1].pk
+
+    def test_caps_limit_at_max(self, tweets):
+        # Even if caller asks for an absurdly high limit, must not exceed MAX_LIMIT.
+        results = search_tweets("python", limit=MAX_LIMIT + 1000)
+        assert len(results) <= MAX_LIMIT
+
+    def test_strips_whitespace_around_query(self, tweets):
+        results = search_tweets("  python  ")
+        assert len(results) == 2

--- a/apps/search/urls.py
+++ b/apps/search/urls.py
@@ -1,5 +1,11 @@
-from django.urls import URLPattern, URLResolver
+"""URL patterns for the search app (P2-11 / Issue #205)."""
 
-# URL patterns are added in the phase that implements this feature.
-# See docs/ROADMAP.md for ownership.
-urlpatterns: list[URLPattern | URLResolver] = []
+from __future__ import annotations
+
+from django.urls import URLPattern, URLResolver, path
+
+from apps.search.views import SearchView
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("", SearchView.as_view(), name="search"),
+]

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -1,5 +1,34 @@
-"""Views for the search app.
+"""Search API views (P2-11 / Issue #205).
 
-Views are added in the phase that owns this feature.
-See docs/ROADMAP.md for ownership.
+GET /api/v1/search/?q=...&limit=N
+
+未ログインでも検索可。フィルタ演算子は P2-12 (#206) で拡張。
 """
+
+from __future__ import annotations
+
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.search.services import DEFAULT_LIMIT, MAX_LIMIT, search_tweets
+from apps.tweets.serializers import TweetListSerializer
+
+
+class SearchView(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, request: Request) -> Response:
+        query = (request.query_params.get("q") or "").strip()
+        try:
+            limit = max(
+                1,
+                min(int(request.query_params.get("limit", DEFAULT_LIMIT)), MAX_LIMIT),
+            )
+        except (TypeError, ValueError):
+            limit = DEFAULT_LIMIT
+
+        tweets = search_tweets(query, limit=limit)
+        data = TweetListSerializer(tweets, many=True, context={"request": request}).data
+        return Response({"query": query, "results": data, "count": len(data)})


### PR DESCRIPTION
Closes #205 (MVP) — フィルタ演算子は #206 で分離

ADR-0002 で pg_bigm 仮採用なので、Tweet 本文のキーワード検索のみ MVP として実装。Postgres 本番では \`__icontains\` の LIKE に pg_bigm GIN が介入。

## 新規
- \`apps/search/services.py\` — \`search_tweets()\` (空 → []、MAX_LIMIT=100、新しい順)
- \`apps/search/views.py\` — \`SearchView\` (AllowAny、\`GET /api/v1/search/?q=&limit=\`)
- \`apps/search/urls.py\` — URL pattern
- \`apps/search/tests/test_services.py\` — 6 件 (空 / マッチ / 大小文字 / 並び順 / limit cap / トリム)

## スコープ外
- フィルタ演算子パーサ → #206
- ユーザー / タグ検索 → 別 issue
- search index signal 同期 → Meilisearch 採用時のみ必要

CLAUDE.md §4.1.1 ブロッカー条件非該当 → CI 緑なら auto-merge。