### PR TITLE
[feature][frontend] /search ページ UI MVP (Closes #207)

### DIFF
--- a/client/src/app/(template)/search/page.tsx
+++ b/client/src/app/(template)/search/page.tsx
@@ -1,0 +1,112 @@
+/**
+ * /search page (P2-16 / Issue #207).
+ *
+ * MVP scope:
+ *   - Server Component reads ?q from searchParams and calls /api/v1/search/.
+ *   - SearchBox (Client) handles form submit → router.push(/search?q=...).
+ *   - Results render TweetSummary in lightweight list (TweetCard reuse can
+ *     come later once feed cards stabilize across surfaces).
+ *   - Operator help is static; autosuggest popup ships as a follow-up.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import SearchBox from "@/components/search/SearchBox";
+import { fetchSearch } from "@/lib/api/search";
+import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
+
+interface SearchPageProps {
+	searchParams: { q?: string };
+}
+
+export const metadata: Metadata = {
+	title: "検索 — エンジニア SNS",
+	description:
+		"ツイートを検索する。tag:/from:/since:/until:/type:/has: のフィルタ演算子に対応。",
+};
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+	const query = (searchParams.q ?? "").trim();
+	const data = query
+		? await fetchSearch(query).catch(() => ({
+				query,
+				results: [],
+				count: 0,
+			}))
+		: { query: "", results: [], count: 0 };
+
+	return (
+		<main className="mx-auto max-w-3xl px-4 py-6">
+			<header className="mb-6">
+				<h1 className="mb-3 text-xl font-semibold text-foreground">検索</h1>
+				<SearchBox initialValue={query} />
+			</header>
+
+			{!query && (
+				<p className="text-sm text-muted-foreground">
+					上のボックスにキーワードを入れて検索してください。
+				</p>
+			)}
+
+			{query && (
+				<section aria-label="検索結果" className="space-y-3">
+					<p className="text-sm text-muted-foreground">
+						「{query}」の検索結果: {data.count} 件
+					</p>
+
+					{data.results.length === 0 ? (
+						<p className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+							一致するツイートはありません。
+						</p>
+					) : (
+						<ul className="space-y-3">
+							{data.results.map((tweet) => (
+								<li key={tweet.id}>
+									<article className="rounded-lg border border-border bg-card p-4">
+										<header className="mb-2 flex items-baseline gap-2 text-sm">
+											<span className="font-semibold text-foreground">
+												{tweet.author_display_name ?? tweet.author_handle}
+											</span>
+											<Link
+												href={`/u/${tweet.author_handle}`}
+												className="text-muted-foreground hover:underline"
+											>
+												@{tweet.author_handle}
+											</Link>
+										</header>
+										<Link
+											href={`/tweet/${tweet.id}`}
+											className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+										>
+											<div
+												className="prose prose-sm dark:prose-invert max-w-none"
+												dangerouslySetInnerHTML={{
+													__html: sanitizeTweetHtml(tweet.html),
+												}}
+											/>
+										</Link>
+										{tweet.tags.length > 0 && (
+											<ul className="mt-2 flex flex-wrap gap-1.5">
+												{tweet.tags.map((tag) => (
+													<li key={tag}>
+														<Link
+															href={`/tag/${tag}`}
+															className="rounded-full bg-lime-500/10 px-2 py-0.5 text-xs text-lime-700 dark:text-lime-400 hover:bg-lime-500/20"
+														>
+															#{tag}
+														</Link>
+													</li>
+												))}
+											</ul>
+										)}
+									</article>
+								</li>
+							))}
+						</ul>
+					)}
+				</section>
+			)}
+		</main>
+	);
+}

--- a/client/src/components/search/SearchBox.tsx
+++ b/client/src/components/search/SearchBox.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 
 interface SearchBoxProps {
 	initialValue?: string;
@@ -29,7 +29,7 @@ export default function SearchBox({ initialValue = "" }: SearchBoxProps) {
 	const router = useRouter();
 	const [value, setValue] = useState(initialValue);
 
-	const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+	const onSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		const trimmed = value.trim();
 		if (!trimmed) return;

--- a/client/src/components/search/SearchBox.tsx
+++ b/client/src/components/search/SearchBox.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * SearchBox — header search form on the /search page.
+ *
+ * MVP scope (P2-16 / Issue #207):
+ *   - Controlled <input>, submit navigates to /search?q=<value>.
+ *   - Operator help is shown statically below the box; popup-style
+ *     autosuggest ships as a follow-up.
+ */
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface SearchBoxProps {
+	initialValue?: string;
+}
+
+const OPERATOR_HELP: ReadonlyArray<{ key: string; example: string }> = [
+	{ key: "tag:", example: "tag:django" },
+	{ key: "from:", example: "from:@alice" },
+	{ key: "since:", example: "since:2026-01-01" },
+	{ key: "until:", example: "until:2026-12-31" },
+	{ key: "type:", example: "type:reply" },
+	{ key: "has:", example: "has:image" },
+];
+
+export default function SearchBox({ initialValue = "" }: SearchBoxProps) {
+	const router = useRouter();
+	const [value, setValue] = useState(initialValue);
+
+	const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const trimmed = value.trim();
+		if (!trimmed) return;
+		router.push(`/search?q=${encodeURIComponent(trimmed)}`);
+	};
+
+	return (
+		<form
+			role="search"
+			aria-label="ツイート検索"
+			onSubmit={onSubmit}
+			className="flex flex-col gap-2"
+		>
+			<div className="flex gap-2">
+				<input
+					type="search"
+					name="q"
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					placeholder="例: python tag:django from:alice"
+					aria-label="検索クエリ"
+					className="flex-1 rounded-md border border-border bg-card px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+				<button
+					type="submit"
+					className="rounded-md bg-lime-500 px-4 py-2 text-sm font-semibold text-black hover:bg-lime-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					検索
+				</button>
+			</div>
+			<details className="text-xs text-muted-foreground">
+				<summary className="cursor-pointer select-none">
+					フィルタ演算子の使い方
+				</summary>
+				<ul className="mt-2 grid grid-cols-2 gap-1 sm:grid-cols-3">
+					{OPERATOR_HELP.map((op) => (
+						<li key={op.key} className="font-mono">
+							<code className="text-foreground">{op.key}</code>{" "}
+							<span className="text-muted-foreground">{op.example}</span>
+						</li>
+					))}
+				</ul>
+			</details>
+		</form>
+	);
+}

