### PR TITLE
fix(dm): useUserProfile を /api/v1/users/me/ に修正 (Closes #269 後続)

### DIFF
--- a/client/src/components/shared/navbar/AuthAvatar.tsx
+++ b/client/src/components/shared/navbar/AuthAvatar.tsx
@@ -34,7 +34,7 @@ export default function AuthAvatar() {
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
 						<Avatar className="border-pumpkin cursor-pointer border-2">
-							<AvatarImage alt="auth image" src={profile.avatar} />
+							<AvatarImage alt="auth image" src={profile.avatar_url} />
 							<AvatarFallback>
 								<CircleUser className="dark:text-platinum size-8" />
 							</AvatarFallback>

--- a/client/src/hooks/useUseProfile.ts
+++ b/client/src/hooks/useUseProfile.ts
@@ -8,5 +8,6 @@ export function useUserProfile() {
 		skip: !isAuthenticated,
 	});
 
-	return { profile: data?.profile, isLoading, isError };
+	// /api/v1/users/me/ は CustomUser を直接返す (旧 `{profile: ...}` ラップなし)。
+	return { profile: data, isLoading, isError };
 }

--- a/client/src/lib/redux/features/users/usersApiSlice.ts
+++ b/client/src/lib/redux/features/users/usersApiSlice.ts
@@ -1,11 +1,16 @@
 import { baseApiSlice } from "@/lib/redux/features/api/baseApiSlice";
+import { components } from "@/types/api.generated";
 import {
 	NonTenantResponse,
 	ProfileData,
-	ProfileResponse,
 	ProfilesResponse,
 	QueryParams,
 } from "@/types";
+
+// /api/v1/users/me/ の正式レスポンス型 (drf-spectacular generated)。
+// 旧 ProfileResponse `{profile: {...}}` 形式 (legacy cookiecutter) は実 backend に
+// 存在しないエンドポイントを叩いていたため、本 PR で /users/me/ に統一する (#269 後続)。
+export type CurrentUserResponse = components["schemas"]["CustomUser"];
 
 export const usersApiSlice = baseApiSlice.injectEndpoints({
 	endpoints: (builder) => ({
@@ -38,8 +43,10 @@ export const usersApiSlice = baseApiSlice.injectEndpoints({
 			},
 			providesTags: ["User"],
 		}),
-		getUserProfile: builder.query<ProfileResponse, void>({
-			query: () => "/profiles/user/my-profile/",
+		// 旧 endpoint `/profiles/user/my-profile/` (cookiecutter 由来) は backend に
+		// 存在せず 404。実 endpoint は /api/v1/users/me/ で CustomUser を直接返す。
+		getUserProfile: builder.query<CurrentUserResponse, void>({
+			query: () => "/users/me/",
 			providesTags: ["User"],
 		}),
 		updateUserProfile: builder.mutation<ProfileData, ProfileData>({


### PR DESCRIPTION
## 現象

PR #270 で auth race を解消した後、E2E spec が /messages 遷移後 `/login` に飛ばされなくなった代わりに、loading skeleton (`認証情報を確認しています...`) から進まず heading が描画されないことが判明。

## 原因

`useUserProfile` (`hooks/useUseProfile.ts`) → `useGetUserProfileQuery` (`usersApiSlice.ts`) は `/api/v1/profiles/user/my-profile/` を叩いていたが、これは backend に存在せず 404:

```
$ curl https://stg.codeplace.me/api/v1/profiles/user/my-profile/
HTTP 404
```

cookiecutter 由来の legacy endpoint と思われる。本プロジェクトの実 endpoint は `/api/v1/users/me/` で `CustomUser` を直接返す (ラップなし)。

profile が永遠に undefined のままなので、MessagesPage の `if (!isAuthenticated || !profile)` が常に true → loading skeleton 表示が継続。

## 修正

1. `client/src/lib/redux/features/users/usersApiSlice.ts`
   - `getUserProfile` の query: `/profiles/user/my-profile/` → `/users/me/`
   - 戻り型: `ProfileResponse` (`{profile: ...}`) → `CurrentUserResponse` (= `components["schemas"]["CustomUser"]` from drf-spectacular generated types)

2. `client/src/hooks/useUseProfile.ts`
   - `return { profile: data?.profile, ... }` → `return { profile: data, ... }` (data 自体が CustomUser)

3. `client/src/components/shared/navbar/AuthAvatar.tsx`
   - `profile.avatar` (legacy field) → `profile.avatar_url` (実 backend field)

## なぜ気づかなかったか

PR #270 で修正した auth race は backend 通信前の bug で、本 endpoint 不一致は それ以降のレイヤー。auth race fix で初めて /messages 描画路に到達したため、本 bug が顕在化した。Phase 3 spec が CI で動いていればもっと早く検出できたはず (#266 で起票済)。

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功 (frontend 側)
- [ ] stg `/api/v1/users/me/` (cookie 付き) が 200 返す ← 既に確認済
- [ ] stg Phase 3 spec が `/messages` 遷移後 heading が見えるところまで進む

## Follow-up

- types/index.d.ts の Profile / ProfileResponse / ProfileData (legacy) を整理
- 旧 endpoint /profiles/user/* を呼ぶ他コードがあれば追跡
- #266: Phase 3 spec CI 統合 (本 bug を CI で早期検出するため)

Refs: #269 (auth race fix の続き)