### PR TITLE
fix(channels): Redis SSL parameter parsing for stg/prod (Closes #275)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 502
+        "line_number": 521
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-03T02:15:49Z"
+  "generated_at": "2026-05-03T06:24:55Z"
 }

--- a/apps/common/tests/test_channel_layer_config.py
+++ b/apps/common/tests/test_channel_layer_config.py
@@ -1,0 +1,71 @@
+"""CHANNEL_LAYERS の REDIS_URL parsing 回帰テスト (#275).
+
+stg 環境の REDIS_URL は kombu 互換のため `rediss://...?ssl_cert_reqs=CERT_REQUIRED`
+という query string を含む。channels_redis (redis.asyncio) はこの query を
+解釈できず "Invalid SSL Certificate Requirements Flag: CERT_REQUIRED" で
+WebSocket 確立後の channel layer subscribe 時に crash する。
+
+config/settings/base.py で URL の query を strip + dict 形式に変換し、
+ssl_cert_reqs は redis-py が期待する int constant (`ssl.CERT_REQUIRED` 等) で
+渡すことで回避する。本テストはその設定が正しく組まれることを保証する。
+"""
+
+from __future__ import annotations
+
+import ssl
+from importlib import reload
+from unittest import mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "redis_url,expected_address,expects_ssl",
+    [
+        # local 開発: redis:// (no TLS) → そのまま address、ssl_cert_reqs なし
+        ("redis://redis:6379/0", "redis://redis:6379/0", False),
+        # stg/prod: rediss:// + AUTH + query (kombu 互換) → query strip + ssl_cert_reqs 設定
+        (
+            "rediss://:secret-token@example.cache.amazonaws.com:6379/0?ssl_cert_reqs=CERT_REQUIRED",
+            "rediss://:secret-token@example.cache.amazonaws.com:6379/0",
+            True,
+        ),
+        # query が複数あっても全部 strip される
+        (
+            "rediss://host:6379/0?ssl_cert_reqs=CERT_REQUIRED&socket_timeout=5",
+            "rediss://host:6379/0",
+            True,
+        ),
+    ],
+)
+def test_channel_layers_redis_url_parsing(
+    redis_url: str, expected_address: str, expects_ssl: bool
+) -> None:
+    """REDIS_URL の query を strip して dict 形式の hosts に組み直すこと."""
+    with mock.patch.dict("os.environ", {"REDIS_URL": redis_url}):
+        from config.settings import base as settings_base
+
+        reload(settings_base)
+
+        layers = settings_base.CHANNEL_LAYERS["default"]
+        assert layers["BACKEND"] == "channels_redis.core.RedisChannelLayer"
+
+        hosts = layers["CONFIG"]["hosts"]
+        assert len(hosts) == 1
+        host = hosts[0]
+        assert isinstance(host, dict), "channels_redis dict 形式で渡すこと (#275)"
+        assert host["address"] == expected_address, "REDIS_URL の query は strip されている必要あり"
+
+        if expects_ssl:
+            # int constant (ssl.CERT_REQUIRED == 2) で渡されている、文字列ではない
+            assert "ssl_cert_reqs" in host
+            assert host["ssl_cert_reqs"] == ssl.CERT_REQUIRED
+            assert isinstance(host["ssl_cert_reqs"], int), (
+                "redis-py は int constant を期待する。文字列だと "
+                '"Invalid SSL Certificate Requirements Flag" で fail する'
+            )
+        else:
+            assert "ssl_cert_reqs" not in host
+
+    # 後始末: 環境変数を元に戻す → settings を reload して元の状態へ
+    reload(settings_base)

--- a/apps/dm/serializers.py
+++ b/apps/dm/serializers.py
@@ -136,12 +136,17 @@ class GroupInvitationSerializer(serializers.ModelSerializer):
     invitee_id = serializers.IntegerField(source="invitee.pk")
     inviter_handle = serializers.CharField(source="inviter.username", read_only=True, default=None)
     invitee_handle = serializers.CharField(source="invitee.username", read_only=True)
