### PR TITLE
[infra][dm] S3 DM prefix lifecycle + ECS IAM 権限 (Closes #232)

### DIFF
--- a/docs/operations/dm-s3-runbook.md
+++ b/docs/operations/dm-s3-runbook.md
@@ -1,0 +1,131 @@
+# DM 添付の S3 運用 Runbook (P3-07)
+
+> **対応 Issue**: #232
+> **対象モジュール**: `terraform/modules/storage/`、`terraform/environments/stg/main.tf` > **関連 SPEC**: [docs/SPEC.md](../SPEC.md) §7 (DM 添付ファイル)
+>
+> Phase 3 で導入した DM 添付ファイル機能の S3 周りの設定・運用方法をまとめる。
+
+---
+
+## 1. 全体像
+
+DM 添付は media バケット (`sns-stg-media` / `sns-prod-media`) 内の **`dm/` prefix** に格納する。
+
+```
+sns-stg-media/
+├── avatars/      ← Phase 1 (ユーザーアバター)
+├── tweets/       ← Phase 2 (ツイート画像)
+├── articles/     ← Phase 4 (記事添付、未実装)
+└── dm/           ← Phase 3 (DM 添付、本 runbook の対象)
+    └── <year>/<month>/<day>/<message_id>/<filename>
+```
+
+`dm/` prefix だけ別ライフサイクル & 別 IAM 権限を当て、それ以外の prefix は影響を受けない。
+
+---
+
+## 2. ライフサイクル (storage モジュール)
+
+| 経過日数 | アクション            | 目的                                      |
+| -------- | --------------------- | ----------------------------------------- |
+| 90 日    | `GLACIER_IR` へ移行   | 取り出し即時で安価 (S3 Standard の約 1/4) |
+| 365 日   | 削除 (expiration)     | プライバシー + コスト                     |
+| 30 日    | 旧バージョンも削除    | バージョニング暴発防止                    |
+| 1 日     | 不完全 multipart 削除 | upload abort 後のゴミ回収                 |
+
+変更したい場合は `terraform/environments/stg/terraform.tfvars` で:
+
+```hcl
+# storage モジュールに渡す変数 (terraform/modules/storage/variables.tf)
+# dm_attachment_glacier_ir_days = 60
+# dm_attachment_expiration_days = 730
+```
+
+> **注意**: `dm_attachment_expiration_days = 0` は「永続保持」を意味する。法務的に問題ない場合のみ。
+
+---
+
+## 3. IAM 権限 (stg レイヤで wiring)
+
+`storage` 単体では `dm/*` 権限を発行しない。`storage` ↔ `compute` の循環参照を避けるため、
+`terraform/environments/stg/main.tf` で `aws_iam_role_policy.ecs_dm_attachment` として
+両モジュール作成後に attach する。
+
+権限内訳:
+
+| Action                 | Resource                          | 用途                                 |
+| ---------------------- | --------------------------------- | ------------------------------------ |
+| `s3:PutObject`         | `arn:aws:s3:::sns-stg-media/dm/*` | presigned URL 発行 (P3-06)           |
+| `s3:GetObject`         | `arn:aws:s3:::sns-stg-media/dm/*` | 添付ダウンロード (HEAD/Range)        |
+| `s3:DeleteObject`      | `arn:aws:s3:::sns-stg-media/dm/*` | メッセージ削除時の object 削除 (24h) |
+| `s3:GetBucketLocation` | `arn:aws:s3:::sns-stg-media`      | multipart upload 状態確認            |
+
+avatars / tweets / articles など他 prefix には触らないことが保証される (resource path で `dm/*` 限定)。
+
+---
+
+## 4. CORS (presigned PUT/POST)
+
+`var.frontend_origins` で渡した origin だけ presigned URL の PUT/POST を許可する。
+ワイルドカードは validation で禁止 ([s3-presigned-upload.md](./s3-presigned-upload.md) 参照)。
+
+```hcl
+# terraform/environments/stg/main.tf
+module "storage" {
+  frontend_origins = ["https://stg.example.com"]
+}
+```
+
+---
+
+## 5. 暗号化
+
+- バケットレベルで SSE-S3 (AES256) がデフォルト ON。bucket key も有効。
+- アプリ側で `x-amz-server-side-encryption` ヘッダ付与は **不要** (バケットデフォルトで encrypt される)。
+- 強制 deny policy は導入していない (default 暗号化 + IAM block public で十分)。
+  万一マルウェアスキャンや KMS 監査要件が出てきたら、別途 `aws_s3_bucket_policy` で `Deny`
+  ステートメントを足す方針。
+
+---
+
+## 6. 退会・大量削除の運用
+
+- ユーザーが退会した場合の DM object 一括削除は **Phase 9 で scheduled task として実装予定** (現状未実装)。
+- 緊急で個別 object を削除する場合は AWS CLI:
+
+```bash
+aws s3 rm "s3://sns-stg-media/dm/2026/05/01/<message_id>/" --recursive
+```
+
+- バケット全体に `dm/` だけ完全削除したい場合 (テスト環境のリセット):
+
+```bash
+aws s3 rm "s3://sns-stg-media/dm/" --recursive
+```
+
+> **本番では絶対に実行しない**。退会フローは別途 Phase 9 で承認・監査ログ込みで実装する。
+
+---
+
+## 7. 関連: Phase 3 で未実装の運用タスク
+
+| 項目                                | 受け持つ Phase | 備考                                             |
+| ----------------------------------- | -------------- | ------------------------------------------------ |
+| ウイルススキャン (S3 Object Lambda) | Phase 6+       | 添付確定 → ClamAV → 安全タグ付け                 |
+| 退会時の bulk delete                | Phase 9        | RDS user soft-delete → Celery beat で 24h 後実行 |
+| 法的開示要請対応                    | Phase 10       | versioning が ON なので 30 日以内なら復元可      |
+
+---
+
+## 8. apply 手順
+
+```bash
+cd terraform/environments/stg
+terraform fmt
+terraform validate
+terraform plan -out=dm-s3.plan
+# → 差分確認後、ハルナさん手動で:
+terraform apply dm-s3.plan
+```
+
+> CLAUDE.md §9 の通り、`terraform apply` は人間が必ず実行する。Claude は plan までで止まる。

--- a/docs/operations/dm-s3-runbook.md
+++ b/docs/operations/dm-s3-runbook.md
@@ -33,14 +33,23 @@ sns-stg-media/
 | 30 日    | 旧バージョンも削除    | バージョニング暴発防止                    |
 | 1 日     | 不完全 multipart 削除 | upload abort 後のゴミ回収                 |
 
-変更したい場合は `terraform/environments/stg/terraform.tfvars` で:
+> 既存の `cleanup-noncurrent-versions` ルール (filter なし、全 prefix) は `dm/`
+> オブジェクトの noncurrent version にもマッチするが、dm 専用ルールの 30 日が
+> 先に発動するため実効は 30 日 (storage/main.tf のコメント参照)。
+
+stg では `terraform/environments/stg/variables.tf` の `dm_attachment_glacier_ir_days` /
+`dm_attachment_expiration_days` を `terraform.tfvars` で上書きできる:
 
 ```hcl
-# storage モジュールに渡す変数 (terraform/modules/storage/variables.tf)
-# dm_attachment_glacier_ir_days = 60
-# dm_attachment_expiration_days = 730
+# terraform/environments/stg/terraform.tfvars
+dm_attachment_glacier_ir_days = 60
+dm_attachment_expiration_days = 730
 ```
 
+> **制約**: `dm_attachment_expiration_days` は `dm_attachment_glacier_ir_days` より大きい値
+> (または 0 で無期限) を指定。違反すると `terraform plan` の precondition で fail する
+> (apply 前に検出される)。
+>
 > **注意**: `dm_attachment_expiration_days = 0` は「永続保持」を意味する。法務的に問題ない場合のみ。
 
 ---
@@ -51,16 +60,19 @@ sns-stg-media/
 `terraform/environments/stg/main.tf` で `aws_iam_role_policy.ecs_dm_attachment` として
 両モジュール作成後に attach する。
 
-権限内訳:
+権限内訳 (実 ARN は `terraform output media_bucket_arn` で確認):
 
-| Action                 | Resource                          | 用途                                 |
-| ---------------------- | --------------------------------- | ------------------------------------ |
-| `s3:PutObject`         | `arn:aws:s3:::sns-stg-media/dm/*` | presigned URL 発行 (P3-06)           |
-| `s3:GetObject`         | `arn:aws:s3:::sns-stg-media/dm/*` | 添付ダウンロード (HEAD/Range)        |
-| `s3:DeleteObject`      | `arn:aws:s3:::sns-stg-media/dm/*` | メッセージ削除時の object 削除 (24h) |
-| `s3:GetBucketLocation` | `arn:aws:s3:::sns-stg-media`      | multipart upload 状態確認            |
+| Action                 | Resource scope     | 条件                        | 用途                              |
+| ---------------------- | ------------------ | --------------------------- | --------------------------------- |
+| `s3:PutObject`         | `<media_arn>/dm/*` | —                           | presigned URL 発行 (P3-06)        |
+| `s3:GetObject`         | `<media_arn>/dm/*` | —                           | 添付ダウンロード (HEAD/Range)     |
+| `s3:GetObjectVersion`  | `<media_arn>/dm/*` | —                           | versioning ON で 404 誤判定回避   |
+| `s3:DeleteObject`      | `<media_arn>/dm/*` | —                           | メッセージ削除時 (SPEC §7.3、24h) |
+| `s3:ListBucket`        | `<media_arn>`      | `s3:prefix StringLike dm/*` | Glacier IR 復元時の存在確認       |
+| `s3:GetBucketLocation` | `<media_arn>`      | —                           | SDK のリージョン解決              |
 
-avatars / tweets / articles など他 prefix には触らないことが保証される (resource path で `dm/*` 限定)。
+avatars / tweets / articles など他 prefix には触らないことが保証される
+(オブジェクトレベル権限は `dm/*` 限定、ListBucket は `s3:prefix` 条件で絞り込み)。
 
 ---
 
@@ -91,19 +103,47 @@ module "storage" {
 ## 6. 退会・大量削除の運用
 
 - ユーザーが退会した場合の DM object 一括削除は **Phase 9 で scheduled task として実装予定** (現状未実装)。
-- 緊急で個別 object を削除する場合は AWS CLI:
+
+### 6.1 削除前の preflight (必須)
+
+prod / stg どちらに対する操作か必ず先に確認する:
 
 ```bash
+aws sts get-caller-identity
+# → "Account": "<id>" を確認。stg と prod で AWS account が異なるはず。
+aws s3 ls s3://sns-stg-media/dm/ | head -20
+# → 想定どおりのバケットを参照しているか確認。
+```
+
+### 6.2 個別 object の削除
+
+```bash
+# まず --dryrun で対象を確認
+aws s3 rm "s3://sns-stg-media/dm/2026/05/01/<message_id>/" --recursive --dryrun
+# 出力を目視確認後、--dryrun を外して実行
 aws s3 rm "s3://sns-stg-media/dm/2026/05/01/<message_id>/" --recursive
 ```
 
-- バケット全体に `dm/` だけ完全削除したい場合 (テスト環境のリセット):
+### 6.3 stg 環境の dm/ 完全リセット (テスト用途のみ)
 
 ```bash
+# Step 1: --dryrun で件数確認
+aws s3 rm "s3://sns-stg-media/dm/" --recursive --dryrun | wc -l
+
+# Step 2: current version 削除 (delete marker が残るだけで実体は復元可能)
 aws s3 rm "s3://sns-stg-media/dm/" --recursive
+
+# Step 3: バージョニング ON のバケットでは current 削除だけでは実体が残る。
+#         全 version + delete marker を削除するには delete-objects API を使う:
+aws s3api list-object-versions \
+  --bucket sns-stg-media --prefix "dm/" \
+  --query '{Objects: [Versions, DeleteMarkers][].{Key:Key, VersionId:VersionId}}' \
+  --output json > /tmp/dm-versions.json
+aws s3api delete-objects --bucket sns-stg-media --delete file:///tmp/dm-versions.json
 ```
 
 > **本番では絶対に実行しない**。退会フローは別途 Phase 9 で承認・監査ログ込みで実装する。
+> 上記コマンドはプロビジョニング後の **stg 環境のテスト用途** に限定する。
 
 ---
 
@@ -120,12 +160,21 @@ aws s3 rm "s3://sns-stg-media/dm/" --recursive
 ## 8. apply 手順
 
 ```bash
+# Step 0: 操作対象アカウントを確認 (stg / prod 取り違え防止)
+aws sts get-caller-identity
+
+# Step 1: フォーマット & 検証
 cd terraform/environments/stg
 terraform fmt
 terraform validate
+
+# Step 2: plan
 terraform plan -out=dm-s3.plan
-# → 差分確認後、ハルナさん手動で:
+
+# Step 3: 差分確認後、ハルナさん手動で:
 terraform apply dm-s3.plan
 ```
 
 > CLAUDE.md §9 の通り、`terraform apply` は人間が必ず実行する。Claude は plan までで止まる。
+> apply 直前に `aws sts get-caller-identity` でアカウント ID を確認することを必ず行う
+> (security-reviewer HIGH-2: prod / stg バケット名が 4 文字差のため誤操作リスク高)。

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -100,6 +100,11 @@ module "storage" {
   # 二段階 apply (architect PR #53 HIGH): 初回は空、edge 作成後に tfvars で
   # `cloudfront_distribution_arn_override` を埋めて再 apply。
   cloudfront_oac_arn = var.cloudfront_distribution_arn_override
+
+  # DM 添付の lifecycle (P3-07 / Issue #232)。stg は default 値 (90/365) で運用想定だが、
+  # 必要に応じて terraform.tfvars で上書き可能にする。
+  dm_attachment_glacier_ir_days = var.dm_attachment_glacier_ir_days
+  dm_attachment_expiration_days = var.dm_attachment_expiration_days
 }
 
 # ---------------------------------------------------------------------------
@@ -324,19 +329,40 @@ module "observability" {
 # ---------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "ecs_dm_attachment_access" {
+  # オブジェクトレベル: PutObject / GetObject / DeleteObject を dm/ prefix 限定で許可。
+  # GetObjectVersion は versioning ON のバケットで HEAD/GET が誤って 404 になる事象を
+  # 避けるため (security-reviewer HIGH-1: AWS は ListBucket なしの場合 NoSuchKey 扱い)。
   statement {
-    sid    = "AllowDMAttachmentPutGetDelete"
+    sid    = "AllowDMAttachmentObjectAccessStg"
     effect = "Allow"
     actions = [
       "s3:PutObject",
       "s3:GetObject",
+      "s3:GetObjectVersion",
       "s3:DeleteObject",
     ]
     resources = ["${module.storage.media_bucket_arn}/dm/*"]
   }
 
+  # バケットレベル ListBucket: `dm/` prefix 限定で許可
+  # (security-reviewer HIGH-1: ListBucket がないと Glacier IR 復元時等に 404 誤判定)。
   statement {
-    sid       = "AllowDMAttachmentBucketLocation"
+    sid       = "AllowDMAttachmentListStg"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [module.storage.media_bucket_arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["dm/*", "dm/", "dm"]
+    }
+  }
+
+  # バケットレベル GetBucketLocation: SDK がリクエスト署名のリージョン解決に
+  # 暗黙発行する。s3:prefix 条件は GetBucketLocation に適用されないため別 statement。
+  statement {
+    sid       = "AllowDMAttachmentBucketLocationStg"
     effect    = "Allow"
     actions   = ["s3:GetBucketLocation"]
     resources = [module.storage.media_bucket_arn]

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -311,3 +311,40 @@ module "observability" {
   rds_allocated_storage_gb = var.rds_allocated_storage_gb
   enable_rds_alarms        = true
 }
+
+# ---------------------------------------------------------------------------
+# 8. DM 添付の S3 直アップロード権限 (P3-07 / Issue #232)
+# ---------------------------------------------------------------------------
+# storage <-> compute の循環参照を避けるため、両モジュール作成後に
+# stg レイヤで直接 IAM role policy を attach する:
+#   - PutObject  : presigned URL 経由のアップロード確定後に metadata 確認
+#   - GetObject  : 添付ダウンロード (ヘッド確認 + ファイルサイズ確認、SPEC §7)
+#   - DeleteObject : メッセージ削除時のオブジェクト削除 (SPEC §7.3、24h 削除キュー)
+# 全部 dm/* prefix 限定なので avatar / tweet 画像 / article などには影響しない。
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "ecs_dm_attachment_access" {
+  statement {
+    sid    = "AllowDMAttachmentPutGetDelete"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${module.storage.media_bucket_arn}/dm/*"]
+  }
+
+  statement {
+    sid       = "AllowDMAttachmentBucketLocation"
+    effect    = "Allow"
+    actions   = ["s3:GetBucketLocation"]
+    resources = [module.storage.media_bucket_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_dm_attachment" {
+  name   = "${var.project}-stg-ecs-dm-attachment"
+  role   = module.compute.ecs_task_role_name
+  policy = data.aws_iam_policy_document.ecs_dm_attachment_access.json
+}

--- a/terraform/environments/stg/variables.tf
+++ b/terraform/environments/stg/variables.tf
@@ -129,3 +129,17 @@ variable "waf_rate_limit_per_5min" {
   type        = number
   default     = 2000
 }
+
+# ---------- DM 添付 (P3-07 / Issue #232) ----------
+
+variable "dm_attachment_glacier_ir_days" {
+  description = "dm/ prefix の object を Glacier IR に移すまでの日数 (storage モジュール経由)"
+  type        = number
+  default     = 90
+}
+
+variable "dm_attachment_expiration_days" {
+  description = "dm/ prefix の object を完全削除するまでの日数 (0 で無期限、storage モジュール経由)"
+  type        = number
+  default     = 365
+}

--- a/terraform/modules/data/outputs.tf
+++ b/terraform/modules/data/outputs.tf
@@ -63,6 +63,6 @@ output "redis_connection_url" {
   # 無いと `ValueError: A rediss:// URL must have parameter ssl_cert_reqs ...` で
   # celery worker が起動失敗する (django redis cache 側は redis-py がデフォルトで
   # CERT_REQUIRED 扱いするので問題ない)。
-  value       = "rediss://:${var.redis_auth_token}@${aws_elasticache_replication_group.this.primary_endpoint_address}:${aws_elasticache_replication_group.this.port}/0?ssl_cert_reqs=CERT_REQUIRED"
-  sensitive   = true
+  value     = "rediss://:${var.redis_auth_token}@${aws_elasticache_replication_group.this.primary_endpoint_address}:${aws_elasticache_replication_group.this.port}/0?ssl_cert_reqs=CERT_REQUIRED"
+  sensitive = true
 }

--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -230,9 +230,9 @@ resource "aws_ecs_task_definition" "celery_worker" {
 
   container_definitions = jsonencode([
     {
-      name        = "celery-worker"
-      image       = "${var.ecr_repository_urls["django"]}:${var.image_tag}" # Django image を共有
-      essential   = true
+      name      = "celery-worker"
+      image     = "${var.ecr_repository_urls["django"]}:${var.image_tag}" # Django image を共有
+      essential = true
       # /start-celeryworker は Dockerfile で `celery -A config.celery_app worker`
       # を exec する。直接 inline で書くと "config" モジュールに celery 属性が無く
       # `Module 'config' has no attribute 'celery'` で exit 2 する。
@@ -265,9 +265,9 @@ resource "aws_ecs_task_definition" "celery_beat" {
 
   container_definitions = jsonencode([
     {
-      name        = "celery-beat"
-      image       = "${var.ecr_repository_urls["django"]}:${var.image_tag}"
-      essential   = true
+      name      = "celery-beat"
+      image     = "${var.ecr_repository_urls["django"]}:${var.image_tag}"
+      essential = true
       # /start-celerybeat は migrate django_celery_beat → celery -A config.celery_app
       # beat の順で exec する。直接 inline 書きだと celery_app 解決に失敗する。
       command     = ["/start-celerybeat"]

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -137,8 +137,24 @@ resource "aws_s3_bucket_lifecycle_configuration" "backup" {
 
 # media: 旧バージョンのみ削除、本体は永続。
 # DM 添付 (`dm/` prefix) は別ルールでコスト + プライバシー対応 (P3-07)。
+#
+# NOTE: `cleanup-noncurrent-versions` ルールは `filter {}` (全 prefix 対象) のため
+# `dm/` オブジェクトの noncurrent version にもマッチする。dm 専用ルールの
+# `noncurrent_days = 30` の方が早く発動するため、実効は 30 日 (意図どおり)。
 resource "aws_s3_bucket_lifecycle_configuration" "media" {
   bucket = aws_s3_bucket.this["media"].id
+
+  # cross-variable 検査: 期限なしを許容するが、削除する場合は Glacier IR transition
+  # より大きい日数でなければ S3 が apply 時にエラーを返す。
+  lifecycle {
+    precondition {
+      condition = (
+        var.dm_attachment_expiration_days == 0 ||
+        var.dm_attachment_expiration_days > var.dm_attachment_glacier_ir_days
+      )
+      error_message = "dm_attachment_expiration_days は dm_attachment_glacier_ir_days より大きい値か 0 (無期限) を指定。"
+    }
+  }
 
   rule {
     id     = "cleanup-noncurrent-versions"

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -135,7 +135,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "backup" {
   }
 }
 
-# media: 旧バージョンのみ削除、本体は永続
+# media: 旧バージョンのみ削除、本体は永続。
+# DM 添付 (`dm/` prefix) は別ルールでコスト + プライバシー対応 (P3-07)。
 resource "aws_s3_bucket_lifecycle_configuration" "media" {
   bucket = aws_s3_bucket.this["media"].id
 
@@ -151,6 +152,39 @@ resource "aws_s3_bucket_lifecycle_configuration" "media" {
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
+    }
+  }
+
+  # DM 添付: 90 日後 Glacier IR、365 日後削除 (P3-07).
+  # コスト削減 + プライバシー (退会後も無期限保持しない、SPEC §プライバシー)。
+  # 退会時のバルク削除は別途 scheduled task で実装する想定 (Phase 9)。
+  # avatar / articles など他 prefix は影響を受けない (filter.prefix=dm/ で限定)。
+  rule {
+    id     = "dm-attachment-archive-and-expire"
+    status = "Enabled"
+
+    filter {
+      prefix = "dm/"
+    }
+
+    transition {
+      days          = var.dm_attachment_glacier_ir_days
+      storage_class = "GLACIER_IR"
+    }
+
+    dynamic "expiration" {
+      for_each = var.dm_attachment_expiration_days > 0 ? [1] : []
+      content {
+        days = var.dm_attachment_expiration_days
+      }
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
     }
   }
 }

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -73,3 +73,19 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "dm_attachment_glacier_ir_days" {
+  description = "dm/ prefix の object を Glacier IR に移すまでの日数 (P3-07)"
+  type        = number
+  default     = 90
+}
+
+variable "dm_attachment_expiration_days" {
+  description = "dm/ prefix の object を完全削除するまでの日数 (0 で削除しない、P3-07)"
+  type        = number
+  default     = 365
+  validation {
+    condition     = var.dm_attachment_expiration_days == 0 || var.dm_attachment_expiration_days >= 30
+    error_message = "0 (無期限) か 30 日以上を指定。"
+  }
+}

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -78,10 +78,18 @@ variable "dm_attachment_glacier_ir_days" {
   description = "dm/ prefix の object を Glacier IR に移すまでの日数 (P3-07)"
   type        = number
   default     = 90
+  validation {
+    condition     = var.dm_attachment_glacier_ir_days >= 1
+    error_message = "1 日以上を指定 (S3 lifecycle は days=0 を拒否)。"
+  }
 }
 
 variable "dm_attachment_expiration_days" {
-  description = "dm/ prefix の object を完全削除するまでの日数 (0 で削除しない、P3-07)"
+  description = <<-EOT
+    dm/ prefix の object を完全削除するまでの日数 (0 で削除しない、P3-07)。
+    Glacier IR への transition (`dm_attachment_glacier_ir_days`) より大きい値を指定する。
+    cross-variable 制約は lifecycle resource の precondition で検査する。
+  EOT
   type        = number
   default     = 365
   validation {


### PR DESCRIPTION
## Summary

P3-07 (Issue #232): DM 添付ファイル機能 (Phase 3) のための S3 周りの Terraform 設定を整備。

- `dm/` prefix 専用の lifecycle rule (90 日 → Glacier IR / 365 日 → expire) を `storage` モジュールに追加
- ECS task role に `s3:PutObject/GetObject/GetObjectVersion/DeleteObject` を `dm/*` 限定で attach (`storage` ↔ `compute` 循環参照を避けるため stg レイヤで wiring)
- `s3:ListBucket` を `s3:prefix StringLike dm/*` 条件付きで付与 (Glacier IR 復元時の 404 誤判定回避、security-reviewer HIGH)
- 上書き可能な variable (`dm_attachment_glacier_ir_days` / `dm_attachment_expiration_days`) を stg まで pass-through
- lifecycle に precondition (`expiration > glacier_ir_days`) を追加 (apply 時 S3 エラー回避)
- `docs/operations/dm-s3-runbook.md` を新規追加 (lifecycle / IAM / 退会時 bulk delete preflight / apply 手順)

avatars / tweets / articles 等の他 prefix には一切影響しない (resource path で `dm/*` 限定)。

## サブエージェントレビュー結果 (修正済)

| reviewer | finding | 対応 |
| -------- | ------- | ---- |
| code-reviewer HIGH-1 | runbook の tfvars 手順が機能しない | stg/variables.tf に変数追加 + main.tf で pass-through |
| code-reviewer HIGH-2 | cross-variable validation 欠落 | precondition で `expiration > glacier_ir_days` 強制 |
| security-reviewer HIGH-1 | s3:ListBucket 欠落で Glacier IR 復元時 404 | ListBucket + GetObjectVersion 追加、prefix 条件で `dm/*` 限定 |
| security-reviewer HIGH-2 | bulk delete runbook が誤操作リスク | sts get-caller-identity / --dryrun / バージョニング込み完全削除手順を追記 |

その他 MEDIUM / LOW (CORS GET=`*` の既存挙動、SSE-KMS 未採用、SID 環境名付与) は本 PR スコープ外として現状のまま (今後 prod 化時に再検討)。

## Test plan

- [x] `terraform fmt -recursive` OK
- [x] `terraform validate` OK
- [x] `pytest apps/dm/tests/test_consumer.py` 10 件 pass (terraform-only PR だが pre-push hook で全件確認)
- [x] pre-commit hooks (prettier / detect-secrets) OK
- [ ] CI (terraform plan job) green を待ってマージ
- [ ] `terraform apply` はハルナさん手動

## 関連

- Closes #232
- 依存: #231 (P3-06 presigned URL backend) は本 PR の IAM policy が前提
- 関連 SPEC: §7 (DM 添付ファイル)、§7.3 (削除フロー)