### PR TITLE
fix(channels): ssl_cert_reqs を小文字 string で渡す (PR #279 follow-up)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 521
+        "line_number": 526
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-03T06:24:55Z"
+  "generated_at": "2026-05-03T07:00:06Z"
 }

--- a/apps/common/tests/test_channel_layer_config.py
+++ b/apps/common/tests/test_channel_layer_config.py
@@ -1,18 +1,23 @@
 """CHANNEL_LAYERS の REDIS_URL parsing 回帰テスト (#275).
 
 stg 環境の REDIS_URL は kombu 互換のため `rediss://...?ssl_cert_reqs=CERT_REQUIRED`
-という query string を含む。channels_redis (redis.asyncio) はこの query を
-解釈できず "Invalid SSL Certificate Requirements Flag: CERT_REQUIRED" で
-WebSocket 確立後の channel layer subscribe 時に crash する。
+という query string を含む。channels_redis (redis.asyncio 5.0.x) はこの query を
+解釈できず以下のいずれかで crash する:
+
+1. URL string をそのまま渡す → "Invalid SSL Certificate Requirements Flag:
+   CERT_REQUIRED" (大文字 "CERT_REQUIRED" は redis-py の expected enum 外)
+2. `ssl_cert_reqs=ssl.CERT_REQUIRED` (int constant) を dict で渡す →
+   `'RedisSSLContext' object has no attribute 'cert_reqs'` (str 以外は
+   `__init__` の if/elif を抜けて attribute 未設定になる、PR #279 1st attempt)
 
 config/settings/base.py で URL の query を strip + dict 形式に変換し、
-ssl_cert_reqs は redis-py が期待する int constant (`ssl.CERT_REQUIRED` 等) で
-渡すことで回避する。本テストはその設定が正しく組まれることを保証する。
+ssl_cert_reqs は **小文字 string "required"** で渡す (redis-py 5.0.x の
+`RedisSSLContext.__init__` が小文字 string のみ受理する仕様)。本テストは
+その設定が正しく組まれることを保証する。
 """
 
 from __future__ import annotations
 
-import ssl
 from importlib import reload
 from unittest import mock
 
