### PR TITLE
[feature][backend] 検索演算子 tag/from/since/until/type/has (Closes #206)

### DIFF
--- a/apps/search/parser.py
+++ b/apps/search/parser.py
@@ -1,0 +1,98 @@
+"""Search query parser (P2-12 / Issue #206).
+
+Parses queries like ``python tag:django from:alice since:2026-01-01 has:image``
+into a structured ``ParsedQuery``: free-text keywords + a dict of operators.
+
+Supported operators:
+    tag:<name>          # restrict to tweets carrying the tag (multiple allowed)
+    from:<handle>       # restrict to tweets whose author handle matches
+    since:<YYYY-MM-DD>  # created_at >= midnight JST
+    until:<YYYY-MM-DD>  # created_at <  next-day midnight JST
+    type:<kind>         # original | reply | repost | quote
+    has:<kind>          # image | code
+
+Unknown operator names and malformed values are silently dropped — the goal is
+to never throw on user input. Validation is the caller's job (``services.py``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
+# operator名 → 値のリスト (tag/has/type は複数可、from/since/until は最後勝ち)
+_OPERATOR_NAMES = {"tag", "from", "since", "until", "type", "has"}
+_OPERATOR_RE = re.compile(r"^(?P<key>[a-z]+):(?P<value>.+)$")
+_HANDLE_RE = re.compile(r"^[A-Za-z0-9_]{1,32}$")
+_TYPE_VALUES = {"original", "reply", "repost", "quote"}
+_HAS_VALUES = {"image", "code"}
+
+
+@dataclass
+class ParsedQuery:
+    keywords: str = ""
+    tags: list[str] = field(default_factory=list)
+    from_handle: str | None = None
+    since: date | None = None
+    until: date | None = None
+    type: str | None = None
+    has: list[str] = field(default_factory=list)
+
+
+def _parse_date(value: str) -> date | None:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def parse_search_query(raw: str) -> ParsedQuery:
+    """Split ``raw`` into operators + keyword tokens.
+
+    Whitespace is the only token boundary; quoted strings are not yet
+    supported (a follow-up can add ``"phrase search"`` if demand emerges).
+    """
+    parsed = ParsedQuery()
+    keyword_tokens: list[str] = []
+
+    for token in (raw or "").split():
+        match = _OPERATOR_RE.match(token)
+        if match is None:
+            keyword_tokens.append(token)
+            continue
+
+        key = match.group("key").lower()
+        value = match.group("value")
+
+        if key not in _OPERATOR_NAMES:
+            # Unknown operator — keep the literal in keywords so users still
+            # get *some* result instead of a silent miss.
+            keyword_tokens.append(token)
+            continue
+
+        if key == "tag" and value:
+            parsed.tags.append(value.lstrip("#").lower())
+        elif key == "from":
+            handle = value.lstrip("@")
+            if _HANDLE_RE.match(handle):
+                parsed.from_handle = handle
+        elif key == "since":
+            d = _parse_date(value)
+            if d is not None:
+                parsed.since = d
+        elif key == "until":
+            d = _parse_date(value)
+            if d is not None:
+                parsed.until = d
+        elif key == "type":
+            v = value.lower()
+            if v in _TYPE_VALUES:
+                parsed.type = v
+        elif key == "has":
+            v = value.lower()
+            if v in _HAS_VALUES and v not in parsed.has:
+                parsed.has.append(v)
+
+    parsed.keywords = " ".join(keyword_tokens).strip()
+    return parsed

--- a/apps/search/services.py
+++ b/apps/search/services.py
@@ -1,37 +1,88 @@
-"""Search services (P2-11 / Issue #205).
+"""Search services (P2-11 / Issue #205, P2-12 operators / #206).
 
-MVP: Tweet 本文への単純キーワード検索。
+Tweet 本文へのキーワード検索 + フィルタ演算子 (tag/from/since/until/type/has)。
 
 ADR-0002 で pg_bigm + Lindera を仮採用しているので、Postgres 本番では
-``body %% query`` (pg_bigm `%>` 演算子) 相当の N-gram マッチが GIN index で
-動く。Django ORM レベルでは ``body__icontains`` を使い、postgres 上で
-pg_bigm 拡張が `LIKE` 演算子に介入する形で高速化する。
-
-フィルタ演算子 (tag:/from:/since:/until:/type:/has:) は P2-12 (#206) で
-拡張する。本サービスはキーワード単独のシンプル検索のみ。
+``body__icontains`` の LIKE 演算子に pg_bigm GIN index が介入する形で
+高速化される。
 """
 
 from __future__ import annotations
 
+from datetime import datetime, time, timedelta
+
+from django.db.models import QuerySet
+from django.utils import timezone
+
+from apps.search.parser import ParsedQuery, parse_search_query
 from apps.tweets.models import Tweet
 
 DEFAULT_LIMIT = 20
 MAX_LIMIT = 100
 
 
-def search_tweets(query: str, limit: int = DEFAULT_LIMIT) -> list[Tweet]:
-    """Tweet 本文に ``query`` を含むものを新しい順に返す.
+def _apply_filters(qs: QuerySet[Tweet], parsed: ParsedQuery) -> QuerySet[Tweet]:
+    """Apply each operator from ``parsed`` to ``qs``.
 
-    空文字 / 空白のみのクエリは空リストを返す。``limit`` は上限 ``MAX_LIMIT``
-    でクランプする。
+    Order of filters: cheap exact matches (type / from) → range (since/until)
+    → m2m joins (tag) → string contains (has:code) → exists check (has:image).
     """
-    cleaned = (query or "").strip()
-    if not cleaned:
+    if parsed.type is not None:
+        qs = qs.filter(type=parsed.type)
+
+    if parsed.from_handle is not None:
+        # 既存実装の handle 列名は ``username`` (Phase 1 の get_user_model 拡張)。
+        # 大文字小文字を意識しない比較で UX をブレさせない。
+        qs = qs.filter(author__username__iexact=parsed.from_handle)
+
+    tz = timezone.get_current_timezone()
+    if parsed.since is not None:
+        start = timezone.make_aware(datetime.combine(parsed.since, time.min), tz)
+        qs = qs.filter(created_at__gte=start)
+    if parsed.until is not None:
+        # until は exclusive: ``until:2026-04-23`` は ~ 2026-04-23 23:59:59 を含む。
+        end = timezone.make_aware(datetime.combine(parsed.until + timedelta(days=1), time.min), tz)
+        qs = qs.filter(created_at__lt=end)
+
+    for tag in parsed.tags:
+        qs = qs.filter(tweet_tags__tag__name=tag)
+
+    if "image" in parsed.has:
+        qs = qs.filter(images__isnull=False)
+    if "code" in parsed.has:
+        # Markdown フェンス記法のコードブロック検知。
+        qs = qs.filter(body__contains="```")
+
+    if parsed.tags or "image" in parsed.has:
+        qs = qs.distinct()
+
+    return qs
+
+
+def search_tweets(query: str, limit: int = DEFAULT_LIMIT) -> list[Tweet]:
+    """Tweet を ``query`` で検索する。
+
+    クエリ文字列は ``parse_search_query`` で operator + keywords に分解し、
+    keywords は本文 (body) に対する icontains マッチ、operator は
+    ``_apply_filters`` で QuerySet に適用する。空クエリは空リストを返す。
+    """
+    parsed = parse_search_query(query)
+    has_filter = bool(
+        parsed.keywords
+        or parsed.tags
+        or parsed.from_handle
+        or parsed.since
+        or parsed.until
+        or parsed.type
+        or parsed.has
+    )
+    if not has_filter:
         return []
 
     capped = max(1, min(limit, MAX_LIMIT))
-    return list(
-        Tweet.objects.select_related("author")
-        .filter(body__icontains=cleaned)
-        .order_by("-created_at", "-id")[:capped]
-    )
+    qs: QuerySet[Tweet] = Tweet.objects.select_related("author")
+    qs = _apply_filters(qs, parsed)
+    if parsed.keywords:
+        qs = qs.filter(body__icontains=parsed.keywords)
+
+    return list(qs.order_by("-created_at", "-id")[:capped])

--- a/apps/search/tests/test_parser.py
+++ b/apps/search/tests/test_parser.py
@@ -1,0 +1,119 @@
+"""Tests for the search query parser (P2-12 / Issue #206)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from apps.search.parser import parse_search_query
+
+
+class TestKeywordOnly:
+    def test_empty_returns_empty_struct(self):
+        p = parse_search_query("")
+        assert p.keywords == ""
+        assert p.tags == []
+        assert p.from_handle is None
+        assert p.type is None
+        assert p.has == []
+
+    def test_plain_keywords_pass_through(self):
+        p = parse_search_query("python rust ruby")
+        assert p.keywords == "python rust ruby"
+
+
+class TestTag:
+    def test_single_tag(self):
+        p = parse_search_query("hello tag:django")
+        assert p.tags == ["django"]
+        assert p.keywords == "hello"
+
+    def test_multiple_tags(self):
+        p = parse_search_query("tag:django tag:python")
+        assert p.tags == ["django", "python"]
+        assert p.keywords == ""
+
+    def test_strips_leading_hash_and_lowercases(self):
+        p = parse_search_query("tag:#Django")
+        assert p.tags == ["django"]
+
+
+class TestFromHandle:
+    def test_handle(self):
+        p = parse_search_query("from:alice")
+        assert p.from_handle == "alice"
+
+    def test_handle_with_at_prefix(self):
+        p = parse_search_query("from:@alice")
+        assert p.from_handle == "alice"
+
+    def test_invalid_handle_dropped(self):
+        p = parse_search_query("from:in valid")
+        assert p.from_handle is None
+        # "valid" は別 token として keyword 行に残る
+        assert "valid" in p.keywords
+
+
+class TestDateRange:
+    def test_since(self):
+        p = parse_search_query("since:2026-01-15")
+        assert p.since == date(2026, 1, 15)
+
+    def test_until(self):
+        p = parse_search_query("until:2026-12-31")
+        assert p.until == date(2026, 12, 31)
+
+    def test_invalid_date_dropped(self):
+        p = parse_search_query("since:2026-13-99")
+        assert p.since is None
+
+    def test_garbage_date_dropped(self):
+        p = parse_search_query("since:yesterday")
+        assert p.since is None
+
+
+class TestType:
+    def test_valid_type(self):
+        for kind in ("original", "reply", "repost", "quote"):
+            p = parse_search_query(f"type:{kind}")
+            assert p.type == kind
+
+    def test_invalid_type_dropped(self):
+        p = parse_search_query("type:foo")
+        assert p.type is None
+
+
+class TestHas:
+    def test_image(self):
+        p = parse_search_query("has:image")
+        assert p.has == ["image"]
+
+    def test_code(self):
+        p = parse_search_query("has:code")
+        assert p.has == ["code"]
+
+    def test_dedup(self):
+        p = parse_search_query("has:image has:image has:code")
+        assert p.has == ["image", "code"]
+
+    def test_invalid_has_dropped(self):
+        p = parse_search_query("has:link")
+        assert p.has == []
+
+
+class TestComposite:
+    def test_full_query(self):
+        p = parse_search_query(
+            "python tag:django from:alice since:2026-01-01 until:2026-12-31 type:reply has:image"
+        )
+        assert p.keywords == "python"
+        assert p.tags == ["django"]
+        assert p.from_handle == "alice"
+        assert p.since == date(2026, 1, 1)
+        assert p.until == date(2026, 12, 31)
+        assert p.type == "reply"
+        assert p.has == ["image"]
+
+    def test_unknown_operator_kept_as_keyword(self):
+        p = parse_search_query("hello unknown:foo world")
+        # unknown:foo は token として keywords に残る
+        assert "unknown:foo" in p.keywords.split()

--- a/apps/search/tests/test_parser.py
+++ b/apps/search/tests/test_parser.py
@@ -47,10 +47,9 @@ class TestFromHandle:
         assert p.from_handle == "alice"
 
     def test_invalid_handle_dropped(self):
-        p = parse_search_query("from:in valid")
+        # ハイフンや記号を含む handle は regex 不適合で drop される
+        p = parse_search_query("from:bad-handle!")
         assert p.from_handle is None
-        # "valid" は別 token として keyword 行に残る
-        assert "valid" in p.keywords
 
 
 class TestDateRange:


### PR DESCRIPTION
Closes #206 (P2-12)

#205 のキーワード検索に SPEC §10 フィルタ演算子を追加。

## 演算子
| 演算子 | 例 | 動作 |
|---|---|---|
| \`tag:<name>\` | \`tag:django tag:python\` | AND |
| \`from:<handle>\` | \`from:@alice\` | 英数+\`_\`、無効値は drop |
| \`since:/until:\` | \`since:2026-01-01\` | created_at 範囲 (until は exclusive) |
| \`type:<kind>\` | \`type:reply\` | original/reply/repost/quote |
| \`has:<kind>\` | \`has:image\`/\`has:code\` | 添付画像 or Markdown フェンス検知 |

不正値は silent drop、未知演算子は keyword として残す。

## 新規
- \`apps/search/parser.py\` — ParsedQuery + parse_search_query
- \`apps/search/tests/test_parser.py\` — 17 件

## 変更
- \`apps/search/services.py\` — \`_apply_filters()\` で QuerySet 拡張、m2m は distinct

## スコープ外
- ユーザー/タグ自体の検索、フレーズ検索 (\`"..."\`) は別 issue 候補

CLAUDE.md §4.1.1 非該当 → CI 緑なら auto-merge。