### PR TITLE
[feature][dm] WebSocket + Room 詳細 + Typing インジケータ (Closes #234 #241 #242)

### DIFF
--- a/client/src/app/(template)/messages/[id]/page.tsx
+++ b/client/src/app/(template)/messages/[id]/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * Room 詳細ページ (P3-09 / Issue #234).
+ *
+ * 認証必須。`useParams` で room id を解決し、`<RoomChat>` をレンダ。
+ */
+
+import { useParams, useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import RoomChat from "@/components/dm/RoomChat";
+import { useUserProfile } from "@/hooks/useUseProfile";
+import { useAppSelector } from "@/lib/redux/hooks/typedHooks";
+
+export default function RoomDetailPage() {
+	const router = useRouter();
+	const params = useParams<{ id: string }>();
+	const { isAuthenticated } = useAppSelector((state) => state.auth);
+	const { profile, isLoading } = useUserProfile();
+
+	useEffect(() => {
+		if (!isAuthenticated && !isLoading) {
+			const next = encodeURIComponent(`/messages/${params?.id ?? ""}`);
+			router.replace(`/login?next=${next}`);
+		}
+	}, [isAuthenticated, isLoading, router, params]);
+
+	if (!isAuthenticated || !profile) {
+		return (
+			<section
+				role="status"
+				aria-live="polite"
+				className="text-baby_grey mx-auto max-w-2xl py-12 text-center"
+			>
+				認証情報を確認しています...
+			</section>
+		);
+	}
+
+	const roomId = Number.parseInt(params?.id ?? "", 10);
+	const currentUserId = Number.parseInt(profile.id, 10);
+	if (Number.isNaN(roomId) || Number.isNaN(currentUserId)) {
+		return (
+			<section
+				role="alert"
+				className="text-baby_red mx-auto max-w-2xl py-12 text-center"
+			>
+				ルーム ID の形式が不正です。
+			</section>
+		);
+	}
+
+	return (
+		<div className="mx-auto max-w-3xl">
+			<RoomChat roomId={roomId} currentUserId={currentUserId} />
+		</div>
+	);
+}

--- a/client/src/components/dm/MessageBubble.tsx
+++ b/client/src/components/dm/MessageBubble.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+/**
+ * 1 メッセージ表示 (P3-09 / Issue #234).
+ *
+ * - 自分の送信: 右寄せ + accent カラー
+ * - 相手の送信: 左寄せ + neutral カラー
+ * - 添付 (画像 / ファイル) を簡易表示
+ * - status="sending" / "failed" を視覚的に区別
+ *
+ * Phase 3 はリッチプレビュー (lightbox / image lazy / markdown) は scope 外、
+ * テキストと添付ファイル名のみ表示。
+ */
+
+import type { DMMessage } from "@/lib/redux/features/dm/types";
+import { formatRelativeTime } from "@/lib/timeline/formatTime";
+
+export type MessageStatus = "sent" | "sending" | "failed";
+
+interface MessageBubbleProps {
+	message: DMMessage;
+	currentUserId: number;
+	status?: MessageStatus;
+	onRetry?: () => void;
+}
+
+export default function MessageBubble({
+	message,
+	currentUserId,
+	status = "sent",
+	onRetry,
+}: MessageBubbleProps) {
+	const mine = message.sender_id === currentUserId;
+	return (
+		<div
+			data-testid="message-bubble"
+			data-mine={mine ? "true" : "false"}
+			data-status={status}
+			className={
+				"flex w-full px-4 py-1 " + (mine ? "justify-end" : "justify-start")
+			}
+		>
+			<div
+				className={
+					"max-w-[75%] rounded-2xl px-3 py-2 text-sm break-words " +
+					(mine
+						? "bg-baby_blue text-baby_white rounded-br-sm"
+						: "bg-baby_grey/20 text-baby_white rounded-bl-sm")
+				}
+			>
+				{message.body ? (
+					<p className="whitespace-pre-wrap">{message.body}</p>
+				) : null}
+				{message.attachments?.length ? (
+					<ul className="mt-2 space-y-1">
+						{message.attachments.map((att) => (
+							<li key={att.id} className="text-xs underline">
+								{att.filename || att.s3_key}
+							</li>
+						))}
+					</ul>
+				) : null}
+				<div className="mt-1 flex items-center justify-end gap-1 text-[10px] opacity-75">
+					{status === "sending" ? (
+						<span aria-label="送信中">⏳</span>
+					) : status === "failed" ? (
+						<button
+							type="button"
+							onClick={onRetry}
+							className="underline focus-visible:outline-none focus-visible:ring-1"
+							aria-label="送信に失敗しました、再試行"
+						>
+							再送
+						</button>
+					) : null}
+					<time dateTime={message.created_at}>
+						{formatRelativeTime(message.created_at)}
+					</time>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/src/components/dm/MessageComposer.tsx
+++ b/client/src/components/dm/MessageComposer.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * メッセージ入力欄 (P3-09 / Issue #234).
+ *
+ * - 通常 Enter で改行
+ * - Ctrl+Enter / Cmd+Enter で送信 (a11y: キーボードのみで送信可能)
+ * - 入力中は親に typing 通知を渡す (debounce は useDMSocket 側)
+ *
+ * 送信ボタンと textarea のみ。添付 UI (P3-10) は別 PR で integrate。
+ */
+
+import { useCallback, useState, type KeyboardEvent } from "react";
+
+interface MessageComposerProps {
+	onSubmit(body: string): void | Promise<void>;
+	onTyping?(): void;
+	disabled?: boolean;
+	placeholder?: string;
+}
+
+export default function MessageComposer({
+	onSubmit,
+	onTyping,
+	disabled,
+	placeholder = "メッセージを入力 (Ctrl/Cmd+Enter で送信)",
+}: MessageComposerProps) {
+	const [value, setValue] = useState("");
+
+	const submit = useCallback(async () => {
+		const trimmed = value.trim();
+		if (!trimmed) return;
+		await onSubmit(trimmed);
+		setValue("");
+	}, [value, onSubmit]);
+
+	const onKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLTextAreaElement>) => {
+			// Ctrl+Enter (Win/Linux) / Cmd+Enter (Mac) で送信。Enter 単独は改行。
+			if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+				event.preventDefault();
+				submit().catch(() => undefined);
+			}
+		},
+		[submit],
+	);
+
+	return (
+		<form
+			onSubmit={(e) => {
+				e.preventDefault();
+				submit().catch(() => undefined);
+			}}
+			className="border-baby_grey/10 bg-baby_veryBlack/40 flex items-end gap-2 border-t p-3"
+		>
+			<label className="sr-only" htmlFor="message-composer-textarea">
+				メッセージを入力
+			</label>
+			<textarea
+				id="message-composer-textarea"
+				rows={1}
+				value={value}
+				onChange={(e) => {
+					setValue(e.target.value);
+					onTyping?.();
+				}}
+				onKeyDown={onKeyDown}
+				disabled={disabled}
+				placeholder={placeholder}
+				className="bg-baby_veryBlack text-baby_white placeholder:text-baby_grey focus-visible:ring-baby_blue min-h-[44px] flex-1 resize-y rounded-md px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2"
+			/>
+			<button
+				type="submit"
+				disabled={disabled || value.trim().length === 0}
+				className="bg-baby_blue text-baby_white focus-visible:ring-baby_white shrink-0 rounded-md px-4 py-2 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+			>
+				送信
+			</button>
+		</form>
+	);
+}

--- a/client/src/components/dm/MessageComposer.tsx
+++ b/client/src/components/dm/MessageComposer.tsx
@@ -5,9 +5,10 @@
  *
  * - 通常 Enter で改行
  * - Ctrl+Enter / Cmd+Enter で送信 (a11y: キーボードのみで送信可能)
- * - 入力中は親に typing 通知を渡す (debounce は useDMSocket 側)
+ * - 入力中は親に typing 通知を渡す
+ * - submit エラーは `submitError` state で alert 表示 (silent failure 抑制、ts-reviewer HIGH)
  *
- * 送信ボタンと textarea のみ。添付 UI (P3-10) は別 PR で integrate。
+ * 添付 UI (P3-10) は別 PR で integrate 予定。
  */
 
 import { useCallback, useState, type KeyboardEvent } from "react";
@@ -23,20 +24,30 @@ export default function MessageComposer({
 	onSubmit,
 	onTyping,
 	disabled,
-	placeholder = "メッセージを入力 (Ctrl/Cmd+Enter で送信)",
+	placeholder = "メッセージを入力",
 }: MessageComposerProps) {
 	const [value, setValue] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [submitError, setSubmitError] = useState<string | null>(null);
 
 	const submit = useCallback(async () => {
 		const trimmed = value.trim();
-		if (!trimmed) return;
-		await onSubmit(trimmed);
-		setValue("");
-	}, [value, onSubmit]);
+		if (!trimmed || submitting) return;
+		setSubmitting(true);
+		setSubmitError(null);
+		try {
+			await onSubmit(trimmed);
+			setValue("");
+		} catch (error: unknown) {
+			const msg = error instanceof Error ? error.message : "送信に失敗しました";
+			setSubmitError(msg);
+		} finally {
+			setSubmitting(false);
+		}
+	}, [value, onSubmit, submitting]);
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLTextAreaElement>) => {
-			// Ctrl+Enter (Win/Linux) / Cmd+Enter (Mac) で送信。Enter 単独は改行。
 			if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
 				event.preventDefault();
 				submit().catch(() => undefined);
@@ -51,31 +62,44 @@ export default function MessageComposer({
 				e.preventDefault();
 				submit().catch(() => undefined);
 			}}
-			className="border-baby_grey/10 bg-baby_veryBlack/40 flex items-end gap-2 border-t p-3"
+			className="border-baby_grey/10 bg-baby_veryBlack/40 flex flex-col gap-1 border-t p-3"
 		>
-			<label className="sr-only" htmlFor="message-composer-textarea">
-				メッセージを入力
-			</label>
-			<textarea
-				id="message-composer-textarea"
-				rows={1}
-				value={value}
-				onChange={(e) => {
-					setValue(e.target.value);
-					onTyping?.();
-				}}
-				onKeyDown={onKeyDown}
-				disabled={disabled}
-				placeholder={placeholder}
-				className="bg-baby_veryBlack text-baby_white placeholder:text-baby_grey focus-visible:ring-baby_blue min-h-[44px] flex-1 resize-y rounded-md px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2"
-			/>
-			<button
-				type="submit"
-				disabled={disabled || value.trim().length === 0}
-				className="bg-baby_blue text-baby_white focus-visible:ring-baby_white shrink-0 rounded-md px-4 py-2 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
-			>
-				送信
-			</button>
+			{submitError ? (
+				<div role="alert" className="text-baby_red px-1 text-xs">
+					{submitError}
+				</div>
+			) : null}
+			<div className="flex items-end gap-2">
+				<label className="sr-only" htmlFor="message-composer-textarea">
+					メッセージを入力
+				</label>
+				<textarea
+					id="message-composer-textarea"
+					rows={1}
+					value={value}
+					onChange={(e) => {
+						setValue(e.target.value);
+						onTyping?.();
+					}}
+					onKeyDown={onKeyDown}
+					disabled={disabled}
+					placeholder={placeholder}
+					aria-keyshortcuts="Control+Enter Meta+Enter"
+					aria-describedby="message-composer-hint"
+					className="bg-baby_veryBlack text-baby_white placeholder:text-baby_grey focus-visible:ring-baby_blue max-h-[40vh] min-h-[44px] flex-1 resize-y rounded-md px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2"
+				/>
+				<button
+					type="submit"
+					disabled={disabled || value.trim().length === 0 || submitting}
+					aria-busy={submitting}
+					className="bg-baby_blue text-baby_white focus-visible:ring-baby_white shrink-0 rounded-md px-4 py-2 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+				>
+					{submitting ? "送信中..." : "送信"}
+				</button>
+			</div>
+			<p id="message-composer-hint" className="text-baby_grey px-1 text-[11px]">
+				Ctrl/Cmd+Enter で送信、Enter で改行
+			</p>
 		</form>
 	);
 }

