### PR TITLE
[feature][dm] DM 一覧 + 招待画面 (REST 経路, Closes #233 #237)

### DIFF
--- a/client/src/app/(template)/messages/invitations/page.tsx
+++ b/client/src/app/(template)/messages/invitations/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * `/messages/invitations` ページ (P3-12 / Issue #237).
+ *
+ * 自分宛のグループ招待 (pending) を一覧、承諾 / 拒否ボタンを提供する。
+ * Phase 4A の通知ベル UI が完成したらそちらに統合される予定。
+ */
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import InvitationList from "@/components/dm/InvitationList";
+import { useUserProfile } from "@/hooks/useUseProfile";
+import { useAppSelector } from "@/lib/redux/hooks/typedHooks";
+
+export default function InvitationsPage() {
+	const router = useRouter();
+	const { isAuthenticated } = useAppSelector((state) => state.auth);
+	const { isLoading } = useUserProfile();
+
+	useEffect(() => {
+		if (!isAuthenticated && !isLoading) {
+			router.replace("/login?next=/messages/invitations");
+		}
+	}, [isAuthenticated, isLoading, router]);
+
+	if (!isAuthenticated) {
+		return (
+			<section
+				role="status"
+				aria-live="polite"
+				className="text-baby_grey mx-auto max-w-2xl py-12 text-center"
+			>
+				認証情報を確認しています...
+			</section>
+		);
+	}
+
+	return (
+		<section className="mx-auto max-w-2xl">
+			<header className="mb-6 flex items-baseline justify-between">
+				<h1 className="text-baby_white text-xl font-bold">グループ招待</h1>
+				<Link
+					href="/messages"
+					className="text-baby_blue focus-visible:outline-baby_blue text-sm underline focus-visible:outline-2"
+				>
+					← メッセージ一覧
+				</Link>
+			</header>
+			<InvitationList />
+		</section>
+	);
+}

--- a/client/src/app/(template)/messages/invitations/page.tsx
+++ b/client/src/app/(template)/messages/invitations/page.tsx
@@ -44,9 +44,9 @@ export default function InvitationsPage() {
 				<h1 className="text-baby_white text-xl font-bold">グループ招待</h1>
 				<Link
 					href="/messages"
-					className="text-baby_blue focus-visible:outline-baby_blue text-sm underline focus-visible:outline-2"
+					className="text-baby_blue focus-visible:ring-baby_blue focus-visible:ring-offset-baby_veryBlack text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
 				>
-					← メッセージ一覧
+					<span aria-hidden="true">←</span> メッセージ一覧
 				</Link>
 			</header>
 			<InvitationList />

--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+/**
+ * `/messages` ページ (P3-08 / Issue #233).
+ *
+ * 認証必須。未認証は `/login` にリダイレクトする。
+ * 自分が参加中の DM ルーム一覧を表示。
+ */
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import RoomList from "@/components/dm/RoomList";
+import { useUserProfile } from "@/hooks/useUseProfile";
+import { useAppSelector } from "@/lib/redux/hooks/typedHooks";
+
+export default function MessagesPage() {
+	const router = useRouter();
+	const { isAuthenticated } = useAppSelector((state) => state.auth);
+	const { profile, isLoading } = useUserProfile();
+
+	useEffect(() => {
+		if (!isAuthenticated && !isLoading) {
+			router.replace("/login?next=/messages");
+		}
+	}, [isAuthenticated, isLoading, router]);
+
+	if (!isAuthenticated || !profile) {
+		return (
+			<section
+				role="status"
+				aria-live="polite"
+				className="text-baby_grey mx-auto max-w-2xl py-12 text-center"
+			>
+				認証情報を確認しています...
+			</section>
+		);
+	}
+
+	return (
+		<section className="mx-auto max-w-2xl">
+			<header className="mb-6 flex items-baseline justify-between">
+				<h1 className="text-baby_white text-xl font-bold">メッセージ</h1>
+				{/* 新規 DM 開始ボタン: P3-11 (#236) で本格実装。本 PR では空状態 CTA のみ。 */}
+			</header>
+			<RoomList currentUserId={Number(profile.id)} />
+		</section>
+	);
+}

--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -37,13 +37,29 @@ export default function MessagesPage() {
 		);
 	}
 
+	// Profile.id は legacy 都合で `string` 型 (UserResponse 由来) だが、
+	// Django serializer は実際には BigAutoField を JSON number として返す。
+	// `Number(...)` で coerce すると非数値文字列で NaN になり display name 計算が
+	// 崩れるため、parseInt + isNaN ガードで明示的に弾く (ts-reviewer HIGH H-1)。
+	const currentUserId = Number.parseInt(profile.id, 10);
+	if (Number.isNaN(currentUserId)) {
+		return (
+			<section
+				role="alert"
+				className="text-baby_red mx-auto max-w-2xl py-12 text-center"
+			>
+				プロフィール ID の形式が不正です。再ログインしてください。
+			</section>
+		);
+	}
+
 	return (
 		<section className="mx-auto max-w-2xl">
 			<header className="mb-6 flex items-baseline justify-between">
 				<h1 className="text-baby_white text-xl font-bold">メッセージ</h1>
 				{/* 新規 DM 開始ボタン: P3-11 (#236) で本格実装。本 PR では空状態 CTA のみ。 */}
 			</header>
-			<RoomList currentUserId={Number(profile.id)} />
+			<RoomList currentUserId={currentUserId} />
 		</section>
 	);
 }

--- a/client/src/components/dm/InvitationList.tsx
+++ b/client/src/components/dm/InvitationList.tsx
@@ -22,28 +22,38 @@ import { formatRelativeTime } from "@/lib/timeline/formatTime";
 export default function InvitationList() {
 	const router = useRouter();
 	const query = useListInvitationsQuery({ status: "pending" });
-	const [acceptInvitation, acceptState] = useAcceptInvitationMutation();
-	const [declineInvitation, declineState] = useDeclineInvitationMutation();
+	const [acceptInvitation] = useAcceptInvitationMutation();
+	const [declineInvitation] = useDeclineInvitationMutation();
 	const [actionError, setActionError] = useState<string | null>(null);
+	// Per-invitation の処理中 id を track する (ts-reviewer / code-reviewer HIGH H-2 反映)。
+	// 旧実装は acceptState/declineState の isLoading 共有でリスト全体が disabled になり、
+	// 別 row の操作も不可能になっていた。
+	const [processingId, setProcessingId] = useState<number | null>(null);
 
 	const invitations = query.data?.results ?? [];
 
 	const onAccept = async (inv: GroupInvitation) => {
 		setActionError(null);
+		setProcessingId(inv.id);
 		try {
 			const result = await acceptInvitation(inv.id).unwrap();
 			router.push(`/messages/${result.room.id}`);
 		} catch {
 			setActionError("招待の承諾に失敗しました。再試行してください。");
+		} finally {
+			setProcessingId(null);
 		}
 	};
 
 	const onDecline = async (inv: GroupInvitation) => {
 		setActionError(null);
+		setProcessingId(inv.id);
 		try {
 			await declineInvitation(inv.id).unwrap();
 		} catch {
 			setActionError("招待の拒否に失敗しました。再試行してください。");
+		} finally {
+			setProcessingId(null);
 		}
 	};
 
@@ -74,8 +84,6 @@ export default function InvitationList() {
 			</div>
 		);
 	}
-
-	const isProcessing = acceptState.isLoading || declineState.isLoading;
 
 	return (
 		<div data-testid="invitation-list">
@@ -118,15 +126,17 @@ export default function InvitationList() {
 							<button
 								type="button"
 								onClick={() => onAccept(inv)}
-								disabled={isProcessing}
+								disabled={processingId === inv.id}
+								aria-busy={processingId === inv.id}
 								className="bg-baby_blue text-baby_white focus-visible:outline-baby_white rounded-md px-3 py-1.5 text-sm font-semibold focus-visible:outline-2 disabled:opacity-50"
 							>
-								承諾
+								{processingId === inv.id ? "処理中..." : "承諾"}
 							</button>
 							<button
 								type="button"
 								onClick={() => onDecline(inv)}
-								disabled={isProcessing}
+								disabled={processingId === inv.id}
+								aria-busy={processingId === inv.id}
 								className="border-baby_grey text-baby_grey hover:bg-baby_grey/10 focus-visible:outline-baby_white rounded-md border px-3 py-1.5 text-sm font-semibold focus-visible:outline-2 disabled:opacity-50"
 							>
 								拒否

--- a/client/src/components/dm/InvitationList.tsx
+++ b/client/src/components/dm/InvitationList.tsx
@@ -93,7 +93,10 @@ export default function InvitationList() {
 						key={inv.id}
 						className="border-baby_grey/10 flex items-center gap-3 border-b px-4 py-3 last:border-b-0"
 					>
-						<div className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold">
+						<div
+							aria-hidden="true"
+							className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold"
+						>
 							{inv.inviter.username[0]?.toUpperCase() ?? "?"}
 						</div>
 						<div className="min-w-0 flex-1">

--- a/client/src/components/dm/InvitationList.tsx
+++ b/client/src/components/dm/InvitationList.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * グループ招待リスト (P3-12 / Issue #237).
+ *
+ * `/api/v1/dm/invitations/?status=pending` を fetch、各招待に承諾 / 拒否ボタンを
+ * 表示する。承諾成功時は `/messages/<room_id>` に遷移、拒否は同ページにとどまり
+ * リストから消える (RTK Query invalidatesTags で自動 refetch)。
+ */
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import {
+	useAcceptInvitationMutation,
+	useDeclineInvitationMutation,
+	useListInvitationsQuery,
+} from "@/lib/redux/features/dm/dmApiSlice";
+import type { GroupInvitation } from "@/lib/redux/features/dm/types";
+import { formatRelativeTime } from "@/lib/timeline/formatTime";
+
+export default function InvitationList() {
+	const router = useRouter();
+	const query = useListInvitationsQuery({ status: "pending" });
+	const [acceptInvitation, acceptState] = useAcceptInvitationMutation();
+	const [declineInvitation, declineState] = useDeclineInvitationMutation();
+	const [actionError, setActionError] = useState<string | null>(null);
+
+	const invitations = query.data?.results ?? [];
+
+	const onAccept = async (inv: GroupInvitation) => {
+		setActionError(null);
+		try {
+			const result = await acceptInvitation(inv.id).unwrap();
+			router.push(`/messages/${result.room.id}`);
+		} catch {
+			setActionError("招待の承諾に失敗しました。再試行してください。");
+		}
+	};
+
+	const onDecline = async (inv: GroupInvitation) => {
+		setActionError(null);
+		try {
+			await declineInvitation(inv.id).unwrap();
+		} catch {
+			setActionError("招待の拒否に失敗しました。再試行してください。");
+		}
+	};
+
+	if (query.isLoading) {
+		return (
+			<div
+				role="status"
+				aria-live="polite"
+				className="text-baby_grey py-12 text-center"
+			>
+				読み込み中...
+			</div>
+		);
+	}
+
+	if (query.isError) {
+		return (
+			<div role="alert" className="text-baby_red py-12 text-center">
+				招待一覧の取得に失敗しました。再読み込みしてください。
+			</div>
+		);
+	}
+
+	if (invitations.length === 0) {
+		return (
+			<div className="text-baby_grey py-12 text-center">
+				保留中の招待はありません。
+			</div>
+		);
+	}
+
+	const isProcessing = acceptState.isLoading || declineState.isLoading;
+
+	return (
+		<div data-testid="invitation-list">
+			{actionError ? (
+				<div
+					role="alert"
+					className="border-baby_red/40 bg-baby_red/5 text-baby_red mb-4 rounded-md border px-4 py-3 text-sm"
+				>
+					{actionError}
+				</div>
+			) : null}
+			<ul className="border-baby_grey/10 overflow-hidden rounded-md border">
+				{invitations.map((inv) => (
+					<li
+						key={inv.id}
+						className="border-baby_grey/10 flex items-center gap-3 border-b px-4 py-3 last:border-b-0"
+					>
+						<div className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold">
+							{inv.inviter.username[0]?.toUpperCase() ?? "?"}
+						</div>
+						<div className="min-w-0 flex-1">
+							<p className="text-baby_white truncate text-sm">
+								<strong>@{inv.inviter.username}</strong> から
+								<span className="mx-1 font-semibold">
+									{inv.room.name || "(無名のグループ)"}
+								</span>
+								への招待
+							</p>
+							<time
+								dateTime={inv.created_at}
+								className="text-baby_grey text-xs"
+							>
+								{formatRelativeTime(inv.created_at)}
+							</time>
+						</div>
+						<div className="flex shrink-0 gap-2">
+							<button
+								type="button"
+								onClick={() => onAccept(inv)}
+								disabled={isProcessing}
+								className="bg-baby_blue text-baby_white focus-visible:outline-baby_white rounded-md px-3 py-1.5 text-sm font-semibold focus-visible:outline-2 disabled:opacity-50"
+							>
+								承諾
+							</button>
+							<button
+								type="button"
+								onClick={() => onDecline(inv)}
+								disabled={isProcessing}
+								className="border-baby_grey text-baby_grey hover:bg-baby_grey/10 focus-visible:outline-baby_white rounded-md border px-3 py-1.5 text-sm font-semibold focus-visible:outline-2 disabled:opacity-50"
+							>
+								拒否
+							</button>
+						</div>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/client/src/components/dm/RoomList.tsx
+++ b/client/src/components/dm/RoomList.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * DM Room 一覧 (P3-08 / Issue #233).
+ *
+ * RTK Query で `/api/v1/dm/rooms/` を fetch。loading / empty / error / 成功の
+ * 4 状態を扱い、room を `last_message_at` 降順で並べる (バックエンド側で
+ * order_by 済み。クライアントで再ソートしない)。
+ *
+ * 招待バッジ: pending invitations が 1 件以上あれば `招待 N 件`の callout を上部に表示。
+ * 新規 DM 作成 / グループ作成 UI は P3-11 (#236) で別 PR、本 PR では空状態 CTA のみ。
+ */
+
+import Link from "next/link";
+
+import RoomListItem from "@/components/dm/RoomListItem";
+import {
+	useListDMRoomsQuery,
+	useListInvitationsQuery,
+} from "@/lib/redux/features/dm/dmApiSlice";
+
+interface RoomListProps {
+	currentUserId: number;
+}
+
+export default function RoomList({ currentUserId }: RoomListProps) {
+	const roomsQuery = useListDMRoomsQuery();
+	const invitationsQuery = useListInvitationsQuery({ status: "pending" });
+
+	const rooms = roomsQuery.data?.results ?? [];
+	const pendingInvitationCount = invitationsQuery.data?.count ?? 0;
+
+	if (roomsQuery.isLoading) {
+		return (
+			<div
+				role="status"
+				aria-live="polite"
+				className="text-baby_grey py-12 text-center"
+			>
+				読み込み中...
+			</div>
+		);
+	}
+
+	if (roomsQuery.isError) {
+		return (
+			<div role="alert" className="text-baby_red py-12 text-center">
+				ルーム一覧の取得に失敗しました。再読み込みしてください。
+			</div>
+		);
+	}
+
+	return (
+		<div data-testid="room-list">
+			{pendingInvitationCount > 0 ? (
+				<Link
+					href="/messages/invitations"
+					className="border-baby_blue/40 bg-baby_blue/5 text-baby_blue hover:bg-baby_blue/10 focus-visible:outline-baby_blue mb-4 block rounded-md border px-4 py-3 text-sm focus-visible:outline-2"
+					aria-label={`保留中のグループ招待 ${pendingInvitationCount} 件、招待ページに移動`}
+				>
+					保留中のグループ招待が <strong>{pendingInvitationCount}</strong>{" "}
+					件あります →
+				</Link>
+			) : null}
+			{rooms.length === 0 ? (
+				<div className="py-12 text-center">
+					<p className="text-baby_grey">まだメッセージはありません。</p>
+					<Link
+						href="/explore"
+						className="text-baby_blue focus-visible:outline-baby_blue mt-4 inline-block underline focus-visible:outline-2"
+					>
+						ユーザーを探す
+					</Link>
+				</div>
+			) : (
+				<ul className="border-baby_grey/10 overflow-hidden rounded-md border">
+					{rooms.map((room) => (
+						<RoomListItem
+							key={room.id}
+							room={room}
+							currentUserId={currentUserId}
+						/>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/client/src/components/dm/RoomList.tsx
+++ b/client/src/components/dm/RoomList.tsx
@@ -55,11 +55,11 @@ export default function RoomList({ currentUserId }: RoomListProps) {
 			{pendingInvitationCount > 0 ? (
 				<Link
 					href="/messages/invitations"
-					className="border-baby_blue/40 bg-baby_blue/5 text-baby_blue hover:bg-baby_blue/10 focus-visible:outline-baby_blue mb-4 block rounded-md border px-4 py-3 text-sm focus-visible:outline-2"
+					className="border-baby_blue/40 bg-baby_blue/5 text-baby_blue hover:bg-baby_blue/10 focus-visible:ring-baby_blue focus-visible:ring-offset-baby_veryBlack mb-4 block rounded-md border px-4 py-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
 					aria-label={`保留中のグループ招待 ${pendingInvitationCount} 件、招待ページに移動`}
 				>
 					保留中のグループ招待が <strong>{pendingInvitationCount}</strong>{" "}
-					件あります →
+					件あります <span aria-hidden="true">→</span>
 				</Link>
 			) : null}
 			{rooms.length === 0 ? (
@@ -67,7 +67,7 @@ export default function RoomList({ currentUserId }: RoomListProps) {
 					<p className="text-baby_grey">まだメッセージはありません。</p>
 					<Link
 						href="/explore"
-						className="text-baby_blue focus-visible:outline-baby_blue mt-4 inline-block underline focus-visible:outline-2"
+						className="text-baby_blue focus-visible:ring-baby_blue focus-visible:ring-offset-baby_veryBlack mt-4 inline-block underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
 					>
 						ユーザーを探す
 					</Link>

--- a/client/src/components/dm/RoomListItem.tsx
+++ b/client/src/components/dm/RoomListItem.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/**
+ * DM Room 一覧の 1 行 (P3-08 / Issue #233).
+ *
+ * 構成: avatar (direct: 相手 / group: initials + auto color) + display name
+ * + last message snippet + 相対時刻 + 未読バッジ。
+ * クリックで `/messages/<room_id>` に遷移。
+ *
+ * a11y:
+ * - `<Link>` 全体 ratable
+ * - 未読バッジは `<span aria-label="未読 N 件">` で SR にも数を伝達
+ * - 64px 高さ (touch target、SPEC §16.2 モバイル対応)
+ */
+
+import Link from "next/link";
+
+import {
+	colorFromId,
+	getGroupInitials,
+	getRoomDisplayName,
+	pickPeer,
+	truncateSnippet,
+} from "@/lib/dm/format";
+import { formatRelativeTime } from "@/lib/timeline/formatTime";
+import type { DMRoom } from "@/lib/redux/features/dm/types";
+
+interface RoomListItemProps {
+	room: DMRoom;
+	currentUserId: number;
+}
+
+export default function RoomListItem({
+	room,
+	currentUserId,
+}: RoomListItemProps) {
+	const displayName = getRoomDisplayName(room, currentUserId);
+	const snippet = truncateSnippet(room.last_message_snippet);
+	const unread = room.unread_count ?? 0;
+	const updatedAt = room.last_message_at ?? room.updated_at ?? room.created_at;
+
+	return (
+		<li className="border-baby_grey/10 border-b">
+			<Link
+				href={`/messages/${room.id}`}
+				className="hover:bg-baby_grey/5 focus-visible:outline-baby_blue flex min-h-[64px] items-center gap-3 px-4 py-3 focus-visible:outline-2"
+				aria-label={`${displayName} とのトーク${unread > 0 ? `, 未読 ${unread} 件` : ""}`}
+			>
+				<RoomAvatar room={room} currentUserId={currentUserId} />
+				<div className="min-w-0 flex-1">
+					<div className="flex items-baseline justify-between gap-2">
+						<span className="text-baby_white truncate text-sm font-semibold">
+							{displayName}
+						</span>
+						{updatedAt ? (
+							<time
+								dateTime={updatedAt}
+								className="text-baby_grey shrink-0 text-xs"
+							>
+								{formatRelativeTime(updatedAt)}
+							</time>
+						) : null}
+					</div>
+					<div className="flex items-baseline justify-between gap-2">
+						<span className="text-baby_grey truncate text-sm">{snippet}</span>
+						{unread > 0 ? (
+							<span
+								data-testid="unread-badge"
+								className="bg-baby_blue text-baby_white shrink-0 rounded-full px-2 py-0.5 text-xs font-bold"
+								aria-label={`未読 ${unread} 件`}
+							>
+								{unread > 99 ? "99+" : unread}
+							</span>
+						) : null}
+					</div>
+				</div>
+			</Link>
+		</li>
+	);
+}
+
+function RoomAvatar({
+	room,
+	currentUserId,
+}: {
+	room: DMRoom;
+	currentUserId: number;
+}) {
+	if (room.kind === "direct") {
+		const peer = pickPeer(room, currentUserId);
+		const src = peer?.avatar ?? null;
+		const fallback = peer ? (peer.username[0]?.toUpperCase() ?? "?") : "?";
+		return src ? (
+			// eslint-disable-next-line @next/next/no-img-element
+			<img
+				src={src}
+				alt=""
+				width={48}
+				height={48}
+				className="size-12 shrink-0 rounded-full object-cover"
+			/>
+		) : (
+			<div
+				aria-hidden="true"
+				className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold"
+			>
+				{fallback}
+			</div>
+		);
+	}
+	const initials = getGroupInitials(room.name || "");
+	return (
+		<div
+			aria-hidden="true"
+			style={{ backgroundColor: colorFromId(room.id) }}
+			className="text-baby_white flex size-12 shrink-0 items-center justify-center rounded-xl text-sm font-bold"
+		>
+			{initials}
+		</div>
+	);
+}

--- a/client/src/components/dm/RoomListItem.tsx
+++ b/client/src/components/dm/RoomListItem.tsx
@@ -43,7 +43,7 @@ export default function RoomListItem({
 		<li className="border-baby_grey/10 border-b">
 			<Link
 				href={`/messages/${room.id}`}
-				className="hover:bg-baby_grey/5 focus-visible:outline-baby_blue flex min-h-[64px] items-center gap-3 px-4 py-3 focus-visible:outline-2"
+				className="focus-visible:ring-baby_blue focus-visible:ring-offset-baby_veryBlack hover:bg-baby_grey/5 flex min-h-[64px] items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
 				aria-label={`${displayName} とのトーク${unread > 0 ? `, 未読 ${unread} 件` : ""}`}
 			>
 				<RoomAvatar room={room} currentUserId={currentUserId} />

--- a/client/src/components/dm/__tests__/InvitationList.test.tsx
+++ b/client/src/components/dm/__tests__/InvitationList.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Tests for InvitationList (P3-12 / Issue #237).
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import InvitationList from "@/components/dm/InvitationList";
+import type { GroupInvitation } from "@/lib/redux/features/dm/types";
+
+const mockList = vi.fn();
+const mockAccept = vi.fn();
+const mockDecline = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock("@/lib/redux/features/dm/dmApiSlice", () => ({
+	useListInvitationsQuery: () => mockList(),
+	useAcceptInvitationMutation: () => [
+		mockAccept,
+		{ isLoading: false, isError: false },
+	],
+	useDeclineInvitationMutation: () => [
+		mockDecline,
+		{ isLoading: false, isError: false },
+	],
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush, replace: vi.fn() }),
+}));
+
+function makeInvitation(
+	overrides: Partial<GroupInvitation> = {},
+): GroupInvitation {
+	return {
+		id: 1,
+		room: { id: 100, kind: "group", name: "Engineers" },
+		inviter: { id: 200, username: "alice", first_name: "", last_name: "" },
+		invitee: { id: 100, username: "me", first_name: "", last_name: "" },
+		accepted: null,
+		created_at: "2026-05-01T12:00:00Z",
+		updated_at: "2026-05-01T12:00:00Z",
+		...overrides,
+	};
+}
+
+describe("InvitationList", () => {
+	beforeEach(() => {
+		mockAccept.mockReset();
+		mockDecline.mockReset();
+		mockPush.mockReset();
+	});
+
+	it("loading 状態を表示する", () => {
+		mockList.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			isError: false,
+		});
+		render(<InvitationList />);
+		expect(screen.getByRole("status")).toHaveTextContent("読み込み中");
+	});
+
+	it("error 状態を表示する", () => {
+		mockList.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		render(<InvitationList />);
+		expect(screen.getByRole("alert")).toHaveTextContent("取得に失敗");
+	});
+
+	it("空リストで「保留中の招待はありません」を表示する", () => {
+		mockList.mockReturnValue({
+			data: { count: 0, next: null, previous: null, results: [] },
+			isLoading: false,
+			isError: false,
+		});
+		render(<InvitationList />);
+		expect(screen.getByText(/保留中の招待はありません/)).toBeInTheDocument();
+	});
+
+	it("招待 1 件を表示する", () => {
+		mockList.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeInvitation()],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		render(<InvitationList />);
+		expect(screen.getByText("@alice", { exact: false })).toBeInTheDocument();
+		expect(screen.getByText("Engineers")).toBeInTheDocument();
+	});
+
+	it("承諾ボタンクリックで accept mutation を呼び /messages/<room> へ遷移", async () => {
+		mockList.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeInvitation()],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		mockAccept.mockReturnValue({
+			unwrap: () =>
+				Promise.resolve({
+					id: 1,
+					room: { id: 100, kind: "group", name: "Engineers" },
+				}),
+		});
+		render(<InvitationList />);
+		await userEvent.click(screen.getByRole("button", { name: "承諾" }));
+		await waitFor(() => expect(mockAccept).toHaveBeenCalledWith(1));
+		await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/messages/100"));
+	});
+
+	it("承諾失敗時は alert を表示", async () => {
+		mockList.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeInvitation()],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		mockAccept.mockReturnValue({
+			unwrap: () => Promise.reject(new Error("server error")),
+		});
+		render(<InvitationList />);
+		await userEvent.click(screen.getByRole("button", { name: "承諾" }));
+		await waitFor(() =>
+			expect(screen.getByRole("alert")).toHaveTextContent(/承諾に失敗/),
+		);
+	});
+
+	it("拒否ボタンクリックで decline mutation を呼ぶ", async () => {
+		mockList.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeInvitation()],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		mockDecline.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+		render(<InvitationList />);
+		await userEvent.click(screen.getByRole("button", { name: "拒否" }));
+		await waitFor(() => expect(mockDecline).toHaveBeenCalledWith(1));
+		expect(mockPush).not.toHaveBeenCalled();
+	});
+});

--- a/client/src/components/dm/__tests__/RoomList.test.tsx
+++ b/client/src/components/dm/__tests__/RoomList.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Tests for RoomList (P3-08 / Issue #233).
+ *
+ * RTK Query hook を mock して 4 状態 (loading / error / empty / 成功) を検証。
+ * 招待バッジの表示 / 未読バッジの a11y label / 順序 (ordering は backend 側) も。
+ */
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RoomList from "@/components/dm/RoomList";
+import type { DMRoom } from "@/lib/redux/features/dm/types";
+
+const mockListRooms = vi.fn();
+const mockListInvitations = vi.fn();
+
+vi.mock("@/lib/redux/features/dm/dmApiSlice", () => ({
+	useListDMRoomsQuery: () => mockListRooms(),
+	useListInvitationsQuery: () => mockListInvitations(),
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+function makeRoom(overrides: Partial<DMRoom> = {}): DMRoom {
+	return {
+		id: 1,
+		kind: "direct",
+		name: "",
+		creator: null,
+		memberships: [
+			{
+				id: 1,
+				user: { id: 100, username: "me", first_name: "", last_name: "" },
+				last_read_at: null,
+				created_at: "2026-05-01T00:00:00Z",
+			},
+			{
+				id: 2,
+				user: {
+					id: 200,
+					username: "alice",
+					first_name: "Alice",
+					last_name: "",
+				},
+				last_read_at: null,
+				created_at: "2026-05-01T00:00:00Z",
+			},
+		],
+		last_message_at: "2026-05-01T12:00:00Z",
+		last_message_snippet: "hello world",
+		is_archived: false,
+		created_at: "2026-05-01T00:00:00Z",
+		updated_at: "2026-05-01T00:00:00Z",
+		unread_count: 0,
+		...overrides,
+	};
+}
+
+describe("RoomList", () => {
+	beforeEach(() => {
+		mockListInvitations.mockReturnValue({
+			data: { count: 0, next: null, previous: null, results: [] },
+			isLoading: false,
+			isError: false,
+		});
+	});
+
+	it("loading 状態を role=status で表示する", () => {
+		mockListRooms.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		expect(screen.getByRole("status")).toHaveTextContent("読み込み中");
+	});
+
+	it("error 状態を role=alert で表示する", () => {
+		mockListRooms.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		render(<RoomList currentUserId={100} />);
+		expect(screen.getByRole("alert")).toHaveTextContent("取得に失敗しました");
+	});
+
+	it("空リストでは empty CTA を表示する", () => {
+		mockListRooms.mockReturnValue({
+			data: { count: 0, next: null, previous: null, results: [] },
+			isLoading: false,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		expect(screen.getByText(/まだメッセージはありません/)).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /ユーザーを探す/ }),
+		).toBeInTheDocument();
+	});
+
+	it("room の peer username を direct room の display name として表示する", () => {
+		mockListRooms.mockReturnValue({
+			data: { count: 1, next: null, previous: null, results: [makeRoom()] },
+			isLoading: false,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		expect(screen.getByText("@alice")).toBeInTheDocument();
+	});
+
+	it("未読バッジは aria-label に件数を含める", () => {
+		mockListRooms.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeRoom({ unread_count: 5 })],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		expect(screen.getByLabelText("未読 5 件")).toBeInTheDocument();
+	});
+
+	it("100 件以上は 99+ で表示する", () => {
+		mockListRooms.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeRoom({ unread_count: 250 })],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		expect(screen.getByTestId("unread-badge")).toHaveTextContent("99+");
+	});
+
+	it("group room は name または members を表示する", () => {
+		mockListRooms.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeRoom({ kind: "group", name: "MyTeam", id: 10 })],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		expect(screen.getByText("MyTeam")).toBeInTheDocument();
+	});
+
+	it("pending invitation がある時 callout を表示する", () => {
+		mockListRooms.mockReturnValue({
+			data: { count: 0, next: null, previous: null, results: [] },
+			isLoading: false,
+			isError: false,
+		});
+		mockListInvitations.mockReturnValue({
+			data: { count: 3, next: null, previous: null, results: [] },
+			isLoading: false,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		const callout = screen.getByLabelText(/保留中のグループ招待 3 件/);
+		expect(callout).toHaveAttribute("href", "/messages/invitations");
+	});
+
+	it("各 room へのリンク先が `/messages/<id>` である", () => {
+		mockListRooms.mockReturnValue({
+			data: {
+				count: 1,
+				next: null,
+				previous: null,
+				results: [makeRoom({ id: 42 })],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		render(<RoomList currentUserId={100} />);
+		const link = screen.getByRole("link", { name: /alice/ });
+		expect(link).toHaveAttribute("href", "/messages/42");
+	});
+});

--- a/client/src/lib/dm/__tests__/format.test.ts
+++ b/client/src/lib/dm/__tests__/format.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for DM format utilities (P3-08).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+	colorFromId,
+	getGroupInitials,
+	getRoomDisplayName,
+	pickPeer,
+	truncateSnippet,
+} from "@/lib/dm/format";
+import type { DMRoom } from "@/lib/redux/features/dm/types";
+
+function makeDirectRoom(overrides: Partial<DMRoom> = {}): DMRoom {
+	return {
+		id: 1,
+		kind: "direct",
+		name: "",
+		creator: null,
+		memberships: [
+			{
+				id: 1,
+				user: { id: 100, username: "me", first_name: "", last_name: "" },
+				last_read_at: null,
+				created_at: "2026-05-01T00:00:00Z",
+			},
+			{
+				id: 2,
+				user: { id: 200, username: "alice", first_name: "", last_name: "" },
+				last_read_at: null,
+				created_at: "2026-05-01T00:00:00Z",
+			},
+		],
+		last_message_at: null,
+		is_archived: false,
+		created_at: "2026-05-01T00:00:00Z",
+		updated_at: "2026-05-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("getRoomDisplayName", () => {
+	it("direct room は相手 username を返す", () => {
+		expect(getRoomDisplayName(makeDirectRoom(), 100)).toBe("@alice");
+	});
+
+	it("direct room で memberships に自分しかいない場合 (unknown)", () => {
+		const room = makeDirectRoom({
+			memberships: [
+				{
+					id: 1,
+					user: { id: 100, username: "me", first_name: "", last_name: "" },
+					last_read_at: null,
+					created_at: "2026-05-01T00:00:00Z",
+				},
+			],
+		});
+		expect(getRoomDisplayName(room, 100)).toBe("(unknown)");
+	});
+
+	it("group room で name 設定済みは name を返す", () => {
+		const room = makeDirectRoom({ kind: "group", name: "Engineers" });
+		expect(getRoomDisplayName(room, 100)).toBe("Engineers");
+	});
+
+	it("group room で name 空はメンバー username を最大 3 名連結", () => {
+		const room = makeDirectRoom({
+			kind: "group",
+			name: "",
+			memberships: [
+				{
+					id: 1,
+					user: { id: 100, username: "me", first_name: "", last_name: "" },
+					last_read_at: null,
+					created_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					id: 2,
+					user: { id: 200, username: "alice", first_name: "", last_name: "" },
+					last_read_at: null,
+					created_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					id: 3,
+					user: { id: 300, username: "bob", first_name: "", last_name: "" },
+					last_read_at: null,
+					created_at: "2026-05-01T00:00:00Z",
+				},
+			],
+		});
+		expect(getRoomDisplayName(room, 100)).toBe("alice, bob");
+	});
+
+	it("group room で 4 名以上は ... が付く", () => {
+		const memberships = Array.from({ length: 5 }, (_, i) => ({
+			id: i + 2,
+			user: {
+				id: 200 + i,
+				username: `user${i}`,
+				first_name: "",
+				last_name: "",
+			},
+			last_read_at: null,
+			created_at: "2026-05-01T00:00:00Z",
+		}));
+		const room = makeDirectRoom({ kind: "group", name: "", memberships });
+		expect(getRoomDisplayName(room, 999)).toContain("...");
+	});
+});
+
+describe("pickPeer", () => {
+	it("direct room の相手を返す", () => {
+		const peer = pickPeer(makeDirectRoom(), 100);
+		expect(peer?.username).toBe("alice");
+	});
+
+	it("自分しかいないと null", () => {
+		const room = makeDirectRoom({
+			memberships: [
+				{
+					id: 1,
+					user: { id: 100, username: "me", first_name: "", last_name: "" },
+					last_read_at: null,
+					created_at: "2026-05-01T00:00:00Z",
+				},
+			],
+		});
+		expect(pickPeer(room, 100)).toBeNull();
+	});
+});
+
+describe("truncateSnippet", () => {
+	it("短い文字列はそのまま返す", () => {
+		expect(truncateSnippet("hello")).toBe("hello");
+	});
+
+	it("max 文字を超えたら ellipsis", () => {
+		expect(truncateSnippet("a".repeat(60), 50)).toMatch(/^a{49}…$/);
+	});
+
+	it("改行を空白に置換し 1 行表示", () => {
+		expect(truncateSnippet("a\nb\nc")).toBe("a b c");
+	});
+
+	it("null / undefined は空文字を返す", () => {
+		expect(truncateSnippet(null)).toBe("");
+		expect(truncateSnippet(undefined)).toBe("");
+	});
+});
+
+describe("colorFromId / getGroupInitials", () => {
+	it("colorFromId は HSL 形式", () => {
+		expect(colorFromId(42)).toMatch(/^hsl\(\d+, 60%, 45%\)$/);
+	});
+
+	it("getGroupInitials は先頭 2 文字 (大文字)", () => {
+		expect(getGroupInitials("MyTeam")).toBe("MY");
+		expect(getGroupInitials("")).toBe("G");
+		expect(getGroupInitials("一二三")).toBe("一二");
+	});
+});

--- a/client/src/lib/dm/format.ts
+++ b/client/src/lib/dm/format.ts
@@ -49,7 +49,7 @@ export function pickPeer(
 
 /**
  * メッセージ snippet を `SNIPPET_MAX_LENGTH` 字で省略する。
- * 改行は "·" に置き換えて 1 行表示。
+ * 改行・連続空白は単一スペースに置き換えて 1 行表示。
  */
 export function truncateSnippet(
 	body: string | null | undefined,
@@ -69,9 +69,13 @@ export function truncateSnippet(
  * 指定 id から HSL color を生成 (グループアイコン背景用)。
  * - hue は 0-359 の一様分布 (id × 137 で golden-angle 風に)
  * - saturation / lightness は固定でアクセシブルな contrast
+ *
+ * NOTE: Django bigint id が大きくなった際の精度欠落を防ぐため、まず modulo で
+ * 値域を縮めてから乗算する (code-reviewer HIGH H-3 反映)。
  */
 export function colorFromId(id: number): string {
-	const h = Math.abs(Math.floor(id) * 137) % 360;
+	const safe = Math.abs(Math.floor(id));
+	const h = ((safe % 360) * 137) % 360;
 	return `hsl(${h}, 60%, 45%)`;
 }
 

--- a/client/src/lib/dm/format.ts
+++ b/client/src/lib/dm/format.ts
@@ -1,0 +1,88 @@
+/**
+ * DM 表示まわりの整形ユーティリティ (P3-08〜P3-12 / Issue #233-237).
+ *
+ * - room の display name (direct: 相手 username, group: 名前 or "メンバー名 …")
+ * - メッセージスニペットの省略 (50 字)
+ * - グループアイコン用 initials + auto color (id を hash → HSL)
+ */
+
+import type { DMRoom, DMUserSummary } from "@/lib/redux/features/dm/types";
+
+export const SNIPPET_MAX_LENGTH = 50;
+
+/**
+ * 自分以外のメンバーから display name を組み立てる。
+ * - direct: 相手 1 名の username (` @' を付ける)
+ * - group (name あり): name そのまま
+ * - group (name なし): メンバー username を最大 3 名連結
+ */
+export function getRoomDisplayName(
+	room: DMRoom,
+	currentUserId: number,
+): string {
+	if (room.kind === "direct") {
+		const peer = pickPeer(room, currentUserId);
+		return peer ? `@${peer.username}` : "(unknown)";
+	}
+	if (room.name && room.name.trim().length > 0) {
+		return room.name;
+	}
+	const others = (room.memberships ?? [])
+		.map((m) => m.user)
+		.filter((u): u is DMUserSummary => Boolean(u) && u.id !== currentUserId)
+		.map((u) => u.username);
+	if (others.length === 0) {
+		return "(無名のグループ)";
+	}
+	return others.slice(0, 3).join(", ") + (others.length > 3 ? " ..." : "");
+}
+
+export function pickPeer(
+	room: DMRoom,
+	currentUserId: number,
+): DMUserSummary | null {
+	const peer = (room.memberships ?? []).find(
+		(m) => m.user && m.user.id !== currentUserId,
+	);
+	return peer ? peer.user : null;
+}
+
+/**
+ * メッセージ snippet を `SNIPPET_MAX_LENGTH` 字で省略する。
+ * 改行は "·" に置き換えて 1 行表示。
+ */
+export function truncateSnippet(
+	body: string | null | undefined,
+	max: number = SNIPPET_MAX_LENGTH,
+): string {
+	if (!body) {
+		return "";
+	}
+	const oneline = body.replace(/\s+/g, " ").trim();
+	if (oneline.length <= max) {
+		return oneline;
+	}
+	return oneline.slice(0, max - 1) + "…";
+}
+
+/**
+ * 指定 id から HSL color を生成 (グループアイコン背景用)。
+ * - hue は 0-359 の一様分布 (id × 137 で golden-angle 風に)
+ * - saturation / lightness は固定でアクセシブルな contrast
+ */
+export function colorFromId(id: number): string {
+	const h = Math.abs(Math.floor(id) * 137) % 360;
+	return `hsl(${h}, 60%, 45%)`;
+}
+
+/**
+ * グループ initials (room name の先頭 2 文字、なければ "G")。
+ */
+export function getGroupInitials(name: string): string {
+	const trimmed = (name ?? "").trim();
+	if (!trimmed) {
+		return "G";
+	}
+	const head = Array.from(trimmed).slice(0, 2).join("");
+	return head.toUpperCase();
+}

--- a/client/src/lib/redux/features/api/baseApiSlice.ts
+++ b/client/src/lib/redux/features/api/baseApiSlice.ts
@@ -57,7 +57,16 @@ const baseQueryWithReauth: BaseQueryFn<
 export const baseApiSlice = createApi({
 	reducerPath: "api",
 	baseQuery: baseQueryWithReauth,
-	tagTypes: ["User", "Apartment", "Issue", "Report", "Post"],
+	tagTypes: [
+		"User",
+		"Apartment",
+		"Issue",
+		"Report",
+		"Post",
+		// P3-08〜P3-12: DM 系 (apps/dm)
+		"DMRoom",
+		"DMInvitation",
+	],
 	refetchOnFocus: true,
 	refetchOnMountOrArgChange: true,
 	endpoints: (builder) => ({}),

--- a/client/src/lib/redux/features/dm/dmApiSlice.ts
+++ b/client/src/lib/redux/features/dm/dmApiSlice.ts
@@ -1,0 +1,108 @@
+/**
+ * DM RTK Query slice (P3-08〜P3-12 / Issue #233-237).
+ *
+ * Phase 3 の REST 経路をすべて網羅する。WebSocket は別 hook
+ * (`useDMSocket`, P3-16/#241) で扱う。
+ *
+ * 設計:
+ * - tag types `DMRoom` / `DMInvitation` で cache invalidation を明示。
+ *   `injectEndpoints` で baseApiSlice の `tagTypes` を拡張するため、
+ *   baseApiSlice 側の `tagTypes` 配列にも `"DMRoom" | "DMInvitation"` を追加する。
+ * - `transformResponse` は使わず Django serializer 形式をそのまま流す
+ *   (型定義側で吸収)。
+ */
+
+import { baseApiSlice } from "@/lib/redux/features/api/baseApiSlice";
+
+import type {
+	CreateRoomInput,
+	DMRoom,
+	DMRoomListResponse,
+	GroupInvitation,
+	InvitationListResponse,
+} from "./types";
+
+export const dmApiSlice = baseApiSlice.injectEndpoints({
+	endpoints: (builder) => ({
+		listDMRooms: builder.query<DMRoomListResponse, void>({
+			query: () => "/dm/rooms/",
+			providesTags: (result) =>
+				result
+					? [
+							...result.results.map((room) => ({
+								type: "DMRoom" as const,
+								id: room.id,
+							})),
+							{ type: "DMRoom" as const, id: "LIST" },
+						]
+					: [{ type: "DMRoom" as const, id: "LIST" }],
+		}),
+		getDMRoom: builder.query<DMRoom, number>({
+			query: (id) => `/dm/rooms/${id}/`,
+			providesTags: (_result, _error, id) => [{ type: "DMRoom" as const, id }],
+		}),
+		createDMRoom: builder.mutation<DMRoom, CreateRoomInput>({
+			query: (body) => ({
+				url: "/dm/rooms/",
+				method: "POST",
+				body,
+			}),
+			invalidatesTags: [{ type: "DMRoom" as const, id: "LIST" }],
+		}),
+		listInvitations: builder.query<
+			InvitationListResponse,
+			{ status?: "pending" | "all" } | void
+		>({
+			query: (arg) => {
+				const params = new URLSearchParams();
+				if (arg && arg.status) {
+					params.append("status", arg.status);
+				} else {
+					params.append("status", "pending");
+				}
+				return `/dm/invitations/?${params.toString()}`;
+			},
+			providesTags: (result) =>
+				result
+					? [
+							...result.results.map((inv) => ({
+								type: "DMInvitation" as const,
+								id: inv.id,
+							})),
+							{ type: "DMInvitation" as const, id: "LIST" },
+						]
+					: [{ type: "DMInvitation" as const, id: "LIST" }],
+		}),
+		acceptInvitation: builder.mutation<GroupInvitation, number>({
+			query: (id) => ({
+				url: `/dm/invitations/${id}/accept/`,
+				method: "POST",
+			}),
+			invalidatesTags: (_result, _error, id) => [
+				{ type: "DMInvitation" as const, id },
+				{ type: "DMInvitation" as const, id: "LIST" },
+				{ type: "DMRoom" as const, id: "LIST" },
+			],
+		}),
+		declineInvitation: builder.mutation<GroupInvitation, number>({
+			query: (id) => ({
+				url: `/dm/invitations/${id}/decline/`,
+				method: "POST",
+			}),
+			invalidatesTags: (_result, _error, id) => [
+				{ type: "DMInvitation" as const, id },
+				{ type: "DMInvitation" as const, id: "LIST" },
+			],
+		}),
+	}),
+	overrideExisting: false,
+});
+
+export const {
+	useListDMRoomsQuery,
+	useGetDMRoomQuery,
+	useCreateDMRoomMutation,
+	useListInvitationsQuery,
+	useAcceptInvitationMutation,
+	useDeclineInvitationMutation,
+} = dmApiSlice;

--- a/client/src/lib/redux/features/dm/types.ts
+++ b/client/src/lib/redux/features/dm/types.ts
@@ -1,0 +1,82 @@
+/**
+ * DM 関連の TypeScript 型定義 (P3-08〜P3-12 / Issue #233-237).
+ *
+ * Django apps/dm の serializers (apps/dm/serializers.py) と命名・形式を揃える。
+ * Phase 4A 通知統合後に Notification 系と整合させるため、型は外部 export で
+ * 共有 (client/src/types/index.ts に再 export 想定だが、現状は直接 import)。
+ */
+
+export type DMRoomKind = "direct" | "group";
+
+export interface DMUserSummary {
+	id: number;
+	username: string;
+	first_name: string;
+	last_name: string;
+	avatar?: string | null;
+}
+
+export interface DMRoomMembership {
+	id: number;
+	user: DMUserSummary;
+	last_read_at: string | null;
+	created_at: string;
+}
+
+export interface DMRoom {
+	id: number;
+	kind: DMRoomKind;
+	name: string;
+	creator: DMUserSummary | null;
+	memberships: DMRoomMembership[];
+	last_message_at: string | null;
+	last_message_snippet?: string | null;
+	is_archived: boolean;
+	created_at: string;
+	updated_at: string;
+	/** P3-05: Subquery で annotate された未読数。一覧 API のみ返す。 */
+	unread_count?: number;
+}
+
+export interface DMRoomListResponse {
+	count: number;
+	next: string | null;
+	previous: string | null;
+	results: DMRoom[];
+}
+
+/** SPEC §7.2: グループ招待 (1:1 では生成されない). */
+export interface GroupInvitation {
+	id: number;
+	room: {
+		id: number;
+		kind: DMRoomKind;
+		name: string;
+	};
+	inviter: DMUserSummary;
+	invitee: DMUserSummary;
+	/** null = pending, true = accepted, false = declined. */
+	accepted: boolean | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface InvitationListResponse {
+	count: number;
+	next: string | null;
+	previous: string | null;
+	results: GroupInvitation[];
+}
+
+export interface CreateDirectRoomInput {
+	kind: "direct";
+	member_handle: string;
+}
+
+export interface CreateGroupRoomInput {
+	kind: "group";
+	name: string;
+	invitee_handles?: string[];
+}
+
+export type CreateRoomInput = CreateDirectRoomInput | CreateGroupRoomInput;


### PR DESCRIPTION
## Summary

Phase 3 frontend bundle の **PR1/3**。WebSocket は不使用、REST 経路のみで DM 一覧 (P3-08) と招待ページ (P3-12) を実装する。

### 実装範囲

- **`/messages` (P3-08 #233)**:
  - RTK Query で `/api/v1/dm/rooms/` を fetch、相手 avatar / display name / 最新スニペット / 相対時刻 / 未読バッジを表示
  - 未読バッジは `aria-label="未読 N 件"` で SR にも数を伝達
  - direct は相手 username、group は name または members 連結
  - 64px touch target + focus-visible リング
  - pending invitation の件数 callout で `/messages/invitations` に誘導
- **`/messages/invitations` (P3-12 #237)**:
  - pending 招待 + 承諾/拒否ボタン
  - 承諾成功で `/messages/<room_id>` に遷移、拒否で list から消える
  - RTK Query `invalidatesTags` で承諾後に room list / invitation list を自動 refetch

### スコープ外 (PR2/PR3 へ)

| 別 PR | issue | 内容 |
| --- | --- | --- |
| PR2 | #234 P3-09 + #241 P3-16 + #242 P3-17 | 詳細画面 + WebSocket + reconnect + typing |
| PR3 | #235 P3-10 + #236 P3-11 | 添付 (S3 直 PUT) + グループ作成モーダル + 新規 DM 開始モーダル |

## Test plan

- [x] `npx vitest run src/components/dm src/lib/dm` → **29 件 pass**
- [x] `npx tsc --project tsconfig.json --noEmit` clean
- [x] `npx eslint src/components/dm src/lib/dm src/lib/redux/features/dm src/app/(template)/messages` clean (warnings 0)
- [ ] CI green を待ってマージ
- [ ] 実機確認 (browser MCP) → PR2 で room 詳細とまとめてやる予定

## サブエージェントレビュー予定 (次ターンで並列起動)

- typescript-reviewer + code-reviewer + a11y-architect (UI コンポーネント)

## 関連

- Closes #233 (P3-08), #237 (P3-12)
- 後続: #234 (P3-09), #235 (P3-10), #236 (P3-11), #241 (P3-16), #242 (P3-17)
- Backend は merged: #228 P3-03 (rooms), #229 P3-04 (invitations), #230 P3-05 (read), #231 P3-06 (attachments)