### PR TITLE
[infra][dm] Daphne (Channels) ECS service + autoscaling + runbook (Closes #238)

### DIFF
--- a/docs/operations/dm-channels-runbook.md
+++ b/docs/operations/dm-channels-runbook.md
@@ -77,14 +77,17 @@ aws elbv2 describe-target-health --target-group-arn "$TG_ARN" \
 ### 3.3 WebSocket 接続テスト
 
 ```bash
-# wscat (npm install -g wscat) で /ws/health/ に 101 (switching protocols) を期待
+# wscat (npm install -g wscat) で /ws/health/ に 101 (switching protocols) を期待。
+# health_consumer は connect 直後に code=1000 (Normal Closure) で close するため、
+# wscat が "Disconnected (code: 1000)" と表示するのが正常動作。
 wscat -c "wss://stg.example.com/ws/health/"
-# 期待: Connected (press CTRL+C to quit)
 
 # 認証必須の DM room へは Cookie JWT 付きで:
-COOKIE="access=...; refresh=..."
-wscat -c "wss://stg.example.com/ws/dm/<room_id>/" -H "Cookie: $COOKIE"
+# 履歴に残さないよう -s で非エコー入力する (security MEDIUM M-3)。
+read -s COOKIE_HEADER
+wscat -c "wss://stg.example.com/ws/dm/<room_id>/" -H "Cookie: $COOKIE_HEADER"
 # 期待: Connected (4401 / 4403 で close されない)
+unset COOKIE_HEADER
 ```
 
 ### 3.4 Sticky session cookie の確認
@@ -147,7 +150,8 @@ ALB idle_timeout 超過の可能性。Channels 側で keepalive ping (60s 間隔
 
 ### 5.5 cutover 中に既存接続が drop
 
-`deregistration_delay` を増やす (現状 300s)。または `deployment_minimum_healthy_percent = 100` を確認。
+`deregistration_delay` (daphne TG は 300s に設定済 — `compute/main.tf` `local.target_groups.daphne`) を確認。
+または `deployment_minimum_healthy_percent = 100` を確認。app / next TG は 30s で別設定。
 
 ---
 

--- a/docs/operations/dm-channels-runbook.md
+++ b/docs/operations/dm-channels-runbook.md
@@ -1,0 +1,158 @@
+# Daphne / Channels 運用 Runbook (P3-13)
+
+> **対応 Issue**: #238
+> **対象モジュール**: `terraform/modules/services/` (daphne ECS), `terraform/modules/compute/` (ALB target group)
+> **関連 SPEC**: [docs/SPEC.md](../SPEC.md) §7 (DM リアルタイム), [docs/ARCHITECTURE.md](../ARCHITECTURE.md) §3.3 / §3.4 / §3.5
+
+Phase 3 で追加した Daphne (ASGI WebSocket server) の運用手順をまとめる。
+
+---
+
+## 1. 全体像
+
+```
+                  CloudFront / ALB
+                        │
+        ┌───────────────┼───────────────┐
+        │               │               │
+   /api/* /admin/*    /*ws/*           その他 (Next.js)
+        │               │               │
+   target=app       target=daphne   target=next
+   (Django,8000)    (Daphne,8001)   (Next.js,3000)
+                    sticky 24h
+                    idle 3600s
+```
+
+- WebSocket は再接続時に **同じ Daphne タスク** に戻すため target group は ALB cookie で sticky (24h)
+- ALB の `idle_timeout = 3600s` は config/asgi.py 側の Channels 設定と整合
+- Daphne 単体は CPU 256 / Memory 512MB (stg)、Auto Scaling は CPU 80% で min=1, max=2
+
+---
+
+## 2. apply 手順
+
+```bash
+# Step 0: 操作対象アカウントを確認 (stg / prod 取り違え防止)
+aws sts get-caller-identity
+
+cd terraform/environments/stg
+terraform fmt
+terraform validate
+terraform plan -out=daphne.plan
+# → 差分確認後、ハルナさん手動で:
+terraform apply daphne.plan
+```
+
+> CLAUDE.md §9 の通り、`terraform apply` は人間が必ず実行する。Claude は plan までで止まる。
+
+---
+
+## 3. 動作確認手順
+
+### 3.1 ECS task の起動確認
+
+```bash
+aws ecs describe-services \
+  --cluster sns-stg-cluster \
+  --services sns-stg-daphne \
+  --query 'services[0].{Desired:desiredCount,Running:runningCount,Status:status}'
+# 期待: Desired=1, Running=1, Status="ACTIVE"
+
+aws ecs describe-tasks \
+  --cluster sns-stg-cluster \
+  --tasks $(aws ecs list-tasks --cluster sns-stg-cluster --service-name sns-stg-daphne --query 'taskArns[]' --output text) \
+  --query 'tasks[0].{LastStatus:lastStatus,HealthStatus:healthStatus,StartedAt:startedAt}'
+# 期待: LastStatus="RUNNING", HealthStatus="HEALTHY"
+```
+
+### 3.2 ALB target group の Healthy count
+
+```bash
+TG_ARN=$(aws elbv2 describe-target-groups --names sns-stg-daphne --query 'TargetGroups[0].TargetGroupArn' --output text)
+aws elbv2 describe-target-health --target-group-arn "$TG_ARN" \
+  --query 'TargetHealthDescriptions[].{Target:Target.Id,State:TargetHealth.State}'
+# 期待: 全 target が State=healthy
+```
+
+### 3.3 WebSocket 接続テスト
+
+```bash
+# wscat (npm install -g wscat) で /ws/health/ に 101 (switching protocols) を期待
+wscat -c "wss://stg.example.com/ws/health/"
+# 期待: Connected (press CTRL+C to quit)
+
+# 認証必須の DM room へは Cookie JWT 付きで:
+COOKIE="access=...; refresh=..."
+wscat -c "wss://stg.example.com/ws/dm/<room_id>/" -H "Cookie: $COOKIE"
+# 期待: Connected (4401 / 4403 で close されない)
+```
+
+### 3.4 Sticky session cookie の確認
+
+```bash
+curl -is "https://stg.example.com/ws/health/" | grep -i "set-cookie"
+# 期待: AWSALB= ... のクッキーが返る (target stickiness 24h)
+```
+
+### 3.5 Cutover (deployment) 中の WebSocket 挙動
+
+cutover 中は新旧両方の Daphne タスクが Healthy になり、deregistration_delay (300s) 中は
+旧タスクへの既存 WebSocket 接続を維持しつつ新規接続は新タスクへ振り分ける想定:
+
+```bash
+# 新 task definition revision を deploy
+aws ecs update-service --cluster sns-stg-cluster --service sns-stg-daphne --force-new-deployment
+
+# 1 分後の状態確認
+sleep 60
+aws ecs describe-services --cluster sns-stg-cluster --services sns-stg-daphne \
+  --query 'services[0].deployments[].{Status:status,Desired:desiredCount,Running:runningCount,Created:createdAt}'
+# 期待: PRIMARY と ACTIVE が両方表示される (blue/green 風)、既存接続は ACTIVE 側で維持
+```
+
+---
+
+## 4. Auto Scaling の挙動
+
+| 条件                                         | 動作                      |
+| -------------------------------------------- | ------------------------- |
+| Daphne CPU avg > 80% (3 datapoints in 1 min) | task を 1 増やす (上限 2) |
+| Daphne CPU avg < 80% × 5 min                 | task を 1 減らす (下限 1) |
+
+Auto Scaling は `aws_appautoscaling_*` で AWS Application Auto Scaling 経由。
+CloudWatch アラーム / SNS 通知は Phase P3-18 (#243) で別途実装する。
+
+> WebSocket connection 数を直接 metric にできないため CPU を proxy として使っている。
+> Phase 4 で CW custom metric (active connections) に切り替え予定。
+
+---
+
+## 5. トラブルシュート
+
+### 5.1 `wscat` で 503
+
+target group が Healthy 0 の可能性。`describe-target-health` で確認。task の起動失敗なら CloudWatch Logs `/ecs/sns-stg/daphne` を確認。
+
+### 5.2 4401 Unauthorized で即 close
+
+Cookie JWT が無効。Django 側の auth middleware で reject されている。fast の場合は config/asgi.py の `JWTAuthMiddleware` 関連ログを確認。
+
+### 5.3 4403 Forbidden で即 close
+
+room メンバーでない。クライアントの room_id 解決ミス。
+
+### 5.4 接続中に突然 1006 abnormal close
+
+ALB idle_timeout 超過の可能性。Channels 側で keepalive ping (60s 間隔程度) を Phase 4 で導入予定。
+
+### 5.5 cutover 中に既存接続が drop
+
+`deregistration_delay` を増やす (現状 300s)。または `deployment_minimum_healthy_percent = 100` を確認。
+
+---
+
+## 6. 関連ドキュメント
+
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md) §3.3 ALB / §3.4 ECS Daphne / §3.5 Auto Scaling
+- [docs/operations/phase-3-stub-bridges.md](./phase-3-stub-bridges.md) — Phase 4 移行用ブリッジスタブ
+- [docs/SPEC.md](../SPEC.md) §7 — DM リアルタイム要件

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -48,9 +48,16 @@ locals {
     daphne = {
       port     = 8001
       protocol = "HTTP"
-      health   = "/ws/health/"
+      # ALB target group の health check は HTTP probe で WebSocket upgrade ではない。
+      # daphne は ProtocolTypeRouter 経由で HTTP も処理し、django_asgi_app → urls.py で
+      # /api/health/ を返す。/ws/health/ は urls.py に未登録 (asgi.py の docstring 参照)
+      # のため CRITICAL C-1 として `/api/health/` に修正 (architect review)。
+      health = "/api/health/"
       # WebSocket 再接続を同じタスクに張り付かせるため sticky (ARCHITECTURE §3.4)
       sticky = true
+      # WebSocket 接続を deregister 中も維持するため 300s (ARCHITECTURE §3.4)。
+      # app/next は 30s で十分なので per-TG で値を分ける (architect HIGH H-1)。
+      deregistration_delay = 300
     }
   }
 }
@@ -193,7 +200,8 @@ resource "aws_lb_target_group" "this" {
   vpc_id      = var.vpc_id
   target_type = "ip" # Fargate awsvpc mode
 
-  deregistration_delay = 30
+  # daphne (WebSocket) は cutover 時に既存接続を 300s 維持。app/next は 30s で十分。
+  deregistration_delay = lookup(each.value, "deregistration_delay", 30)
 
   # architect PR #51 MEDIUM: matcher を "200" に絞り、リダイレクトを
   # 健全状態と誤認しないようにする。

--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -49,6 +49,10 @@ locals {
     # `*` を追加して DisallowedHost を回避。Phase 2 で Django 側に health-check
     # 専用 middleware (ALLOWED_HOSTS bypass) を入れたら厳密化する。
     { name = "ALLOWED_HOSTS", value = "${var.domain},*" },
+    # P3-13 (security HIGH H-1): config/settings/base.py の fail-fast ガードを満たす。
+    # OriginValidator (Channels) で WebSocket cross-site 防御を行うため、
+    # 自ドメインのみを許可する。Origin スキームは https を強制 (Cookie JWT は Secure)。
+    { name = "DJANGO_CHANNELS_ALLOWED_ORIGINS", value = "https://${var.domain}" },
     # Mailgun secret (`sns/stg/mailgun/api-key`) が placeholder のままでメール
     # 配信できないため、stg は console backend で送信内容を CloudWatch Logs に
     # ダンプする運用にしてある。アクティベーション URL は
@@ -315,10 +319,10 @@ resource "aws_ecs_task_definition" "daphne" {
         "--proxy-headers",
         "config.asgi:application",
       ]
+      # awsvpc では hostPort は containerPort と同値固定なので省略 (architect MEDIUM M-2)。
       portMappings = [
         {
           containerPort = 8001
-          hostPort      = 8001
           protocol      = "tcp"
         }
       ]

--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -98,6 +98,8 @@ locals {
     "celery-worker"  = "/ecs/${local.prefix}/celery-worker"
     "celery-beat"    = "/ecs/${local.prefix}/celery-beat"
     "django-migrate" = aws_cloudwatch_log_group.migrate.name
+    # P3-13: Daphne (Channels ASGI) — observability module が log group を作成する。
+    "daphne" = "/ecs/${local.prefix}/daphne"
   }
 }
 
@@ -287,6 +289,57 @@ resource "aws_ecs_task_definition" "celery_beat" {
   tags = local.common_tags
 }
 
+# ---------- daphne (Channels ASGI WebSocket server, P3-13) ----------
+resource "aws_ecs_task_definition" "daphne" {
+  family                   = "${local.prefix}-daphne"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.daphne_cpu
+  memory                   = var.daphne_memory
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "daphne"
+      image     = "${var.ecr_repository_urls["django"]}:${var.image_tag}" # Django image を共有
+      essential = true
+      # SPEC §7 / ARCHITECTURE §3.4: Daphne で ASGI を起動。idle_timeout=3600 (ALB) と整合。
+      # Daphne 自体の websocket idle は 0 (無制限) に近い、コネクション維持は ALB 側で管理。
+      command = [
+        "daphne",
+        "-b",
+        "0.0.0.0",
+        "-p",
+        "8001",
+        "--proxy-headers",
+        "config.asgi:application",
+      ]
+      portMappings = [
+        {
+          containerPort = 8001
+          hostPort      = 8001
+          protocol      = "tcp"
+        }
+      ]
+      environment = local.common_env
+      secrets     = local.django_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = local.log_group_names["daphne"]
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "daphne"
+        }
+      }
+      # ALB target group の health check (/ws/health/) と一致させるため、
+      # container 内の health check は省略 (ALB 側で十分)。
+    }
+  ])
+
+  tags = local.common_tags
+}
+
 # ---------- django-migrate (one-shot, cd-stg.yml run-task) ----------
 resource "aws_ecs_task_definition" "django_migrate" {
   family                   = "${local.prefix}-django-migrate"
@@ -410,6 +463,46 @@ resource "aws_ecs_service" "celery_worker" {
   tags = local.common_tags
 }
 
+# daphne (ALB target group=daphne, port 8001, sticky session — P3-13)
+# WebSocket は再接続時に同じ task に貼り付けるため target group 側で sticky 設定済み。
+# deployment は max=200 で blue/green 風に切り替え、cutover 中も既存接続を維持する。
+resource "aws_ecs_service" "daphne" {
+  name             = "${local.prefix}-daphne"
+  cluster          = var.ecs_cluster_arn
+  task_definition  = aws_ecs_task_definition.daphne.arn
+  desired_count    = var.daphne_desired_count
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arns["daphne"]
+    container_name   = "daphne"
+    container_port   = 8001
+  }
+
+  # WebSocket connection の急な drop を避けるため、cutover 中は新旧両方が available。
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  # 既存接続が切れる前に target group から外す猶予 (deregistration_delay) を target group 側で 300s 設定済み。
+  # 本 service 側では task の安全な置き換えのため health_check_grace_period を長めに取る。
+  health_check_grace_period_seconds = 60
+
+  # cd-stg.yml が `force-new-deployment` で更新するため、image tag 変更で
+  # terraform plan に毎回差分が出ないよう、task_definition revision の管理は CD に委譲。
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+
+  tags = local.common_tags
+}
+
 # celery-beat (must be 1 task only — duplicates cause double scheduling)
 resource "aws_ecs_service" "celery_beat" {
   name             = "${local.prefix}-celery-beat"
@@ -434,4 +527,36 @@ resource "aws_ecs_service" "celery_beat" {
   }
 
   tags = local.common_tags
+}
+
+#####################################################################
+# Application Auto Scaling — daphne (P3-13 / Issue #238)
+#####################################################################
+# ARCHITECTURE §3.5: stg では Daphne は min=1 / max=2、CPU 80% で scale up。
+# WebSocket 接続数を直接ターゲットにしたいが ECS service の組み込みメトリクスは
+# CPU / Memory のみのため、CPU を proxy として使う (Phase 4 で CW custom metric 検討)。
+
+resource "aws_appautoscaling_target" "daphne" {
+  service_namespace  = "ecs"
+  scalable_dimension = "ecs:service:DesiredCount"
+  resource_id        = "service/${replace(var.ecs_cluster_arn, "/^.+\\//", "")}/${aws_ecs_service.daphne.name}"
+  min_capacity       = var.daphne_autoscaling_min_capacity
+  max_capacity       = var.daphne_autoscaling_max_capacity
+}
+
+resource "aws_appautoscaling_policy" "daphne_cpu" {
+  name               = "${local.prefix}-daphne-cpu-target"
+  service_namespace  = aws_appautoscaling_target.daphne.service_namespace
+  scalable_dimension = aws_appautoscaling_target.daphne.scalable_dimension
+  resource_id        = aws_appautoscaling_target.daphne.resource_id
+  policy_type        = "TargetTrackingScaling"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = var.daphne_autoscaling_cpu_target
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
 }