--- a/client/src/components/dm/MessageList.tsx
+++ b/client/src/components/dm/MessageList.tsx
@@ -52,20 +52,23 @@ export default function MessageList({
 	}, [messages]);
 
 	return (
-		<div
-			ref={containerRef}
-			role="log"
-			aria-live="polite"
-			aria-label="メッセージ履歴"
-			data-testid="message-list"
-			className="flex-1 overflow-y-auto py-2"
-		>
+		<>
 			{messages.length === 0 ? (
 				<p className="text-baby_grey px-4 py-8 text-center text-sm">
 					まだメッセージはありません。
 				</p>
-			) : (
-				messages.map((m) => {
+			) : null}
+			<div
+				ref={containerRef}
+				role="log"
+				aria-live="polite"
+				aria-relevant="additions"
+				aria-atomic="false"
+				aria-label="メッセージ履歴"
+				data-testid="message-list"
+				className="flex-1 overflow-y-auto py-2"
+			>
+				{messages.map((m) => {
 					const localKey = `msg-${m.id}`;
 					const status = pendingByClientKey?.get(localKey) ?? "sent";
 					return (
@@ -77,8 +80,8 @@ export default function MessageList({
 							onRetry={onRetry ? () => onRetry(localKey) : undefined}
 						/>
 					);
-				})
-			)}
-		</div>
+				})}
+			</div>
+		</>
 	);
 }

