### PR TITLE
fix(auth): COOKIE_DOMAIN 設定 + Phase 3 spec WS-skip 解除 (#281 follow-up)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 526
+        "line_number": 531
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-03T07:00:06Z"
+  "generated_at": "2026-05-03T09:35:50Z"
 }

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -57,13 +57,18 @@ def set_auth_cookies(
     response: Response, access_token: str, refresh_token: str | None = None
 ) -> None:
     access_token_lifetime = settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"].total_seconds()
-    cookie_settings = {
+    cookie_settings: dict[str, object] = {
         "path": settings.COOKIE_PATH,
         "secure": settings.COOKIE_SECURE,
         "httponly": settings.COOKIE_HTTPONLY,
         "samesite": settings.COOKIE_SAMESITE,
         "max_age": access_token_lifetime,
     }
+    # #281 follow-up: stg/prod で wss を ws.<domain> サブドメインに分離したため、
+    # 親 domain (.stg.codeplace.me 等) で cookie を発行して subdomain 間で共有する。
+    # 未設定 (local) は host-only cookie のまま。
+    if settings.COOKIE_DOMAIN:
+        cookie_settings["domain"] = settings.COOKIE_DOMAIN
     response.set_cookie(settings.COOKIE_NAME, access_token, **cookie_settings)
 
     if refresh_token:
@@ -91,15 +96,18 @@ def _delete_auth_cookie(response: Response, name: str) -> None:
     delete 指示する。
     """
 
-    response.set_cookie(
-        name,
-        "",
-        max_age=0,
-        path=settings.COOKIE_PATH,
-        secure=settings.COOKIE_SECURE,
-        httponly=settings.COOKIE_HTTPONLY,
-        samesite=settings.COOKIE_SAMESITE,
-    )
+    delete_kwargs: dict[str, object] = {
+        "max_age": 0,
+        "path": settings.COOKIE_PATH,
+        "secure": settings.COOKIE_SECURE,
+        "httponly": settings.COOKIE_HTTPONLY,
+        "samesite": settings.COOKIE_SAMESITE,
+    }
+    # #281 follow-up: 削除も同 domain で発行しないとブラウザが別 cookie 扱いして
+    # クライアント側に古い cookie が残る。set 時と同じ domain attr を使う。
+    if settings.COOKIE_DOMAIN:
+        delete_kwargs["domain"] = settings.COOKIE_DOMAIN
+    response.set_cookie(name, "", **delete_kwargs)
 
 
 class CustomTokenObtainPairView(TokenObtainPairView):

--- a/client/e2e/phase3.spec.ts
+++ b/client/e2e/phase3.spec.ts
@@ -201,11 +201,9 @@ test.describe("Phase 3 — DM golden path", () => {
 	test("direct DM (API bootstrap) → /messages/<id> で送信 → bob 側 WebSocket 受信", async ({
 		browser,
 	}) => {
-		// stg で wss://stg.codeplace.me/ws/dm/<id>/ が CloudFront 403 で接続不可
-		// (#275)。WebSocket が確立できないと composer が disabled のままなので spec
-		// 完走不能。infra fix 後に skip 解除。
-		test.skip(true, "stg WebSocket /ws/* CloudFront 403 (#275)");
-
+		// #281 で wss://ws.<domain>/ws/dm/<id>/ 経路に切替 (CloudFront bypass)、
+		// channels Redis SSL も #279/#280 で fix 済。WebSocket 完全動作するため
+		// skip 解除。
 		// alice / bob の API context で direct room を確保 (UI に DM 起動 button が
 		// 無くても fixture 経由でセットアップできる。#272 の wire-up 完了後は
 		// プロフィール経由 click に置き換える)。
@@ -259,9 +257,8 @@ test.describe("Phase 3 — DM golden path", () => {
 		browser,
 	}) => {
 		// REST POST /api/v1/dm/rooms/<id>/messages/ は GET only (405)。送信は
-		// WebSocket 経由のみ → stg では #275 で blocked。
-		test.skip(true, "WebSocket 必須 (#275 待ち)");
-
+		// WebSocket 経由のみ。#281 で WebSocket 経路 (ws.<domain>) が完全動作する
+		// ため、UI 経由で alice が送信 → bob 側未読バッジ表示の golden path を検証。
 		const aliceApi = await apiAuthed(ALICE.email, ALICE.password);
 		const roomId = await apiEnsureDirectRoom(aliceApi, BOB.handle);
 		await aliceApi.api.dispose();
@@ -303,9 +300,8 @@ test.describe("Phase 3 — DM golden path", () => {
 	test("typing インジケータ: alice 入力中 → bob 側に '入力中...' 表示", async ({
 		browser,
 	}) => {
-		// typing.update は WebSocket broadcast 経由なので #275 で blocked。
-		test.skip(true, "WebSocket 必須 (#275 待ち)");
-
+		// typing.update は WebSocket broadcast 経由。#281 で ws.<domain> 経路が
+		// 完全動作するため skip 解除。
 		const aliceApi = await apiAuthed(ALICE.email, ALICE.password);
 		const roomId = await apiEnsureDirectRoom(aliceApi, BOB.handle);
 		await aliceApi.api.dispose();

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -368,6 +368,11 @@ COOKIE_SAMESITE = "Lax"
 COOKIE_PATH = "/"
 COOKIE_HTTPONLY = True
 COOKIE_SECURE = getenv("COOKIE_SECURE", "False").lower() == "true"
+# #281 follow-up: stg/prod で wss を別 subdomain (ws.stg.codeplace.me) に分けたため、
+# cookies を親 domain (.stg.codeplace.me) に設定して subdomain 間で共有する。
+# 未設定 (= local) では cookie の domain は request host に固定される (subdomain
+# 共有しない)。stg/prod では env で `.stg.codeplace.me` 等を設定すること。
+COOKIE_DOMAIN: str | None = getenv("COOKIE_DOMAIN") or None
 
 if SENTRY_ENVIRONMENT in ("stg", "production") and not COOKIE_SECURE:
     from django.core.exceptions import ImproperlyConfigured

--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -43,6 +43,10 @@ locals {
     { name = "CELERY_RESULT_BACKEND", value = var.redis_url_template },
     { name = "DJANGO_ADMIN_URL", value = "admin/" },
     { name = "COOKIE_SECURE", value = "True" },
+    # #281 follow-up: cookie を親 domain で発行して ws.<domain> サブドメイン
+    # (CloudFront bypass の WebSocket 専用) と stg.<domain> で共有する。
+    # 先頭 "." 必須 (RFC 6265: subdomain 包含)。
+    { name = "COOKIE_DOMAIN", value = ".${var.domain}" },
     { name = "CORS_ALLOWED_ORIGINS", value = var.cors_allowed_origins },
     # ALB target group health check は target IP を Host ヘッダに使うため (例
     # `Host: 10.0.12.176:8000`)、stg では VPC CIDR の各 IP を網羅できないので


### PR DESCRIPTION
## 背景

PR #282 で `wss://ws.<domain>/ws/dm/<id>/` サブドメイン経路を追加して CloudFront bypass で WebSocket が動くようになった。だがブラウザは cookies を host-only で保持するため、`stg.codeplace.me` の auth cookies が `ws.stg.codeplace.me` に送信されない。結果 playwright 経由 spec で WebSocket 接続後に Channels JWTAuthMiddleware が認証 cookie を読めず composer disabled で完走不能。

## 修正

### Backend

`config/settings/base.py`:
```python
COOKIE_DOMAIN: str | None = getenv("COOKIE_DOMAIN") or None
```

`apps/users/views.py` の `set_auth_cookies` / `_delete_auth_cookie` で `COOKIE_DOMAIN` 設定時のみ `domain` kwarg を Set-Cookie に追加。未設定 (local) は host-only 維持で後方互換。

### Terraform

`modules/services/main.tf` の common_env に `COOKIE_DOMAIN=.${var.domain}` (例: `.stg.codeplace.me`) を追加。先頭 `.` は RFC 6265 でサブドメイン包含。

### E2E spec

`client/e2e/phase3.spec.ts` の WebSocket 依存 3 シナリオ (direct DM / 未読バッジ / typing) の `test.skip` を解除。

## terraform 適用済 (本セッション内)

- `terraform apply` 実行済 (rev 12 task def に COOKIE_DOMAIN env 追加)
- ECS service を rev 12 に pin 済 (`aws ecs update-service --task-definition sns-stg-django:12 --force-new-deployment`)
- ⚠️ ただし ECR image はまだ古い views.py のまま。本 PR merge → cd-stg deploy で新 image build → 新 task が起動して初めて COOKIE_DOMAIN を読んで cookie に Domain attr が付く

## 検証

- ✅ `pytest -k cookie` 26/26 pass (local 環境では COOKIE_DOMAIN=None なので既存挙動)
- ✅ rev 12 task def に COOKIE_DOMAIN=.stg.codeplace.me 含まれる
- ⏳ stg `Set-Cookie: access=...; Domain=.stg.codeplace.me; ...` の確認は cd-stg deploy 後

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功 (django 新 image build)
- [ ] stg login レスポンスで `Set-Cookie: access=...; Domain=.stg.codeplace.me;` を確認
- [ ] Phase 3 spec の WebSocket 依存 3 件が green に

Refs: #277 (E2E 拡張)、#279/#280 (Channels SSL)、#282 (ws.<domain> bypass)、Closes #281