### PR TITLE
[feature][frontend] ツイート本文 もっと見る 展開 (Closes #190)

### DIFF
--- a/client/src/components/timeline/ExpandableBody.tsx
+++ b/client/src/components/timeline/ExpandableBody.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * ExpandableBody — collapse-aware tweet body container (P2-18 / Issue #190).
+ *
+ * Long tweet bodies (char_count > THRESHOLD) are clipped with a
+ * max-height + gradient mask; clicking "もっと見る" reveals the full HTML.
+ * Short tweets render unchanged so we don't pay state cost or layout shift.
+ *
+ * The ``html`` is *already DOMPurify-sanitized* by the caller (TweetCard
+ * uses isomorphic-dompurify before passing it in). This component only owns
+ * collapsed/expanded presentation, never sanitization.
+ */
+
+import { useState } from "react";
+
+interface ExpandableBodyProps {
+	html: string;
+	charCount: number;
+	className?: string;
+}
+
+const TRUNCATE_THRESHOLD = 200;
+const COLLAPSED_MAX_HEIGHT = "12rem";
+
+export default function ExpandableBody({
+	html,
+	charCount,
+	className,
+}: ExpandableBodyProps) {
+	const isLong = charCount > TRUNCATE_THRESHOLD;
+	const [expanded, setExpanded] = useState(false);
+
+	if (!isLong) {
+		return (
+			<div className={className} dangerouslySetInnerHTML={{ __html: html }} />
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-1">
+			<div
+				data-testid="expandable-body"
+				aria-expanded={expanded}
+				style={
+					expanded
+						? undefined
+						: {
+								maxHeight: COLLAPSED_MAX_HEIGHT,
+								WebkitMaskImage:
+									"linear-gradient(to bottom, black 75%, transparent 100%)",
+								maskImage:
+									"linear-gradient(to bottom, black 75%, transparent 100%)",
+							}
+				}
+				className={`${className ?? ""} ${expanded ? "" : "overflow-hidden"}`}
+				dangerouslySetInnerHTML={{ __html: html }}
+			/>
+			<button
+				type="button"
+				onClick={() => setExpanded((v) => !v)}
+				className="self-start text-xs font-semibold text-lime-600 dark:text-lime-400 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+			>
+				{expanded ? "閉じる" : "もっと見る"}
+			</button>
+		</div>
+	);
+}

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import React, { useMemo, useState } from "react";
 import DOMPurify from "isomorphic-dompurify";
 import ReactionBar from "@/components/reactions/ReactionBar";
+import ExpandableBody from "@/components/timeline/ExpandableBody";
 import PostDialog from "@/components/tweets/PostDialog";
 import RepostButton from "@/components/tweets/RepostButton";
 import type { TweetSummary } from "@/lib/api/tweets";
@@ -113,10 +114,11 @@ export default function TweetCard({ tweet }: TweetCardProps) {
 				</div>
 			</header>
 
-			{/* Tweet body — DOMPurify sanitized HTML */}
-			<div
+			{/* Tweet body — DOMPurify sanitized HTML, P2-18 expandable. */}
+			<ExpandableBody
+				html={safeHtml}
+				charCount={tweet.char_count}
 				className="prose prose-sm dark:prose-invert max-w-none text-sm text-foreground"
-				dangerouslySetInnerHTML={{ __html: safeHtml }}
 			/>
 
 			{/* Images grid (up to 4 images) */}

--- a/client/src/components/timeline/__tests__/ExpandableBody.test.tsx
+++ b/client/src/components/timeline/__tests__/ExpandableBody.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for ExpandableBody (P2-18 / Issue #190).
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import ExpandableBody from "@/components/timeline/ExpandableBody";
+
+describe("ExpandableBody — short body", () => {
+	it("renders the html directly without a 'もっと見る' button when char_count is small", () => {
+		render(<ExpandableBody html="<p>short</p>" charCount={50} />);
+		expect(screen.queryByRole("button", { name: /もっと見る/ })).toBeNull();
+		expect(screen.getByText("short")).toBeInTheDocument();
+	});
+
+	it("does not render aria-expanded for short bodies", () => {
+		render(<ExpandableBody html="<p>short</p>" charCount={50} />);
+		expect(document.querySelector("[aria-expanded]")).toBeNull();
+	});
+});
+
+describe("ExpandableBody — long body", () => {
+	const longHtml = "<p>" + "a".repeat(400) + "</p>";
+
+	it("shows the 'もっと見る' button when char_count > threshold", () => {
+		render(<ExpandableBody html={longHtml} charCount={400} />);
+		expect(
+			screen.getByRole("button", { name: /もっと見る/ }),
+		).toBeInTheDocument();
+	});
+
+	it("starts collapsed (aria-expanded='false')", () => {
+		render(<ExpandableBody html={longHtml} charCount={400} />);
+		const body = screen.getByTestId("expandable-body");
+		expect(body.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("toggles to expanded when 'もっと見る' is clicked", async () => {
+		render(<ExpandableBody html={longHtml} charCount={400} />);
+		await userEvent.click(screen.getByRole("button", { name: /もっと見る/ }));
+		const body = screen.getByTestId("expandable-body");
+		expect(body.getAttribute("aria-expanded")).toBe("true");
+		expect(screen.getByRole("button", { name: /閉じる/ })).toBeInTheDocument();
+	});
+
+	it("collapses again when '閉じる' is clicked", async () => {
+		render(<ExpandableBody html={longHtml} charCount={400} />);
+		await userEvent.click(screen.getByRole("button", { name: /もっと見る/ }));
+		await userEvent.click(screen.getByRole("button", { name: /閉じる/ }));
+		expect(
+			screen.getByTestId("expandable-body").getAttribute("aria-expanded"),
+		).toBe("false");
+	});
+
+	it("applies max-height inline style when collapsed", () => {
+		render(<ExpandableBody html={longHtml} charCount={400} />);
+		const body = screen.getByTestId("expandable-body");
+		expect(body.style.maxHeight).toBeTruthy();
+	});
+
+	it("removes the max-height when expanded", async () => {
+		render(<ExpandableBody html={longHtml} charCount={400} />);
+		await userEvent.click(screen.getByRole("button", { name: /もっと見る/ }));
+		const body = screen.getByTestId("expandable-body");
+		expect(body.style.maxHeight).toBe("");
+	});
+});


### PR DESCRIPTION
Closes #190 (P2-18)

長文ツイートを X 準拠で collapse/expand。\`char_count > 200\` で max-height + gradient mask、「もっと見る」で全文展開。

## 新規
- \`client/src/components/timeline/ExpandableBody.tsx\` — short bypass / aria-expanded / inline maxHeight + mask

## 変更
- \`TweetCard.tsx\` — body 描画を \`<ExpandableBody>\` でラップ

## テスト
ExpandableBody 8 件、vitest 274/274 PASS、tsc/lint クリーン

## スコープ外
- 行数 (line-clamp) ベース判定
- コードブロック / 画像個別 collapse

CLAUDE.md §4.1.1 非該当 → CI 緑なら auto-merge。