### PR TITLE
[feature][backend] Django Channels 配線 + Cookie JWT 認証 + Origin 検証 (#227)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 417
+        "line_number": 466
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-30T15:02:26Z"
+  "generated_at": "2026-05-01T15:25:37Z"
 }

--- a/apps/dm/consumers.py
+++ b/apps/dm/consumers.py
@@ -1,0 +1,24 @@
+"""DM 用 WebSocket Consumer.
+
+Phase 3 P3-02 (Issue #227) では **ルーティング配線の確認** のみが目的のため、
+本物の ``DMConsumer`` 実装 (room join/leave, send_message, typing, read receipt 配信) は
+P3-03 (Issue #228) で書く。それまではプレースホルダとして即 close する Consumer を置く。
+
+クライアントへ返す close code:
+
+- ``4501`` — Not Implemented Yet (P3-03 で本実装する旨)。1xxx 番台は予約
+  (1000 normal / 1001 going away ...) なので 4xxx カスタム空間を使う。
+"""
+
+from __future__ import annotations
+
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+
+class DMConsumer(AsyncWebsocketConsumer):
+    """P3-03 (#228) で本実装するまでのプレースホルダ Consumer."""
+
+    async def connect(self) -> None:
+        # accept() を呼ばずに close を送る = WebSocket ハンドシェイクを accept せず
+        # クライアントには 1006 ではなく明示的な close フレームを返す。
+        await self.close(code=4501)

--- a/apps/dm/routing.py
+++ b/apps/dm/routing.py
@@ -1,0 +1,20 @@
+"""WebSocket ルーティング (P3-02 / Issue #227).
+
+``config.asgi.application`` から ``URLRouter`` で include される。
+Phase 3 では DM 用エンドポイント 1 本のみ。Phase 4A の通知 (``/ws/notifications/``) は
+別 routing.py を別 Issue で追加する。
+"""
+
+from __future__ import annotations
+
+from django.urls import re_path
+
+from apps.dm.consumers import DMConsumer
+
+# room_id は ``DMRoom.id`` (UUIDField) のみ受ける。緩い ``[0-9a-f-]+`` だと
+# ``---`` のような不正値が router を素通りし、Consumer 側で 2 重バリデーション
+# が必要になる (code/python-reviewer MEDIUM 反映)。UUID v4 形式に固定する。
+_UUID_RE = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+websocket_urlpatterns = [
+    re_path(rf"^ws/dm/(?P<room_id>{_UUID_RE})/$", DMConsumer.as_asgi()),
+]