--- a/terraform/modules/services/outputs.tf
+++ b/terraform/modules/services/outputs.tf
@@ -14,6 +14,11 @@ output "celery_beat_service_name" {
   value = aws_ecs_service.celery_beat.name
 }
 
+output "daphne_service_name" {
+  description = "P3-13 daphne (Channels) ECS service 名"
+  value       = aws_ecs_service.daphne.name
+}
+
 output "service_names_csv" {
   description = "cd-stg.yml の vars.ECS_SERVICES に貼る用 (カンマ区切り)"
   value = join(",", [
@@ -21,6 +26,7 @@ output "service_names_csv" {
     aws_ecs_service.next.name,
     aws_ecs_service.celery_worker.name,
     aws_ecs_service.celery_beat.name,
+    aws_ecs_service.daphne.name,
   ])
 }
 

--- a/terraform/modules/services/variables.tf
+++ b/terraform/modules/services/variables.tf
@@ -47,8 +47,16 @@ variable "ecr_repository_urls" {
 }
 
 variable "target_group_arns" {
-  description = "Map of ALB target group logical name → ARN. Must contain 'app' (django) and 'next' (Next.js SSR)."
+  description = "Map of ALB target group logical name → ARN. Must contain 'app' (django), 'next' (Next.js SSR), and 'daphne' (Channels WebSocket, P3-13)."
   type        = map(string)
+  validation {
+    condition = (
+      contains(keys(var.target_group_arns), "app") &&
+      contains(keys(var.target_group_arns), "next") &&
+      contains(keys(var.target_group_arns), "daphne")
+    )
+    error_message = "target_group_arns must contain 'app', 'next', and 'daphne' keys."
+  }
 }
 
 variable "private_subnet_ids" {
@@ -161,6 +169,44 @@ variable "celery_memory" {
   description = "Fargate memory (MiB) for celery-worker and celery-beat."
   type        = number
   default     = 512
+}
+
+# ---------- daphne (P3-13 / Issue #238) ----------
+
+variable "daphne_cpu" {
+  description = "Fargate CPU units for the Daphne (Channels) task."
+  type        = number
+  default     = 256
+}
+
+variable "daphne_memory" {
+  description = "Fargate memory (MiB) for the Daphne (Channels) task."
+  type        = number
+  default     = 512
+}
+
+variable "daphne_desired_count" {
+  description = "Desired running count of Daphne tasks. ARCHITECTURE §3.5 で stg は min=1。"
+  type        = number
+  default     = 1
+}
+
+variable "daphne_autoscaling_min_capacity" {
+  description = "Daphne の Application Auto Scaling 下限 (ARCHITECTURE §3.5)."
+  type        = number
+  default     = 1
+}
+
+variable "daphne_autoscaling_max_capacity" {
+  description = "Daphne の Application Auto Scaling 上限 (ARCHITECTURE §3.5)."
+  type        = number
+  default     = 2
+}
+
+variable "daphne_autoscaling_cpu_target" {
+  description = "Daphne の CPU target tracking 値 (パーセント、ARCHITECTURE §3.5 で 80%)."
+  type        = number
+  default     = 80
 }
 
 variable "log_retention_days" {


### PR DESCRIPTION
## Summary

P3-13 (Issue #238): WebSocket / DM real-time のための ECS daphne service を services モジュールに追加。ALB target group `daphne` (port 8001, sticky 24h) と /ws/* listener rule は P0.5/P3-02 で既に compute モジュールにあるため再利用。

### 主な追加

- **services モジュール**:
  - `aws_ecs_task_definition.daphne` (Django image を共有, daphne 起動コマンド)
  - `aws_ecs_service.daphne` (target group "daphne" sticky, deployment min=100/max=200)
  - `aws_appautoscaling_target/policy.daphne` (ARCHITECTURE §3.5: min=1/max=2/CPU 80%)
  - `daphne_cpu/memory/desired_count` + autoscaling vars
  - `target_group_arns` validation で "daphne" 必須
  - `service_names_csv` に daphne 追加 (cd-stg.yml 連動)

- **compute モジュール (修正)**:
  - daphne TG の health check を `/api/health/` に (asgi.py 設計と整合)
  - daphne TG の `deregistration_delay = 300s` に (app/next は 30s 維持)

- **runbook**: `docs/operations/dm-channels-runbook.md` 新規 (apply / 起動確認 / wscat / cutover / autoscaling / トラブルシュート)

## サブエージェントレビュー対応

| reviewer | severity | finding | 対応 |
| -------- | -------- | ------- | ---- |
| code-architect | CRITICAL C-1 | daphne TG `/ws/health/` は urls.py 未登録で 404 → unhealthy | `/api/health/` に修正 |
| code-architect HIGH H-1 / security HIGH H-2 | HIGH | deregistration_delay 30s vs 300s 乖離 | daphne のみ 300s |
| security-reviewer HIGH H-1 | HIGH | `DJANGO_CHANNELS_ALLOWED_ORIGINS` env 未注入で fail-fast | common_env に追加 |
| code-architect MEDIUM M-2 | MEDIUM | hostPort の冗長指定 | 削除 (awsvpc 固定) |
| security-reviewer MEDIUM M-3 | MEDIUM | runbook で Cookie 平文保持 | `read -s` に変更 |
| code-architect LOW L-2/L-3 | LOW | wscat 1000 close / 表記不一致 | runbook 補足 |

スコープ外として残置 (本 PR 範囲外):
- security HIGH H-3 ALLOWED_HOSTS=`*` (既存設定、Phase 2 起源)
- security MEDIUM M-1 共有 ecs_task_role の S3 権限 (P3-07 で wiring 済、Phase 9 に最小権限分割)
- security MEDIUM M-4 asgi.py の `assert` (本 PR で追加していない)

## Test plan

- [x] `terraform fmt -recursive` OK
- [x] `terraform validate` OK
- [x] pre-commit hooks 全 pass (prettier / detect-secrets / pytest local gate)
- [ ] CI green を待ってマージ
- [ ] `terraform apply` (compute TG 変更含む) はハルナさん手動

## 関連

- Closes #238
- 依存: ALB / target group / listener rule (#199 P3-02 既マージ)
- 後続: #243 (P3-18 CloudWatch)、#247 (P3-22 stg deploy 検証)
- ARCHITECTURE.md §3.3-§3.5 / SPEC §7