+    # frontend (`InvitationList.tsx`) で「@inviter から <group_name> への招待」を
+    # 表示するため room.name を inline で返す (#276)。room の他フィールドは
+    # 不要なので flat に追加 (round trip 削減)。
+    room_name = serializers.CharField(source="room.name", read_only=True)
 
     class Meta:
         model = GroupInvitation
         fields = (
             "id",
             "room_id",
+            "room_name",
             "inviter_id",
             "inviter_handle",
             "invitee_id",

--- a/apps/dm/tests/test_views_rooms_and_invitations.py
+++ b/apps/dm/tests/test_views_rooms_and_invitations.py
@@ -159,6 +159,33 @@ class TestInvitationLifecycle:
         results = body["results"] if isinstance(body, dict) and "results" in body else body
         assert len(results) == 1
 
+    def test_invitation_serializer_includes_flat_handles_and_room_name(self) -> None:
+        """frontend `InvitationList` が `inviter_handle` / `room_name` を直接読むため
+        nested object ではなく flat に出ることを保証する (#276 type drift fix)."""
+        creator = make_user(username="alice_inviter")
+        invitee = make_user(username="bob_invitee")
+        room = create_group_room(creator=creator, name="phase3-test-group")
+        invite_user_to_room(room=room, inviter=creator, invitee=invitee)
+
+        response = _api(invitee).get("/api/v1/dm/invitations/")
+        assert response.status_code == 200
+        body = response.json()
+        results = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert len(results) == 1
+        inv = results[0]
+
+        # flat fields (旧 nested は frontend で undefined access を起こしていた)
+        assert inv["inviter_id"] == creator.pk
+        assert inv["inviter_handle"] == "alice_inviter"
+        assert inv["invitee_id"] == invitee.pk
+        assert inv["invitee_handle"] == "bob_invitee"
+        assert inv["room_id"] == room.pk
+        assert inv["room_name"] == "phase3-test-group"
+        # nested object は存在しない (back-compat の保証も兼ねる)
+        assert "inviter" not in inv
+        assert "invitee" not in inv
+        assert "room" not in inv
+
     def test_accept_creates_membership(self) -> None:
         creator = make_user()
         invitee = make_user()

--- a/client/e2e/phase3.spec.ts
+++ b/client/e2e/phase3.spec.ts
@@ -347,11 +347,39 @@ test.describe("Phase 3 — DM golden path", () => {
 		}
 	});
 
