### PR TITLE
[fix][infra] CD-stg: npm ci --legacy-peer-deps + .npmrc COPY

### DIFF
--- a/client/docker/production/Dockerfile
+++ b/client/docker/production/Dockerfile
@@ -8,11 +8,16 @@ RUN apk add --no-cache libc6-compat
 ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
 
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
 
+# --legacy-peer-deps mirrors the local install policy declared in
+# client/.npmrc. Without this flag npm ci aborts on peer dependency
+# conflicts that the lock file was generated under (eslint-config-standard ↔
+# eslint-plugin-n versions, axios update on #199, sidebar/explore deps).
+# Keeping the .npmrc COPY above as belt-and-braces.
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f package-lock.json ]; then npm ci --legacy-peer-deps; \
   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i; \
   else echo "Lockfile not found." && exit 1; \
   fi


### PR DESCRIPTION
## 症状

\`cd-stg.yml\` が連続 fail (3 commits)。最新 run (\`3f44f24\` for #223) のエラー:

\`\`\`
npm ERR! Missing: @webassemblyjs/helper-api-error@1.13.2 from lock file
buildx failed with: ERROR: failed to build: process npm ci returned non-zero
\`\`\`

stg に Phase 2 機能が反映されていない原因。

## 原因

- \`client/.npmrc\` に \`legacy-peer-deps=true\` を入れているが、\`client/docker/production/Dockerfile\` の COPY 行に \`.npmrc\` が含まれていなかった
- Docker build ステージ内で \`.npmrc\` 不在 → \`npm ci\` が素 (peer 衝突 strict) で走り fail
- Phase 2 中の依存追加 (axios upgrade #199 / sidebar / explore / reactions) で transitive deps の解決が legacy-peer-deps モードでしか整合しない状態

## 修正

- COPY 行に \`.npmrc*\` を追加 (glob で fail しない)
- \`npm ci\` → \`npm ci --legacy-peer-deps\` を直書き (二重防御: .npmrc が COPY されてなくても明示で動く)

これで CD-stg の build が再度通り、main 上の Phase 2 機能が stg に反映される。

CLAUDE.md §4.1.1 ブロッカー条件非該当 → CI 緑なら auto-merge。