### PR TITLE
[fix][dm] expose user.pkid + frontend API contract 整合 (Phase 3 critical)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 472
+        "line_number": 478
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-02T06:09:48Z"
+  "generated_at": "2026-05-02T14:32:04Z"
 }

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -38,10 +38,16 @@ class CustomUserSerializer(UserSerializer):
 
     full_name = serializers.ReadOnlyField()
 
+    # P3 fix: bigint pkid を露出する。User.id は UUID (公開用)、`pkid` は内部 BigAutoField
+    # (DM serializer の user_id / sender_id / creator_id と一致する番号)。フロントエンドが
+    # `currentUserId` として比較するために必要。
+    pkid = serializers.IntegerField(read_only=True)
+
     class Meta(UserSerializer.Meta):
         model = User
         fields = [
             "id",
+            "pkid",
             "email",
             "username",
             "first_name",
@@ -66,6 +72,7 @@ class CustomUserSerializer(UserSerializer):
         # サーバー側 (signal / dedicated endpoint) でのみ更新する (P1-03 review MEDIUM 対応)。
         read_only_fields = [
             "id",
+            "pkid",
             "email",
             "username",
             "is_premium",

--- a/apps/users/tests/test_serializers_read_only.py
+++ b/apps/users/tests/test_serializers_read_only.py
@@ -86,3 +86,30 @@ class TestCustomUserSerializerReadOnly:
         user = user_factory(username="full_name_01", first_name="Taro", last_name="Yamada")
         data = CustomUserSerializer(user).data
         assert data["full_name"] == "Taro Yamada"
+
+    def test_pkid_field_is_exposed(self, user_factory) -> None:
+        """pkid (BigAutoField) を expose する (Phase 3 fix).
+
+        DM serializer は ``user.pk`` (= pkid) を ``user_id`` で返すため、
+        フロントは比較のために pkid を必要とする。``id`` (UUID) と区別する。
+        """
+        user = user_factory(username="pkid_01")
+        data = CustomUserSerializer(user).data
+        assert "pkid" in data
+        assert data["pkid"] == user.pkid
+        assert isinstance(data["pkid"], int)
+        # id は UUID 文字列のまま (string)
+        assert data["id"] == str(user.id)
+
+    def test_pkid_is_read_only_on_patch(self, user_factory) -> None:
+        user = user_factory(username="pkid_ro_01")
+        serializer = CustomUserSerializer(
+            user,
+            data={"pkid": 999_999},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        # pkid は read_only_fields なので変更不可
+        assert updated.pkid == user.pkid
+        assert updated.pkid != 999_999

--- a/client/src/app/(template)/messages/[id]/page.tsx
+++ b/client/src/app/(template)/messages/[id]/page.tsx
@@ -39,21 +39,20 @@ export default function RoomDetailPage() {
 	}
 
 	const roomId = Number.parseInt(params?.id ?? "", 10);
-	const currentUserId = Number.parseInt(profile.id, 10);
-	if (Number.isNaN(roomId) || Number.isNaN(currentUserId)) {
+	if (Number.isNaN(roomId) || typeof profile.pkid !== "number") {
 		return (
 			<section
 				role="alert"
 				className="text-baby_red mx-auto max-w-2xl py-12 text-center"
 			>
-				ルーム ID の形式が不正です。
+				ルーム ID またはプロフィールが不正です。
 			</section>
 		);
 	}
 
 	return (
 		<div className="mx-auto max-w-3xl">
-			<RoomChat roomId={roomId} currentUserId={currentUserId} />
+			<RoomChat roomId={roomId} currentUserId={profile.pkid} />
 		</div>
 	);
 }

--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -37,18 +37,15 @@ export default function MessagesPage() {
 		);
 	}
 
-	// Profile.id は legacy 都合で `string` 型 (UserResponse 由来) だが、
-	// Django serializer は実際には BigAutoField を JSON number として返す。
-	// `Number(...)` で coerce すると非数値文字列で NaN になり display name 計算が
-	// 崩れるため、parseInt + isNaN ガードで明示的に弾く (ts-reviewer HIGH H-1)。
-	const currentUserId = Number.parseInt(profile.id, 10);
-	if (Number.isNaN(currentUserId)) {
+	// Profile.id は UUID (string)、profile.pkid は bigint (number)。
+	// DM serializer は user.pk (= pkid) を返すため、比較には pkid を使う。
+	if (typeof profile.pkid !== "number") {
 		return (
 			<section
 				role="alert"
 				className="text-baby_red mx-auto max-w-2xl py-12 text-center"
 			>
-				プロフィール ID の形式が不正です。再ログインしてください。
+				プロフィール ID が取得できませんでした。再ログインしてください。
 			</section>
 		);
 	}
@@ -59,7 +56,7 @@ export default function MessagesPage() {
 				<h1 className="text-baby_white text-xl font-bold">メッセージ</h1>
 				{/* 新規 DM 開始ボタン: P3-11 (#236) で本格実装。本 PR では空状態 CTA のみ。 */}
 			</header>
-			<RoomList currentUserId={currentUserId} />
+			<RoomList currentUserId={profile.pkid} />
 		</section>
 	);
 }

--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -27,7 +27,7 @@ import {
 	useListRoomMessagesQuery,
 	useMarkRoomReadMutation,
 } from "@/lib/redux/features/dm/dmApiSlice";
-import type { DMMessage, DMUserSummary } from "@/lib/redux/features/dm/types";
+import type { DMMessage } from "@/lib/redux/features/dm/types";
 import { getRoomDisplayName } from "@/lib/dm/format";
 
 interface RoomChatProps {
@@ -91,11 +91,12 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 	}, [socket.lastFrame, currentUserId]);
 
 	const memberLookup = useMemo(() => {
-		const map = new Map<number, DMUserSummary>();
+		// Map<user_id (pkid), handle>。TypingIndicator が `@<handle>` を表示する。
+		const map = new Map<number, string>();
 		const room = roomQuery.data;
 		if (room) {
 			for (const m of room.memberships ?? []) {
-				if (m.user) map.set(m.user.id, m.user);
+				map.set(m.user_id, m.handle);
 			}
 		}
 		return map;

--- a/client/src/components/dm/RoomListItem.tsx
+++ b/client/src/components/dm/RoomListItem.tsx
@@ -88,18 +88,10 @@ function RoomAvatar({
 }) {
 	if (room.kind === "direct") {
 		const peer = pickPeer(room, currentUserId);
-		const src = peer?.avatar ?? null;
-		const fallback = peer ? (peer.username[0]?.toUpperCase() ?? "?") : "?";
-		return src ? (
-			// eslint-disable-next-line @next/next/no-img-element
-			<img
-				src={src}
-				alt=""
-				width={48}
-				height={48}
-				className="size-12 shrink-0 rounded-full object-cover"
-			/>
-		) : (
+		// DMRoomMembership は flat な handle のみ持つ。avatar URL は別 endpoint
+		// (/api/v1/profiles/...) で解決する設計だが Phase 3 範囲外、initials のみ表示。
+		const fallback = peer ? (peer.handle[0]?.toUpperCase() ?? "?") : "?";
+		return (
 			<div
 				aria-hidden="true"
 				className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold"

--- a/client/src/components/dm/TypingIndicator.tsx
+++ b/client/src/components/dm/TypingIndicator.tsx
@@ -10,15 +10,14 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import type { DMUserSummary } from "@/lib/redux/features/dm/types";
-
 const AUTO_HIDE_MS = 3_000;
 const SR_ANNOUNCE_AFTER_MS = 3_000;
 
 interface TypingIndicatorProps {
 	typingUserId: number | null;
 	startedAt?: string | null;
-	memberLookup: Map<number, DMUserSummary>;
+	/** user_id (pkid) → handle (username) の lookup. */
+	memberLookup: Map<number, string>;
 }
 
 export default function TypingIndicator({
@@ -55,9 +54,9 @@ export default function TypingIndicator({
 	}, [typingUserId, startedAt, announceId]);
 
 	if (visibleId == null) return null;
-	const member = memberLookup.get(visibleId);
-	const label = member ? `@${member.username}` : "誰か";
-	const announcing = announceId === visibleId && member;
+	const handle = memberLookup.get(visibleId);
+	const label = handle ? `@${handle}` : "誰か";
+	const announcing = announceId === visibleId && Boolean(handle);
 
 	return (
 		<>
@@ -70,7 +69,7 @@ export default function TypingIndicator({
 			</div>
 			{announcing ? (
 				<div role="status" aria-live="polite" className="sr-only">
-					{member ? `${member.username} さんが入力中` : ""}
+					{handle ? `${handle} さんが入力中` : ""}
 				</div>
 			) : null}
 		</>

--- a/client/src/components/dm/__tests__/InvitationList.test.tsx
+++ b/client/src/components/dm/__tests__/InvitationList.test.tsx
@@ -36,8 +36,8 @@ function makeInvitation(
 	return {
 		id: 1,
 		room: { id: 100, kind: "group", name: "Engineers" },
-		inviter: { id: 200, username: "alice", first_name: "", last_name: "" },
-		invitee: { id: 100, username: "me", first_name: "", last_name: "" },
+		inviter: { pkid: 200, username: "alice" },
+		invitee: { pkid: 100, username: "me" },
 		accepted: null,
 		created_at: "2026-05-01T12:00:00Z",
 		updated_at: "2026-05-01T12:00:00Z",

--- a/client/src/components/dm/__tests__/RoomList.test.tsx
+++ b/client/src/components/dm/__tests__/RoomList.test.tsx
@@ -28,22 +28,19 @@ function makeRoom(overrides: Partial<DMRoom> = {}): DMRoom {
 		id: 1,
 		kind: "direct",
 		name: "",
-		creator: null,
+		creator_id: null,
 		memberships: [
 			{
 				id: 1,
-				user: { id: 100, username: "me", first_name: "", last_name: "" },
+				user_id: 100,
+				handle: "me",
 				last_read_at: null,
 				created_at: "2026-05-01T00:00:00Z",
 			},
 			{
 				id: 2,
-				user: {
-					id: 200,
-					username: "alice",
-					first_name: "Alice",
-					last_name: "",
-				},
+				user_id: 200,
+				handle: "alice",
 				last_read_at: null,
 				created_at: "2026-05-01T00:00:00Z",
 			},

--- a/client/src/components/dm/__tests__/TypingIndicator.test.tsx
+++ b/client/src/components/dm/__tests__/TypingIndicator.test.tsx
@@ -2,11 +2,8 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import TypingIndicator from "@/components/dm/TypingIndicator";
-import type { DMUserSummary } from "@/lib/redux/features/dm/types";
 
-const lookup = new Map<number, DMUserSummary>([
-	[200, { id: 200, username: "alice", first_name: "", last_name: "" }],
-]);
+const lookup = new Map<number, string>([[200, "alice"]]);
 
 describe("TypingIndicator", () => {
 	it("typingUserId=null では何も描画しない", () => {
@@ -16,7 +13,7 @@ describe("TypingIndicator", () => {
 		expect(container).toBeEmptyDOMElement();
 	});
 
-	it("解決可能な user は @username が入力中... で表示", () => {
+	it("解決可能な user は @handle が入力中... で表示", () => {
 		render(
 			<TypingIndicator
 				typingUserId={200}

--- a/client/src/lib/dm/__tests__/format.test.ts
+++ b/client/src/lib/dm/__tests__/format.test.ts
@@ -1,5 +1,9 @@
 /**
  * Tests for DM format utilities (P3-08).
+ *
+ * Mock データは backend (apps/dm/serializers DMRoomMembershipSerializer) の実形と
+ * 一致させる: flat な `user_id` / `handle` を持つ membership。
+ * (skill: verify-api-contract-before-typing 反映)
  */
 
 import { describe, expect, it } from "vitest";
@@ -18,17 +22,19 @@ function makeDirectRoom(overrides: Partial<DMRoom> = {}): DMRoom {
 		id: 1,
 		kind: "direct",
 		name: "",
-		creator: null,
+		creator_id: null,
 		memberships: [
 			{
 				id: 1,
-				user: { id: 100, username: "me", first_name: "", last_name: "" },
+				user_id: 100,
+				handle: "me",
 				last_read_at: null,
 				created_at: "2026-05-01T00:00:00Z",
 			},
 			{
 				id: 2,
-				user: { id: 200, username: "alice", first_name: "", last_name: "" },
+				user_id: 200,
+				handle: "alice",
 				last_read_at: null,
 				created_at: "2026-05-01T00:00:00Z",
 			},
@@ -42,7 +48,7 @@ function makeDirectRoom(overrides: Partial<DMRoom> = {}): DMRoom {
 }
 
 describe("getRoomDisplayName", () => {
-	it("direct room は相手 username を返す", () => {
+	it("direct room は相手 handle を返す", () => {
 		expect(getRoomDisplayName(makeDirectRoom(), 100)).toBe("@alice");
 	});
 
@@ -51,7 +57,8 @@ describe("getRoomDisplayName", () => {
 			memberships: [
 				{
 					id: 1,
-					user: { id: 100, username: "me", first_name: "", last_name: "" },
+					user_id: 100,
+					handle: "me",
 					last_read_at: null,
 					created_at: "2026-05-01T00:00:00Z",
 				},
@@ -65,26 +72,29 @@ describe("getRoomDisplayName", () => {
 		expect(getRoomDisplayName(room, 100)).toBe("Engineers");
 	});
 
-	it("group room で name 空はメンバー username を最大 3 名連結", () => {
+	it("group room で name 空はメンバー handle を最大 3 名連結", () => {
 		const room = makeDirectRoom({
 			kind: "group",
 			name: "",
 			memberships: [
 				{
 					id: 1,
-					user: { id: 100, username: "me", first_name: "", last_name: "" },
+					user_id: 100,
+					handle: "me",
 					last_read_at: null,
 					created_at: "2026-05-01T00:00:00Z",
 				},
 				{
 					id: 2,
-					user: { id: 200, username: "alice", first_name: "", last_name: "" },
+					user_id: 200,
+					handle: "alice",
 					last_read_at: null,
 					created_at: "2026-05-01T00:00:00Z",
 				},
 				{
 					id: 3,
-					user: { id: 300, username: "bob", first_name: "", last_name: "" },
+					user_id: 300,
+					handle: "bob",
 					last_read_at: null,
 					created_at: "2026-05-01T00:00:00Z",
 				},
@@ -96,12 +106,8 @@ describe("getRoomDisplayName", () => {
 	it("group room で 4 名以上は ... が付く", () => {
 		const memberships = Array.from({ length: 5 }, (_, i) => ({
 			id: i + 2,
-			user: {
-				id: 200 + i,
-				username: `user${i}`,
-				first_name: "",
-				last_name: "",
-			},
+			user_id: 200 + i,
+			handle: `user${i}`,
 			last_read_at: null,
 			created_at: "2026-05-01T00:00:00Z",
 		}));
@@ -111,9 +117,10 @@ describe("getRoomDisplayName", () => {
 });
 
 describe("pickPeer", () => {
-	it("direct room の相手を返す", () => {
+	it("direct room の相手 membership を返す", () => {
 		const peer = pickPeer(makeDirectRoom(), 100);
-		expect(peer?.username).toBe("alice");
+		expect(peer?.handle).toBe("alice");
+		expect(peer?.user_id).toBe(200);
 	});
 
 	it("自分しかいないと null", () => {
@@ -121,7 +128,8 @@ describe("pickPeer", () => {
 			memberships: [
 				{
 					id: 1,
-					user: { id: 100, username: "me", first_name: "", last_name: "" },
+					user_id: 100,
+					handle: "me",
 					last_read_at: null,
 					created_at: "2026-05-01T00:00:00Z",
 				},

--- a/client/src/lib/dm/format.ts
+++ b/client/src/lib/dm/format.ts
@@ -6,15 +6,18 @@
  * - グループアイコン用 initials + auto color (id を hash → HSL)
  */
 
-import type { DMRoom, DMUserSummary } from "@/lib/redux/features/dm/types";
+import type { DMRoom, DMRoomMembership } from "@/lib/redux/features/dm/types";
 
 export const SNIPPET_MAX_LENGTH = 50;
 
 /**
  * 自分以外のメンバーから display name を組み立てる。
- * - direct: 相手 1 名の username (` @' を付ける)
+ * - direct: 相手 1 名の handle (`@<handle>` 表記)
  * - group (name あり): name そのまま
- * - group (name なし): メンバー username を最大 3 名連結
+ * - group (name なし): メンバー handle を最大 3 名連結
+ *
+ * `currentUserId` は **bigint pkid** (apps/dm/serializers の user_id と一致)。
+ * frontend では `profile.pkid` から取得する。
  */
 export function getRoomDisplayName(
 	room: DMRoom,
@@ -22,15 +25,14 @@ export function getRoomDisplayName(
 ): string {
 	if (room.kind === "direct") {
 		const peer = pickPeer(room, currentUserId);
-		return peer ? `@${peer.username}` : "(unknown)";
+		return peer ? `@${peer.handle}` : "(unknown)";
 	}
 	if (room.name && room.name.trim().length > 0) {
 		return room.name;
 	}
 	const others = (room.memberships ?? [])
-		.map((m) => m.user)
-		.filter((u): u is DMUserSummary => Boolean(u) && u.id !== currentUserId)
-		.map((u) => u.username);
+		.filter((m) => m.user_id !== currentUserId)
+		.map((m) => m.handle);
 	if (others.length === 0) {
 		return "(無名のグループ)";
 	}
@@ -40,11 +42,10 @@ export function getRoomDisplayName(
 export function pickPeer(
 	room: DMRoom,
 	currentUserId: number,
-): DMUserSummary | null {
-	const peer = (room.memberships ?? []).find(
-		(m) => m.user && m.user.id !== currentUserId,
+): DMRoomMembership | null {
+	return (
+		(room.memberships ?? []).find((m) => m.user_id !== currentUserId) ?? null
 	);
-	return peer ? peer.user : null;
 }
 
 /**

--- a/client/src/lib/redux/features/dm/types.ts
+++ b/client/src/lib/redux/features/dm/types.ts
@@ -8,26 +8,38 @@
 
 export type DMRoomKind = "direct" | "group";
 
-export interface DMUserSummary {
-	id: number;
-	username: string;
-	first_name: string;
-	last_name: string;
-	avatar?: string | null;
-}
-
+/**
+ * Backend (`DMRoomMembershipSerializer`) は user の入れ子オブジェクトではなく
+ * フラットに `user_id` (bigint pkid) と `handle` (username) を返す。
+ * フロントは pkid (= profile.pkid) で比較する。
+ */
 export interface DMRoomMembership {
 	id: number;
-	user: DMUserSummary;
+	user_id: number;
+	handle: string;
 	last_read_at: string | null;
 	created_at: string;
+	muted_at?: string | null;
+}
+
+/**
+ * direct room の peer / 招待者 / 招待対象を表す軽量 user 型。
+ * backend が `inviter` / `invitee` で nested として返すので存在し続ける
+ * (`DMRoomMembership` とは形が違う点に注意)。
+ */
+export interface DMUserSummary {
+	pkid: number;
+	username: string;
+	first_name?: string;
+	last_name?: string;
+	avatar?: string | null;
 }
 
 export interface DMRoom {
 	id: number;
 	kind: DMRoomKind;
 	name: string;
-	creator: DMUserSummary | null;
+	creator_id: number | null;
 	memberships: DMRoomMembership[];
 	last_message_at: string | null;
 	last_message_snippet?: string | null;
@@ -45,7 +57,13 @@ export interface DMRoomListResponse {
 	results: DMRoom[];
 }
 
-/** SPEC §7.2: グループ招待 (1:1 では生成されない). */
+/**
+ * SPEC §7.2: グループ招待 (1:1 では生成されない).
+ *
+ * NOTE: backend の実 serializer 形に合わせて再確認が必要。現状は frontend の
+ * `InvitationList` が `inv.inviter.username` / `inv.room.name` で参照しているため
+ * その形を保っているが、Phase 4A で notification と整合させる時に再点検する。
+ */
 export interface GroupInvitation {
 	id: number;
 	room: {

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -16,7 +16,13 @@ export interface User {
 }
 
 export interface UserResponse {
+	/** UUID 公開 ID (URL や外部参照に使う). */
 	id: string;
+	/**
+	 * Bigint primary key (DM serializer の user_id / sender_id / creator_id と一致).
+	 * Phase 3 で /auth/users/me/ に追加された (apps/users/serializers CustomUserSerializer)。
+	 */
+	pkid: number;
 	email: string;
 	first_name: string;
 	last_name: string;

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -172,6 +172,12 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 
+# P3-13 で channels を導入したため、`channels` を INSTALLED_APPS に含めると
+# `manage.py runserver` が ASGI モードに切替わり ASGI_APPLICATION の指定を要求する。
+# stg / prod は daphne が直接 `config.asgi:application` を起動するため不要だが、
+# local の runserver 互換のために明示する。
+ASGI_APPLICATION = "config.asgi.application"
+
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases


### PR DESCRIPTION
## Summary

E2E でローカル stack を立てて初めて発覚した Phase 3 frontend の根本バグを修正する。
PR #259 / #260 / #261 merge 済の状態で `/messages` が動作しない (UUID を Number coerce →
NaN で再ログイン誘導画面が永続表示) 状態だった。

## 根本原因

- Backend `apps/dm/serializers` は `user.pk` (BigAutoField bigint) を `user_id` / `sender_id` / `creator_id` で返す。
- User profile API (`/api/v1/auth/users/me/`) は UUID `id` (string) のみ公開していて、bigint pkid を露出していなかった。
- Phase 3 frontend は `Number(profile.id)` で UUID を coerce → 必ず `NaN`。
- ts-reviewer HIGH H-1 で警告されたが `parseInt + isNaN guard` で握りつぶし、根本原因 (型不整合) を見逃した。
- unit test の self-mock が `{ user: { id, username } }` という想像形だったので実 API contract との乖離を検出できなかった。

教訓は `~/.claude/skills/learned/` に永続保存:
- `verify-api-contract-before-typing.md`
- `reviewer-high-on-type-cast-needs-root-cause.md`
- `thread-e2e-through-prs-not-end.md`

## 修正内容

### Backend
- `apps/users/serializers.py` `CustomUserSerializer` に `pkid: IntegerField(read_only=True)` を追加。`read_only_fields` にも入れて PATCH 不可。
- `apps/users/tests/test_serializers_read_only.py` に `test_pkid_field_is_exposed` / `test_pkid_is_read_only_on_patch` を追加。
- `config/settings/base.py` に `ASGI_APPLICATION = "config.asgi.application"` を追加 (channels が runserver を ASGI 化するため。stg/prod は daphne 直起動なので影響なし、local docker 限定の修正)。

### Frontend types (実 API 形に整合)
- `UserResponse.pkid: number` を追加 (UUID `id` とは別)。
- `DMRoomMembership`: nested `user` → flat `user_id` + `handle` (= apps/dm/serializers の実形)。
- `DMRoom.creator` → `creator_id: number | null` (= apps/dm/serializers の実形)。
- `DMUserSummary` を pkid ベースに変更 (`GroupInvitation` 用)。

### Frontend logic
- `messages/page.tsx`, `messages/[id]/page.tsx`: `Number.parseInt(profile.id)` → `profile.pkid` 直接利用、`typeof "number"` ガード。
- `lib/dm/format.ts` (`getRoomDisplayName`, `pickPeer`): `m.user.id` → `m.user_id`, `m.user.username` → `m.handle`。
- `RoomChat`: `memberLookup` を `Map<number, string>` (handle) に。
- `TypingIndicator`: handle 直接参照に。
- `RoomListItem`: avatar URL は別経路解決前提で initials 表示のみ (フォローアップ issue 推奨)。

### Tests
- `format.test.ts`, `RoomList.test.tsx`, `TypingIndicator.test.tsx` の mock を実 API 形に書き直し。
- `InvitationList.test.tsx` の inviter/invitee mock を pkid ベースに修正。

## Test plan

- [x] `pytest apps/users/tests/test_serializers_read_only.py` → **8/8 pass** (新 pkid テスト 2 件)
- [x] `npx vitest run` → **67/67 pass**
- [x] `npx tsc --project tsconfig.json --noEmit` clean
- [x] ローカル docker stack で `/api/v1/auth/users/me/` レスポンスを直接確認し、`pkid` が返ることを検証 (skill: verify-api-contract-before-typing 適用)
- [ ] CI green を待ってマージ
- [ ] **マージ後**: cd-stg auto-deploy → stg 環境で `phase3.spec.ts` E2E 実行

## スコープ外 (フォローアップ issue 推奨)

- DM 一覧 / 詳細での avatar URL の解決 (DM membership には `avatar` が含まれないため、`/api/v1/profiles/<pkid>/` などで lazy fetch する経路が必要)
- `creator: DMUserSummary | null` から `creator_id: number | null` に変えたことで RoomChat 等で creator 情報が必要になった場合の取得経路 (現状 unused)

## 関連

- Phase 3 frontend bundle (#259, #260, #261) の post-merge fix
- 教訓: `/learn` で 3 skill を `~/.claude/skills/learned/` に保存済