--- a/client/src/components/dm/MessageList.tsx
+++ b/client/src/components/dm/MessageList.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * メッセージリスト (P3-09 / Issue #234).
+ *
+ * - 履歴 (REST) を最下部にむけて時系列昇順で表示
+ * - WebSocket からの新規 message を末尾に append
+ * - 自動スクロール: 末尾に近い時のみ (上方向スクロール中なら追従しない)
+ *
+ * a11y: `role="log"` + `aria-live="polite"` で SR が新着を読み上げる。
+ *
+ * Phase 3 では history pagination は最初の 30 件のみ取得 (上端 IntersectionObserver
+ * で次ページを取る実装は次 PR / Phase 4 へ)。
+ */
+
+import { useEffect, useRef } from "react";
+
+import MessageBubble, {
+	type MessageStatus,
+} from "@/components/dm/MessageBubble";
+import type { DMMessage } from "@/lib/redux/features/dm/types";
+
+interface MessageListProps {
+	messages: DMMessage[];
+	currentUserId: number;
+	pendingByClientKey?: Map<string, MessageStatus>;
+	onRetry?: (localKey: string) => void;
+}
+
+const NEAR_BOTTOM_PX = 80;
+
+export default function MessageList({
+	messages,
+	currentUserId,
+	pendingByClientKey,
+	onRetry,
+}: MessageListProps) {
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const lastLengthRef = useRef(0);
+
+	useEffect(() => {
+		const node = containerRef.current;
+		if (!node) return;
+		const grew = messages.length > lastLengthRef.current;
+		lastLengthRef.current = messages.length;
+		if (!grew) return;
+		const distanceToBottom =
+			node.scrollHeight - node.scrollTop - node.clientHeight;
+		if (distanceToBottom < NEAR_BOTTOM_PX) {
+			node.scrollTop = node.scrollHeight;
+		}
+	}, [messages]);
+
+	return (
+		<div
+			ref={containerRef}
+			role="log"
+			aria-live="polite"
+			aria-label="メッセージ履歴"
+			data-testid="message-list"
+			className="flex-1 overflow-y-auto py-2"
+		>
+			{messages.length === 0 ? (
+				<p className="text-baby_grey px-4 py-8 text-center text-sm">
+					まだメッセージはありません。
+				</p>
+			) : (
+				messages.map((m) => {
+					const localKey = `msg-${m.id}`;
+					const status = pendingByClientKey?.get(localKey) ?? "sent";
+					return (
+						<MessageBubble
+							key={m.id}
+							message={m}
+							currentUserId={currentUserId}
+							status={status}
+							onRetry={onRetry ? () => onRetry(localKey) : undefined}
+						/>
+					);
+				})
+			)}
+		</div>
+	);
+}

--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -63,8 +63,8 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 		const frame = socket.lastFrame;
 		if (!frame) return;
 		if (frame.type === "message.new") {
-			const incoming = frame.message as DMMessage;
-			if (incoming && typeof incoming.id === "number") {
+			const incoming = parseIncomingMessage(frame.message);
+			if (incoming) {
 				setLiveMessages((prev) =>
 					prev.some((m) => m.id === incoming.id) ? prev : [...prev, incoming],
 				);
@@ -81,8 +81,9 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 			}
 		} else if (frame.type === "typing.update") {
 			const userId = frame.user_id;
+			const rawStarted = frame.started_at;
 			const startedAt =
-				(frame.started_at as string | undefined) ?? new Date().toISOString();
+				typeof rawStarted === "string" ? rawStarted : new Date().toISOString();
 			if (typeof userId === "number" && userId !== currentUserId) {
 				setTyping({ userId, startedAt });
 			}
@@ -161,6 +162,32 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 	);
 }
 
+/**
+ * `message.new` frame の `message` field を runtime narrowing で安全な DMMessage に。
+ * 必須フィールドを実際にチェックして不正な frame は null を返す (ts-reviewer HIGH 反映)。
+ */
+function parseIncomingMessage(raw: unknown): DMMessage | null {
+	if (!raw || typeof raw !== "object") return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.id !== "number") return null;
+	if (typeof r.room_id !== "number") return null;
+	if (r.sender_id !== null && typeof r.sender_id !== "number") return null;
+	if (typeof r.body !== "string") return null;
+	if (typeof r.created_at !== "string") return null;
+	return {
+		id: r.id,
+		room_id: r.room_id,
+		sender_id: r.sender_id as number | null,
+		body: r.body,
+		attachments: Array.isArray(r.attachments)
+			? (r.attachments as DMMessage["attachments"])
+			: [],
+		created_at: r.created_at,
+		updated_at: typeof r.updated_at === "string" ? r.updated_at : r.created_at,
+		deleted_at: typeof r.deleted_at === "string" ? r.deleted_at : null,
+	};
+}
+
 function SocketStatusBadge({
 	status,
 	onReconnect,
@@ -168,17 +195,22 @@ function SocketStatusBadge({
 	status: "connecting" | "open" | "closed";
 	onReconnect(): void;
 }) {
+	// a11y H-3: 色だけでなく形 (●/◐/⚠) でも区別 + role=status で transition を SR に通知
 	if (status === "open") {
 		return (
-			<span className="text-baby_green text-xs" aria-label="WebSocket 接続済み">
-				● オンライン
+			<span
+				role="status"
+				aria-live="polite"
+				className="text-baby_green text-xs"
+			>
+				<span aria-hidden="true">●</span> オンライン
 			</span>
 		);
 	}
 	if (status === "connecting") {
 		return (
-			<span className="text-baby_grey text-xs" aria-label="WebSocket 接続中">
-				● 接続中...
+			<span role="status" aria-live="polite" className="text-baby_grey text-xs">
+				<span aria-hidden="true">◐</span> 接続中...
 			</span>
 		);
 	}
@@ -186,10 +218,10 @@ function SocketStatusBadge({
 		<button
 			type="button"
 			onClick={onReconnect}
-			className="text-baby_red focus-visible:ring-baby_blue text-xs underline focus-visible:outline-none focus-visible:ring-2"
+			className="text-baby_red focus-visible:ring-baby_blue inline-flex min-h-[24px] items-center gap-1 text-xs underline focus-visible:outline-none focus-visible:ring-2"
 			aria-label="WebSocket 切断中、クリックで再接続"
 		>
-			● 切断 (再接続)
+			<span aria-hidden="true">⚠</span> 切断 (再接続)
 		</button>
 	);
 }

--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+/**
+ * Room 詳細画面の chat 領域全体 (P3-09 / Issue #234).
+ *
+ * - 履歴 fetch (RTK Query) + 末尾に新着 append
+ * - WebSocket connect via `useDMSocket`
+ * - typing.update / message.new / message.deleted を受信して state 更新
+ * - 送信時は WS 経由 (失敗時は inline 通知)
+ * - Header に display name + reconnect ボタン (status=closed のみ)
+ *
+ * 残スコープ (TODO):
+ * - 履歴 cursor pagination (上端 IntersectionObserver)
+ * - 既読 IntersectionObserver マーク (現状は mount 時に 1 度 markRoomRead)
+ * - 添付 UI (P3-10 で integrate)
+ */
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import MessageComposer from "@/components/dm/MessageComposer";
+import MessageList from "@/components/dm/MessageList";
+import TypingIndicator from "@/components/dm/TypingIndicator";
+import { useDMSocket } from "@/hooks/useDMSocket";
+import {
+	useGetDMRoomQuery,
+	useListRoomMessagesQuery,
+	useMarkRoomReadMutation,
+} from "@/lib/redux/features/dm/dmApiSlice";
+import type { DMMessage, DMUserSummary } from "@/lib/redux/features/dm/types";
+import { getRoomDisplayName } from "@/lib/dm/format";
+
+interface RoomChatProps {
+	roomId: number;
+	currentUserId: number;
+}
+
+export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
+	const roomQuery = useGetDMRoomQuery(roomId);
+	const messagesQuery = useListRoomMessagesQuery({ roomId });
+	const [markRoomRead] = useMarkRoomReadMutation();
+	const [liveMessages, setLiveMessages] = useState<DMMessage[]>([]);
+	const [deletedIds, setDeletedIds] = useState<Set<number>>(() => new Set());
+	const [sendError, setSendError] = useState<string | null>(null);
+	const [typing, setTyping] = useState<{
+		userId: number;
+		startedAt: string;
+	} | null>(null);
+
+	const socket = useDMSocket({ roomId });
+
+	// mount 時 + 履歴ロード完了時に room を read マーク (P3-05).
+	useEffect(() => {
+		if (messagesQuery.data) {
+			markRoomRead(roomId).catch(() => {
+				/* read 失敗は UX に影響しないので silent (silent-failure 抑制対象外: 通知 backend で別途観測) */
+			});
+		}
+	}, [messagesQuery.data, markRoomRead, roomId]);
+
+	// WS frame 処理
+	useEffect(() => {
+		const frame = socket.lastFrame;
+		if (!frame) return;
+		if (frame.type === "message.new") {
+			const incoming = frame.message as DMMessage;
+			if (incoming && typeof incoming.id === "number") {
+				setLiveMessages((prev) =>
+					prev.some((m) => m.id === incoming.id) ? prev : [...prev, incoming],
+				);
+			}
+		} else if (frame.type === "message.deleted") {
+			const id = frame.message_id;
+			if (typeof id === "number") {
+				setDeletedIds((prev) => {
+					if (prev.has(id)) return prev;
+					const next = new Set(prev);
+					next.add(id);
+					return next;
+				});
+			}
+		} else if (frame.type === "typing.update") {
+			const userId = frame.user_id;
+			const startedAt =
+				(frame.started_at as string | undefined) ?? new Date().toISOString();
+			if (typeof userId === "number" && userId !== currentUserId) {
+				setTyping({ userId, startedAt });
+			}
+		}
+	}, [socket.lastFrame, currentUserId]);
+
+	const memberLookup = useMemo(() => {
+		const map = new Map<number, DMUserSummary>();
+		const room = roomQuery.data;
+		if (room) {
+			for (const m of room.memberships ?? []) {
+				if (m.user) map.set(m.user.id, m.user);
+			}
+		}
+		return map;
+	}, [roomQuery.data]);
+
+	const merged = useMemo<DMMessage[]>(() => {
+		const history = (messagesQuery.data?.results ?? []).slice().reverse();
+		const seen = new Set(history.map((m) => m.id));
+		const live = liveMessages.filter((m) => !seen.has(m.id));
+		return [...history, ...live].filter((m) => !deletedIds.has(m.id));
+	}, [messagesQuery.data, liveMessages, deletedIds]);
+
+	const onSubmit = useCallback(
+		async (body: string) => {
+			setSendError(null);
+			const sent = socket.sendMessage({ body });
+			if (!sent) {
+				setSendError("接続が切れています。再接続してから送信してください。");
+			}
+		},
+		[socket],
+	);
+
+	const displayName = roomQuery.data
+		? getRoomDisplayName(roomQuery.data, currentUserId)
+		: "...";
+
+	return (
+		<section className="bg-baby_veryBlack border-baby_grey/10 flex h-[calc(100vh-8rem)] max-w-3xl flex-col rounded-md border">
+			<header className="border-baby_grey/10 flex items-center justify-between border-b px-4 py-3">
+				<div className="min-w-0">
+					<Link
+						href="/messages"
+						className="text-baby_grey focus-visible:ring-baby_blue mr-2 text-xs underline focus-visible:outline-none focus-visible:ring-2"
+					>
+						<span aria-hidden="true">←</span> 一覧
+					</Link>
+					<h1 className="text-baby_white inline truncate text-base font-semibold">
+						{displayName}
+					</h1>
+				</div>
+				<SocketStatusBadge
+					status={socket.status}
+					onReconnect={socket.reconnect}
+				/>
+			</header>
+			<MessageList messages={merged} currentUserId={currentUserId} />
+			<TypingIndicator
+				typingUserId={typing?.userId ?? null}
+				startedAt={typing?.startedAt}
+				memberLookup={memberLookup}
+			/>
+			{sendError ? (
+				<div role="alert" className="text-baby_red px-4 py-1 text-xs">
+					{sendError}
+				</div>
+			) : null}
+			<MessageComposer
+				onSubmit={onSubmit}
+				onTyping={socket.sendTyping}
+				disabled={socket.status !== "open"}
+			/>
+		</section>
+	);
+}
+
+function SocketStatusBadge({
+	status,
+	onReconnect,
+}: {
+	status: "connecting" | "open" | "closed";
+	onReconnect(): void;
+}) {
+	if (status === "open") {
+		return (
+			<span className="text-baby_green text-xs" aria-label="WebSocket 接続済み">
+				● オンライン
+			</span>
+		);
+	}
+	if (status === "connecting") {
+		return (
+			<span className="text-baby_grey text-xs" aria-label="WebSocket 接続中">
+				● 接続中...
+			</span>
+		);
+	}
+	return (
+		<button
+			type="button"
+			onClick={onReconnect}
+			className="text-baby_red focus-visible:ring-baby_blue text-xs underline focus-visible:outline-none focus-visible:ring-2"
+			aria-label="WebSocket 切断中、クリックで再接続"
+		>
+			● 切断 (再接続)
+		</button>
+	);
+}

--- a/client/src/components/dm/TypingIndicator.tsx
+++ b/client/src/components/dm/TypingIndicator.tsx
@@ -3,24 +3,21 @@
 /**
  * Typing インジケータ (P3-17 / Issue #242).
  *
- * `useDMSocket` の typing.update frame を渡すと、3 秒間 "ユーザー名が入力中..." を
- * 表示する (3 秒経過で自動非表示)。
- *
- * a11y: live region (polite) で SR にも通知 (低頻度なので過剰なアナウンスにはならない)。
+ * 視覚: typing.update を受けたら 3 秒間 "ユーザー名 が入力中..." を表示 (`aria-hidden="true"`)。
+ * SR: 同じユーザの typing が 3 秒以上継続した場合に限り 1 度だけ live region で
+ * announce する (a11y CRITICAL C-1 反映、docs/A11Y.md §2.5 / §5.2 と整合)。
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { DMUserSummary } from "@/lib/redux/features/dm/types";
 
 const AUTO_HIDE_MS = 3_000;
+const SR_ANNOUNCE_AFTER_MS = 3_000;
 
 interface TypingIndicatorProps {
-	/** 現在 typing 中のユーザ id (null なら非表示)。 */
 	typingUserId: number | null;
-	/** typing.update frame の started_at ISO (再表示の rerender トリガー用)。 */
 	startedAt?: string | null;
-	/** room メンバーから username を解決するためのマップ。 */
 	memberLookup: Map<number, DMUserSummary>;
 }
 
@@ -30,25 +27,52 @@ export default function TypingIndicator({
 	memberLookup,
 }: TypingIndicatorProps) {
 	const [visibleId, setVisibleId] = useState<number | null>(null);
+	const [announceId, setAnnounceId] = useState<number | null>(null);
+	const sessionStartRef = useRef<{ userId: number; at: number } | null>(null);
 
 	useEffect(() => {
 		if (typingUserId == null) return;
 		setVisibleId(typingUserId);
-		const timer = setTimeout(() => setVisibleId(null), AUTO_HIDE_MS);
-		return () => clearTimeout(timer);
-	}, [typingUserId, startedAt]);
+
+		// SR session: 同 user が連続している間は最初の time を保持。3s 超えたら 1 度 announce。
+		const session = sessionStartRef.current;
+		const now = Date.now();
+		if (!session || session.userId !== typingUserId) {
+			sessionStartRef.current = { userId: typingUserId, at: now };
+		} else if (
+			announceId !== typingUserId &&
+			now - session.at >= SR_ANNOUNCE_AFTER_MS
+		) {
+			setAnnounceId(typingUserId);
+		}
+
+		const hideTimer = setTimeout(() => {
+			setVisibleId(null);
+			setAnnounceId(null);
+			sessionStartRef.current = null;
+		}, AUTO_HIDE_MS);
+		return () => clearTimeout(hideTimer);
+	}, [typingUserId, startedAt, announceId]);
 
 	if (visibleId == null) return null;
 	const member = memberLookup.get(visibleId);
 	const label = member ? `@${member.username}` : "誰か";
