### PR TITLE
fix(dm): InvitationList の type drift を解消 + room_name field 追加 (Closes #276)

### DIFF
--- a/apps/dm/serializers.py
+++ b/apps/dm/serializers.py
@@ -136,12 +136,17 @@ class GroupInvitationSerializer(serializers.ModelSerializer):
     invitee_id = serializers.IntegerField(source="invitee.pk")
     inviter_handle = serializers.CharField(source="inviter.username", read_only=True, default=None)
     invitee_handle = serializers.CharField(source="invitee.username", read_only=True)
+    # frontend (`InvitationList.tsx`) で「@inviter から <group_name> への招待」を
+    # 表示するため room.name を inline で返す (#276)。room の他フィールドは
+    # 不要なので flat に追加 (round trip 削減)。
+    room_name = serializers.CharField(source="room.name", read_only=True)
 
     class Meta:
         model = GroupInvitation
         fields = (
             "id",
             "room_id",
+            "room_name",
             "inviter_id",
             "inviter_handle",
             "invitee_id",

--- a/apps/dm/tests/test_views_rooms_and_invitations.py
+++ b/apps/dm/tests/test_views_rooms_and_invitations.py
@@ -159,6 +159,33 @@ class TestInvitationLifecycle:
         results = body["results"] if isinstance(body, dict) and "results" in body else body
         assert len(results) == 1
 
+    def test_invitation_serializer_includes_flat_handles_and_room_name(self) -> None:
+        """frontend `InvitationList` が `inviter_handle` / `room_name` を直接読むため
+        nested object ではなく flat に出ることを保証する (#276 type drift fix)."""
+        creator = make_user(username="alice_inviter")
+        invitee = make_user(username="bob_invitee")
+        room = create_group_room(creator=creator, name="phase3-test-group")
+        invite_user_to_room(room=room, inviter=creator, invitee=invitee)
+
+        response = _api(invitee).get("/api/v1/dm/invitations/")
+        assert response.status_code == 200
+        body = response.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert len(results) == 1
+        inv = results[0]
+
+        # flat fields (旧 nested は frontend で undefined access を起こしていた)
+        assert inv["inviter_id"] == creator.pk
+        assert inv["inviter_handle"] == "alice_inviter"
+        assert inv["invitee_id"] == invitee.pk
+        assert inv["invitee_handle"] == "bob_invitee"
+        assert inv["room_id"] == room.pk
+        assert inv["room_name"] == "phase3-test-group"
+        # nested object は存在しない (back-compat の保証も兼ねる)
+        assert "inviter" not in inv
+        assert "invitee" not in inv
+        assert "room" not in inv
+
     def test_accept_creates_membership(self) -> None:
         creator = make_user()
         invitee = make_user()

--- a/client/e2e/phase3.spec.ts
+++ b/client/e2e/phase3.spec.ts
@@ -347,11 +347,39 @@ test.describe("Phase 3 — DM golden path", () => {
 		}
 	});
 
-	test("グループ招待拒否: alice が API で group + bob 招待 → bob が UI で「拒否」", async () => {
-		// `client/src/components/dm/InvitationList.tsx` で `inv.inviter.username` /
-		// `inv.room.name` を参照するが API は flat (`inviter_handle` / `room_id`)。
-		// 型 drift で runtime crash → 招待主 / group 名が表示されない。#276 で別途 fix。
-		test.skip(true, "InvitationList の型 drift bug (#276 待ち)");
+	test("グループ招待拒否: alice が API で group + bob 招待 → bob が UI で「拒否」", async ({
+		browser,
+	}) => {
+		// #276 で InvitationList の type drift 修正 + room_name field 追加済。
+		const aliceApi = await apiAuthed(ALICE.email, ALICE.password);
+		const groupName = `decline-test-${Date.now()}`;
+		await apiCreateGroupWithInvite(aliceApi, groupName, [BOB.handle]);
+		await aliceApi.api.dispose();
+
+		const bobCtx = await browser.newContext();
+		const bobPage = await bobCtx.newPage();
+		try {
+			await login(bobPage, BOB.email, BOB.password);
+			await bobPage.goto("/messages/invitations");
+
+			// 招待が表示されている
+			await expect(bobPage.getByText(groupName)).toBeVisible({
+				timeout: 10_000,
+			});
+
+			// 「拒否」ボタン click → 該当招待が消える
+			const declineBtn = bobPage
+				.getByRole("button", { name: /拒否|decline/i })
+				.first();
+			await declineBtn.click();
+
+			// 拒否後はリストから消える (RTK Query invalidatesTags で auto refetch)
+			await expect(bobPage.getByText(groupName)).not.toBeVisible({
+				timeout: 10_000,
+			});
+		} finally {
+			await bobCtx.close();
+		}
 	});
 
 	test("グループ作成 + 招待承諾 + 双方向送受信 (UI wire-up #273 待ち)", async ({

--- a/client/src/components/dm/InvitationList.tsx
+++ b/client/src/components/dm/InvitationList.tsx
@@ -37,7 +37,8 @@ export default function InvitationList() {
 		setProcessingId(inv.id);
 		try {
 			const result = await acceptInvitation(inv.id).unwrap();
-			router.push(`/messages/${result.room.id}`);
+			// API は flat (`room_id`)。旧 `result.room.id` (nested) は #276 で修正。
+			router.push(`/messages/${result.room_id}`);
 		} catch {
 			setActionError("招待の承諾に失敗しました。再試行してください。");
 		} finally {
@@ -105,13 +106,14 @@ export default function InvitationList() {
 							aria-hidden="true"
 							className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold"
 						>
-							{inv.inviter.username[0]?.toUpperCase() ?? "?"}
+							{inv.inviter_handle?.[0]?.toUpperCase() ?? "?"}
 						</div>
 						<div className="min-w-0 flex-1">
 							<p className="text-baby_white truncate text-sm">
-								<strong>@{inv.inviter.username}</strong> から
+								<strong>@{inv.inviter_handle ?? "(削除されたユーザー)"}</strong>{" "}
+								から
 								<span className="mx-1 font-semibold">
-									{inv.room.name || "(無名のグループ)"}
+									{inv.room_name || "(無名のグループ)"}
 								</span>
 								への招待
 							</p>

--- a/client/src/lib/redux/features/dm/types.ts
+++ b/client/src/lib/redux/features/dm/types.ts
@@ -60,21 +60,21 @@ export interface DMRoomListResponse {
 /**
  * SPEC §7.2: グループ招待 (1:1 では生成されない).
  *
- * NOTE: backend の実 serializer 形に合わせて再確認が必要。現状は frontend の
- * `InvitationList` が `inv.inviter.username` / `inv.room.name` で参照しているため
- * その形を保っているが、Phase 4A で notification と整合させる時に再点検する。
+ * backend `GroupInvitationSerializer` (apps/dm/serializers.py) と完全一致させる。
+ * 旧定義は `{inviter: {...}, room: {...}}` の nested 想定だったが、実 API は
+ * flat (`inviter_handle` / `room_id` / `room_name`)。 #276 で fix。
  */
 export interface GroupInvitation {
 	id: number;
-	room: {
-		id: number;
-		kind: DMRoomKind;
-		name: string;
-	};
-	inviter: DMUserSummary;
-	invitee: DMUserSummary;
+	room_id: number;
+	room_name: string;
+	inviter_id: number | null;
+	inviter_handle: string | null;
+	invitee_id: number;
+	invitee_handle: string;
 	/** null = pending, true = accepted, false = declined. */
 	accepted: boolean | null;
+	responded_at: string | null;
 	created_at: string;
 	updated_at: string;
 }

--- a/client/src/types/api.generated.ts
+++ b/client/src/types/api.generated.ts
@@ -1346,6 +1346,7 @@ export interface components {
 		GroupInvitation: {
 			readonly id: number;
 			readonly room_id: number;
+			readonly room_name: string;
 			inviter_id: number | null;
 			readonly inviter_handle: string;
 			invitee_id: number;


### PR DESCRIPTION
## 背景

PR #277 で Phase 3 spec 拡張時に発見した type drift bug。frontend `InvitationList.tsx` は `inv.inviter.username` / `inv.room.name` (nested) を参照するが、実 API (`GroupInvitationSerializer`) は flat (`inviter_handle` / `room_id` のみ)。

結果:
- `inv.inviter.username` → undefined access → React runtime crash
- `inv.room.name` → undefined → "(無名のグループ)" placeholder
- accept invitation 後の `router.push('/messages/${result.room.id}')` も `undefined`

## 修正

### Backend
- `apps/dm/serializers.py`: `GroupInvitationSerializer` に `room_name = serializers.CharField(source="room.name", read_only=True)` 追加
- `test_views_rooms_and_invitations.py`: flat fields + room_name の存在 / nested object の不在を assert する test 追加

### Frontend
- `client/src/lib/redux/features/dm/types.ts`: `GroupInvitation` を flat 構造に再定義 (room_id / room_name / inviter_handle / invitee_handle)
- `client/src/components/dm/InvitationList.tsx`:
  - `inv.inviter.username` → `inv.inviter_handle ?? "(削除されたユーザー)"`
  - `inv.room.name` → `inv.room_name`
  - `result.room.id` → `result.room_id`
- `client/src/types/api.generated.ts`: `npm run gen:api-types` で再生成 (room_name 反映)

### E2E
- `client/e2e/phase3.spec.ts`: `グループ招待拒否` test の `test.skip(#276)` を解除

## 動作確認

- pytest: TestInvitationLifecycle 5/5 pass (新 1 件含む)
- backend schema endpoint: `GroupInvitation.room_name` が露出することを curl 確認

## 教訓

過去にも同パターン (PR #263 / #271) が発生。根本対策は #266 (CI codegen check) で別途。

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功
- [ ] stg `/messages/invitations` で group 名が正しく表示
- [ ] Phase 3 spec の `グループ招待拒否` が緑

Refs: #277 (E2E 拡張で本 bug 顕在化)、#266 (CI codegen check 統合)、Closes #276