### PR TITLE
fix(test): InvitationList.test.tsx の fixture を flat GroupInvitation に追従

### DIFF
--- a/client/src/components/dm/__tests__/InvitationList.test.tsx
+++ b/client/src/components/dm/__tests__/InvitationList.test.tsx
@@ -33,12 +33,17 @@ vi.mock("next/navigation", () => ({
 function makeInvitation(
 	overrides: Partial<GroupInvitation> = {},
 ): GroupInvitation {
+	// PR #278 (#276) で GroupInvitation を flat 化済 (room_id / inviter_handle 等)。
 	return {
 		id: 1,
-		room: { id: 100, kind: "group", name: "Engineers" },
-		inviter: { pkid: 200, username: "alice" },
-		invitee: { pkid: 100, username: "me" },
+		room_id: 100,
+		room_name: "Engineers",
+		inviter_id: 200,
+		inviter_handle: "alice",
+		invitee_id: 100,
+		invitee_handle: "me",
 		accepted: null,
+		responded_at: null,
 		created_at: "2026-05-01T12:00:00Z",
 		updated_at: "2026-05-01T12:00:00Z",
 		...overrides,
@@ -110,11 +115,7 @@ describe("InvitationList", () => {
 			isError: false,
 		});
 		mockAccept.mockReturnValue({
-			unwrap: () =>
-				Promise.resolve({
-					id: 1,
-					room: { id: 100, kind: "group", name: "Engineers" },
-				}),
+			unwrap: () => Promise.resolve(makeInvitation()),
 		});
 		render(<InvitationList />);
 		await userEvent.click(screen.getByRole("button", { name: "承諾" }));


### PR DESCRIPTION
## 背景

PR #283 で frontend tsc CI が fail (#276 / PR #278 で GroupInvitation を flat 化済だが InvitationList.test.tsx の makeInvitation fixture が古い nested 形式のまま)。**PR #283 は CI fail を見落として merge してしまった**ため、本 PR で main を緑に戻す。

## 修正

`client/src/components/dm/__tests__/InvitationList.test.tsx`:
- `room: {id, kind, name}` → `room_id` + `room_name` (flat)
- `inviter: {pkid, username}` → `inviter_id` + `inviter_handle`
- `invitee: {pkid, username}` → `invitee_id` + `invitee_handle`
- `responded_at: null` を追加 (interface 必須)
- 承諾遷移テストの `mockAccept` resolve も同 fixture を使うように整理

## 検証

- ✅ vitest 7/7 pass (InvitationList.test.tsx)
- ✅ tsc --noEmit clean

## Test plan

- [ ] CI 全 pass (frontend tsc + vitest)

Refs: PR #283 follow-up、PR #278 (#276 Closes)