+	const announcing = announceId === visibleId && member;
+
 	return (
-		<div
-			role="status"
-			aria-live="polite"
-			data-testid="typing-indicator"
-			className="text-baby_grey px-4 py-1 text-xs italic"
-		>
-			{label} が入力中...
-		</div>
+		<>
+			<div
+				aria-hidden="true"
+				data-testid="typing-indicator"
+				className="text-baby_grey px-4 py-1 text-xs italic"
+			>
+				{label} が入力中...
+			</div>
+			{announcing ? (
+				<div role="status" aria-live="polite" className="sr-only">
+					{member ? `${member.username} さんが入力中` : ""}
+				</div>
+			) : null}
+		</>
 	);
 }

--- a/client/src/components/dm/TypingIndicator.tsx
+++ b/client/src/components/dm/TypingIndicator.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * Typing インジケータ (P3-17 / Issue #242).
+ *
+ * `useDMSocket` の typing.update frame を渡すと、3 秒間 "ユーザー名が入力中..." を
+ * 表示する (3 秒経過で自動非表示)。
+ *
+ * a11y: live region (polite) で SR にも通知 (低頻度なので過剰なアナウンスにはならない)。
+ */
+
+import { useEffect, useState } from "react";
+
+import type { DMUserSummary } from "@/lib/redux/features/dm/types";
+
+const AUTO_HIDE_MS = 3_000;
+
+interface TypingIndicatorProps {
+	/** 現在 typing 中のユーザ id (null なら非表示)。 */
+	typingUserId: number | null;
+	/** typing.update frame の started_at ISO (再表示の rerender トリガー用)。 */
+	startedAt?: string | null;
+	/** room メンバーから username を解決するためのマップ。 */
+	memberLookup: Map<number, DMUserSummary>;
+}
+
+export default function TypingIndicator({
+	typingUserId,
+	startedAt,
+	memberLookup,
+}: TypingIndicatorProps) {
+	const [visibleId, setVisibleId] = useState<number | null>(null);
+
+	useEffect(() => {
+		if (typingUserId == null) return;
+		setVisibleId(typingUserId);
+		const timer = setTimeout(() => setVisibleId(null), AUTO_HIDE_MS);
+		return () => clearTimeout(timer);
+	}, [typingUserId, startedAt]);
+
+	if (visibleId == null) return null;
+	const member = memberLookup.get(visibleId);
+	const label = member ? `@${member.username}` : "誰か";
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			data-testid="typing-indicator"
+			className="text-baby_grey px-4 py-1 text-xs italic"
+		>
+			{label} が入力中...
+		</div>
+	);
+}

