### PR TITLE
feat(dm): メッセージ削除 UI (hover delete button) (Closes #274)

### DIFF
--- a/client/e2e/phase3.spec.ts
+++ b/client/e2e/phase3.spec.ts
@@ -439,13 +439,71 @@ test.describe("Phase 3 — DM golden path", () => {
 		}
 	});
 
-	test("メッセージ削除 — alice が削除すると bob 側でも消える (UI #274 待ち)", async ({
+	test("メッセージ削除 — alice が削除すると bob 側でも消える", async ({
 		browser,
 	}) => {
-		test.skip(
-			true,
-			"削除 UI (long-press / hover メニュー) は P3-09 範囲外、フォローアップ #274 で wire-up",
-		);
+		// #274 で MessageBubble に hover delete button + RoomChat に
+		// useDeleteMessageMutation 配線済。alice が send → 自分のバブルから
+		// 削除 → bob 側で WebSocket `message.deleted` event を受けて消える。
+		const aliceApi = await apiAuthed(ALICE.email, ALICE.password);
+		const roomId = await apiEnsureDirectRoom(aliceApi, BOB.handle);
+		await aliceApi.api.dispose();
+
+		const aliceCtx = await browser.newContext();
+		const bobCtx = await browser.newContext();
+		const alicePage = await aliceCtx.newPage();
+		const bobPage = await bobCtx.newPage();
+
+		try {
+			await login(alicePage, ALICE.email, ALICE.password);
+			await login(bobPage, BOB.email, BOB.password);
+			await alicePage.goto(`/messages/${roomId}`);
+			await bobPage.goto(`/messages/${roomId}`);
+
+			// composer 表示待ち = WebSocket 接続完了の代理
+			await expect(alicePage.getByPlaceholder("メッセージを入力")).toBeVisible({
+				timeout: 15_000,
+			});
+			await expect(bobPage.getByPlaceholder("メッセージを入力")).toBeVisible({
+				timeout: 15_000,
+			});
+
+			// alice が message を送信
+			const marker = `delete-test ${Date.now()}`;
+			await alicePage.getByPlaceholder("メッセージを入力").fill(marker);
+			await alicePage.getByRole("button", { name: "送信" }).click();
+			await expect(alicePage.getByText(marker)).toBeVisible({
+				timeout: 5_000,
+			});
+			// bob 側にも届く
+			await expect(bobPage.getByText(marker)).toBeVisible({ timeout: 10_000 });
+
+			// 自分のバブル内の delete button (aria-label="メッセージを削除") を click。
+			// confirm() が auto-dismiss されないよう dialog ハンドラを登録。
+			alicePage.once("dialog", (dialog) => dialog.accept());
+			const myBubble = alicePage
+				.getByTestId("message-bubble")
+				.filter({
+					hasText: marker,
+					has: alicePage.locator('[data-mine="true"]'),
+				})
+				.first();
+			// hover で button を露出させてから click
+			await myBubble.hover();
+			await myBubble.getByRole("button", { name: "メッセージを削除" }).click();
+
+			// alice 側で消える
+			await expect(alicePage.getByText(marker)).not.toBeVisible({
+				timeout: 5_000,
+			});
+			// bob 側でも消える (WebSocket message.deleted broadcast 経由)
+			await expect(bobPage.getByText(marker)).not.toBeVisible({
+				timeout: 10_000,
+			});
+		} finally {
+			await aliceCtx.close();
+			await bobCtx.close();
+		}
 	});
 
 	test("典型的な a11y 観点 — keyboard で /messages → 招待へ遷移", async ({

--- a/client/src/components/dm/MessageBubble.tsx
+++ b/client/src/components/dm/MessageBubble.tsx
@@ -22,6 +22,8 @@ interface MessageBubbleProps {
 	currentUserId: number;
 	status?: MessageStatus;
 	onRetry?: () => void;
+	/** #274: 自分の送信メッセージで delete button を出す callback. mine=false 時は無視。 */
+	onDelete?: (messageId: number) => void;
 }
 
 export default function MessageBubble({
@@ -29,25 +31,47 @@ export default function MessageBubble({
 	currentUserId,
 	status = "sent",
 	onRetry,
+	onDelete,
 }: MessageBubbleProps) {
 	const mine = message.sender_id === currentUserId;
+	const canDelete = mine && status === "sent" && onDelete;
 	return (
 		<div
 			data-testid="message-bubble"
 			data-mine={mine ? "true" : "false"}
 			data-status={status}
 			className={
-				"flex w-full px-4 py-1 " + (mine ? "justify-end" : "justify-start")
+				"group flex w-full px-4 py-1 " +
+				(mine ? "justify-end" : "justify-start")
 			}
 		>
 			<div
 				className={
-					"max-w-[75%] rounded-2xl px-3 py-2 text-sm break-words " +
+					"relative max-w-[75%] rounded-2xl px-3 py-2 text-sm break-words " +
 					(mine
 						? "bg-baby_blue text-baby_white rounded-br-sm"
 						: "bg-baby_grey/20 text-baby_white rounded-bl-sm")
 				}
 			>
+				{/* #274: hover で出る削除 button (desktop)。focus-within で keyboard ユーザにも露出。 */}
+				{canDelete ? (
+					<button
+						type="button"
+						onClick={() => {
+							if (
+								typeof window !== "undefined" &&
+								!window.confirm("このメッセージを削除しますか？")
+							) {
+								return;
+							}
+							onDelete(message.id);
+						}}
+						aria-label="メッセージを削除"
+						className="bg-baby_red text-baby_white absolute -top-2 -right-2 hidden size-6 items-center justify-center rounded-full text-xs opacity-0 transition group-hover:flex group-hover:opacity-100 focus-visible:flex focus-visible:opacity-100 focus-visible:ring-2"
+					>
+						✕
+					</button>
+				) : null}
 				{message.body ? (
 					<p className="whitespace-pre-wrap">{message.body}</p>
 				) : null}

--- a/client/src/components/dm/MessageList.tsx
+++ b/client/src/components/dm/MessageList.tsx
@@ -25,6 +25,8 @@ interface MessageListProps {
 	currentUserId: number;
 	pendingByClientKey?: Map<string, MessageStatus>;
 	onRetry?: (localKey: string) => void;
+	/** #274: 自分の sent メッセージを削除する callback. 未指定なら delete UI 非表示。 */
+	onDelete?: (messageId: number) => void;
 }
 
 const NEAR_BOTTOM_PX = 80;
@@ -34,6 +36,7 @@ export default function MessageList({
 	currentUserId,
 	pendingByClientKey,
 	onRetry,
+	onDelete,
 }: MessageListProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const lastLengthRef = useRef(0);
@@ -78,6 +81,7 @@ export default function MessageList({
 							currentUserId={currentUserId}
 							status={status}
 							onRetry={onRetry ? () => onRetry(localKey) : undefined}
+							onDelete={onDelete}
 						/>
 					);
 				})}

--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -23,6 +23,7 @@ import MessageList from "@/components/dm/MessageList";
 import TypingIndicator from "@/components/dm/TypingIndicator";
 import { useDMSocket } from "@/hooks/useDMSocket";
 import {
+	useDeleteMessageMutation,
 	useGetDMRoomQuery,
 	useListRoomMessagesQuery,
 	useMarkRoomReadMutation,
@@ -39,6 +40,33 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 	const roomQuery = useGetDMRoomQuery(roomId);
 	const messagesQuery = useListRoomMessagesQuery({ roomId });
 	const [markRoomRead] = useMarkRoomReadMutation();
+	const [deleteMessage] = useDeleteMessageMutation();
+	// #274: 削除 button からのコールバック。楽観的に deletedIds に追加 + REST DELETE。
+	// backend は WebSocket で `message.deleted` を broadcast するので、相手側にも
+	// 自動反映される (frame.type === "message.deleted" 経路)。失敗時は undo して
+	// inline error を出す。
+	const onDelete = useCallback(
+		async (messageId: number) => {
+			setDeletedIds((prev) => {
+				if (prev.has(messageId)) return prev;
+				const next = new Set(prev);
+				next.add(messageId);
+				return next;
+			});
+			try {
+				await deleteMessage(messageId).unwrap();
+			} catch {
+				setDeletedIds((prev) => {
+					if (!prev.has(messageId)) return prev;
+					const next = new Set(prev);
+					next.delete(messageId);
+					return next;
+				});
+				setSendError("メッセージの削除に失敗しました。再試行してください。");
+			}
+		},
+		[deleteMessage],
+	);
 	const [liveMessages, setLiveMessages] = useState<DMMessage[]>([]);
 	const [deletedIds, setDeletedIds] = useState<Set<number>>(() => new Set());
 	const [sendError, setSendError] = useState<string | null>(null);
@@ -143,7 +171,11 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 					onReconnect={socket.reconnect}
 				/>
 			</header>
-			<MessageList messages={merged} currentUserId={currentUserId} />
+			<MessageList
+				messages={merged}
+				currentUserId={currentUserId}
+				onDelete={onDelete}
+			/>
 			<TypingIndicator
 				typingUserId={typing?.userId ?? null}
 				startedAt={typing?.startedAt}

--- a/client/src/lib/redux/features/dm/dmApiSlice.ts
+++ b/client/src/lib/redux/features/dm/dmApiSlice.ts
@@ -122,6 +122,17 @@ export const dmApiSlice = baseApiSlice.injectEndpoints({
 				{ type: "DMRoom" as const, id: "LIST" },
 			],
 		}),
+		// #274: 自分の DM message を soft-delete する。SPEC §7.3。
+		// backend (apps/dm/views.py MessageDestroyView) は WebSocket 経由で
+		// `message.deleted` イベントを broadcast するため、UI 側はサーバ応答を
+		// 待たず楽観的に消す or broadcast を待つ。RoomChat は WS 経由で
+		// `setMessages(prev => prev.filter(m => m.id !== id))` する想定 (P3-09)。
+		deleteMessage: builder.mutation<void, number>({
+			query: (id) => ({
+				url: `/dm/messages/${id}/`,
+				method: "DELETE",
+			}),
+		}),
 	}),
 	overrideExisting: false,
 });
@@ -135,4 +146,5 @@ export const {
 	useDeclineInvitationMutation,
 	useListRoomMessagesQuery,
 	useMarkRoomReadMutation,
+	useDeleteMessageMutation,
 } = dmApiSlice;


### PR DESCRIPTION
## 背景

backend (apps/dm/views.py MessageDestroyView + WebSocket message.deleted broadcast) は P3-09 で実装済だが、frontend に削除トリガーする UI が無く Phase 3 spec の「メッセージ削除」テストが skip されていた。

## 実装

### Frontend mutation
`dmApiSlice.deleteMessage`: `DELETE /api/v1/dm/messages/<id>/` を mutation 化 + `useDeleteMessageMutation` hook を export

### MessageBubble (削除 UI)
- `onDelete?: (messageId) => void` prop 追加
- 自分の sent メッセージのみ `<button aria-label="メッセージを削除">` を hover 露出
- `window.confirm` で誤削除防止
- `group-hover` + `focus-visible` で keyboard 操作にも対応

### MessageList → RoomChat 配線
- `onDelete` prop を pass-through
- RoomChat:
  - `useDeleteMessageMutation` 取得
  - 楽観的に `deletedIds` に追加 → REST DELETE 失敗時は undo + inline error
  - backend は WebSocket で message.deleted を broadcast → 既存の `frame.type === "message.deleted"` ハンドラで相手側にも反映

### E2E spec
- `メッセージ削除` test の `test.skip` を解除
- alice send → 自分のバブル hover → delete button click (confirm() 受諾) → alice 側で消える + bob 側でも WebSocket 経由で消える assert

## 検証

- ✅ vitest 356/356 pass
- ✅ tsc --noEmit clean

## Test plan

- [ ] CI 全 pass
- [ ] cd-stg deploy 成功
- [ ] stg `/messages/<id>` で自分のバブル hover → 削除 button が表示
- [ ] click + confirm → 自分側で消える、相手側でも消える
- [ ] Phase 3 spec の削除テストが green に

Refs: P3-09 (#234)、Phase 3 spec (#246)、Closes #274