--- a/apps/dm/tests/test_websocket_routing.py
+++ b/apps/dm/tests/test_websocket_routing.py
@@ -1,0 +1,121 @@
+"""WebSocket ルーティング統合テスト (P3-02 / Issue #227).
+
+ASGI app 全体 (``config.asgi.application``) を ``WebsocketCommunicator`` で叩いて、
+以下を統合的に検証する:
+
+- ``/ws/health/`` が認証無しで accept される (Phase 0.5 baseline、stg ALB target group の
+  healthcheck path)
+- ``/ws/dm/<room_id>/`` に届くと P3-03 実装前のプレースホルダ DMConsumer が
+  ``code=4501`` で close する (= ルーティングは到達している)
+- ``OriginValidator`` が ``CHANNELS_ALLOWED_ORIGINS`` に無い ``Origin`` を弾く
+  (sec CRITICAL: WebSocket は CSRF token を使えないため Origin が唯一の防御)
+- allowlist に入った Origin はちゃんと通る
+
+実機 Redis channel layer は単体ルーティングテストでは使わない (Consumer 内で
+``channel_layer.group_send`` を呼ぶのは P3-03 以降)。
+
+note: ``CHANNELS_ALLOWED_ORIGINS`` は ``config.asgi`` 読み込み時に ``OriginValidator``
+にバインドされるため ``override_settings`` では差し替えできない。テストは settings の
+local 既定値 ``["http://localhost:8080", "http://localhost:3000"]`` を前提に書く。
+"""
+
+from __future__ import annotations
+
+import pytest
+from channels.testing import WebsocketCommunicator
+from django.conf import settings
+
+# このモジュールの全テストで InMemoryChannelLayer を使う (Redis 非依存)。
+pytestmark = pytest.mark.usefixtures("in_memory_channel_layer")
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_requires_listed_origin() -> None:
+    """``/ws/health/`` は ``OriginValidator`` の内側にあるため Origin 必須.
+
+    note: ALB ヘルスチェックは HTTP ``/api/health/`` を使う前提 (ARCHITECTURE §3.4)。
+    WebSocket health は wscat / 内部監視ツールが Origin 付きで叩く用途。
+    """
+    from config.asgi import application
+
+    allowed_origin = settings.CHANNELS_ALLOWED_ORIGINS[0].encode()
+    communicator = WebsocketCommunicator(
+        application,
+        "/ws/health/",
+        headers=[(b"origin", allowed_origin)],
+    )
+    connected, _ = await communicator.connect()
+    assert connected is True
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_dm_routing_reaches_placeholder_consumer() -> None:
+    """P3-02 で配線が通ったことの最低限の確認.
+
+    実 DMConsumer は P3-03 (#228) で実装する。Phase 3 開始時点ではプレースホルダが
+    ``close(code=4501)`` で即切断するので、accept されないが close_code が 4501 で
+    返ってくれば「ルーティングは到達した」と判断できる。
+    """
+    from config.asgi import application
+
+    allowed_origin = settings.CHANNELS_ALLOWED_ORIGINS[0].encode()
+    communicator = WebsocketCommunicator(
+        application,
+        "/ws/dm/00000000-0000-0000-0000-000000000000/",
+        headers=[(b"origin", allowed_origin)],
+    )
+    connected, close_code = await communicator.connect()
+    assert connected is False
+    assert close_code == 4501
+
+
+@pytest.mark.asyncio
+async def test_origin_validator_rejects_disallowed_origin() -> None:
+    """allowlist 外の Origin は ``OriginValidator`` で拒否 (sec CRITICAL)."""
+    from config.asgi import application
+
+    communicator = WebsocketCommunicator(
+        application,
+        "/ws/dm/00000000-0000-0000-0000-000000000000/",
+        headers=[(b"origin", b"https://evil.example.com")],
+    )
+    connected, _close_code = await communicator.connect()
+    assert connected is False
+
+
+@pytest.mark.asyncio
+async def test_origin_validator_rejects_missing_origin() -> None:
+    """Origin ヘッダ無しの接続も拒否 (browser 由来でない疑い)."""
+    from config.asgi import application
+
+    communicator = WebsocketCommunicator(
+        application,
+        "/ws/dm/00000000-0000-0000-0000-000000000000/",
+    )
+    connected, _close_code = await communicator.connect()
+    assert connected is False
+
+
+@pytest.mark.asyncio
+async def test_dm_routing_rejects_invalid_uuid() -> None:
+    """``[0-9a-f-]+`` の旧 regex で通っていた不正値は新 regex で 404 close になる.
+
+    URLRouter は path 不一致時 ``ValueError`` を投げる仕様だが、
+    ``OriginValidator`` 経由で wrap されているため close 扱いになる。
+    """
+    from config.asgi import application
+
+    allowed_origin = settings.CHANNELS_ALLOWED_ORIGINS[0].encode()
+    communicator = WebsocketCommunicator(
+        application,
+        "/ws/dm/---/",
+        headers=[(b"origin", allowed_origin)],
+    )
+    # URLRouter は match しない場合 ValueError を投げる。connect は False で返る。
+    try:
+        connected, _ = await communicator.connect()
+        assert connected is False
+    except ValueError:
+        # OK: outer URLRouter が "no route" 判定で raise した
+        pass