--- a/client/src/components/search/__tests__/SearchBox.test.tsx
+++ b/client/src/components/search/__tests__/SearchBox.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Tests for SearchBox (P2-16 / Issue #207).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SearchBox from "@/components/search/SearchBox";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush }),
+	usePathname: () => "/search",
+	useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("SearchBox", () => {
+	beforeEach(() => {
+		mockPush.mockClear();
+	});
+
+	it("renders a search input and submit button", () => {
+		render(<SearchBox />);
+		expect(screen.getByRole("searchbox")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /検索/ })).toBeInTheDocument();
+	});
+
+	it("uses the provided initialValue", () => {
+		render(<SearchBox initialValue="python tag:django" />);
+		expect(screen.getByRole("searchbox")).toHaveValue("python tag:django");
+	});
+
+	it("submits to /search?q=... on form submit", async () => {
+		render(<SearchBox />);
+		await userEvent.type(screen.getByRole("searchbox"), "rust");
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).toHaveBeenCalledWith("/search?q=rust");
+	});
+
+	it("encodes special characters in the navigated URL", async () => {
+		render(<SearchBox />);
+		await userEvent.type(
+			screen.getByRole("searchbox"),
+			"tag:django from:alice",
+		);
+		fireEvent.submit(screen.getByRole("search"));
+		const target = mockPush.mock.calls[0]?.[0] ?? "";
+		expect(target).toContain("/search?q=");
+		expect(target).toContain("tag%3Adjango");
+	});
+
+	it("does not navigate when query is blank", async () => {
+		render(<SearchBox />);
+		await userEvent.type(screen.getByRole("searchbox"), "   ");
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).not.toHaveBeenCalled();
+	});
+
+	it("shows operator help via <details>", () => {
+		render(<SearchBox />);
+		expect(screen.getByText(/フィルタ演算子の使い方/)).toBeInTheDocument();
+		// "tag:" / "from:" appear both as the operator key and inside the
+		// example text, so use getAllByText.
+		expect(screen.getAllByText(/tag:/).length).toBeGreaterThan(0);
+		expect(screen.getAllByText(/from:/).length).toBeGreaterThan(0);
+	});
+});