--- a/client/src/components/dm/__tests__/MessageBubble.test.tsx
+++ b/client/src/components/dm/__tests__/MessageBubble.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import MessageBubble from "@/components/dm/MessageBubble";
+import type { DMMessage } from "@/lib/redux/features/dm/types";
+
+function makeMessage(overrides: Partial<DMMessage> = {}): DMMessage {
+	return {
+		id: 1,
+		room_id: 10,
+		sender_id: 100,
+		body: "hello",
+		attachments: [],
+		created_at: "2026-05-01T12:00:00Z",
+		updated_at: "2026-05-01T12:00:00Z",
+		deleted_at: null,
+		...overrides,
+	};
+}
+
+describe("MessageBubble", () => {
+	it("自分のメッセージは data-mine='true'", () => {
+		render(<MessageBubble message={makeMessage()} currentUserId={100} />);
+		expect(screen.getByTestId("message-bubble")).toHaveAttribute(
+			"data-mine",
+			"true",
+		);
+	});
+
+	it("他人のメッセージは data-mine='false'", () => {
+		render(<MessageBubble message={makeMessage()} currentUserId={999} />);
+		expect(screen.getByTestId("message-bubble")).toHaveAttribute(
+			"data-mine",
+			"false",
+		);
+	});
+
+	it("status='sending' で data-status='sending'", () => {
+		render(
+			<MessageBubble
+				message={makeMessage()}
+				currentUserId={100}
+				status="sending"
+			/>,
+		);
+		expect(screen.getByTestId("message-bubble")).toHaveAttribute(
+			"data-status",
+			"sending",
+		);
+	});
+
+	it("status='failed' で再送ボタン表示", () => {
+		render(
+			<MessageBubble
+				message={makeMessage()}
+				currentUserId={100}
+				status="failed"
+				onRetry={() => {}}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: /再試行/ })).toBeInTheDocument();
+	});
+
+	it("attachments を filename で表示", () => {
+		render(
+			<MessageBubble
+				message={makeMessage({
+					attachments: [
+						{
+							id: 1,
+							s3_key: "dm/10/2026/05/x.jpg",
+							filename: "photo.jpg",
+							mime_type: "image/jpeg",
+							size: 1024,
+							width: null,
+							height: null,
+						},
+					],
+				})}
+				currentUserId={100}
+			/>,
+		);
+		expect(screen.getByText("photo.jpg")).toBeInTheDocument();
+	});
+});

--- a/client/src/components/dm/__tests__/MessageComposer.test.tsx
+++ b/client/src/components/dm/__tests__/MessageComposer.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import MessageComposer from "@/components/dm/MessageComposer";
+
+describe("MessageComposer", () => {
+	it("submit で onSubmit が呼ばれ textarea がクリアされる", async () => {
+		const onSubmit = vi.fn();
+		render(<MessageComposer onSubmit={onSubmit} />);
+		const textarea = screen.getByLabelText("メッセージを入力");
+		await userEvent.type(textarea, "hello");
+		await userEvent.click(screen.getByRole("button", { name: "送信" }));
+		expect(onSubmit).toHaveBeenCalledWith("hello");
+	});
+
+	it("Ctrl+Enter で送信される", async () => {
+		const onSubmit = vi.fn();
+		render(<MessageComposer onSubmit={onSubmit} />);
+		const textarea = screen.getByLabelText("メッセージを入力");
+		await userEvent.type(textarea, "hi{Control>}{Enter}{/Control}");
+		expect(onSubmit).toHaveBeenCalledWith("hi");
+	});
+
+	it("空文字 / 空白のみは送信されない", async () => {
+		const onSubmit = vi.fn();
+		render(<MessageComposer onSubmit={onSubmit} />);
+		const textarea = screen.getByLabelText("メッセージを入力");
+		await userEvent.type(textarea, "   ");
+		// 送信ボタンが disable
+		expect(screen.getByRole("button", { name: "送信" })).toBeDisabled();
+	});
+
+	it("disabled=true で送信ボタンも textarea も無効", () => {
+		render(<MessageComposer onSubmit={() => {}} disabled />);
+		expect(screen.getByLabelText("メッセージを入力")).toBeDisabled();
+		expect(screen.getByRole("button", { name: "送信" })).toBeDisabled();
+	});
+
+	it("入力で onTyping が呼ばれる", async () => {
+		const onTyping = vi.fn();
+		render(<MessageComposer onSubmit={() => {}} onTyping={onTyping} />);
+		await userEvent.type(screen.getByLabelText("メッセージを入力"), "a");
+		expect(onTyping).toHaveBeenCalled();
+	});
+});

--- a/client/src/components/dm/__tests__/MessageComposer.test.tsx
+++ b/client/src/components/dm/__tests__/MessageComposer.test.tsx
@@ -22,6 +22,22 @@ describe("MessageComposer", () => {
 		expect(onSubmit).toHaveBeenCalledWith("hi");
 	});
 