@@ -57,12 +62,12 @@ def test_channel_layers_redis_url_parsing(
         assert host["address"] == expected_address, "REDIS_URL の query は strip されている必要あり"
 
         if expects_ssl:
-            # int constant (ssl.CERT_REQUIRED == 2) で渡されている、文字列ではない
+            # 小文字 string で渡されている (大文字 / int constant は invalid)
             assert "ssl_cert_reqs" in host
-            assert host["ssl_cert_reqs"] == ssl.CERT_REQUIRED
-            assert isinstance(host["ssl_cert_reqs"], int), (
-                "redis-py は int constant を期待する。文字列だと "
-                '"Invalid SSL Certificate Requirements Flag" で fail する'
+            assert host["ssl_cert_reqs"] == "required"
+            assert isinstance(host["ssl_cert_reqs"], str), (
+                "redis-py 5.0.x は小文字 string を期待。"
+                "int constant を渡すと cert_reqs 属性未設定で AttributeError"
             )
         else:
             assert "ssl_cert_reqs" not in host

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,5 +1,4 @@
 import re
-import ssl
 from datetime import timedelta
 from os import getenv, path
 from pathlib import Path
@@ -302,20 +301,26 @@ CELERY_WORKERS_SEND_TASKS_EVENTS = True
 # はメッセージの TTL 秒。共に Channels の defaults よりやや余裕を持たせた値。
 #
 # #275: stg の REDIS_URL は kombu/celery 互換のため `?ssl_cert_reqs=CERT_REQUIRED`
-# (文字列) を含む。channels_redis (= redis-py async) はこの query string を解釈
-# できず "Invalid SSL Certificate Requirements Flag: CERT_REQUIRED" で fail する。
-# → URL から query 部分を剥がして dict 形式の `address` に渡し、SSL 設定は
-# redis-py の expected な constants (`ssl.CERT_REQUIRED` / `ssl.CERT_NONE`) で
-# 渡す。この差異は同じ rediss:// URL を共有しつつ celery は kombu パーサ、channels
-# は redis-py async パーサが処理する非対称性に起因する (channels-redis #361 参照)。
+# (大文字文字列) を含む。channels_redis (= redis-py async 5.0.x) はこの URL の
+# query を parse して `cert_reqs="CERT_REQUIRED"` を試行するが、redis-py が
+# 期待するのは小文字の {"none", "optional", "required"} のみで、"CERT_REQUIRED"
+# は invalid として `Invalid SSL Certificate Requirements Flag: CERT_REQUIRED`。
+#
+# 解決策: URL の query を strip して address だけ渡し、`ssl_cert_reqs` は dict
+# 形式の host kwarg として **小文字 "required"** で明示する。redis-py 5.0.x の
+# `RedisSSLContext` は文字列を内部で `ssl.CERT_REQUIRED` 等の constant に変換
+# する (PR #279 1st attempt で int constant を直接渡したところ
+# `'RedisSSLContext' object has no attribute 'cert_reqs'` の AttributeError で
+# crash した、redis/asyncio/connection.py:RedisSSLContext.__init__ 参照)。
+#
+# celery / kombu は引き続き query 付き URL を直接使用 (parser が違うため影響なし)。
 _redis_url_raw = getenv("REDIS_URL", "redis://redis:6379/0")
-# query string (`?ssl_cert_reqs=...&...`) を strip
 _redis_url_clean = re.sub(r"\?.*$", "", _redis_url_raw)
 _channels_host: dict[str, object] = {"address": _redis_url_clean}
 if _redis_url_clean.startswith("rediss://"):
-    # ElastiCache はサーバ証明書が AWS 管理の CA で署名されているため verify する
-    # (CERT_REQUIRED)。Local 開発の rediss:// 検証は不要なので呼び分けないこと。
-    _channels_host["ssl_cert_reqs"] = ssl.CERT_REQUIRED
+    # ElastiCache はサーバ証明書が AWS 管理の CA で署名されているため verify する。
+    # 小文字 "required" で渡すこと (大文字 "CERT_REQUIRED" や int constant は invalid)。
+    _channels_host["ssl_cert_reqs"] = "required"
 
 CHANNEL_LAYERS = {
     "default": {


### PR DESCRIPTION
## 背景

PR #279 で `_channels_host["ssl_cert_reqs"] = ssl.CERT_REQUIRED` (int constant) として fix を入れたが、stg deploy 後に新たな例外:

```
redis.exceptions.ConnectionError: 'RedisSSLContext' object has no attribute 'cert_reqs'
```

## 原因

redis-py 5.0.3 の `RedisSSLContext.__init__`:

```python
def __init__(self, cert_reqs: Optional[str] = None, ...):
    if cert_reqs is None:
        self.cert_reqs = ssl.CERT_NONE
    elif isinstance(cert_reqs, str):
        CERT_REQS = {"none": ssl.CERT_NONE, "optional": ssl.CERT_OPTIONAL, "required": ssl.CERT_REQUIRED}
        if cert_reqs not in CERT_REQS:
            raise RedisError(f"Invalid SSL Certificate Requirements Flag: {cert_reqs}")
        self.cert_reqs = CERT_REQS[cert_reqs]
    # ↑ int constant を渡すと if/elif どちらも抜けて self.cert_reqs が未設定
```

## 修正

```diff
-_channels_host["ssl_cert_reqs"] = ssl.CERT_REQUIRED  # int constant
+_channels_host["ssl_cert_reqs"] = "required"  # 小文字 string
```

URL の query param `?ssl_cert_reqs=CERT_REQUIRED` は **大文字** で kombu/celery 用。redis-py 5.0.x は **小文字 "required"** を期待する。

## 検証

- `apps/common/tests/test_channel_layer_config.py`: assertion を string ベースに更新、3/3 pass
- 不要 import (`ssl`) を削除

## 経緯

PR #279 で URL parser だけ理解して int を選んでしまった。実 stg にデプロイして daphne logs に新エラーが出てから redis-py 内部実装の str-only 仕様に気づいた。本来 PR #279 前に `RedisSSLContext` source を読むべきだった。

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功
- [ ] daphne 新 task で `RedisError` trace 出ない
- [ ] wss://stg.codeplace.me/ws/dm/<id>/ で 101 Switching Protocols + 持続接続
- [ ] Phase 3 spec の WebSocket 依存 3 件の skip を解除

Refs: #279 (PR #275 の 1st attempt)