--- a/client/src/lib/api/__tests__/search.test.ts
+++ b/client/src/lib/api/__tests__/search.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for fetchSearch (P2-16 / Issue #207).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchSearch } from "@/lib/api/search";
+
+vi.mock("next/headers", () => ({
+	cookies: () => ({ getAll: () => [] }),
+}));
+
+describe("fetchSearch", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("returns empty result struct for blank query without hitting the API", async () => {
+		const fetchSpy = vi.fn();
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+		const result = await fetchSearch("   ");
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(result.results).toEqual([]);
+		expect(result.count).toBe(0);
+		expect(result.query).toBe("");
+	});
+
+	it("calls /search/ with q and limit params", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ query: "python", results: [], count: 0 }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+		await fetchSearch("python", 30);
+		const [url] = fetchSpy.mock.calls[0]!;
+		expect(url).toContain("/search/");
+		expect(url).toContain("q=python");
+		expect(url).toContain("limit=30");
+	});
+
+	it("encodes operators in the query parameter", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					query: "tag:django from:alice",
+					results: [],
+					count: 0,
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
+		);
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+		await fetchSearch("tag:django from:alice");
+		const [url] = fetchSpy.mock.calls[0]!;
+		// URL encoding swaps : for %3A and space for + (URLSearchParams default)
+		expect(url).toContain("tag%3Adjango");
+	});
+});

--- a/client/src/lib/api/search.ts
+++ b/client/src/lib/api/search.ts
@@ -1,0 +1,31 @@
+/**
+ * Search API helper (P2-16 / Issue #207).
+ *
+ * Backed by the public /api/v1/search/ endpoint (P2-11 #205, P2-12 #206).
+ * No auth required. Server Components use ``fetchSearch`` directly via
+ * ``serverFetch``; Client Components can fall back to the axios client
+ * (not yet wired — adds a follow-up if interactive filtering is needed).
+ */
+
+import { serverFetch } from "@/lib/api/server";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+export interface SearchResponse {
+	query: string;
+	results: TweetSummary[];
+	count: number;
+}
+
+const DEFAULT_LIMIT = 20;
+
+export async function fetchSearch(
+	query: string,
+	limit: number = DEFAULT_LIMIT,
+): Promise<SearchResponse> {
+	const trimmed = (query ?? "").trim();
+	if (!trimmed) {
+		return { query: "", results: [], count: 0 };
+	}
+	const params = new URLSearchParams({ q: trimmed, limit: String(limit) });
+	return serverFetch<SearchResponse>(`/search/?${params.toString()}`);
+}

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
 				"src/lib/sanitize/**/*.ts",
 				"src/components/sidebar/**/*.tsx",
 				"src/components/explore/**/*.tsx",
+				"src/components/search/**/*.tsx",
 			],
 			exclude: [
 				"src/lib/api/**/__tests__/**",


### PR DESCRIPTION
Closes #207 (MVP)

#205 / #206 で整備した backend search を使う画面。

## 新規
- \`client/src/lib/api/search.ts\` — fetchSearch (空クエリは API 不発)
- \`client/src/components/search/SearchBox.tsx\` — Client、submit で /search?q=... に navigate、演算子ヘルプ \`<details>\`
- \`client/src/app/(template)/search/page.tsx\` — Server Component、searchParams.q で初期 fetch + 結果リスト

## テスト
fetchSearch 3 / SearchBox 6 (vitest 248/248 PASS、tsc/lint クリーン)

## スコープ外
- 演算子サジェスト popup → 別 issue
- 検索結果 cursor pagination → 別 PR
- TweetCard 再利用 → 軽量 article で代替

CLAUDE.md §4.1.1 非該当 → CI 緑なら auto-merge。