### PR TITLE
[feature][backend] DM → Phase 4 ブリッジスタブ + 差し替え手順書 (#240)

### DIFF
--- a/apps/dm/integrations/__init__.py
+++ b/apps/dm/integrations/__init__.py
@@ -1,0 +1,8 @@
+"""Phase 4 (Notifications / Moderation) との疎結合インターフェース層.
+
+Phase 3 の DM 機能は Phase 4A (通知) / Phase 4B (Block/Mute) より前に出荷される。
+両 Phase が未実装の段階で DM Consumer / API が呼び出せるよう、本 package に
+**no-op スタブ**を置き、Phase 4 着手時に中身を差し替えるだけで結線が完了する設計とする。
+
+差し替え手順は ``docs/operations/phase-3-stub-bridges.md`` を参照。
+"""

--- a/apps/dm/integrations/moderation.py
+++ b/apps/dm/integrations/moderation.py
@@ -1,0 +1,56 @@
+"""DM → モデレーション (Phase 4B Block/Mute) のブリッジ (P3-15 / Issue #240).
+
+Phase 3 では ``apps.moderation`` の Block / Mute モデルがまだ無いため、本モジュールは
+**常に「ブロック/ミュートされていない」**を返すスタブとして動作する。Phase 4B 着手時に
+``apps.moderation`` の Block / Mute モデルを参照する実装に差し替える。
+
+呼び出し点 (Phase 3 で正しい場所に配置済):
+
+- :mod:`apps.dm.consumers` の ``send_message`` 前 → :func:`is_dm_blocked` で判定
+- :mod:`apps.dm.consumers` の typing/read broadcast 時 → 任意 (Phase 4B 着手時に決定)
+
+Phase 4B での差し替え方法は ``docs/operations/phase-3-stub-bridges.md`` を参照。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser
+
+
+def is_dm_blocked(user_a: AbstractBaseUser, user_b: AbstractBaseUser) -> bool:
+    """``user_a`` と ``user_b`` の **どちらか一方** がもう片方を Block していれば ``True``.
+
+    Phase 3 は **常に False** (Block 機能は Phase 4B で実装)。
+
+    Phase 4B 差し替え時の実装イメージ::
+
+        from django.db.models import Q
+        from apps.moderation.models import Block
+
+        if user_a.pk == user_b.pk:
+            return False
+        return Block.objects.filter(
+            Q(blocker=user_a, blockee=user_b) | Q(blocker=user_b, blockee=user_a)
+        ).exists()
+
+    関係は双方向 (片方が block していれば送信不可) — security-reviewer Phase 2 が指摘した
+    パターンと同じ方針。Phase 4B でも同じ規約を踏襲する。
+    """
+
+    return False
+
+
+def is_dm_muted(user: AbstractBaseUser, target: AbstractBaseUser) -> bool:
+    """``user`` が ``target`` をミュートしていれば ``True`` (一方向).
+
+    Phase 3 は **常に False** (Mute 機能は Phase 4B で実装)。
+
+    ミュートはブロックと違い相手は気づかない (SPEC §14.3)。送信そのものは許可、
+    受信側の通知ベル / TL 表示で抑制するため、DM Consumer ではほぼ使わず Phase 4B で
+    通知 / TL 側が利用する想定。
+    """
+
+    return False

--- a/apps/dm/integrations/notifications.py
+++ b/apps/dm/integrations/notifications.py
@@ -1,0 +1,119 @@
+"""DM → 通知 (Phase 4A) のブリッジ (P3-15 / Issue #240).
+
+Phase 3 では ``apps.notifications`` がまだ通知ディスパッチ実装を持たないため、
+本モジュールは **no-op** として動作する。Phase 4A の ``apps.notifications`` 完成時に
+``apps.notifications.signals.emit_notification`` を実装すれば、本モジュールは
+**自動で dispatch 経路に切り替わる** (caller の DM Consumer / 招待 API は無変更)。
+
+Phase 4A 側で実装すべきシグネチャ::
+
+    def emit_notification(*, recipient_id: int, kind: str, **payload) -> None:
+        ...
+
+呼び出し点 (Phase 3 で正しい場所に配置済の予定 — 詳細は phase-3-stub-bridges.md):
+
+- :mod:`apps.dm.consumers` の ``send_message`` 直後 → :func:`emit_dm_message`
+- 招待 API (P3-04 で実装予定) の accept フロー直後 → :func:`emit_dm_invite`
+
+Phase 4A での差し替え方法:
+
+1. ``apps.notifications.signals`` に上記シグネチャの関数を実装する
+2. Django 起動時 1 回だけ動的 import で resolve するため、**プロセス再起動が必要**
+   (zero-downtime hot reload では reflect されない、運用で許容)
+3. payload schema (``recipient_id``, ``actor_id``, ``room_id``, ``message_id`` /
+   ``invitation_id``) を ``Notification`` モデルの ``target_type`` / ``target_id``
+   にマッピングする責務は emit_notification 側にある (本モジュールは丸投げ)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    from apps.dm.models import GroupInvitation, Message
+
+_logger = structlog.get_logger(__name__)
+
+
+# code-reviewer HIGH 反映: 毎回 ImportError を踏むと Phase 3 のホットパス
+# (高頻度 send_message) で stat/import の無駄が出る。プロセス起動時に 1 回だけ
+# resolve して cache する。Phase 4A デプロイ時は **プロセス再起動が必要** (運用許容)。
+_emit_notification_resolved: bool = False
+_emit_notification_impl: Callable[..., None] | None = None
+
+
+def _resolve_emit_notification() -> Callable[..., None] | None:
+    global _emit_notification_resolved, _emit_notification_impl
+
+    if _emit_notification_resolved:
+        return _emit_notification_impl
+
+    try:
+        from apps.notifications.signals import emit_notification  # type: ignore[attr-defined]
+
+        _emit_notification_impl = emit_notification
+    except ImportError:
+        # Phase 3 では期待される挙動 (Phase 4A 未実装)。起動時 1 回のみログる。
+        _emit_notification_impl = None
+        _logger.info("dm.notifications.stub_active")
+    _emit_notification_resolved = True
+    return _emit_notification_impl
+
+
+def _dispatch_or_noop(kind: str, recipient_id: int | str, **payload: Any) -> None:
+    """``apps.notifications`` が未実装なら静かに no-op 動作.
+
+    Phase 4A 着手時、``apps.notifications.signals.emit_notification`` を実装すれば
+    自動で dispatch 経路に切り替わる。コール側 (DM Consumer / 招待 API) は変更不要。
+
+    note: Phase 4A 実装が **シグネチャを誤った場合** (例: ``recipient_id`` を
+    ``recipient`` に rename) 呼び出しは ``TypeError`` を投げる。本モジュールは
+    それを **意図的に捕捉しない** ことで silent failure を防ぐ — Phase 4A デプロイの
+    smoke test で必ず検出される設計 (architect HIGH 反映)。
+    """
+
+    impl = _resolve_emit_notification()
+    if impl is None:
+        return  # Phase 3 期待動作 — 何もしない
+    impl(recipient_id=recipient_id, kind=kind, **payload)
+
+
+def emit_dm_message(message: Message) -> None:
+    """新着 DM 1 件あたり、room 内の他メンバー全員に ``dm_message`` 通知を送る.
+
+    Phase 3 は no-op (アプリ内バナー / 未読数表示は WebSocket の broadcast で十分)。
+    Phase 4A で「アプリを開いていない時の通知ベル赤バッジ」用に通知レコードを作る。
+    """
+
+    if message.sender_id is None:
+        return  # 退会済みユーザーの message — 通知対象不在
+
+    for member in message.room.memberships.exclude(user_id=message.sender_id):
+        _dispatch_or_noop(
+            "dm_message",
+            recipient_id=member.user_id,
+            actor_id=message.sender_id,
+            room_id=message.room_id,
+            message_id=message.pk,
+        )
+
+
+def emit_dm_invite(invitation: GroupInvitation) -> None:
+    """グループ招待発生時、被招待者に ``dm_invite`` 通知を送る.
+
+    Phase 3 は no-op。Phase 4A で被招待者の通知一覧 + ベルバッジに反映する。
+    """
+
+    if invitation.invitee_id is None:
+        return
+
+    _dispatch_or_noop(
+        "dm_invite",
+        recipient_id=invitation.invitee_id,
+        actor_id=invitation.inviter_id,
+        room_id=invitation.room_id,
+        invitation_id=invitation.pk,
+    )

--- a/apps/dm/tests/test_integrations.py
+++ b/apps/dm/tests/test_integrations.py
@@ -1,0 +1,227 @@
+"""Phase 4 移行用ブリッジスタブのテスト (P3-15 / Issue #240).
+
+Phase 3 では本モジュールは no-op / 常に False を返すスタブとして動作する。本テストは
+Phase 4 着手時にも生き続ける性質を確認する:
+
+- :mod:`apps.dm.integrations.notifications` の no-op がエラーを投げない
+- :mod:`apps.dm.integrations.moderation` の常時 ``False`` 動作
+- 各関数のシグネチャ (Phase 4 で実装に差し替えても callers は無変更で済む)
+- monkey patch 経由で Phase 4 動作 (Block 検出 / 通知 dispatch) を擬似的に再現可能
+- Phase 4A の signature mismatch は **silent fail せず TypeError が伝播** する
+  (運用安全装置)
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from apps.dm.integrations import moderation, notifications
+from apps.dm.models import DMRoom
+from apps.dm.tests._factories import make_message, make_room, make_user
+
+
+@pytest.fixture
+def reset_emit_notification_cache():
+    """``_resolve_emit_notification`` の起動時 1 回キャッシュを各テストで初期化.
+
+    notifications モジュールは ``_emit_notification_resolved`` / ``_emit_notification_impl``
+    を module-global で持つため、別テストで monkeypatch した結果が次のテストに
+    染み出さないよう、毎回 reset する。
+    """
+
+    notifications._emit_notification_resolved = False
+    notifications._emit_notification_impl = None
+    yield
+    notifications._emit_notification_resolved = False
+    notifications._emit_notification_impl = None
+
+
+class ModerationStubTests:
+    """is_dm_blocked / is_dm_muted は Phase 3 では常に False."""
+
+    def test_is_dm_blocked_returns_false_for_distinct_users(self) -> None:
+        a = make_user()
+        b = make_user()
+        assert moderation.is_dm_blocked(a, b) is False
+
+    def test_is_dm_blocked_returns_false_for_same_user(self) -> None:
+        a = make_user()
+        assert moderation.is_dm_blocked(a, a) is False
+
+    def test_is_dm_muted_returns_false(self) -> None:
+        a = make_user()
+        b = make_user()
+        assert moderation.is_dm_muted(a, b) is False
+
+
+@pytest.mark.django_db
+class TestModerationStubs(ModerationStubTests):
+    """db アクセスが必要な ModerationStubTests を pytest-django で実行する wrapper."""
+
+
+def _check_block_via_module_attr(user_a, user_b) -> bool:
+    """テスト用の薄い caller — `moderation.is_dm_blocked` を **module attr 経由** で呼ぶ.
+
+    Consumer が ``from apps.dm.integrations import moderation`` (module import) で
+    ``moderation.is_dm_blocked(a, b)`` と呼び出す形を想定する。
+    monkeypatch.setattr で module 属性を差し替えれば、本 helper も差し替え後の
+    関数を呼ぶ — caller-level indirection が通っていることの確認 (code HIGH 反映)。
+    """
+
+    return moderation.is_dm_blocked(user_a, user_b)
+
+
+@pytest.mark.django_db
+class TestModerationCallerIndirection:
+    """Phase 4B 移行時、callers が ``moderation.is_dm_blocked`` を module attr 経由で
+    呼んでいる前提で monkeypatch が caller にも反映されることを確認する."""
+
+    def test_monkeypatch_affects_module_attr_caller(self, monkeypatch) -> None:
+        a = make_user()
+        b = make_user()
+
+        # 既定 (スタブ) 動作: False
+        assert _check_block_via_module_attr(a, b) is False
+
+        def _block_everything(user_a, user_b):
+            return True
+
+        monkeypatch.setattr(moderation, "is_dm_blocked", _block_everything)
+
+        # caller (`_check_block_via_module_attr`) は moderation.is_dm_blocked を
+        # 経由しているため、patch 後は True を返す。これが "caller indirection" の証拠。
+        assert _check_block_via_module_attr(a, b) is True
+
+
+@pytest.mark.django_db
+class TestNotificationsStubs:
+    """no-op stub が呼ばれてもエラーにならない."""
+
+    def test_emit_dm_message_is_noop_without_notifications_app(
+        self, reset_emit_notification_cache
+    ) -> None:
+        room = make_room(kind=DMRoom.Kind.GROUP)
+        sender = make_user()
+        member_a = make_user()
+        member_b = make_user()
+        from apps.dm.models import DMRoomMembership
+
+        DMRoomMembership.objects.create(room=room, user=sender)
+        DMRoomMembership.objects.create(room=room, user=member_a)
+        DMRoomMembership.objects.create(room=room, user=member_b)
+
+        message = make_message(room, sender=sender)
+
+        # 例外を投げないこと (Phase 4A 未実装下では何もしないだけ)
+        notifications.emit_dm_message(message)
+
+    def test_emit_dm_message_skips_when_sender_deleted(self, reset_emit_notification_cache) -> None:
+        """sender が SET_NULL で None になっている message は通知対象外."""
+        room = make_room()
+        message = make_message(room)
+        message.sender = None
+        message.save()
+
+        notifications.emit_dm_message(message)  # 例外なし
+
+    def test_emit_dm_invite_is_noop(self, reset_emit_notification_cache) -> None:
+        from apps.dm.models import GroupInvitation
+
+        room = make_room(kind=DMRoom.Kind.GROUP)
+        inviter = make_user()
+        invitee = make_user()
+        invitation = GroupInvitation.objects.create(room=room, inviter=inviter, invitee=invitee)
+
+        notifications.emit_dm_invite(invitation)  # 例外なし
+
+    def test_emit_dm_invite_skips_when_invitee_id_is_none(
+        self, reset_emit_notification_cache
+    ) -> None:
+        """invitee_id が None なら早期 return (CASCADE 削除との理論的整合).
+
+        前バージョンは ``invitation.invitee = None`` のみで ``invitee_id`` が
+        descriptor 経由で sync されないため guard branch を通っていなかった
+        (code MEDIUM 反映)。今回は ``invitee_id`` を直接 None に置く。
+        """
+        from apps.dm.models import GroupInvitation
+
+        room = make_room(kind=DMRoom.Kind.GROUP)
+        inviter = make_user()
+        invitee = make_user()
+        invitation = GroupInvitation.objects.create(room=room, inviter=inviter, invitee=invitee)
+        invitation.invitee_id = None  # FK descriptor をバイパスして直接 None
+
+        notifications.emit_dm_invite(invitation)  # 早期 return で例外なし
+
+
+@pytest.mark.django_db
+class TestNotificationsMonkeyPatchable:
+    """Phase 4A 移行時、emit_notification を import できるようになると自動で dispatch."""
+
+    def test_monkeypatch_emit_notification_is_called(
+        self, monkeypatch, reset_emit_notification_cache
+    ) -> None:
+        room = make_room(kind=DMRoom.Kind.GROUP)
+        sender = make_user()
+        recipient = make_user()
+        from apps.dm.models import DMRoomMembership
+
+        DMRoomMembership.objects.create(room=room, user=sender)
+        DMRoomMembership.objects.create(room=room, user=recipient)
+        message = make_message(room, sender=sender)
+
+        captured: list[dict] = []
+
+        def _spy(*, recipient_id, kind, **payload):
+            """Phase 4A の実シグネチャを mirror した spy."""
+            captured.append({"recipient_id": recipient_id, "kind": kind, **payload})
+
+        # Phase 4A の実装エントリポイントを擬似的に注入
+        # (apps.notifications.signals は本 PR では未実装のため動的に生やす)
+        fake_signals = types.ModuleType("apps.notifications.signals")
+        fake_signals.emit_notification = _spy  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "apps.notifications.signals", fake_signals)
+
+        notifications.emit_dm_message(message)
+
+        # sender 以外の room member 1 名 (= recipient) に dispatch されている
+        assert len(captured) == 1
+        call = captured[0]
+        assert call["kind"] == "dm_message"
+        assert call["recipient_id"] == recipient.pk
+        assert call["actor_id"] == sender.pk
+        assert call["room_id"] == room.pk
+        assert call["message_id"] == message.pk
+
+    def test_signature_mismatch_propagates_typeerror(
+        self, monkeypatch, reset_emit_notification_cache
+    ) -> None:
+        """Phase 4A 実装が誤って ``recipient`` (旧名) を期待した場合、
+        ``TypeError`` が **silently 飲み込まれずに伝播** する.
+
+        これは Phase 4A デプロイ smoke test で signature mismatch を即座に検知する
+        ための「安全装置」(architect HIGH 反映)。本テストが失敗するようになったら
+        ``_dispatch_or_noop`` の except 節が広すぎる。
+        """
+        room = make_room(kind=DMRoom.Kind.GROUP)
+        sender = make_user()
+        recipient = make_user()
+        from apps.dm.models import DMRoomMembership
+
+        DMRoomMembership.objects.create(room=room, user=sender)
+        DMRoomMembership.objects.create(room=room, user=recipient)
+        message = make_message(room, sender=sender)
+
+        # 誤シグネチャ (recipient 引数だけ受け取る)
+        def _wrong_signature(*, recipient, kind):
+            pass  # pragma: no cover - 呼ばれる前に TypeError
+
+        fake_signals = types.ModuleType("apps.notifications.signals")
+        fake_signals.emit_notification = _wrong_signature  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "apps.notifications.signals", fake_signals)
+
+        with pytest.raises(TypeError):
+            notifications.emit_dm_message(message)

--- a/docs/operations/phase-3-stub-bridges.md
+++ b/docs/operations/phase-3-stub-bridges.md
@@ -1,0 +1,103 @@
+# Phase 3 → Phase 4 ブリッジスタブの差し替え手順
+
+> Phase 3 (DM) は Phase 4A (通知) / Phase 4B (Block/Mute) より先にリリースされる。
+> Phase 4 着手時、本ドキュメントの手順に沿って `apps/dm/integrations/` 配下の 2 ファイルを
+> 差し替えれば DM 機能側のコードは無変更で結線できる。
+
+関連 Issue:
+
+- 起票元: P3-15 (#240)
+- 差し替え先: Phase 4A 通知 / Phase 4B モデレーション (Issue 番号は Phase 4 着手時)
+
+---
+
+## 1. ブリッジが置かれている場所
+
+```text
+apps/dm/integrations/
+├── __init__.py
+├── notifications.py   ← Phase 4A 着手時に差し替え
+└── moderation.py      ← Phase 4B 着手時に差し替え
+```
+
+呼び出し点 (Phase 4 では触らない):
+
+| ファイル                  | 状態             | 行/関数                    | 呼び出している関数                         |
+| ------------------------- | ---------------- | -------------------------- | ------------------------------------------ |
+| `apps/dm/consumers.py`    | P3-03 で配置予定 | `send_message` 前ガード    | `moderation.is_dm_blocked(sender, peer)`   |
+| `apps/dm/consumers.py`    | P3-03 で配置予定 | `transaction.on_commit` 後 | `notifications.emit_dm_message(message)`   |
+| `apps/dm/views_invite.py` | P3-04 で配置予定 | invite accept 直後         | `notifications.emit_dm_invite(invitation)` |
+
+> 本 PR (#240) はブリッジ関数本体の no-op スタブ + 移行手順書だけを置く。実際の
+> 呼び出し点配線は P3-03 (#228) / P3-04 (#229) で実装される。
+
+---
+
+## 2. Phase 4A (通知) 着手時の差し替えチェックリスト
+
+`apps/dm/integrations/notifications.py` の差し替え手順:
+
+- [ ] `apps/notifications/signals.py` に **以下の正確な signature で** `emit_notification` を実装 (signature mismatch は smoke test で TypeError を発生させる安全装置あり、`test_signature_mismatch_propagates_typeerror` 参照):
+
+  ```python
+  def emit_notification(*, recipient_id: int, kind: str, **payload) -> None:
+      ...
+  ```
+
+- [ ] その関数が `Notification.objects.create(...)` + WebSocket `/ws/notifications/` で broadcast する
+- [ ] **payload schema を Notification モデルにマッピング**:
+  - `dm_message` 種別: `room_id` / `message_id` / `actor_id` を ER §2.x の
+    `target_type="dm_message"` + `target_id=message_id` に正規化
+  - `dm_invite` 種別: 同様に `invitation_id` を `target_id` に
+  - `room_id` は ER の `Notification` モデルに直接対応せず **payload 側で
+    extra context として保持** する。`emit_notification` は `**payload` で受け流すか
+    明示的に `payload.pop("room_id", None)` で吸収する責務を持つ (architect HIGH 反映)
+- [ ] **プロセス再起動が必要**: `apps/dm/integrations/notifications.py` は起動時 1 回だけ
+      動的 import で resolve するため、Phase 4A デプロイ時は ECS task の rollout が必須
+      (zero-downtime hot reload では自動切替されない)
+- [ ] **ここを差し替える必要は基本的に無い**: `_dispatch_or_noop` が `try: from apps.notifications.signals import emit_notification` で動的 import するため、`apps.notifications` 側を実装するだけで自動で dispatch 経路に切り替わる
+- [ ] 既存 monkey-patch test (`apps/dm/tests/test_integrations.py::TestNotificationsMonkeyPatchable`) を **削除せず**、本実装に対しても spec として有効な状態で残す
+- [ ] 本ファイル §1 の表から「Phase 4A 着手時に差し替え」の注記を消す
+
+---
+
+## 3. Phase 4B (Block/Mute) 着手時の差し替えチェックリスト
+
+`apps/dm/integrations/moderation.py` の差し替え手順:
+
+- [ ] `apps/moderation/models.py` に `Block` / `Mute` モデルを実装
+- [ ] `is_dm_blocked(user_a, user_b)` を **双方向検索** に置換:
+
+  ```python
+  from django.db.models import Q
+  from apps.moderation.models import Block
+
+  def is_dm_blocked(user_a, user_b) -> bool:
+      if user_a.pk == user_b.pk:
+          return False
+      return Block.objects.filter(
+          Q(blocker=user_a, blockee=user_b) | Q(blocker=user_b, blockee=user_a)
+      ).exists()
+  ```
+
+- [ ] `is_dm_muted(user, target)` を **一方向** で実装 (mute は片方向)
+- [ ] テスト `apps/dm/tests/test_integrations.py::TestModerationMonkeyPatchable::test_monkeypatch_to_true_changes_behavior` は **本実装後も spec として残す** (Phase 3 のスタブ動作を Phase 4B が壊していないことの保険)
+- [ ] DM Consumer の積分テスト (P3-03 で書いた「monkeypatch して 4403」テスト) を **削除せず本物の Block レコードを作る形に書き換え**
+- [ ] 本ファイル §1 の表から「Phase 4B 着手時に差し替え」の注記を消す
+
+---
+
+## 4. 差し替え時にやってはいけないこと
+
+- ❌ `apps/dm/integrations/` 配下のファイル名を変えない (呼び出し点が import している)
+- ❌ 関数シグネチャ (`is_dm_blocked(user_a, user_b) -> bool` 等) を変えない
+- ❌ Phase 3 のスタブテストを丸ごと削除しない (一部は spec として Phase 4 後も生かす)
+- ❌ DM Consumer / 招待 API 側の呼び出し点コードを直接書き換えない (本ファイル § 1 の表通りなら無変更で済む)
+
+---
+
+## 5. なぜこの設計を選んだか
+
+- Phase 3 で完全な Block/Mute / 通知を実装すると Phase 3 スコープが膨らみ stg リリースが遅れる
+- 一方、Phase 3 で **呼び出し点だけ正しく入れておかない** と、Phase 4 で全 DM 関連コードを書き換える羽目になる
+- 上記 2 つを両立させる中庸として「呼び出し点は確定 + 中身は no-op スタブ + Phase 4 でファイル単位で差し替え」を採用 (planner レビュー C-3 / phase-3.md 設計判断より)


### PR DESCRIPTION
## Summary

Phase 3 (DM) は Phase 4A (通知) / Phase 4B (Block/Mute) より先にリリースされる前提で、呼び出し点だけ正しい場所に置きつつ中身は no-op スタブとする疎結合設計。Phase 4 着手時に `apps/dm/integrations/{notifications,moderation}.py` を **ファイル単位で差し替える** だけで DM Consumer / API 側のコードは無変更で結線できる。

Closes #240

## 主な変更

- **`apps/dm/integrations/notifications.py`** (`emit_dm_message` / `emit_dm_invite`)
  - `apps.notifications.signals.emit_notification` を起動時 1 回だけ動的 import で resolve、未実装 (Phase 3) なら以降は no-op
  - Phase 4A 実装時は **プロセス再起動で自動的に dispatch 経路へ切り替わる** (zero-downtime hot reload は非対応、運用で許容)
  - signature mismatch (Phase 4A 実装ミス) は **TypeError を意図的に伝播** させて smoke test で検出可能
- **`apps/dm/integrations/moderation.py`** (`is_dm_blocked` / `is_dm_muted`)
  - Phase 3 は常に `False`、Phase 4B で Block / Mute モデル参照に差し替え
  - is_dm_blocked は **双方向** (片方 block で送信不可、SPEC §14.2)
- **`docs/operations/phase-3-stub-bridges.md`** — 差し替えチェックリスト
  - Phase 4A: 正確なシグネチャ + payload schema → `Notification.target_type/target_id` への正規化責務
  - Phase 4B: `Q` import + 双方向検索の正しい snippet
  - 残すべきテスト一覧 (Phase 4 着手後も spec として生きる)
  - 差し替え時にやってはいけないこと

## レビュー反映 (CRITICAL 0 / HIGH 5 / MEDIUM 3)

サブエージェント並列レビュー (code-reviewer + code-architect):

| 指摘 | 対応 |
|---|---|
| **HIGH** docstring が `emit_notification(recipient,...)` だが実装は `recipient_id=` (architect) | docstring を実シグネチャ `(*, recipient_id, kind, **payload)` に修正 |
| **HIGH** `_dispatch_or_noop` が毎回 ImportError でホットパス劣化 (code) | 起動時 1 回キャッシュに変更 (`_resolve_emit_notification`) |
| **HIGH** moderation monkeypatch test が caller indirection を実証していない (code) | `_check_block_via_module_attr` ヘルパ経由で module attr 経由 caller を実演 |
| **HIGH** payload schema (`room_id`) が ER Notification モデルに対応無し (architect) | runbook §2 に `target_type/target_id` への正規化責務を明記 |
| **HIGH** Phase 4A signature mismatch が silent fail (architect) | `test_signature_mismatch_propagates_typeerror` で TypeError 伝播を保証 |
| MEDIUM 差し替え snippet に `Q` import 漏れ | docstring + runbook 両方に追加 |
| MEDIUM runbook §1 表が "配置済" 誤り | 状態列を追加し "P3-03/P3-04 で配置予定" に修正 |
| MEDIUM `test_emit_dm_invite_skips_when_invitee_deleted` が誤った branch | `invitation.invitee_id = None` で書き換え |

## Test plan

- [x] `pytest apps/dm/tests/test_integrations.py` — **10 passed**
- [x] カバレッジ: `apps.dm.integrations` **100%**
- [x] `pre-commit` 全 pass
- [ ] CI green → squash merge

## 次の Issue

- **#228 (P3-03 DMConsumer)** が本 PR の `apps.dm.integrations.moderation.is_dm_blocked` を `send_message` 前ガードで呼ぶ
- **#229 (P3-04 グループ招待 API)** が `apps.dm.integrations.notifications.emit_dm_invite` を accept フローで呼ぶ
- 本 PR は **呼び出し点の配線は含まない** (それぞれの後続 Issue で実装)