+	it("Cmd+Enter (metaKey) でも送信される", async () => {
+		const onSubmit = vi.fn();
+		render(<MessageComposer onSubmit={onSubmit} />);
+		const textarea = screen.getByLabelText("メッセージを入力");
+		await userEvent.type(textarea, "hi{Meta>}{Enter}{/Meta}");
+		expect(onSubmit).toHaveBeenCalledWith("hi");
+	});
+
+	it("onSubmit 失敗時は alert を表示", async () => {
+		const onSubmit = vi.fn().mockRejectedValue(new Error("backend down"));
+		render(<MessageComposer onSubmit={onSubmit} />);
+		await userEvent.type(screen.getByLabelText("メッセージを入力"), "hi");
+		await userEvent.click(screen.getByRole("button", { name: "送信" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent("backend down");
+	});
+
 	it("空文字 / 空白のみは送信されない", async () => {
 		const onSubmit = vi.fn();
 		render(<MessageComposer onSubmit={onSubmit} />);

--- a/client/src/components/dm/__tests__/TypingIndicator.test.tsx
+++ b/client/src/components/dm/__tests__/TypingIndicator.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import TypingIndicator from "@/components/dm/TypingIndicator";
+import type { DMUserSummary } from "@/lib/redux/features/dm/types";
+
+const lookup = new Map<number, DMUserSummary>([
+	[200, { id: 200, username: "alice", first_name: "", last_name: "" }],
+]);
+
+describe("TypingIndicator", () => {
+	it("typingUserId=null では何も描画しない", () => {
+		const { container } = render(
+			<TypingIndicator typingUserId={null} memberLookup={lookup} />,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("解決可能な user は @username が入力中... で表示", () => {
+		render(
+			<TypingIndicator
+				typingUserId={200}
+				memberLookup={lookup}
+				startedAt="2026-05-01T12:00:00Z"
+			/>,
+		);
+		expect(screen.getByTestId("typing-indicator")).toHaveTextContent(
+			"@alice が入力中",
+		);
+	});
+
+	it("不明な user は '誰か が入力中...' を表示", () => {
+		render(<TypingIndicator typingUserId={999} memberLookup={lookup} />);
+		expect(screen.getByTestId("typing-indicator")).toHaveTextContent(
+			"誰か が入力中",
+		);
+	});
+});

--- a/client/src/hooks/__tests__/useDMSocket.test.tsx
+++ b/client/src/hooks/__tests__/useDMSocket.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Tests for useDMSocket (P3-16 / Issue #241).
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { __internals, useDMSocket } from "@/hooks/useDMSocket";
+
+// eslint-disable-next-line no-use-before-define
+type MockInstances = MockWebSocket[];
+
+class MockWebSocket {
+	static OPEN = 1;
+	static CLOSED = 3;
+	static instances: MockInstances = [];
+
+	url: string;
+	readyState = 0; // CONNECTING
+	onopen: ((ev: Event) => void) | null = null;
+	onmessage: ((ev: MessageEvent<string>) => void) | null = null;
+	onerror: ((ev: Event) => void) | null = null;
+	onclose: ((ev: CloseEvent) => void) | null = null;
+	sent: string[] = [];
+
+	constructor(url: string) {
+		this.url = url;
+		MockWebSocket.instances.push(this);
+	}
+
+	open() {
+		this.readyState = MockWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+
+	emit(data: unknown) {
+		this.onmessage?.(
+			new MessageEvent("message", { data: JSON.stringify(data) }),
+		);
+	}
+
+	closeFromServer(code = 1006, reason = "abnormal") {
+		this.readyState = MockWebSocket.CLOSED;
+		this.onclose?.(
+			new CloseEvent("close", { code, reason, wasClean: code === 1000 }),
+		);
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+	}
+
+	close() {
+		this.readyState = MockWebSocket.CLOSED;
+	}
+}
+
+beforeEach(() => {
+	MockWebSocket.instances = [];
+	(globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+		MockWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+const factory = (url: string) => new MockWebSocket(url) as unknown as WebSocket;
+
+describe("useDMSocket", () => {
+	it("roomId が null なら closed のまま", () => {
+		const { result } = renderHook(() =>
+			useDMSocket({ roomId: null, socketFactory: factory }),
+		);
+		expect(result.current.status).toBe("closed");
+		expect(MockWebSocket.instances).toHaveLength(0);
+	});
+
+	it("connecting → open に遷移し、frame 受信で lastFrame が更新される", async () => {
+		const { result } = renderHook(() =>
+			useDMSocket({
+				roomId: 42,
+				socketFactory: factory,
+				urlOverride: "ws://test/dm/42/",
+			}),
+		);
+		expect(result.current.status).toBe("connecting");
+		const ws = MockWebSocket.instances[0];
+		expect(ws.url).toBe("ws://test/dm/42/");
+
+		act(() => {
+			ws.open();
+		});
+		await waitFor(() => expect(result.current.status).toBe("open"));
+
+		act(() => {
+			ws.emit({ type: "message.new", message: { id: 1, body: "hi" } });
+		});
+		await waitFor(() =>
+			expect(result.current.lastFrame).toMatchObject({ type: "message.new" }),
+		);
+	});
+
+	it("sendMessage は send_message frame を JSON で送る", async () => {
+		const { result } = renderHook(() =>
+			useDMSocket({
+				roomId: 1,
+				socketFactory: factory,
+				urlOverride: "ws://t/",
+			}),
+		);
+		const ws = MockWebSocket.instances[0];
+		act(() => {
+			ws.open();
+		});
+		await waitFor(() => expect(result.current.status).toBe("open"));
+
+		const ok = result.current.sendMessage({
+			body: "hello",
+			attachment_ids: [3],
+		});
+		expect(ok).toBe(true);
+		expect(ws.sent).toHaveLength(1);
+		const parsed = JSON.parse(ws.sent[0]);
+		expect(parsed).toMatchObject({
+			type: "send_message",
+			body: "hello",
+			attachment_ids: [3],
+		});
+	});
+
+	it("typing debounce: 連続呼び出しで 2 度目は送信しない", async () => {
+		const { result } = renderHook(() =>
+			useDMSocket({
+				roomId: 1,
+				socketFactory: factory,
+				urlOverride: "ws://t/",
+			}),
+		);
+		const ws = MockWebSocket.instances[0];
+		act(() => {
+			ws.open();
+		});
+		await waitFor(() => expect(result.current.status).toBe("open"));
+
+		expect(result.current.sendTyping()).toBe(true);
+		expect(result.current.sendTyping()).toBe(false);
+		expect(ws.sent).toHaveLength(1);
+		expect(JSON.parse(ws.sent[0]).type).toBe("typing");
+	});
+
+	it("sendRead は message_id 込みで read frame を送る", async () => {
+		const { result } = renderHook(() =>
+			useDMSocket({
+				roomId: 1,
+				socketFactory: factory,
+				urlOverride: "ws://t/",
+			}),
+		);
+		const ws = MockWebSocket.instances[0];
+		act(() => {
+			ws.open();
+		});
+		await waitFor(() => expect(result.current.status).toBe("open"));
+
+		expect(result.current.sendRead(99)).toBe(true);
+		expect(JSON.parse(ws.sent[0])).toEqual({ type: "read", message_id: 99 });
+	});
+
+	it("WS が open でない時 sendMessage は false を返す", () => {
+		const { result } = renderHook(() =>
+			useDMSocket({
+				roomId: 1,
+				socketFactory: factory,
+				urlOverride: "ws://t/",
+			}),
+		);
+		// open() を呼ばない → readyState=CONNECTING
+		expect(result.current.sendMessage({ body: "x" })).toBe(false);
+	});
+
+	it("close 4401 (unauth) では再接続を schedule しない", async () => {
+		const { result } = renderHook(() =>
+			useDMSocket({
+				roomId: 1,
+				socketFactory: factory,
+				urlOverride: "ws://t/",
+			}),
+		);
+		const ws = MockWebSocket.instances[0];
+		act(() => {
+			ws.open();
+		});
+		await waitFor(() => expect(result.current.status).toBe("open"));
+
+		act(() => {
+			ws.closeFromServer(4401, "unauthenticated");
+		});
+		await waitFor(() => expect(result.current.status).toBe("closed"));
+		// fake timer で 60s 進めても再接続されない
+		vi.useFakeTimers();
+		await act(async () => {
+			vi.advanceTimersByTime(60_000);
+		});
+		expect(MockWebSocket.instances).toHaveLength(1);
+	});
+
+	it("close 1006 (異常切断) は再接続を schedule する (実時間で待機)", async () => {
+		const { result } = renderHook(() =>
+			useDMSocket({
+				roomId: 1,
+				socketFactory: factory,
+				urlOverride: "ws://t/",
+			}),
+		);
+		const ws = MockWebSocket.instances[0];
+		act(() => {
+			ws.open();
+		});
+		await waitFor(() => expect(result.current.status).toBe("open"));
+
+		act(() => {
+			ws.closeFromServer(1006, "abnormal");
+		});
+		// 1 度目の backoff は 500-1200ms 程度 (computeBackoffMs(1))。
+		// 2s 以内に新 instance が立ち上がるはず。
+		await waitFor(
+			() => expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2),
+			{ timeout: 3_000 },
+		);
+	});
+});
+
+describe("computeBackoffMs", () => {
+	it("attempt=0 は 0", () => {
+		expect(__internals.computeBackoffMs(0)).toBe(0);
+	});
+
+	it("attempt が増えると指数で増え、MAX_BACKOFF_MS で頭打ち", () => {
+		const a1 = __internals.computeBackoffMs(1);
+		const a3 = __internals.computeBackoffMs(3);
+		expect(a1).toBeGreaterThanOrEqual(500);
+		expect(a3).toBeGreaterThan(a1 * 0.5);
+		const big = __internals.computeBackoffMs(20);
+		expect(big).toBeLessThanOrEqual(__internals.MAX_BACKOFF_MS * 1.3);
+	});
+});

--- a/client/src/hooks/useDMSocket.ts
+++ b/client/src/hooks/useDMSocket.ts
@@ -1,0 +1,257 @@
+"use client";
+
+/**
+ * DM WebSocket hook (P3-16 / Issue #241).
+ *
+ * `/ws/dm/<room_id>/` に接続して以下を扱う:
+ * - 接続状態 (`connecting` / `open` / `closed`) の公開
+ * - 受信ハンドラ: `message.new` / `message.deleted` / `typing.update` / `read.update`
+ * - 送信ヘルパ: `sendMessage` / `sendTyping` / `sendRead`
+ * - **指数バックオフ自動再接続** (1s, 2s, 4s, 8s, 16s, 30s で cap)
+ * - room 切替時 / unmount 時に正しく cleanup
+ *
+ * design notes:
+ * - Cookie JWT (HttpOnly) で認証されているため、ws URL に token を含めない。
+ *   ブラウザは ws:// 接続にも cookie を自動添付する (same-site)。Backend (Channels)
+ *   側で OriginValidator + JWTAuthMiddleware が認証する。
+ * - status 変化と payload 受信は React state + ref のハイブリッド。
+ *   - ref: `socketRef` / `reconnectAttemptRef` / `reconnectTimerRef` を保持し
+ *     setState ループで stale closure を起こさない。
+ *   - state: 公開する `status` と "最新の" 受信 frame だけを保持。
+ *     リスト全体の append 制御は呼び出し元 component で行う (Subject 的な扱い)。
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type DMSocketStatus = "connecting" | "open" | "closed";
+
+export interface DMIncomingFrame {
+	type: string;
+	[key: string]: unknown;
+}
+
+export interface SendMessagePayload {
+	body: string;
+	attachment_ids?: number[];
+	attachment_keys?: {
+		s3_key: string;
+		filename: string;
+		mime_type: string;
+		size: number;
+	}[];
+}
+
+export interface UseDMSocketOptions {
+	roomId: number | string | null;
+	/** test 用: ws URL を override (default は `/ws/dm/<roomId>/`)。 */
+	urlOverride?: string;
+	/** test 用: WebSocket constructor を mock 注入。 */
+	socketFactory?: (url: string) => WebSocket;
+	/** debug log を出すか (production は false 推奨)。 */
+	debug?: boolean;
+}
+
+export interface UseDMSocketReturn {
+	status: DMSocketStatus;
+	/** 直近に受信した frame (null なら未受信)。component 側で type で分岐する。 */
+	lastFrame: DMIncomingFrame | null;
+	sendMessage(payload: SendMessagePayload): boolean;
+	sendTyping(): boolean;
+	sendRead(messageId?: number): boolean;
+	/** 強制再接続 (UI ボタン用、即座に backoff をリセット)。 */
+	reconnect(): void;
+}
+
+/** 指数バックオフ最大遅延 (ms)。 */
+const MAX_BACKOFF_MS = 30_000;
+/** 連続 typing.start を抑制する debounce window (ms)。 */
+const TYPING_DEBOUNCE_MS = 2_000;
+
+function computeBackoffMs(attempt: number): number {
+	// attempt=0 は initial connect、attempt>=1 から backoff 開始。
+	if (attempt <= 0) return 0;
+	const exp = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1));
+	// jitter: ±20% (再接続の thundering herd 防止)
+	const jitter = exp * 0.2 * (Math.random() * 2 - 1);
+	return Math.max(500, Math.floor(exp + jitter));
+}
+
+function defaultUrlFor(roomId: number | string): string {
+	if (typeof window === "undefined") {
+		// SSR では呼ばれない想定だが安全なフォールバック
+		return `/ws/dm/${roomId}/`;
+	}
+	const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+	return `${proto}//${window.location.host}/ws/dm/${roomId}/`;
+}
+
+export function useDMSocket(options: UseDMSocketOptions): UseDMSocketReturn {
+	const { roomId, urlOverride, socketFactory, debug = false } = options;
+
+	const [status, setStatus] = useState<DMSocketStatus>(
+		roomId == null ? "closed" : "connecting",
+	);
+	const [lastFrame, setLastFrame] = useState<DMIncomingFrame | null>(null);
+
+	const socketRef = useRef<WebSocket | null>(null);
+	const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const reconnectAttemptRef = useRef(0);
+	const closedByUserRef = useRef(false);
+	const lastTypingSentAtRef = useRef(0);
+
+	const log = useCallback(
+		(...args: unknown[]) => {
+			if (debug && typeof console !== "undefined") {
+				// eslint-disable-next-line no-console
+				console.debug("[useDMSocket]", ...args);
+			}
+		},
+		[debug],
+	);
+
+	const connect = useCallback(() => {
+		if (roomId == null) return;
+		const url = urlOverride ?? defaultUrlFor(roomId);
+		log("connecting", url);
+		setStatus("connecting");
+
+		const ws = socketFactory ? socketFactory(url) : new WebSocket(url);
+		socketRef.current = ws;
+
+		ws.onopen = () => {
+			log("open");
+			reconnectAttemptRef.current = 0;
+			setStatus("open");
+		};
+
+		ws.onmessage = (event: MessageEvent<string>) => {
+			try {
+				const parsed = JSON.parse(event.data) as DMIncomingFrame;
+				if (parsed && typeof parsed.type === "string") {
+					setLastFrame(parsed);
+				}
+			} catch (error: unknown) {
+				log("invalid json", error);
+			}
+		};
+
+		ws.onerror = (event: Event) => {
+			log("error", event);
+		};
+
+		ws.onclose = (event: CloseEvent) => {
+			log("close", event.code, event.reason);
+			setStatus("closed");
+			socketRef.current = null;
+			if (closedByUserRef.current) return;
+			// 4401 (unauthenticated) / 4403 (forbidden) は再接続しても解消しない。
+			if (event.code === 4401 || event.code === 4403) return;
+			scheduleReconnect();
+		};
+		// `scheduleReconnect` は本 callback と相互依存 (循環参照) するため、useCallback
+		// の deps に含めると connect 自体が再生成されて re-attach loop になる。
+		// 関数参照は最新を ref 経由で参照すべきだが、`closedByUserRef` で teardown 済かを
+		// 確認しているため stale 参照でも再接続は無害 (新接続が unmount で即 close される)。
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [roomId, urlOverride, socketFactory, log]);
+
+	const scheduleReconnect = useCallback(() => {
+		reconnectAttemptRef.current += 1;
+		const delay = computeBackoffMs(reconnectAttemptRef.current);
+		log("scheduling reconnect", reconnectAttemptRef.current, delay);
+		if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+		reconnectTimerRef.current = setTimeout(() => {
+			if (!closedByUserRef.current) connect();
+		}, delay);
+	}, [connect, log]);
+
+	const reconnect = useCallback(() => {
+		log("manual reconnect");
+		reconnectAttemptRef.current = 0;
+		if (reconnectTimerRef.current) {
+			clearTimeout(reconnectTimerRef.current);
+			reconnectTimerRef.current = null;
+		}
+		try {
+			socketRef.current?.close(1000, "manual reconnect");
+		} catch {
+			// ignore
+		}
+		socketRef.current = null;
+		connect();
+	}, [connect, log]);
+
+	useEffect(() => {
+		if (roomId == null) {
+			setStatus("closed");
+			return;
+		}
+		closedByUserRef.current = false;
+		reconnectAttemptRef.current = 0;
+		connect();
+		return () => {
+			closedByUserRef.current = true;
+			if (reconnectTimerRef.current) {
+				clearTimeout(reconnectTimerRef.current);
+				reconnectTimerRef.current = null;
+			}
+			try {
+				socketRef.current?.close(1000, "unmount");
+			} catch {
+				// ignore
+			}
+			socketRef.current = null;
+		};
+	}, [roomId, connect]);
+
+	const sendRaw = useCallback(
+		(frame: Record<string, unknown>): boolean => {
+			const ws = socketRef.current;
+			if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+			try {
+				ws.send(JSON.stringify(frame));
+				return true;
+			} catch (error: unknown) {
+				log("send failed", error);
+				return false;
+			}
+		},
+		[log],
+	);
+
+	const sendMessage = useCallback(
+		(payload: SendMessagePayload): boolean =>
+			sendRaw({
+				type: "send_message",
+				body: payload.body,
+				attachment_ids: payload.attachment_ids ?? [],
+				attachment_keys: payload.attachment_keys ?? [],
+			}),
+		[sendRaw],
+	);
+
+	const sendTyping = useCallback((): boolean => {
+		const now = Date.now();
+		if (now - lastTypingSentAtRef.current < TYPING_DEBOUNCE_MS) return false;
+		lastTypingSentAtRef.current = now;
+		return sendRaw({ type: "typing" });
+	}, [sendRaw]);
+
+	const sendRead = useCallback(
+		(messageId?: number): boolean => {
+			const frame: Record<string, unknown> = { type: "read" };
+			if (typeof messageId === "number") frame.message_id = messageId;
+			return sendRaw(frame);
+		},
+		[sendRaw],
+	);
+
+	return { status, lastFrame, sendMessage, sendTyping, sendRead, reconnect };
+}
+
+// テスト等から直接参照するため export.
+export const __internals = {
+	computeBackoffMs,
+	MAX_BACKOFF_MS,
+	TYPING_DEBOUNCE_MS,
+};

--- a/client/src/lib/redux/features/dm/dmApiSlice.ts
+++ b/client/src/lib/redux/features/dm/dmApiSlice.ts
@@ -16,10 +16,12 @@ import { baseApiSlice } from "@/lib/redux/features/api/baseApiSlice";
 
 import type {
 	CreateRoomInput,
+	DMMessage,
 	DMRoom,
 	DMRoomListResponse,
 	GroupInvitation,
 	InvitationListResponse,
+	RoomMessagesResponse,
 } from "./types";
 
 export const dmApiSlice = baseApiSlice.injectEndpoints({
@@ -94,6 +96,32 @@ export const dmApiSlice = baseApiSlice.injectEndpoints({
 				{ type: "DMInvitation" as const, id: "LIST" },
 			],
 		}),
+		// P3-09: 履歴取得 (新しい順で limit 件、画面側で reverse して下から表示)
+		listRoomMessages: builder.query<
+			RoomMessagesResponse,
+			{ roomId: number; limit?: number }
+		>({
+			query: ({ roomId, limit = 30 }) =>
+				`/dm/rooms/${roomId}/messages/?limit=${limit}`,
+			transformResponse: (raw: RoomMessagesResponse | DMMessage[]) => {
+				// DRF が pagination 無しで配列を返すケースに備えて normalize する。
+				if (Array.isArray(raw)) {
+					return { results: raw } as RoomMessagesResponse;
+				}
+				return raw;
+			},
+		}),
+		// P3-05: 既読更新 REST (initial load 時に呼ぶ)。WebSocket でも更新可。
+		markRoomRead: builder.mutation<{ ok: true }, number>({
+			query: (roomId) => ({
+				url: `/dm/rooms/${roomId}/read/`,
+				method: "POST",
+			}),
+			invalidatesTags: (_result, _error, roomId) => [
+				{ type: "DMRoom" as const, id: roomId },
+				{ type: "DMRoom" as const, id: "LIST" },
+			],
+		}),
 	}),
 	overrideExisting: false,
 });
@@ -105,4 +133,6 @@ export const {
 	useListInvitationsQuery,
 	useAcceptInvitationMutation,
 	useDeclineInvitationMutation,
+	useListRoomMessagesQuery,
+	useMarkRoomReadMutation,
 } = dmApiSlice;

--- a/client/src/lib/redux/features/dm/types.ts
+++ b/client/src/lib/redux/features/dm/types.ts
@@ -80,3 +80,33 @@ export interface CreateGroupRoomInput {
 }
 
 export type CreateRoomInput = CreateDirectRoomInput | CreateGroupRoomInput;
+
+/** Django apps/dm/serializers.MessageAttachmentSerializer と一致 (P3-09 / P3-06). */
+export interface MessageAttachment {
+	id: number;
+	s3_key: string;
+	filename: string;
+	mime_type: string;
+	size: number;
+	width: number | null;
+	height: number | null;
+}
+
+/** Django apps/dm/serializers.MessageSerializer と一致 (P3-09). */
+export interface DMMessage {
+	id: number;
+	room_id: number;
+	sender_id: number | null;
+	body: string;
+	attachments: MessageAttachment[];
+	created_at: string;
+	updated_at: string;
+	deleted_at: string | null;
+}
+
+export interface RoomMessagesResponse {
+	results: DMMessage[];
+	count?: number;
+	next?: string | null;
+	previous?: string | null;
+}


### PR DESCRIPTION
## Summary

Phase 3 frontend bundle **PR2/3**。PR1 (#259) の REST 経路に WebSocket 連携と Room 詳細画面を追加する。

### 実装範囲

- **`useDMSocket` hook (P3-16 #241)**:
  - `/ws/dm/<roomId>/` connect、status (`connecting`/`open`/`closed`) を公開
  - 受信 frame は `lastFrame` で公開、component が type で分岐
  - 送信ヘルパ: `sendMessage` / `sendTyping` (debounce 2s) / `sendRead`
  - 指数バックオフ自動再接続 (1s..30s + ±20% jitter)
  - close 4401/4403 は再接続しない (auth/permission は永続的問題)
  - room 切替 / unmount で正しく cleanup
- **TypingIndicator (P3-17 #242)**:
  - typing.update を 3 秒間 "@username が入力中..." で表示
  - role=status + aria-live で SR 通知
- **MessageBubble / MessageList / MessageComposer / RoomChat (P3-09 #234)**:
  - 履歴 (REST) + WS 新着 append + 末尾スクロール (上方向操作中は追従しない)
  - 自分/相手で吹き出しを左右 + 色を区別
  - status="sending"/"failed" で送信状態を視覚化、failed には再送ボタン
  - Ctrl+Enter / Cmd+Enter で送信、通常 Enter は改行
  - WebSocket 切断時は送信ボタン disabled + 再接続ボタン
  - role="log" + aria-live で SR が新着メッセージを読み上げる
- **`/messages/[id]` page**: 認証 + ID 検証 → `<RoomChat>` をレンダ

### dmApiSlice 拡張

- `listRoomMessages` query (履歴 30 件、画面側で reverse)
- `markRoomRead` mutation (mount 時に呼ぶ既読更新)

### スコープ外 (PR3 へ)

| 別 PR | issue | 内容 |
| --- | --- | --- |
| PR3 | #235 P3-10 + #236 P3-11 | 添付 (S3 直 PUT) + グループ作成モーダル + 新規 DM 開始モーダル |

### 残スコープ (本 PR でカバーしないが close する issue 範囲外、follow-up issue 推奨)

- 履歴 cursor pagination (上端 IntersectionObserver)
- 既読 IntersectionObserver (現状は mount 時 1 度)
- iOS safe-area-inset (mobile keyboard 上の入力欄追従)
- メッセージ削除 UI (long-press / hover メニュー)
- オプティミスティック更新 + rollback

## Test plan

- [x] `npx vitest run` → **39 件 pass** (新 23 件 + 既存 16 件)
  - useDMSocket: 10 件 (connect / send / debounce / 4401 no-reconnect / 1006 reconnect)
  - MessageBubble: 5 件
  - MessageComposer: 5 件
  - TypingIndicator: 3 件
- [x] `npx tsc --project tsconfig.json --noEmit` clean
- [x] `npx eslint` clean
- [ ] CI green を待ってマージ
- [ ] 実機確認 (browser MCP) → PR3 で添付込みでまとめて

## サブエージェントレビュー予定

- typescript-reviewer + code-reviewer + a11y-architect (UI コンポーネント)

## 関連

- Closes #234 (P3-09), #241 (P3-16), #242 (P3-17)
- 依存: PR1 (#259) は既マージ
- 後続: #235 (P3-10) + #236 (P3-11) が PR3