### PR TITLE
fix(dm): /messages 配下 page の auth race を cookie 直読みで解消 (Closes #269)

### DIFF
--- a/client/src/app/(template)/messages/[id]/page.tsx
+++ b/client/src/app/(template)/messages/[id]/page.tsx
@@ -6,6 +6,7 @@
  * 認証必須。`useParams` で room id を解決し、`<RoomChat>` をレンダ。
  */
 
+import { getCookie } from "cookies-next";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect } from "react";
 
@@ -17,14 +18,18 @@ export default function RoomDetailPage() {
 	const router = useRouter();
 	const params = useParams<{ id: string }>();
 	const { isAuthenticated } = useAppSelector((state) => state.auth);
-	const { profile, isLoading } = useUserProfile();
+	const { profile } = useUserProfile();
 
+	// 認証チェック (#269): cookie を直接読む。Redux の `isAuthenticated` だけ
+	// だと PersistAuth hydration より前に useEffect が走って false-positive
+	// redirect が起きる。詳細は messages/page.tsx の同コメントを参照。
 	useEffect(() => {
-		if (!isAuthenticated && !isLoading) {
+		const isLoggedIn = getCookie("logged_in") === "true";
+		if (!isLoggedIn) {
 			const next = encodeURIComponent(`/messages/${params?.id ?? ""}`);
 			router.replace(`/login?next=${next}`);
 		}
-	}, [isAuthenticated, isLoading, router, params]);
+	}, [router, params]);
 
 	if (!isAuthenticated || !profile) {
 		return (

--- a/client/src/app/(template)/messages/invitations/page.tsx
+++ b/client/src/app/(template)/messages/invitations/page.tsx
@@ -7,6 +7,7 @@
  * Phase 4A の通知ベル UI が完成したらそちらに統合される予定。
  */
 
+import { getCookie } from "cookies-next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -18,13 +19,16 @@ import { useAppSelector } from "@/lib/redux/hooks/typedHooks";
 export default function InvitationsPage() {
 	const router = useRouter();
 	const { isAuthenticated } = useAppSelector((state) => state.auth);
-	const { isLoading } = useUserProfile();
 
+	// 認証チェック (#269): cookie を直接読む。Redux の `isAuthenticated` だけ
+	// だと PersistAuth hydration より前に useEffect が走って false-positive
+	// redirect が起きる。詳細は messages/page.tsx の同コメントを参照。
 	useEffect(() => {
-		if (!isAuthenticated && !isLoading) {
+		const isLoggedIn = getCookie("logged_in") === "true";
+		if (!isLoggedIn) {
 			router.replace("/login?next=/messages/invitations");
 		}
-	}, [isAuthenticated, isLoading, router]);
+	}, [router]);
 
 	if (!isAuthenticated) {
 		return (

--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -7,6 +7,7 @@
  * 自分が参加中の DM ルーム一覧を表示。
  */
 
+import { getCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
@@ -19,11 +20,17 @@ export default function MessagesPage() {
 	const { isAuthenticated } = useAppSelector((state) => state.auth);
 	const { profile, isLoading } = useUserProfile();
 
+	// 認証チェック (#269): cookie (`logged_in`) を直接読んで判定する。
+	// PersistAuth (app/layout.tsx) の useEffect は本ページ useEffect より「後」に
+	// 走るため、Redux の `isAuthenticated` だけ見ると cold load (page.goto 等)
+	// で常に false → 即 /login に redirect される race が起きる。
+	// cookie を直接読めば、まだ Redux が hydrate されていなくても正しく判定できる。
 	useEffect(() => {
-		if (!isAuthenticated && !isLoading) {
+		const isLoggedIn = getCookie("logged_in") === "true";
+		if (!isLoggedIn) {
 			router.replace("/login?next=/messages");
 		}
-	}, [isAuthenticated, isLoading, router]);
+	}, [router]);
 
 	if (!isAuthenticated || !profile) {
 		return (


### PR DESCRIPTION
## 現象 / 問題

PR #268 の Phase 3 spec selector 修正後、stg E2E で login button click は通るが、続く `page.goto("/messages")` で必ず /login に redirect されて完走しない (#269)。

## 原因

/messages 系 page は Redux の `state.auth.isAuthenticated` を見て未認証なら /login に飛ばす。しかし `isAuthenticated` を立てる役の `PersistAuth` は `app/layout.tsx` に置かれており、その useEffect は子コンポーネント (MessagesPage 等) の useEffect より「後」に走る。

cold load (page.goto / 直接 URL 叩き) では:

1. MessagesPage が render
2. 初期 Redux state = `{ isAuthenticated: false }`
3. `useUserProfile` は `skip: !isAuthenticated` で query 発火せず → `isLoading=false`
4. MessagesPage useEffect: `!isAuthenticated && !isLoading` → TRUE → /login に redirect
5. その後 PersistAuth useEffect が発火するが手遅れ

リンク経由 (in-app navigation) では Redux state が hydrate 済なので race は起きないため、人間操作だと気づきにくく自動 E2E で初めて顕在化した。

## 修正

`/messages` / `/messages/[id]/` / `/messages/invitations/` の 3 page で useEffect の判定を「Redux の `isAuthenticated`」ではなく「cookie (`logged_in`) の値を `getCookie` で直接読む」に変更。

cookie は login API が non-HttpOnly で set するため、Redux hydration を待たずに同期的に判定できる。

```diff
-useEffect(() => {
-  if (!isAuthenticated && !isLoading) {
-    router.replace("/login?next=/messages");
-  }
-}, [isAuthenticated, isLoading, router]);
+useEffect(() => {
+  const isLoggedIn = getCookie("logged_in") === "true";
+  if (!isLoggedIn) {
+    router.replace("/login?next=/messages");
+  }
+}, [router]);
```

`!isAuthenticated || !profile` での loading skeleton 表示はそのまま (cookie 有だが Redux/profile がまだ hydrate されてない瞬間に「認証情報を確認しています」を表示)。

## サブエージェントレビュー (typescript-reviewer)

- CRITICAL/HIGH: なし
- MEDIUM (受容): cookie と Redux の二系統認証 → divergence 可能性あり (logout in another tab で stale cookie)。抜本対策は ProtectedRoute wrap か共通 hook 化。本 PR は最小修正で E2E green を優先、別 issue で systemic fix 推奨。
- MEDIUM (確認済 → OK): invitations/page.tsx で `useUserProfile` 削除 → InvitationList が自前で `query.isLoading` を持つので問題なし
- LOW: `getCookie("logged_in") === "true"` の helper 化 (将来 cookie 名変更時のため、Optional)

## 動作確認

- ローカル diff レベル: 3 page とも同パターンで修正
- stg 確認: 本 PR merge → cd-stg deploy 完了後に Phase 3 spec を再実行する

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功
- [ ] stg で `PLAYWRIGHT_BASE_URL=https://stg.codeplace.me` での Phase 3 spec が `/messages` 遷移後に /login に飛ばされない
- [ ] golden path (direct DM / group create) のうち最低 1 つが完走

## Follow-up

- 同 race パターンが他の認証必須 page (timeline, profile/me, etc.) にも存在する可能性。本 PR は Phase 3 範囲のみ。systemic fix は別 issue で。

Closes #269