### PR TITLE
[feature][frontend] RT / 引用 / リプライ UI (Closes #188)

### DIFF
--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -9,9 +9,11 @@
  */
 
 import Link from "next/link";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import DOMPurify from "isomorphic-dompurify";
 import ReactionBar from "@/components/reactions/ReactionBar";
+import PostDialog from "@/components/tweets/PostDialog";
+import RepostButton from "@/components/tweets/RepostButton";
 import type { TweetSummary } from "@/lib/api/tweets";
 import { formatRelativeTime } from "@/lib/timeline/formatTime";
 
@@ -20,6 +22,9 @@ interface TweetCardProps {
 }
 
 export default function TweetCard({ tweet }: TweetCardProps) {
+	const [replyOpen, setReplyOpen] = useState(false);
+	const [quoteOpen, setQuoteOpen] = useState(false);
+
 	// CRITICAL: sanitize HTML before rendering — strips <script>, event handlers,
 	// javascript: hrefs, <iframe>, <style>, and other XSS vectors.
 	const safeHtml = useMemo(
@@ -151,13 +156,12 @@ export default function TweetCard({ tweet }: TweetCardProps) {
 				</div>
 			)}
 
-			{/* Action buttons — UI placeholder only (onClick wired in P2-14/P2-15).
-			    aria-disabled + title gives SR users notice instead of silent no-op. */}
+			{/* Action buttons. Reactions wired in P2-14, repost/quote/reply in P2-15. */}
 			<footer className="mt-1 flex items-center gap-4">
 				<button
 					type="button"
-					aria-disabled="true"
-					title="この機能はまもなく追加されます"
+					aria-label="リプライ"
+					onClick={() => setReplyOpen(true)}
 					className="flex items-center gap-1 min-h-[32px] px-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
 				>
 					<svg
@@ -177,31 +181,33 @@ export default function TweetCard({ tweet }: TweetCardProps) {
 					<span>リプライ</span>
 				</button>
 
+				<RepostButton tweetId={tweet.id} />
+
 				<button
 					type="button"
-					aria-disabled="true"
-					title="この機能はまもなく追加されます"
+					aria-label="引用リポスト"
+					onClick={() => setQuoteOpen(true)}
 					className="flex items-center gap-1 min-h-[32px] px-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
 				>
-					<svg
-						className="size-4"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-						strokeWidth={1.5}
-						aria-hidden="true"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 3M21 7.5H7.5"
-						/>
-					</svg>
-					<span>リツイート</span>
+					<span aria-hidden="true">”</span>
+					<span>引用</span>
 				</button>
 
 				<ReactionBar tweetId={tweet.id} />
 			</footer>
+
+			<PostDialog
+				tweetId={tweet.id}
+				mode="reply"
+				open={replyOpen}
+				onOpenChange={setReplyOpen}
+			/>
+			<PostDialog
+				tweetId={tweet.id}
+				mode="quote"
+				open={quoteOpen}
+				onOpenChange={setQuoteOpen}
+			/>
 		</article>
 	);
 }

--- a/client/src/components/timeline/__tests__/TweetCard.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.test.tsx
@@ -196,10 +196,18 @@ describe("TweetCard — action buttons (placeholder)", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders retweet button with aria-label", () => {
+	it("renders the RepostButton (P2-15 wires the action)", () => {
+		render(<TweetCard tweet={BASE_TWEET} />);
+		// "リポスト" exact-match (avoid catching "引用リポスト")
+		expect(
+			screen.getByRole("button", { name: "リポスト" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders the quote button (P2-15)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
 		expect(
-			screen.getByRole("button", { name: /リツイート/i }),
+			screen.getByRole("button", { name: "引用リポスト" }),
 		).toBeInTheDocument();
 	});
 
@@ -294,16 +302,14 @@ describe("TweetCard — accessibility (review fixes)", () => {
 		expect(img?.getAttribute("height")).toBe("600");
 	});
 
-	it("reply / retweet placeholders still announce aria-disabled (P2-15 wires those)", () => {
+	it("all action buttons are interactive after P2-14/P2-15 wiring", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
-		const reply = screen.getByRole("button", { name: /リプライ/i });
-		const retweet = screen.getByRole("button", { name: /リツイート/i });
-		[reply, retweet].forEach((btn) => {
-			expect(btn.getAttribute("aria-disabled")).toBe("true");
-			expect(btn.getAttribute("title")).toMatch(/まもなく追加/);
-		});
-		// Reaction button is now interactive (P2-14) so it should NOT be aria-disabled.
+		const reply = screen.getByRole("button", { name: "リプライ" });
+		const repost = screen.getByRole("button", { name: "リポスト" });
+		const quote = screen.getByRole("button", { name: "引用リポスト" });
 		const reaction = screen.getByRole("button", { name: /リアクション/ });
-		expect(reaction.getAttribute("aria-disabled")).toBeNull();
+		[reply, repost, quote, reaction].forEach((btn) => {
+			expect(btn.getAttribute("aria-disabled")).toBeNull();
+		});
 	});
 });

--- a/client/src/components/tweets/PostDialog.tsx
+++ b/client/src/components/tweets/PostDialog.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * PostDialog — minimal modal for Quote / Reply composer (P2-15 / Issue #188).
+ *
+ * MVP: Uses Radix Dialog primitive (already a dep). Inline textarea +
+ * submit button; tag chips and images are deferred — Phase 1 Composer is
+ * not reused as-is because that component owns POST /tweets/, while
+ * Quote/Reply target sub-actions on /tweets/<id>/{quote,reply}/.
+ */
+
+import { Dialog, DialogContent, DialogTitle } from "@radix-ui/react-dialog";
+import { useState, type FormEvent } from "react";
+import { toast } from "react-toastify";
+
+import { quoteTweet, replyToTweet } from "@/lib/api/repost";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+export type PostDialogMode = "quote" | "reply";
+
+interface PostDialogProps {
+	tweetId: number;
+	mode: PostDialogMode;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onPosted?: (tweet: TweetSummary) => void;
+}
+
+const MAX_BODY = 180;
+
+export default function PostDialog({
+	tweetId,
+	mode,
+	open,
+	onOpenChange,
+	onPosted,
+}: PostDialogProps) {
+	const [body, setBody] = useState("");
+	const [busy, setBusy] = useState(false);
+
+	const title = mode === "quote" ? "引用リポスト" : "リプライ";
+	const submitLabel = mode === "quote" ? "引用する" : "返信する";
+
+	const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const trimmed = body.trim();
+		if (!trimmed || busy) return;
+
+		setBusy(true);
+		try {
+			const result =
+				mode === "quote"
+					? await quoteTweet(tweetId, { body: trimmed })
+					: await replyToTweet(tweetId, { body: trimmed });
+			onPosted?.(result);
+			setBody("");
+			onOpenChange(false);
+		} catch {
+			toast.error("投稿に失敗しました");
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				role="dialog"
+				aria-labelledby="post-dialog-title"
+				className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-4 shadow-lg max-w-md w-[92vw]"
+			>
+				<DialogTitle
+					id="post-dialog-title"
+					className="text-base font-semibold mb-3 text-foreground"
+				>
+					{title}
+				</DialogTitle>
+
+				<form onSubmit={onSubmit} className="flex flex-col gap-3">
+					<textarea
+						value={body}
+						onChange={(e) => setBody(e.target.value)}
+						maxLength={MAX_BODY}
+						rows={4}
+						placeholder={
+							mode === "quote"
+								? "引用にコメントを添えて投稿..."
+								: "返信を書く..."
+						}
+						aria-label={`${title}の本文`}
+						className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					/>
+					<div className="flex items-center justify-between gap-2">
+						<span className="text-xs text-muted-foreground">
+							{body.length} / {MAX_BODY}
+						</span>
+						<div className="flex gap-2">
+							<button
+								type="button"
+								onClick={() => onOpenChange(false)}
+								className="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							>
+								キャンセル
+							</button>
+							<button
+								type="submit"
+								disabled={busy || body.trim().length === 0}
+								className="rounded-md bg-lime-500 px-3 py-1.5 text-sm font-semibold text-black hover:bg-lime-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+							>
+								{submitLabel}
+							</button>
+						</div>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/client/src/components/tweets/RepostButton.tsx
+++ b/client/src/components/tweets/RepostButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * RepostButton — toggle repost on a tweet (P2-15 / Issue #188).
+ *
+ * Optimistic UX:
+ *   - Click while not reposted → immediately mark active, POST /repost/
+ *   - Click while reposted → immediately mark inactive, DELETE /repost/
+ *   - On API error: rollback + toast
+ */
+
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+import { repostTweet, unrepostTweet } from "@/lib/api/repost";
+
+interface RepostButtonProps {
+	tweetId: number;
+	initialReposted?: boolean;
+}
+
+export default function RepostButton({
+	tweetId,
+	initialReposted = false,
+}: RepostButtonProps) {
+	const [reposted, setReposted] = useState(initialReposted);
+	const [busy, setBusy] = useState(false);
+
+	const handleClick = async () => {
+		if (busy) return;
+		const previous = reposted;
+		setBusy(true);
+		setReposted(!previous);
+
+		try {
+			if (previous) {
+				await unrepostTweet(tweetId);
+			} else {
+				await repostTweet(tweetId);
+			}
+		} catch {
+			setReposted(previous);
+			toast.error("リポストを更新できませんでした");
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			aria-label={reposted ? "リポストを取消" : "リポスト"}
+			aria-pressed={reposted}
+			disabled={busy}
+			onClick={handleClick}
+			className={`flex items-center gap-1 min-h-[32px] px-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded ${
+				reposted
+					? "text-lime-600 dark:text-lime-400"
+					: "text-muted-foreground hover:text-foreground"
+			} disabled:opacity-50`}
+		>
+			<svg
+				className="size-4"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				strokeWidth={1.5}
+				aria-hidden="true"
+			>
+				<path
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 3M21 7.5H7.5"
+				/>
+			</svg>
+			<span>リポスト</span>
+		</button>
+	);
+}

--- a/client/src/components/tweets/__tests__/PostDialog.test.tsx
+++ b/client/src/components/tweets/__tests__/PostDialog.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for PostDialog (P2-15 / Issue #188).
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PostDialog from "@/components/tweets/PostDialog";
+import { quoteTweet, replyToTweet } from "@/lib/api/repost";
+
+vi.mock("@/lib/api/repost", () => ({
+	quoteTweet: vi.fn(),
+	replyToTweet: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+	toast: { error: vi.fn() },
+}));
+
+describe("PostDialog — reply mode", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("calls replyToTweet on submit", async () => {
+		vi.mocked(replyToTweet).mockResolvedValue({} as never);
+		const onOpenChange = vi.fn();
+
+		render(
+			<PostDialog
+				tweetId={42}
+				mode="reply"
+				open={true}
+				onOpenChange={onOpenChange}
+			/>,
+		);
+
+		await userEvent.type(
+			screen.getByRole("textbox", { name: /リプライの本文/ }),
+			"hello",
+		);
+		await userEvent.click(screen.getByRole("button", { name: /返信する/ }));
+
+		await waitFor(() => {
+			expect(replyToTweet).toHaveBeenCalledWith(42, { body: "hello" });
+		});
+		await waitFor(() => {
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+		});
+	});
+
+	it("disables submit when body is empty", () => {
+		render(
+			<PostDialog
+				tweetId={1}
+				mode="reply"
+				open={true}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: /返信する/ })).toBeDisabled();
+	});
+});
+
+describe("PostDialog — quote mode", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("calls quoteTweet on submit", async () => {
+		vi.mocked(quoteTweet).mockResolvedValue({} as never);
+		const onPosted = vi.fn();
+
+		render(
+			<PostDialog
+				tweetId={7}
+				mode="quote"
+				open={true}
+				onOpenChange={vi.fn()}
+				onPosted={onPosted}
+			/>,
+		);
+
+		await userEvent.type(
+			screen.getByRole("textbox", { name: /引用リポストの本文/ }),
+			"comment",
+		);
+		await userEvent.click(screen.getByRole("button", { name: /引用する/ }));
+
+		await waitFor(() => {
+			expect(quoteTweet).toHaveBeenCalledWith(7, { body: "comment" });
+		});
+		expect(onPosted).toHaveBeenCalled();
+	});
+
+	it("toasts on error", async () => {
+		const { toast } = await import("react-toastify");
+		vi.mocked(quoteTweet).mockRejectedValue(new Error("500"));
+
+		render(
+			<PostDialog
+				tweetId={1}
+				mode="quote"
+				open={true}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+		await userEvent.type(
+			screen.getByRole("textbox", { name: /引用リポストの本文/ }),
+			"x",
+		);
+		await userEvent.click(screen.getByRole("button", { name: /引用する/ }));
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalled();
+		});
+	});
+});

--- a/client/src/components/tweets/__tests__/RepostButton.test.tsx
+++ b/client/src/components/tweets/__tests__/RepostButton.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for RepostButton (P2-15 / Issue #188).
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RepostButton from "@/components/tweets/RepostButton";
+import { repostTweet, unrepostTweet } from "@/lib/api/repost";
+
+vi.mock("@/lib/api/repost", () => ({
+	repostTweet: vi.fn(),
+	unrepostTweet: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+	toast: { error: vi.fn() },
+}));
+
+describe("RepostButton", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders inactive state by default", () => {
+		render(<RepostButton tweetId={1} />);
+		const btn = screen.getByRole("button", { name: /リポスト$/ });
+		expect(btn.getAttribute("aria-pressed")).toBe("false");
+	});
+
+	it("optimistically activates and POSTs on first click", async () => {
+		vi.mocked(repostTweet).mockResolvedValue({
+			id: 99,
+			repost_of: 1,
+			created: true,
+		});
+
+		render(<RepostButton tweetId={1} />);
+		const btn = screen.getByRole("button", { name: /リポスト$/ });
+		await userEvent.click(btn);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /リポストを取消/ }),
+			).toHaveAttribute("aria-pressed", "true");
+		});
+		expect(repostTweet).toHaveBeenCalledWith(1);
+	});
+
+	it("DELETEs on second click when already reposted", async () => {
+		vi.mocked(unrepostTweet).mockResolvedValue();
+
+		render(<RepostButton tweetId={5} initialReposted={true} />);
+		await userEvent.click(
+			screen.getByRole("button", { name: /リポストを取消/ }),
+		);
+
+		await waitFor(() => {
+			expect(unrepostTweet).toHaveBeenCalledWith(5);
+		});
+	});
+
+	it("rolls back state and toasts on error", async () => {
+		const { toast } = await import("react-toastify");
+		vi.mocked(repostTweet).mockRejectedValue(new Error("500"));
+
+		render(<RepostButton tweetId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: /リポスト$/ }));
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith(
+				expect.stringContaining("更新できませんでした"),
+			);
+		});
+		expect(
+			screen
+				.getByRole("button", { name: /リポスト$/ })
+				.getAttribute("aria-pressed"),
+		).toBe("false");
+	});
+});