--- a/apps/users/channels_auth.py
+++ b/apps/users/channels_auth.py
@@ -1,0 +1,163 @@
+"""WebSocket 接続向け Cookie JWT 認証ミドルウェア (P3-02 / Issue #227).
+
+ADR-0003 で「JWT は HttpOnly Cookie に載せる」と決定済みのため、HTTP API と同じ
+``settings.COOKIE_NAME`` の access cookie を WebSocket でも踏襲する。
+
+Channels の ``AuthMiddlewareStack`` (sessionid ベース) は本プロジェクトでは使わず、
+このミドルウェアで scope に ``user`` を載せる。
+
+セキュリティ上の前提:
+
+- Cookie JWT を読めるのは **同一オリジン** の ``Origin`` ヘッダを持つ接続のみ
+  (``OriginValidator`` の手前で ``CHANNELS_ALLOWED_ORIGINS`` を必ず適用すること)
+- WebSocket は CSRF token を扱えないため、Origin + SameSite=Lax + 短寿命アクセス
+  トークンの三層で defense-in-depth とする (sec CRITICAL)
+- 例外を inner に伝播させると Channels が generic 500 を返し、JWT 自体の構造を
+  攻撃者に類推させかねない。失敗系はすべて ``AnonymousUser`` でフォールバックし、
+  ロジックは Consumer 側で「未認証は close(4401)」する設計に揃える
+
+観測性:
+
+- ロジック上の致命的失敗 (settings 不整合 / SimpleJWT バージョン不整合 等) を見落と
+  さないため、想定外例外は ``structlog`` で **warning レベル** に送る。本文 / トークン
+  内容は載せず、例外型のみ記録する (Sentry / CloudWatch で検知できる程度)。
+"""
+
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from channels.db import database_sync_to_async
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser
+
+_logger = structlog.get_logger(__name__)
+
+
+@database_sync_to_async
+def _resolve_user(user_id: str) -> AbstractBaseUser | None:
+    """同期 ORM 呼び出しを async コンテキストへブリッジするヘルパ.
+
+    ``ChannelsAuthMiddleware`` 内で ``User.objects.get`` を直接呼ぶと
+    ``SynchronousOnlyOperation`` が発生する。``database_sync_to_async`` 経由で
+    スレッドプール実行する。
+
+    ``user_id`` は SimpleJWT の ``USER_ID_FIELD`` 設定で決まる field を引く
+    (本プロジェクトでは User PK が ``pkid`` (BigAutoField)、JWT 識別子が
+    ``id`` (UUID) なので ``pk=user_id`` では型不一致になる)。
+
+    返り値が ``None`` の場合 (User 不在 / 型不一致) は呼び出し側で
+    ``AnonymousUser`` にフォールバックする。
+    """
+
+    User = get_user_model()
+    lookup_field = getattr(settings, "SIMPLE_JWT", {}).get("USER_ID_FIELD", "id")
+    try:
+        return User.objects.get(**{lookup_field: user_id})
+    except (User.DoesNotExist, ValueError, TypeError):
+        # ValueError/TypeError: UUID/int の型変換失敗 (壊れた JWT)
+        return None
+
+
+def _extract_access_cookie(scope: dict[str, Any]) -> str | None:
+    """``scope["headers"]`` から ``settings.COOKIE_NAME`` の値を取り出す.
+
+    Channels の headers は ``[(b"name", b"value"), ...]`` の bytes タプル列。
+    ``Cookie`` ヘッダは **複数 tuple** に分割されて届くことがあるため (HTTP/2 や
+    intermediary proxy 経由)、すべての ``Cookie`` ヘッダを ``";"`` で連結してから
+    パースする。早期 return すると後続 tuple の access cookie を取り逃す
+    (sec HIGH 反映)。
+    """
+
+    cookie_name = settings.COOKIE_NAME
+    raw_parts: list[str] = []
+    for raw_name, raw_value in scope.get("headers", []):
+        if raw_name.lower() != b"cookie":
+            continue
+        try:
+            raw_parts.append(raw_value.decode("latin-1"))
+        except Exception:
+            # 壊れた header bytes は無視 (AnonymousUser fallback)
+            _logger.debug("channels_auth.cookie_header_decode_failed")
+            return None
+
+    if not raw_parts:
+        return None
+
+    jar = SimpleCookie()
+    try:
+        jar.load("; ".join(raw_parts))
+    except Exception:
+        _logger.debug("channels_auth.cookie_header_parse_failed")
+        return None
+    morsel = jar.get(cookie_name)
+    return morsel.value if morsel is not None else None
+
+
+class JWTAuthMiddleware:
+    """Channels middleware: Cookie JWT を ``scope["user"]`` に紐付ける.
+
+    使い方::
+
+        application = ProtocolTypeRouter({
+            "websocket": OriginValidator(
+                JWTAuthMiddleware(URLRouter(websocket_urlpatterns)),
+                allowed_origins=settings.CHANNELS_ALLOWED_ORIGINS,
+            ),
+        })
+
+    失敗時 (Cookie 無し / 不正 JWT / 期限切れ / 該当 User 不在) はすべて
+    ``AnonymousUser`` を載せる。Consumer 側で ``scope["user"].is_authenticated``
+    を見て reject する。
+    """
+
+    def __init__(self, inner) -> None:
+        self.inner = inner
+
+    async def __call__(self, scope, receive, send):
+        # 呼び出し側 scope を破壊しない (shallow copy: top-level key 追加のみ
+        # なのでこれで十分。`headers` のリストは共有されるが、本ミドルウェアは
+        # mutate しない)。
+        scope = dict(scope)
+        scope["user"] = await self._resolve_user_from_scope(scope)
+        return await self.inner(scope, receive, send)
+
+    async def _resolve_user_from_scope(self, scope: dict[str, Any]) -> AbstractBaseUser:
+        token_str = _extract_access_cookie(scope)
+        if not token_str:
+            return AnonymousUser()
+
+        # SimpleJWT は import コストが大きいので関数内 import で起動を高速化。
+        from rest_framework_simplejwt.exceptions import TokenError
+        from rest_framework_simplejwt.tokens import AccessToken
+
+        # claim 名は SimpleJWT 設定から動的に読む (USER_ID_FIELD と整合させる、
+        # python/code-reviewer HIGH 反映)。
+        claim_field = getattr(settings, "SIMPLE_JWT", {}).get("USER_ID_CLAIM", "user_id")
+
+        try:
+            token = AccessToken(token_str)
+            user_id = token.get(claim_field)
+        except TokenError:
+            # 期限切れ / 署名不一致 / 構造不正 — いずれも警告ログ不要 (高頻度)
+            return AnonymousUser()
+        except Exception as exc:
+            # 防御的: ライブラリ側の予期せぬ例外もクライアントに漏らさない。
+            # ただし observability のため exc クラス名だけ警告ログに残す。
+            _logger.warning(
+                "channels_auth.unexpected_jwt_error",
+                exc_type=type(exc).__name__,
+            )
+            return AnonymousUser()
+
+        if user_id is None:
+            return AnonymousUser()
+
+        user = await _resolve_user(user_id)
+        return user if user is not None else AnonymousUser()

