### PR TITLE
[fix][a11y] role="feed" / aria-posinset / aria-setsize 準拠 (Closes #201)

### DIFF
--- a/client/src/components/timeline/HomeFeed.tsx
+++ b/client/src/components/timeline/HomeFeed.tsx
@@ -127,13 +127,16 @@ export default function HomeFeed({ initialTab, initialTweets }: HomeFeedProps) {
 						<p className="text-sm">ツイートがありません</p>
 					</div>
 				) : (
-					<ul role="list" aria-label="ツイート一覧">
-						{tweets.map((tweet) => (
-							<li key={tweet.id}>
-								<TweetCard tweet={tweet} />
-							</li>
+					<div role="feed" aria-label="タイムライン" aria-busy={isLoading}>
+						{tweets.map((tweet, idx) => (
+							<TweetCard
+								key={tweet.id}
+								tweet={tweet}
+								posinset={idx + 1}
+								setsize={tweets.length}
+							/>
 						))}
-					</ul>
+					</div>
 				)}
 
 				{/* Load more */}

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -20,9 +20,17 @@ import { formatRelativeTime } from "@/lib/timeline/formatTime";
 
 interface TweetCardProps {
 	tweet: TweetSummary;
+	/** 1-based position when rendered inside a `role="feed"` container (#201). */
+	posinset?: number;
+	/** Total feed size; pair with ``posinset`` to satisfy WAI-ARIA feed pattern. */
+	setsize?: number;
 }
 
-export default function TweetCard({ tweet }: TweetCardProps) {
+export default function TweetCard({
+	tweet,
+	posinset,
+	setsize,
+}: TweetCardProps) {
 	const [replyOpen, setReplyOpen] = useState(false);
 	const [quoteOpen, setQuoteOpen] = useState(false);
 
@@ -66,6 +74,8 @@ export default function TweetCard({ tweet }: TweetCardProps) {
 			// (WCAG 2.2 SC 2.4.11 Focus Not Obscured). Tab bar height is 3rem.
 			className="flex flex-col gap-3 border-b border-border px-4 py-3 scroll-mt-12 hover:bg-muted/40 transition-colors"
 			aria-label={`${authorName} のツイート`}
+			aria-posinset={posinset}
+			aria-setsize={setsize}
 		>
 			{/* Author row */}
 			<header className="flex items-center gap-3">

--- a/client/src/components/timeline/__tests__/HomeFeed.test.tsx
+++ b/client/src/components/timeline/__tests__/HomeFeed.test.tsx
@@ -301,6 +301,26 @@ describe("HomeFeed — review fixes", () => {
 		});
 	});
 
+	it("renders the tweet list inside a role='feed' container with aria-busy / aria-label (#201)", () => {
+		render(
+			<HomeFeed initialTab="recommended" initialTweets={INITIAL_TWEETS} />,
+		);
+		const feed = screen.getByRole("feed");
+		expect(feed.getAttribute("aria-label")).toBe("タイムライン");
+		expect(feed.getAttribute("aria-busy")).toBe("false");
+	});
+
+	it("each article in the feed has aria-posinset / aria-setsize (#201)", () => {
+		render(
+			<HomeFeed initialTab="recommended" initialTweets={INITIAL_TWEETS} />,
+		);
+		const articles = document.querySelectorAll("article");
+		articles.forEach((a, idx) => {
+			expect(a.getAttribute("aria-posinset")).toBe(String(idx + 1));
+			expect(a.getAttribute("aria-setsize")).toBe(String(articles.length));
+		});
+	});
+
 	it("announces optimistic prepend via aria-live region", async () => {
 		render(
 			<HomeFeed initialTab="recommended" initialTweets={INITIAL_TWEETS} />,


### PR DESCRIPTION
Closes #201 (P2-13 a11y follow-up)

P2-13 で a11y-architect が指摘したフィードパターン乖離を解消。

## 変更
- \`HomeFeed.tsx\` — \`<ul role="list">\` → \`<div role="feed" aria-label="タイムライン" aria-busy>\` 切替、\`<li>\` 削除、\`posinset\`/\`setsize\` 渡し
- \`TweetCard.tsx\` — \`posinset\`/\`setsize\` props を受け取り article に \`aria-posinset\`/\`aria-setsize\` 付与

## テスト
HomeFeed test に feed pattern 検証 +2、vitest 276/276 PASS、tsc/lint クリーン

## スコープ外
- 「新着 N 件を表示」 gated insertion
- counts inline 化 / count を含む aria-label

CLAUDE.md §4.1.1 非該当 → CI 緑なら auto-merge。