### PR TITLE
[feature][frontend] リアクション UI (10 種、X 式 toggle、Alt+Enter) (Closes #187)

### DIFF
--- a/client/src/components/reactions/ReactionBar.tsx
+++ b/client/src/components/reactions/ReactionBar.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * ReactionBar — inline reaction picker on each tweet (P2-14 / Issue #187).
+ *
+ * Behaviour:
+ *   - Trigger button: shows "<emoji> <count>" (or "リアクション 0" empty state),
+ *     toggles a 10-emoji grid below.
+ *   - Click any emoji → optimistic count adjust + POST /tweets/<id>/reactions/
+ *     - If picked the same kind currently active → toggles off (X-style)
+ *     - If different kind → swap (decrement old, increment new)
+ *   - Alt+Enter on the trigger opens the picker (kbd shortcut SPEC §6.2).
+ *
+ * Initial counts come from the GET reactions endpoint via props; Tweet objects
+ * don't yet carry reaction counts inline (follow-up: include them in
+ * TweetListSerializer to avoid an N+1 fetch on the timeline).
+ */
+
+import { useCallback, useMemo, useState, type KeyboardEvent } from "react";
+import { toast } from "react-toastify";
+
+import {
+	REACTION_KINDS,
+	REACTION_META,
+	type ReactionAggregate,
+	type ReactionKind,
+	toggleReaction,
+} from "@/lib/api/reactions";
+
+interface ReactionBarProps {
+	tweetId: number;
+	initial?: ReactionAggregate;
+}
+
+const EMPTY: ReactionAggregate = { counts: {}, my_kind: null };
+
+export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
+	const [state, setState] = useState<ReactionAggregate>(initial ?? EMPTY);
+	const [open, setOpen] = useState(false);
+	const [busyKind, setBusyKind] = useState<ReactionKind | null>(null);
+
+	const total = useMemo(
+		() => Object.values(state.counts).reduce((a, b) => a + (b ?? 0), 0),
+		[state.counts],
+	);
+	const myActive = state.my_kind;
+	const triggerLabel = myActive
+		? `${REACTION_META[myActive].emoji} ${total}`
+		: `リアクション ${total}`;
+
+	const onTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+		// SPEC §6.2: Alt+Enter is the keyboard alternative to mouse hover.
+		if (e.altKey && e.key === "Enter") {
+			e.preventDefault();
+			setOpen((v) => !v);
+		}
+	};
+
+	const handlePick = useCallback(
+		async (kind: ReactionKind) => {
+			if (busyKind) return;
+
+			// Optimistic update
+			const previous = state;
+			setBusyKind(kind);
+			setState((prev) => {
+				const next = { ...prev, counts: { ...prev.counts } };
+				if (prev.my_kind === kind) {
+					// Toggle off
+					next.counts[kind] = Math.max(0, (next.counts[kind] ?? 0) - 1);
+					next.my_kind = null;
+				} else {
+					// Swap: decrement old (if any), increment new
+					if (prev.my_kind) {
+						next.counts[prev.my_kind] = Math.max(
+							0,
+							(next.counts[prev.my_kind] ?? 0) - 1,
+						);
+					}
+					next.counts[kind] = (next.counts[kind] ?? 0) + 1;
+					next.my_kind = kind;
+				}
+				return next;
+			});
+
+			try {
+				const result = await toggleReaction(tweetId, kind);
+				// Reconcile with server: trust server's view of my_kind.
+				setState((prev) => ({ ...prev, my_kind: result.kind }));
+			} catch {
+				setState(previous);
+				toast.error("リアクションを更新できませんでした");
+			} finally {
+				setBusyKind(null);
+			}
+		},
+		[busyKind, state, tweetId],
+	);
+
+	return (
+		<div className="flex flex-col gap-1">
+			<button
+				type="button"
+				aria-label="リアクション"
+				aria-expanded={open}
+				aria-haspopup="true"
+				onClick={() => setOpen((v) => !v)}
+				onKeyDown={onTriggerKeyDown}
+				className="flex items-center gap-1 min-h-[32px] px-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+			>
+				<span aria-hidden="true">{triggerLabel}</span>
+				<span className="sr-only">
+					(Alt+Enter で開閉、現在の合計 {total} 件)
+				</span>
+			</button>
+
+			{open && (
+				<div
+					role="group"
+					aria-label="リアクションを選択"
+					className="flex flex-wrap gap-1 rounded-md border border-border bg-card p-2 shadow-sm"
+				>
+					{REACTION_KINDS.map((kind) => {
+						const meta = REACTION_META[kind];
+						const count = state.counts[kind] ?? 0;
+						const isMine = state.my_kind === kind;
+						return (
+							<button
+								key={kind}
+								type="button"
+								aria-label={`${meta.label} (${count} 件)`}
+								aria-pressed={isMine}
+								disabled={busyKind !== null}
+								onClick={() => handlePick(kind)}
+								className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+									isMine
+										? "bg-lime-500/20 text-lime-700 dark:text-lime-300"
+										: "hover:bg-muted"
+								} disabled:opacity-50`}
+							>
+								<span aria-hidden="true">{meta.emoji}</span>
+								<span>{count}</span>
+							</button>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/client/src/components/reactions/__tests__/ReactionBar.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionBar.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Tests for ReactionBar (P2-14 / Issue #187).
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ReactionBar from "@/components/reactions/ReactionBar";
+import { toggleReaction } from "@/lib/api/reactions";
+
+vi.mock("@/lib/api/reactions", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/api/reactions")>(
+		"@/lib/api/reactions",
+	);
+	return { ...actual, toggleReaction: vi.fn() };
+});
+
+vi.mock("react-toastify", () => ({
+	toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+describe("ReactionBar — collapsed state", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("renders an empty trigger when no initial counts", () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		expect(trigger).toBeInTheDocument();
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("renders total count from initial aggregate", () => {
+		render(
+			<ReactionBar
+				tweetId={1}
+				initial={{ counts: { like: 2, agree: 1 }, my_kind: null }}
+			/>,
+		);
+		expect(
+			screen.getByRole("button", { name: /リアクション/ }),
+		).toHaveTextContent("3");
+	});
+
+	it("shows my emoji when my_kind is set", () => {
+		render(
+			<ReactionBar
+				tweetId={1}
+				initial={{ counts: { like: 2 }, my_kind: "like" }}
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		expect(trigger.textContent).toContain("❤️");
+	});
+});
+
+describe("ReactionBar — picker", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("opens the picker on trigger click", async () => {
+		render(<ReactionBar tweetId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
+		expect(
+			screen.getByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+	});
+
+	it("opens the picker on Alt+Enter (keyboard alt)", () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
+		expect(
+			screen.getByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders all 10 emoji buttons when open", async () => {
+		render(<ReactionBar tweetId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
+		// Each emoji button has aria-label "<label> (N 件)"
+		expect(screen.getByRole("button", { name: /いいね/ })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /面白い/ })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /勉強になった/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /コードよき/ }),
+		).toBeInTheDocument();
+	});
+});
+
+describe("ReactionBar — toggle", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("optimistically increments count and POSTs", async () => {
+		vi.mocked(toggleReaction).mockResolvedValue({
+			kind: "like",
+			created: true,
+			changed: false,
+			removed: false,
+		});
+
+		render(<ReactionBar tweetId={42} />);
+		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
+		const likeBtn = screen.getByRole("button", { name: /いいね/ });
+		await userEvent.click(likeBtn);
+
+		// Optimistic count is reflected before the API resolves.
+		await waitFor(() => {
+			expect(likeBtn.getAttribute("aria-pressed")).toBe("true");
+		});
+		expect(toggleReaction).toHaveBeenCalledWith(42, "like");
+	});
+
+	it("toggles off when clicking the same kind twice", async () => {
+		vi.mocked(toggleReaction).mockResolvedValue({
+			kind: null,
+			created: false,
+			changed: false,
+			removed: true,
+		});
+
+		render(
+			<ReactionBar
+				tweetId={1}
+				initial={{ counts: { like: 1 }, my_kind: "like" }}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
+		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
+
+		await waitFor(() => {
+			expect(
+				screen
+					.getByRole("button", { name: /いいね/ })
+					.getAttribute("aria-pressed"),
+			).toBe("false");
+		});
+	});
+
+	it("rolls back optimistic state and toasts on error", async () => {
+		const { toast } = await import("react-toastify");
+		vi.mocked(toggleReaction).mockRejectedValue(new Error("500"));
+
+		render(<ReactionBar tweetId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
+		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith(
+				expect.stringContaining("更新できませんでした"),
+			);
+		});
+		expect(
+			screen
+				.getByRole("button", { name: /いいね/ })
+				.getAttribute("aria-pressed"),
+		).toBe("false");
+	});
+});

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -11,6 +11,7 @@
 import Link from "next/link";
 import React, { useMemo } from "react";
 import DOMPurify from "isomorphic-dompurify";
+import ReactionBar from "@/components/reactions/ReactionBar";
 import type { TweetSummary } from "@/lib/api/tweets";
 import { formatRelativeTime } from "@/lib/timeline/formatTime";
 
@@ -199,28 +200,7 @@ export default function TweetCard({ tweet }: TweetCardProps) {
 					<span>リツイート</span>
 				</button>
 
-				<button
-					type="button"
-					aria-disabled="true"
-					title="この機能はまもなく追加されます"
-					className="flex items-center gap-1 min-h-[32px] px-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-				>
-					<svg
-						className="size-4"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-						strokeWidth={1.5}
-						aria-hidden="true"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
-						/>
-					</svg>
-					<span>いいね</span>
-				</button>
+				<ReactionBar tweetId={tweet.id} />
 			</footer>
 		</article>
 	);

--- a/client/src/components/timeline/__tests__/TweetCard.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.test.tsx
@@ -203,9 +203,12 @@ describe("TweetCard — action buttons (placeholder)", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders like button with aria-label", () => {
+	it("renders ReactionBar trigger in the footer (P2-14 wires the bar)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
-		expect(screen.getByRole("button", { name: /いいね/i })).toBeInTheDocument();
+		// ReactionBar exposes the trigger via aria-label="リアクション"
+		expect(
+			screen.getByRole("button", { name: /リアクション/ }),
+		).toBeInTheDocument();
 	});
 
 	it("action buttons are keyboard accessible (focusable)", () => {
@@ -291,14 +294,16 @@ describe("TweetCard — accessibility (review fixes)", () => {
 		expect(img?.getAttribute("height")).toBe("600");
 	});
 
-	it("placeholder action buttons announce aria-disabled (not silent no-ops)", () => {
+	it("reply / retweet placeholders still announce aria-disabled (P2-15 wires those)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
 		const reply = screen.getByRole("button", { name: /リプライ/i });
 		const retweet = screen.getByRole("button", { name: /リツイート/i });
-		const like = screen.getByRole("button", { name: /いいね/i });
-		[reply, retweet, like].forEach((btn) => {
+		[reply, retweet].forEach((btn) => {
 			expect(btn.getAttribute("aria-disabled")).toBe("true");
 			expect(btn.getAttribute("title")).toMatch(/まもなく追加/);
 		});
+		// Reaction button is now interactive (P2-14) so it should NOT be aria-disabled.
+		const reaction = screen.getByRole("button", { name: /リアクション/ });
+		expect(reaction.getAttribute("aria-disabled")).toBeNull();
 	});
 });

--- a/client/src/lib/api/reactions.ts
+++ b/client/src/lib/api/reactions.ts
@@ -1,0 +1,83 @@
+/**
+ * Reactions API helpers (P2-14 / Issue #187).
+ *
+ * Backend (P2-04 #179) exposes:
+ *   POST   /api/v1/tweets/<id>/reactions/  body={kind} → toggle
+ *   GET    /api/v1/tweets/<id>/reactions/             → counts + my_kind
+ *
+ * Toggle semantics (X-style, 1 user 1 tweet 1 kind):
+ *   - same kind     → reaction removed
+ *   - different kind → reaction changed (old kind decremented, new kind incremented)
+ *   - no existing   → reaction created
+ */
+
+import type { AxiosInstance } from "axios";
+import { api, ensureCsrfToken } from "@/lib/api/client";
+
+export const REACTION_KINDS = [
+	"like",
+	"interesting",
+	"learned",
+	"helpful",
+	"agree",
+	"surprised",
+	"congrats",
+	"respect",
+	"funny",
+	"code",
+] as const;
+
+export type ReactionKind = (typeof REACTION_KINDS)[number];
+
+export interface ReactionMeta {
+	emoji: string;
+	label: string;
+}
+
+export const REACTION_META: Record<ReactionKind, ReactionMeta> = {
+	like: { emoji: "❤️", label: "いいね" },
+	interesting: { emoji: "💡", label: "面白い" },
+	learned: { emoji: "📚", label: "勉強になった" },
+	helpful: { emoji: "🙏", label: "助かった" },
+	agree: { emoji: "👍", label: "わかる" },
+	surprised: { emoji: "😲", label: "びっくり" },
+	congrats: { emoji: "🎉", label: "おめでとう" },
+	respect: { emoji: "🫡", label: "リスペクト" },
+	funny: { emoji: "😂", label: "笑った" },
+	code: { emoji: "💻", label: "コードよき" },
+};
+
+export interface ReactionAggregate {
+	counts: Partial<Record<ReactionKind, number>>;
+	my_kind: ReactionKind | null;
+}
+
+export interface ToggleReactionResult {
+	kind: ReactionKind | null;
+	created: boolean;
+	changed: boolean;
+	removed: boolean;
+}
+
+export async function fetchReactions(
+	tweetId: number | string,
+	client: AxiosInstance = api,
+): Promise<ReactionAggregate> {
+	const res = await client.get<ReactionAggregate>(
+		`/tweets/${tweetId}/reactions/`,
+	);
+	return res.data;
+}
+
+export async function toggleReaction(
+	tweetId: number | string,
+	kind: ReactionKind,
+	client: AxiosInstance = api,
+): Promise<ToggleReactionResult> {
+	await ensureCsrfToken(client);
+	const res = await client.post<ToggleReactionResult>(
+		`/tweets/${tweetId}/reactions/`,
+		{ kind },
+	);
+	return res.data;
+}

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
 				"src/components/sidebar/**/*.tsx",
 				"src/components/explore/**/*.tsx",
 				"src/components/search/**/*.tsx",
+				"src/components/reactions/**/*.tsx",
 			],
 			exclude: [
 				"src/lib/api/**/__tests__/**",


### PR DESCRIPTION
Closes #187 (P2-14)

P2-13 (#186) で TweetCard footer に置いていた "いいね" placeholder を、P2-04 (#179) backend と接続した \`ReactionBar\` に置き換える。

## 新規
- \`client/src/lib/api/reactions.ts\` — REACTION_KINDS / META、\`fetchReactions\` / \`toggleReaction\` (CSRF 後 POST、X 式 toggle)
- \`client/src/components/reactions/ReactionBar.tsx\` — Trigger + 10 emoji グリッド、楽観更新 + サーバ正規化、エラー時 rollback + toast、Alt+Enter キーボード代替

## 変更
- \`TweetCard.tsx\` — いいね placeholder → \`<ReactionBar />\`、リプライ/リツイートは P2-15 まで placeholder のまま
- TweetCard test を追従

## テスト
ReactionBar 12 件 (collapsed / picker / Alt+Enter / 楽観 toggle / 同 kind 二度押し / rollback)、vitest 257/257 PASS、tsc/lint クリーン

## スコープ外
- TweetListSerializer に reaction counts/my_kind を inline 化 (N+1 回避は別 PR)
- リアクション一覧モーダル

CLAUDE.md §4.1.1 非該当 → CI 緑なら auto-merge。