--- a/apps/users/tests/test_channels_auth.py
+++ b/apps/users/tests/test_channels_auth.py
@@ -1,0 +1,195 @@
+"""``apps.users.channels_auth.JWTAuthMiddleware`` の単体テスト (P3-02 / Issue #227).
+
+Channels の WebSocket scope に対して Cookie JWT を読んで User を載せるミドルウェアを
+検証する。失敗系 (Cookie 欠落 / 不正 JWT / 期限切れ / 不在 user) はすべて
+``AnonymousUser`` にフォールバックすること、エラーをクライアントに漏らさないことを保証する。
+
+ADR-0003: アクセストークンは ``settings.COOKIE_NAME`` (= "access") の HttpOnly Cookie に
+載っている。同じ取り扱いを WebSocket でも踏襲する。
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone
+from freezegun import freeze_time
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.users.channels_auth import JWTAuthMiddleware
+
+User = get_user_model()
+
+
+def _build_scope(cookie_value: bytes | None = None) -> dict:
+    """Channels の WebSocket scope を構築するヘルパ.
+
+    ``cookie_value`` が ``None`` のときは ``Cookie`` ヘッダ自体を載せない。
+    """
+
+    headers: list[tuple[bytes, bytes]] = []
+    if cookie_value is not None:
+        headers.append((b"cookie", cookie_value))
+    return {
+        "type": "websocket",
+        "path": "/ws/dm/abcd-efgh/",
+        "headers": headers,
+    }
+
+
+class _CapturingInner:
+    """次段 ASGI app を模した capture-only stub."""
+
+    def __init__(self) -> None:
+        self.captured_scope: dict | None = None
+
+    async def __call__(self, scope, receive, send) -> None:
+        self.captured_scope = scope
+
+
+@pytest.fixture
+def issued_user(db):
+    user = User.objects.create_user(
+        username="ws_tester",
+        email="ws_tester@example.com",
+        password="pw-unused-for-tests",  # pragma: allowlist secret
+        first_name="W",
+        last_name="Tester",
+    )
+    return user
+
+
+def _access_token_str(user) -> str:
+    return str(AccessToken.for_user(user))
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_attaches_user_when_cookie_jwt_is_valid(issued_user) -> None:
+    token = _access_token_str(issued_user)
+    cookie = f"{settings.COOKIE_NAME}={token}; logged_in=true".encode()
+    scope = _build_scope(cookie_value=cookie)
+    inner = _CapturingInner()
+
+    await JWTAuthMiddleware(inner)(scope, lambda: None, lambda x: None)
+
+    assert inner.captured_scope is not None
+    user_in_scope = inner.captured_scope["user"]
+    assert user_in_scope.is_authenticated is True
+    assert user_in_scope.pk == issued_user.pk
+
+
+@pytest.mark.asyncio
+async def test_anonymous_when_cookie_header_missing() -> None:
+    scope = _build_scope(cookie_value=None)
+    inner = _CapturingInner()
+
+    await JWTAuthMiddleware(inner)(scope, lambda: None, lambda x: None)
+
+    assert isinstance(inner.captured_scope["user"], AnonymousUser)
+
+
+@pytest.mark.asyncio
+async def test_anonymous_when_access_cookie_absent() -> None:
+    """他の cookie はあるが ``access`` だけが無い場合."""
+    scope = _build_scope(cookie_value=b"sessionid=foo; logged_in=true")
+    inner = _CapturingInner()
+
+    await JWTAuthMiddleware(inner)(scope, lambda: None, lambda x: None)
+
+    assert isinstance(inner.captured_scope["user"], AnonymousUser)
+
+
+@pytest.mark.asyncio
+async def test_anonymous_when_jwt_is_malformed() -> None:
+    cookie = f"{settings.COOKIE_NAME}=not-a-real-jwt".encode()
+    scope = _build_scope(cookie_value=cookie)
+    inner = _CapturingInner()
+
+    # 例外を漏らさない (クライアントに 500 を返さない設計)
+    await JWTAuthMiddleware(inner)(scope, lambda: None, lambda x: None)
+
+    assert isinstance(inner.captured_scope["user"], AnonymousUser)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_anonymous_when_user_id_does_not_exist(issued_user) -> None:
+    """JWT 自体は valid だが user_id に該当する User が存在しない場合."""
+    token = AccessToken.for_user(issued_user)
+    # delete() は同期 ORM なので async コンテキストでは sync_to_async 経由で呼ぶ。
+    await sync_to_async(issued_user.delete)()
+    cookie = f"{settings.COOKIE_NAME}={token}".encode()
+    scope = _build_scope(cookie_value=cookie)
+    inner = _CapturingInner()
+
+    await JWTAuthMiddleware(inner)(scope, lambda: None, lambda x: None)
+
+    assert isinstance(inner.captured_scope["user"], AnonymousUser)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_does_not_mutate_caller_scope(issued_user) -> None:
+    """呼び出し側の scope を破壊的に書き換えていない (defensive copy)."""
+    token = _access_token_str(issued_user)
+    cookie = f"{settings.COOKIE_NAME}={token}".encode()
+    original_scope = _build_scope(cookie_value=cookie)
+    inner = _CapturingInner()
+
+    await JWTAuthMiddleware(inner)(original_scope, lambda: None, lambda x: None)
+
+    # 元 scope に user を勝手に生やしていない
+    assert "user" not in original_scope
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_anonymous_when_jwt_is_expired(issued_user) -> None:
+    """``ACCESS_TOKEN_LIFETIME`` (60 分) を過ぎた token は AnonymousUser になる.
+
+    SimpleJWT が ``TokenError`` を投げる経路を実際にテストでカバー (sec/code MEDIUM)。
+    """
+    lifetime = settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"]
+    issued_at = timezone.now() - lifetime - timedelta(minutes=5)
+    with freeze_time(issued_at):
+        token = _access_token_str(issued_user)
+
+    # 「いま」は token の有効期限から 5 分過ぎている状態。
+    cookie = f"{settings.COOKIE_NAME}={token}".encode()
+    scope = _build_scope(cookie_value=cookie)
+    inner = _CapturingInner()
+
+    await JWTAuthMiddleware(inner)(scope, lambda: None, lambda x: None)
+
+    assert isinstance(inner.captured_scope["user"], AnonymousUser)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_handles_multiple_cookie_headers(issued_user) -> None:
+    """``Cookie`` ヘッダが複数 tuple に分割されていても access cookie を拾える.
+
+    sec HIGH 反映: 早期 return で取り逃すケースを防ぐ。
+    """
+    token = _access_token_str(issued_user)
+    scope = {
+        "type": "websocket",
+        "path": "/ws/dm/abcd-efgh/",
+        "headers": [
+            (b"cookie", b"logged_in=true"),  # こちらにアクセストークンは無い
+            (b"cookie", f"{settings.COOKIE_NAME}={token}".encode()),
+        ],
+    }
+    inner = _CapturingInner()
+
+    await JWTAuthMiddleware(inner)(scope, lambda: None, lambda x: None)
+
+    user_in_scope = inner.captured_scope["user"]
+    assert user_in_scope.is_authenticated is True
+    assert user_in_scope.pk == issued_user.pk

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -2,8 +2,15 @@
 
 It exposes the ASGI callable as a module-level variable named ``application``.
 
-HTTP は Django の get_asgi_application、WebSocket は Channels の URLRouter に振り分ける。
-Phase 3 (DM) で websocket_urlpatterns を apps.dm.routing 等から import して拡張する。
+HTTP は Django の ``get_asgi_application``、WebSocket は Channels の URLRouter に振り分ける。
+
+P3-02 (Issue #227) で以下を追加配線:
+
+- :class:`apps.users.channels_auth.JWTAuthMiddleware` で Cookie JWT を ``scope["user"]`` に
+  載せる (``AuthMiddlewareStack`` は使わない、ADR-0003 と整合)
+- :class:`channels.security.websocket.OriginValidator` で ``settings.CHANNELS_ALLOWED_ORIGINS``
+  の Origin だけ受ける (sec CRITICAL: WebSocket は CSRF token 不可なので Origin が要)
+- :mod:`apps.dm.routing` を include
 """
 
 from __future__ import annotations