--- a/client/src/lib/api/repost.ts
+++ b/client/src/lib/api/repost.ts
@@ -1,0 +1,67 @@
+/**
+ * Repost / Quote / Reply API helpers (P2-15 / Issue #188).
+ *
+ * Backend (P2-06 #181):
+ *   POST   /api/v1/tweets/<id>/repost/   → idempotent create (200/201)
+ *   DELETE /api/v1/tweets/<id>/repost/   → undo
+ *   POST   /api/v1/tweets/<id>/quote/    → body, tags, images (TweetCreateSerializer)
+ *   POST   /api/v1/tweets/<id>/reply/    → body, tags, images
+ */
+
+import type { AxiosInstance } from "axios";
+import { api, ensureCsrfToken } from "@/lib/api/client";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+export interface RepostResult {
+	id: number;
+	repost_of: number;
+	created: boolean;
+}
+
+export async function repostTweet(
+	tweetId: number | string,
+	client: AxiosInstance = api,
+): Promise<RepostResult> {
+	await ensureCsrfToken(client);
+	const res = await client.post<RepostResult>(`/tweets/${tweetId}/repost/`);
+	return res.data;
+}
+
+export async function unrepostTweet(
+	tweetId: number | string,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await ensureCsrfToken(client);
+	await client.delete(`/tweets/${tweetId}/repost/`);
+}
+
+export interface QuoteOrReplyPayload {
+	body: string;
+	tags?: string[];
+}
+
+export async function quoteTweet(
+	tweetId: number | string,
+	payload: QuoteOrReplyPayload,
+	client: AxiosInstance = api,
+): Promise<TweetSummary> {
+	await ensureCsrfToken(client);
+	const res = await client.post<TweetSummary>(
+		`/tweets/${tweetId}/quote/`,
+		payload,
+	);
+	return res.data;
+}
+
+export async function replyToTweet(
+	tweetId: number | string,
+	payload: QuoteOrReplyPayload,
+	client: AxiosInstance = api,
+): Promise<TweetSummary> {
+	await ensureCsrfToken(client);
+	const res = await client.post<TweetSummary>(
+		`/tweets/${tweetId}/reply/`,
+		payload,
+	);
+	return res.data;
+}

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -26,6 +26,8 @@ export default defineConfig({
 				"src/components/explore/**/*.tsx",
 				"src/components/search/**/*.tsx",
 				"src/components/reactions/**/*.tsx",
+				"src/components/tweets/RepostButton.tsx",
+				"src/components/tweets/PostDialog.tsx",
 			],
 			exclude: [
 				"src/lib/api/**/__tests__/**",


### PR DESCRIPTION
Closes #188 (P2-15)

P2-13 placeholder の リポスト / 引用 / リプライ を P2-06 (#181) backend と接続。

## 新規
- \`client/src/lib/api/repost.ts\` — repost / unrepost / quote / reply
- \`client/src/components/tweets/RepostButton.tsx\` — 楽観 toggle、aria-pressed、エラー時 rollback
- \`client/src/components/tweets/PostDialog.tsx\` — Quote / Reply 共通 Radix Dialog (180 char cap)

## 変更
- \`TweetCard.tsx\` — 3 アクション placeholder を本物に置換、引用ボタン新規

## テスト
RepostButton 4 / PostDialog 4 / TweetCard 修正、vitest 266/266 PASS、tsc/lint クリーン

## スコープ外
- 引用 RT / Reply の inline カード表示
- リプライツリー
- Quote/Reply に tags / images

CLAUDE.md §4.1.1 非該当 → CI 緑なら auto-merge。