### PR TITLE
feat(dm): /messages に「+ 新規グループ」 button + Dialog wire-up (Closes #273)

### DIFF
--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -9,9 +9,17 @@
 
 import { getCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
+import GroupCreateForm from "@/components/dm/GroupCreateForm";
 import RoomList from "@/components/dm/RoomList";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
 import { useUserProfile } from "@/hooks/useUseProfile";
 import { useAppSelector } from "@/lib/redux/hooks/typedHooks";
 
@@ -19,6 +27,10 @@ export default function MessagesPage() {
 	const router = useRouter();
 	const { isAuthenticated } = useAppSelector((state) => state.auth);
 	const { profile, isLoading } = useUserProfile();
+	// #273: 「+ 新規グループ」 button → GroupCreateForm を Dialog で開く。
+	// 作成成功時は GroupCreateForm 側で `/messages/<id>` に遷移するため、
+	// open state は cancel button と外クリックで false に戻す。
+	const [groupDialogOpen, setGroupDialogOpen] = useState(false);
 
 	// 認証チェック (#269): cookie (`logged_in`) を直接読んで判定する。
 	// PersistAuth (app/layout.tsx) の useEffect は本ページ useEffect より「後」に
@@ -61,7 +73,25 @@ export default function MessagesPage() {
 		<section className="mx-auto max-w-2xl">
 			<header className="mb-6 flex items-baseline justify-between">
 				<h1 className="text-baby_white text-xl font-bold">メッセージ</h1>
-				{/* 新規 DM 開始ボタン: P3-11 (#236) で本格実装。本 PR では空状態 CTA のみ。 */}
+				{/* #273: 新規グループ作成 button + Dialog wire-up。
+				    GroupCreateForm 自体は P3-11 (#236) で実装済。 */}
+				<Dialog open={groupDialogOpen} onOpenChange={setGroupDialogOpen}>
+					<DialogTrigger asChild>
+						<button
+							type="button"
+							aria-label="新規グループ作成"
+							className="bg-baby_blue text-baby_white focus-visible:ring-baby_white rounded-md px-3 py-1.5 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2"
+						>
+							＋ 新規グループ
+						</button>
+					</DialogTrigger>
+					<DialogContent>
+						<DialogHeader>
+							<DialogTitle>新規グループ作成</DialogTitle>
+						</DialogHeader>
+						<GroupCreateForm onCancel={() => setGroupDialogOpen(false)} />
+					</DialogContent>
+				</Dialog>
 			</header>
 			<RoomList currentUserId={profile.pkid} />
 		</section>


### PR DESCRIPTION
## 背景

GroupCreateForm component (P3-11 / Issue #236) は実装済だが、/messages 一覧画面から開く導線が未実装で Phase 3 spec のグループ作成テストが skip されていた。

## 実装

`client/src/app/(template)/messages/page.tsx`:
- header の右側に「＋ 新規グループ」 button (`aria-label="新規グループ作成"`) を追加
- shadcn Dialog で wrap、内部に GroupCreateForm を mount
- 作成成功時は GroupCreateForm 内で `router.push(/messages/<id>)` で遷移、cancel button で Dialog close

## 検証

- ✅ tsc --noEmit clean
- ⏳ spec 確認は cd-stg deploy 後

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功
- [ ] stg /messages で「＋ 新規グループ」 button が表示
- [ ] click → Dialog 開く → グループ名 + 招待メンバー入力 → 作成 → 新 room 遷移
- [ ] Phase 3 spec のグループ作成テストが green に

Refs: P3-11 (#236)、Phase 3 spec (#246)、Closes #273