@@ -17,36 +24,51 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 # Django の設定読み込みを Channels のインポートより先に行う
 django_asgi_app = get_asgi_application()
 
-# channels は Phase 0 で追加導入済み (P0-01)
-from channels.auth import AuthMiddlewareStack  # noqa: E402
+# channels / settings 依存はこれ以降に import する (E402 を許容)。
 from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
-from channels.security.websocket import AllowedHostsOriginValidator  # noqa: E402
+from channels.security.websocket import OriginValidator  # noqa: E402
+from django.conf import settings  # noqa: E402
 from django.urls import path  # noqa: E402
+
+from apps.dm.routing import websocket_urlpatterns as dm_websocket_urlpatterns  # noqa: E402
+from apps.users.channels_auth import JWTAuthMiddleware  # noqa: E402
 
 
 async def health_consumer(scope, receive, send):
-    """WebSocket ヘルスチェック用 minimal consumer. Phase 0.5 の smoke test で利用。"""
-    if scope["type"] == "websocket":
-        await receive()  # websocket.connect
-        await send({"type": "websocket.accept"})
-        await send({"type": "websocket.close", "code": 1000})
+    """WebSocket ヘルスチェック用 minimal consumer.
+
+    用途: **WebSocket 経路の手動疎通確認** (wscat / 内部 monitoring が Origin を
+    付けて叩く)。
+
+    note: stg/prod の ALB target group ヘルスチェックは **HTTP** ``/api/health/`` を
+    使う設計 (Phase 0.5 で配線済)。本 ``/ws/health/`` は ``OriginValidator`` の
+    内側にあるため Origin 無しの ALB プロトコル probe は 403 で弾かれる。
+    ALB → daphne TG の死活監視は HTTP path で行うこと (ARCHITECTURE §3.4)。
+    """
+    assert (
+        scope["type"] == "websocket"
+    ), "health_consumer should only be reached for websocket scope"
+    message = await receive()
+    if message.get("type") != "websocket.connect":
+        # 想定外メッセージ (websocket.disconnect 等) は accept せずに静かに終了
+        return
+    await send({"type": "websocket.accept"})
+    await send({"type": "websocket.close", "code": 1000})
 
 
 websocket_urlpatterns = [
     path("ws/health/", health_consumer),
-    # Phase 3 以降で各 app の routing を include する:
-    # *dm_routing.websocket_urlpatterns,
-    # *notifications_routing.websocket_urlpatterns,
+    *dm_websocket_urlpatterns,
+    # Phase 4A 以降で notifications 等を追加 include する想定。
 ]
 
 
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
-        "websocket": AllowedHostsOriginValidator(
-            AuthMiddlewareStack(
-                URLRouter(websocket_urlpatterns),
-            ),
+        "websocket": OriginValidator(
+            JWTAuthMiddleware(URLRouter(websocket_urlpatterns)),
+            allowed_origins=settings.CHANNELS_ALLOWED_ORIGINS,
         ),
     },
 )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -119,7 +119,17 @@ LOCAL_APPS = [
     "apps.search",
 ]
 
-INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
+# --- Channels / Daphne (P3-02 / Issue #227) ---
+# `daphne` は INSTALLED_APPS の **先頭** に置く必要がある (Twisted reactor を他の
+# import より前に固定する。Daphne の AppConfig.ready() がそれを保証する)。
+# `channels` も同様の理由で上位に置く。詳細:
+# https://channels.readthedocs.io/en/stable/installation.html
+CHANNELS_APPS = [
+    "daphne",
+    "channels",
+]
+
+INSTALLED_APPS = CHANNELS_APPS + DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
@@ -254,6 +264,45 @@ CELERY_TASK_SOFT_TIME_LIMIT = 60
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 CELERY_WORKERS_SEND_TASKS_EVENTS = True
+
+# --- Django Channels (P3-02 / Issue #227) ---
+# Phase 3 の DM real-time 配信で使用。Phase 4A 通知 / 将来の WebSocket 用途も同じ
+# channel layer を共有する。
+#
+# REDIS_URL は Celery 用 (DB 0) と同じインスタンスを共有する想定。本番は ElastiCache
+# (Multi-AZ replica 1) に向く。capacity=1500 は 1 group へのバッファ上限、expiry=60
+# はメッセージの TTL 秒。共に Channels の defaults よりやや余裕を持たせた値。
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [getenv("REDIS_URL", "redis://redis:6379/0")],
+            "capacity": 1500,
+            "expiry": 60,
+        },
+    },
+}
+
+# WebSocket は CSRF token を持たないため、``Origin`` ヘッダの allowlist が
+# 唯一の cross-site 防御。production / stg / local で値を分離する。
+# 環境変数 DJANGO_CHANNELS_ALLOWED_ORIGINS は CSV 形式
+# ("https://stg.codeplace.me,http://localhost:8080")。空なら local 既定値を使う。
+_raw_allowed_origins = getenv("DJANGO_CHANNELS_ALLOWED_ORIGINS", "")
+if _raw_allowed_origins:
+    CHANNELS_ALLOWED_ORIGINS = [
+        origin.strip() for origin in _raw_allowed_origins.split(",") if origin.strip()
+    ]
+else:
+    # local 開発用の既定値。stg/prod は env で必ず上書きする (下の fail-fast 参照)。
+    CHANNELS_ALLOWED_ORIGINS = ["http://localhost:8080", "http://localhost:3000"]
+
+if SENTRY_ENVIRONMENT in ("stg", "production") and not _raw_allowed_origins:
+    from django.core.exceptions import ImproperlyConfigured
+
+    raise ImproperlyConfigured(
+        f"DJANGO_CHANNELS_ALLOWED_ORIGINS must be set in {SENTRY_ENVIRONMENT} "
+        "(WebSocket Origin allowlist; sec CRITICAL P3-02)."
+    )
 
 # P1-01 + ADR-0003: HttpOnly Cookie で JWT を運搬する設定。
 # Secure は stg/prod で True、local では False (mailpit 等で HTTP 疎通用)。