-	test("グループ招待拒否: alice が API で group + bob 招待 → bob が UI で「拒否」", async () => {
-		// `client/src/components/dm/InvitationList.tsx` で `inv.inviter.username` /
-		// `inv.room.name` を参照するが API は flat (`inviter_handle` / `room_id`)。
-		// 型 drift で runtime crash → 招待主 / group 名が表示されない。#276 で別途 fix。
-		test.skip(true, "InvitationList の型 drift bug (#276 待ち)");
+	test("グループ招待拒否: alice が API で group + bob 招待 → bob が UI で「拒否」", async ({
+		browser,
+	}) => {
+		// #276 で InvitationList の type drift 修正 + room_name field 追加済。
+		const aliceApi = await apiAuthed(ALICE.email, ALICE.password);
+		const groupName = `decline-test-${Date.now()}`;
+		await apiCreateGroupWithInvite(aliceApi, groupName, [BOB.handle]);
+		await aliceApi.api.dispose();
+
+		const bobCtx = await browser.newContext();
+		const bobPage = await bobCtx.newPage();
+		try {
+			await login(bobPage, BOB.email, BOB.password);
+			await bobPage.goto("/messages/invitations");
+
+			// 招待が表示されている
+			await expect(bobPage.getByText(groupName)).toBeVisible({
+				timeout: 10_000,
+			});
+
+			// 「拒否」ボタン click → 該当招待が消える
+			const declineBtn = bobPage
+				.getByRole("button", { name: /拒否|decline/i })
+				.first();
+			await declineBtn.click();
+
+			// 拒否後はリストから消える (RTK Query invalidatesTags で auto refetch)
+			await expect(bobPage.getByText(groupName)).not.toBeVisible({
+				timeout: 10_000,
+			});
+		} finally {
+			await bobCtx.close();
+		}
 	});
 
 	test("グループ作成 + 招待承諾 + 双方向送受信 (UI wire-up #273 待ち)", async ({

--- a/client/src/components/dm/InvitationList.tsx
+++ b/client/src/components/dm/InvitationList.tsx
@@ -37,7 +37,8 @@ export default function InvitationList() {
 		setProcessingId(inv.id);
 		try {
 			const result = await acceptInvitation(inv.id).unwrap();
-			router.push(`/messages/${result.room.id}`);
+			// API は flat (`room_id`)。旧 `result.room.id` (nested) は #276 で修正。
+			router.push(`/messages/${result.room_id}`);
 		} catch {
 			setActionError("招待の承諾に失敗しました。再試行してください。");
 		} finally {
@@ -105,13 +106,14 @@ export default function InvitationList() {
 							aria-hidden="true"
 							className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold"
 						>
-							{inv.inviter.username[0]?.toUpperCase() ?? "?"}
+							{inv.inviter_handle?.[0]?.toUpperCase() ?? "?"}
 						</div>
 						<div className="min-w-0 flex-1">
 							<p className="text-baby_white truncate text-sm">
-								<strong>@{inv.inviter.username}</strong> から
+								<strong>@{inv.inviter_handle ?? "(削除されたユーザー)"}</strong>{" "}
+								から
 								<span className="mx-1 font-semibold">
-									{inv.room.name || "(無名のグループ)"}
+									{inv.room_name || "(無名のグループ)"}
 								</span>
 								への招待
 							</p>

--- a/client/src/lib/redux/features/dm/types.ts
+++ b/client/src/lib/redux/features/dm/types.ts
@@ -60,21 +60,21 @@ export interface DMRoomListResponse {
 /**
  * SPEC §7.2: グループ招待 (1:1 では生成されない).
  *
- * NOTE: backend の実 serializer 形に合わせて再確認が必要。現状は frontend の
- * `InvitationList` が `inv.inviter.username` / `inv.room.name` で参照しているため
- * その形を保っているが、Phase 4A で notification と整合させる時に再点検する。
+ * backend `GroupInvitationSerializer` (apps/dm/serializers.py) と完全一致させる。
+ * 旧定義は `{inviter: {...}, room: {...}}` の nested 想定だったが、実 API は
+ * flat (`inviter_handle` / `room_id` / `room_name`)。 #276 で fix。
  */
 export interface GroupInvitation {
 	id: number;
-	room: {
-		id: number;
-		kind: DMRoomKind;
-		name: string;
-	};
-	inviter: DMUserSummary;
-	invitee: DMUserSummary;
+	room_id: number;
+	room_name: string;
+	inviter_id: number | null;
+	inviter_handle: string | null;
+	invitee_id: number;
+	invitee_handle: string;
 	/** null = pending, true = accepted, false = declined. */
 	accepted: boolean | null;
+	responded_at: string | null;
 	created_at: string;
 	updated_at: string;
 }

--- a/client/src/types/api.generated.ts
+++ b/client/src/types/api.generated.ts
@@ -1346,6 +1346,7 @@ export interface components {
 		GroupInvitation: {
 			readonly id: number;
 			readonly room_id: number;
+			readonly room_name: string;
 			inviter_id: number | null;
 			readonly inviter_handle: string;
 			invitee_id: number;

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,3 +1,5 @@
+import re
+import ssl
 from datetime import timedelta
 from os import getenv, path
 from pathlib import Path
@@ -298,11 +300,28 @@ CELERY_WORKERS_SEND_TASKS_EVENTS = True
 # REDIS_URL は Celery 用 (DB 0) と同じインスタンスを共有する想定。本番は ElastiCache
 # (Multi-AZ replica 1) に向く。capacity=1500 は 1 group へのバッファ上限、expiry=60
 # はメッセージの TTL 秒。共に Channels の defaults よりやや余裕を持たせた値。
+#
+# #275: stg の REDIS_URL は kombu/celery 互換のため `?ssl_cert_reqs=CERT_REQUIRED`
+# (文字列) を含む。channels_redis (= redis-py async) はこの query string を解釈
+# できず "Invalid SSL Certificate Requirements Flag: CERT_REQUIRED" で fail する。
+# → URL から query 部分を剥がして dict 形式の `address` に渡し、SSL 設定は
+# redis-py の expected な constants (`ssl.CERT_REQUIRED` / `ssl.CERT_NONE`) で
+# 渡す。この差異は同じ rediss:// URL を共有しつつ celery は kombu パーサ、channels
+# は redis-py async パーサが処理する非対称性に起因する (channels-redis #361 参照)。
+_redis_url_raw = getenv("REDIS_URL", "redis://redis:6379/0")
+# query string (`?ssl_cert_reqs=...&...`) を strip
+_redis_url_clean = re.sub(r"\?.*$", "", _redis_url_raw)
+_channels_host: dict[str, object] = {"address": _redis_url_clean}
+if _redis_url_clean.startswith("rediss://"):
+    # ElastiCache はサーバ証明書が AWS 管理の CA で署名されているため verify する
+    # (CERT_REQUIRED)。Local 開発の rediss:// 検証は不要なので呼び分けないこと。
+    _channels_host["ssl_cert_reqs"] = ssl.CERT_REQUIRED
+
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [getenv("REDIS_URL", "redis://redis:6379/0")],
+            "hosts": [_channels_host],
             "capacity": 1500,
             "expiry": 60,
         },


### PR DESCRIPTION
## 現象

stg `/messages/<id>` で WebSocket 接続が即時切断される (Phase 3 DM 全機能 stg 死亡)。daphne logs:

```
redis.exceptions.RedisError: Invalid SSL Certificate Requirements Flag: CERT_REQUIRED
WSCONNECTING /ws/dm/3/
WSREJECT
WSDISCONNECT
```

WebSocket handshake は通るが、consumer が channel layer (Redis pub/sub) に subscribe する瞬間に Redis 接続が SSL 例外で fail → consumer crash → close。

## 当初の誤った仮説

最初は CloudFront HTTP/2 + ALB WebSocket upgrade 互換問題と推測したが、調査の結果 **CloudFront / ALB ではなく Redis 接続段階の問題** と判明。daphne logs の trace が決定打。

## 真の原因

stg/prod の `REDIS_URL` は kombu/celery 互換のため `rediss://...?ssl_cert_reqs=CERT_REQUIRED` という query string を含む (`terraform/modules/data/outputs.tf:redis_connection_url`)。

- ✅ kombu (celery) は `ssl_cert_reqs=CERT_REQUIRED` (文字列) を期待
- ❌ redis-py async (channels_redis 経由) は `ssl_cert_reqs` を `int` constant (`ssl.CERT_REQUIRED == 2`) で期待し、文字列を渡されると上記例外

同じ URL を共有しつつ celery は kombu パーサ、channels は redis-py async パーサが処理する非対称性 (channels-redis #361)。

## 修正

`config/settings/base.py`:

```python
import re
import ssl

_redis_url_clean = re.sub(r"\?.*$", "", REDIS_URL)
_channels_host = {"address": _redis_url_clean}
if _redis_url_clean.startswith("rediss://"):
    _channels_host["ssl_cert_reqs"] = ssl.CERT_REQUIRED  # int constant!

CHANNEL_LAYERS = {
    "default": {
        "BACKEND": "channels_redis.core.RedisChannelLayer",
        "CONFIG": {"hosts": [_channels_host], ...},
    },
}
```

`channels_redis.utils.create_pool` (v4.3.0) は dict の `address` key を取り出して `aioredis.ConnectionPool.from_url(address, **rest)` を呼ぶため、残りのキー (`ssl_cert_reqs`) が kwarg として redis-py に正しく渡る。

## 検証

- `apps/common/tests/test_channel_layer_config.py` 追加 (3 シナリオ pytest pass):
  - local `redis://` → ssl_cert_reqs なし
  - stg `rediss://...?ssl_cert_reqs=CERT_REQUIRED` → query strip + int constant
  - 複数 query (`?...&socket_timeout=5`) → 全 strip
- `aioredis.ConnectionPool.from_url('rediss://...', ssl_cert_reqs=ssl.CERT_REQUIRED)` が pool 作成成功することを REPL で確認

## 影響

- ✅ stg `/ws/dm/<room_id>/` で WebSocket 確立、Phase 3 DM 機能 (送受信 / typing / 既読 broadcast) が初めて動作
- ✅ Phase 3 E2E spec の WebSocket 依存 3 シナリオ (#275 で skip 中) 解除可能
- ✅ Phase 4A 通知 (`/ws/notifications/`) など将来の Channels 用途も unblock
- ⚠️ celery / kombu は引き続き query 付き URL 直接使用 (parser 違うため影響なし)

## なぜ気づかなかったか

local 開発は `redis://` (no TLS) なので問題が出ない。stg deploy 後に WebSocket をブラウザから繋ぐ運用テストをしていなかったため気づかれなかった。Phase 3 E2E spec を書いて WebSocket を実 hit したことで初めて daphne logs に crash trace → 検出。

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功
- [ ] stg で wss://stg.codeplace.me/ws/dm/<room_id>/ が 101 Switching Protocols
- [ ] daphne logs に "WSCONNECT" + 持続的な socket あり (即 WSDISCONNECT で切れない)
- [ ] Phase 3 spec の WebSocket 依存 3 件の skip を解除して green に

Refs: #277 (E2E 拡張で本 bug 顕在化)、#268 (daphne 起動 fix)、Closes #275