### PR TITLE
fix(api): RTK Query mutation に X-CSRFToken header を自動注入 (Closes #285)

### DIFF
--- a/client/e2e/phase3.spec.ts
+++ b/client/e2e/phase3.spec.ts
@@ -359,20 +359,28 @@ test.describe("Phase 3 — DM golden path", () => {
 			await bobPage.goto("/messages/invitations");
 
 			// 招待が表示されている
-			await expect(bobPage.getByText(groupName)).toBeVisible({
-				timeout: 10_000,
-			});
+			const inviteRow = bobPage
+				.getByRole("listitem")
+				.filter({ hasText: groupName });
+			await expect(inviteRow).toBeVisible({ timeout: 10_000 });
 
-			// 「拒否」ボタン click → 該当招待が消える
-			const declineBtn = bobPage
-				.getByRole("button", { name: /拒否|decline/i })
-				.first();
-			await declineBtn.click();
+			// 「拒否」ボタン click + decline mutation 完了待ち。
+			// #285 fix: 過去テスト残留 invitation で `.first()` が別招待を decline
+			// する事故を防ぐため、当該 row 内の button に絞る。
+			const declineRequest = bobPage.waitForResponse(
+				(res) =>
+					res.url().includes("/api/v1/dm/invitations/") &&
+					res.url().includes("/decline/") &&
+					res.request().method() === "POST",
+			);
+			await inviteRow.getByRole("button", { name: /拒否|decline/i }).click();
+			const res = await declineRequest;
+			expect(res.status(), "decline API は 200 OK").toBe(200);
 
+			// RTK Query の自動 refetch がブラウザ tab 非表示時に止まることがあるため、
+			// 明示的に invitations API 完了を待ってから再 query を待つ。
 			// 拒否後はリストから消える (RTK Query invalidatesTags で auto refetch)
-			await expect(bobPage.getByText(groupName)).not.toBeVisible({
-				timeout: 10_000,
-			});
+			await expect(inviteRow).not.toBeVisible({ timeout: 15_000 });
 		} finally {
 			await bobCtx.close();
 		}

--- a/client/src/lib/redux/features/api/baseApiSlice.ts
+++ b/client/src/lib/redux/features/api/baseApiSlice.ts
@@ -10,9 +10,40 @@ import { Mutex } from "async-mutex";
 
 const mutex = new Mutex();
 
+const CSRF_COOKIE_NAME = "csrftoken";
+const CSRF_HEADER_NAME = "X-CSRFToken";
+
+/**
+ * `csrftoken` cookie 値を `document.cookie` から抽出。SSR では `document` 未定義
+ * のため null を返す (RTK Query の prepareHeaders は viewer 側でだけ実行される
+ * 想定だが安全のためガード)。
+ */
+function readCsrfTokenFromCookie(): string | null {
+	if (typeof document === "undefined") return null;
+	const match = document.cookie.match(
+		new RegExp(`(?:^|;\\s*)${CSRF_COOKIE_NAME}=([^;]+)`),
+	);
+	return match ? decodeURIComponent(match[1]) : null;
+}
+
 const baseQuery = fetchBaseQuery({
 	baseUrl: "/api/v1",
 	credentials: "include",
+	// #285 fix: state-changing requests (POST / PUT / PATCH / DELETE) には
+	// CSRF Double-Submit cookie のため X-CSRFToken header を注入する必要がある。
+	// 既存の axios client (lib/api/client.ts) と同じ仕組みを RTK Query にも適用。
+	// 未注入だと Django 側 CSRFEnforcingAuthentication が 403 を返す。
+	prepareHeaders: (headers, { type }) => {
+		// type は "query" | "mutation"。mutation は概ね unsafe method なので
+		// 全て CSRF token を注入する。
+		if (type === "mutation") {
+			const csrfToken = readCsrfTokenFromCookie();
+			if (csrfToken) {
+				headers.set(CSRF_HEADER_NAME, csrfToken);
+			}
+		}
+		return headers;
+	},
 });
 
 const baseQueryWithReauth: BaseQueryFn<


### PR DESCRIPTION
## 現象

Phase 3 spec の招待拒否テストが fail。decline API が **403 Forbidden** を返す。

```
POST /api/v1/dm/invitations/<id>/decline/  →  403
Forbidden: /api/v1/dm/invitations/<id>/decline/
```

## 原因

`baseApiSlice.ts` の `fetchBaseQuery` に prepareHeaders がなく、RTK Query の mutation (POST/PUT/PATCH/DELETE) で `X-CSRFToken` header が送信されていなかった。

axios client (`lib/api/client.ts`) には CSRF interceptor があるが、RTK Query は別経路 (fetch) なので自動付与されない。Django の `CSRFEnforcingAuthentication` が CSRF cookie と header の double-submit を要求 → header 欠落で 403。

これは login 以外の **全ての RTK Query mutation** に影響する潜在 bug。declineInvitation で初めて顕在化した (= 他の mutation はそもそも spec で叩かれてなかった or login API のみ axios 経由)。

## 修正

baseQuery に prepareHeaders を追加:

```ts
prepareHeaders: (headers, { type }) => {
  if (type === "mutation") {
    const csrfToken = readCsrfTokenFromCookie();
    if (csrfToken) headers.set("X-CSRFToken", csrfToken);
  }
  return headers;
},
```

- mutation のみ注入 (query は GET なので CSRF 不要)
- cookie 読み取りは `document.cookie` から regex 抽出 (cookies-next の重さを避ける)
- SSR ガード: `typeof document === undefined` は null

## spec 改善 (副次的)

- `getByRole("button", {name: /拒否/}).first()` → 当該招待 row 内の button に絞る (過去テスト残留 invitation で `.first()` が別 row を click する事故を防ぐ)
- `waitForResponse` で decline API status を assert (今回 fix 前の silent 403 を再発見できるように)

## 検証

- ✅ vitest 356/356 pass
- ✅ tsc clean
- ⏳ E2E は cd-stg deploy 後に検証

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功
- [ ] stg で Phase 3 spec の招待拒否テストが green に

Refs: #283 (spec WS-skip 解除で本問題が表面化)、Closes #285