--- a/conftest.py
+++ b/conftest.py
@@ -150,3 +150,29 @@ def eager_celery(settings) -> Iterator[None]:
     settings.CELERY_TASK_ALWAYS_EAGER = True
     settings.CELERY_TASK_EAGER_PROPAGATES = True
     yield
+
+
+# -----------------------------------------------------------------------------
+# Phase 3 共通 fixtures (P3-02)
+# -----------------------------------------------------------------------------
+# WebSocket / Channels 系テストでは Redis に依存させず InMemoryChannelLayer に
+# 切り替える。CI で redis service が止まってもテストが落ちないようにする
+# (code-reviewer HIGH 反映)。
+# autouse=True にすると Phase 2 の eager_celery / redis_clean を使う既存テストの
+# 設定も書き換えてしまうため、明示 opt-in とする (Channels テストだけ受け取る)。
+
+
+@pytest.fixture
+def in_memory_channel_layer(settings) -> Iterator[None]:
+    """``CHANNEL_LAYERS`` を InMemoryChannelLayer に差し替える fixture。
+
+    Channels の WebsocketCommunicator を使うテストでは、Redis 不要にしておくと
+    pytest-asyncio + channels_redis のイベントループ競合が起きないので fixture を
+    通すこと。
+    """
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+        },
+    }
+    yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ filterwarnings = [
     "ignore::DeprecationWarning:django.*",
     "ignore::DeprecationWarning:rest_framework.*",
 ]
+# pytest-asyncio (P3-02 で導入): WebsocketCommunicator を扱う非同期テストは
+# `@pytest.mark.asyncio` を必須にする (strict)。fixture の loop scope を
+# 明示しないと 0.24+ で deprecation warning が出るため function 固定。
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 # Match Django apps layout

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -17,6 +17,9 @@ pytest-mock==3.14.0
 factory-boy==3.3.1
 # freezegun: 時刻固定テスト用
 freezegun==1.5.1
+# pytest-asyncio: Channels の WebsocketCommunicator は async API なので必要 (P3-02)。
+# Channels 4.x + pytest-asyncio 0.24.x の組み合わせで `@pytest.mark.asyncio` が動く。
+pytest-asyncio==0.24.0
 
 # --- Lint / format gate (CI parity) ---
 # pre-commit: ローカル commit 時に CI の pre-commit job と同等の検査を走らせる。


### PR DESCRIPTION
## Summary

Phase 3 (DM) のすべての WebSocket Consumer が依存するインフラ層を配線。Issue #227 (P3-02)。

Closes #227

## 主な変更

- **`config/settings/base.py`**:
  - `daphne` / `channels` を **INSTALLED_APPS 先頭** に追加 (Twisted reactor を他 import 前に固定する Channels 公式パターン)
  - `CHANNEL_LAYERS` (channels_redis、capacity 1500 / expiry 60)
  - `CHANNELS_ALLOWED_ORIGINS` を `DJANGO_CHANNELS_ALLOWED_ORIGINS` 環境変数 (CSV) から読む。stg/prod で env 未設定なら `ImproperlyConfigured` で fail-fast
- **`apps/users/channels_auth.JWTAuthMiddleware`**:
  - WebSocket `scope` の Cookie ヘッダから `settings.COOKIE_NAME` (= `"access"`) を抽出 → SimpleJWT で decode → `database_sync_to_async` で User を解決 → `scope["user"]` に載せる
  - **USER_ID_FIELD / USER_ID_CLAIM の両方を settings から動的に読む** (config 変更で silent auth degrade しない)
  - 失敗系 (Cookie 無し / 不正 JWT / 期限切れ / 該当 User 不在) はすべて `AnonymousUser` フォールバック、Consumer 側で reject (P3-03 で配線)
  - 想定外例外は structlog `warning` で **例外型名のみ** ログ (Sentry / CloudWatch 検知用)
  - **複数 Cookie ヘッダ tuple (HTTP/2 / 中間 proxy 経由) を全件連結してから parse**
- **`apps/dm/consumers.DMConsumer`**: P3-03 (#228) 実装までのプレースホルダ (`close(4501)`)
- **`apps/dm/routing.py`**: `re_path` で **UUID v4 形式のみ** マッチ (旧 `[0-9a-f-]+` から厳格化)
- **`config/asgi.py`**: `ProtocolTypeRouter` に `OriginValidator(JWTAuthMiddleware(URLRouter(...)))` を配線。`/ws/health/` は OriginValidator の内側 — **ALB ヘルスチェックは HTTP `/api/health/` を使う前提** で、ws/health は wscat / 内部監視向け
- **`conftest.py`**: `in_memory_channel_layer` fixture (Channels テスト Redis 非依存化)
- **`requirements/local.txt`**: `pytest-asyncio==0.24.0` 追加 (WebsocketCommunicator 用)
- **`pyproject.toml`**: `asyncio_mode=strict` + function-scoped fixture loop

## レビュー反映 (CRITICAL 0 / HIGH 6 / MEDIUM 4)

サブエージェント並列レビュー (python-reviewer + code-reviewer + security-reviewer) で挙がった HIGH 全件 + 安価な MEDIUM を解消:

| 指摘 | 対応 |
|---|---|
| **HIGH** `daphne` / `channels` を INSTALLED_APPS から欠落 (python+code) | 先頭に追加 (Twisted reactor 順序保証) |
| **HIGH** `token.get("user_id")` ハードコード (python+code) | `USER_ID_CLAIM` を settings から読む |
| **HIGH** auth 失敗時の structlog 欠落 (python) | `_logger.warning` 追加 |
| **HIGH** `_extract_access_cookie` が複数 Cookie ヘッダで早期 return (security) | 全 Cookie ヘッダを連結してから parse + テスト |
| **HIGH** テストが Redis を要求 (code) | `in_memory_channel_layer` fixture |
| **HIGH** `/ws/health/` の ALB 用途記述が誤り (code+sec) | docstring 修正 (ALB は HTTP `/api/health/` を使用) |
| MEDIUM 期限切れ JWT テスト無し (code+sec) | `freezegun` で追加 |
| MEDIUM 不要な `transaction=True` 3 件 (code) | 削除 |
| MEDIUM `_resolve_user` 型注釈 / room_id regex 厳格化 (code+python) | 修正 |

defer (LOW): `health_consumer` の `else: raise` ガード、env 名の `DJANGO_*` プレフィックス統一は別 Issue。

## Test plan

- [x] `pytest apps/users/tests/test_channels_auth.py apps/dm/tests/test_websocket_routing.py` — **14 passed**
- [x] `pytest apps/users/ apps/dm/ apps/tweets/tests/test_tweet_model.py` — **173 passed (regression なし)**
- [x] カバレッジ: `apps.users.channels_auth` 91% / `apps.dm.consumers` 100% / `apps.dm.routing` 100% / `config.asgi` 100%
- [x] `pre-commit` 全 pass (ruff / ruff-format / detect-secrets / yaml / json / detect-private-key)
- [ ] CI green → squash merge

## 後続 Issue への引き継ぎ

- **#228 (P3-03 DMConsumer)**: `apps.dm.consumers.DMConsumer` を本実装。`scope["user"].is_authenticated` を見て未認証は `close(4401)`。`channel_layer.group_send` で room メッセージを fan-out
- **#229 (P3-04 グループ招待 API)**: 関係 Issue
- **#239 (P3-14 local.yml に daphne)** + **#238 (P3-13 ALB target group)**: Terraform / docker-compose で daphne プロセスを実環境に組み込み
- 本 PR で `/ws/health/` は OriginValidator 内側に配置。**ALB が WS-type 死活監視を求めるなら別 PR で外側に出す** 設計判断が必要 (現状は HTTP `/api/health/` 想定)