### PR TITLE
fix(infra): Django ECS healthcheck curl 依存除去 + start.sh 重複 migrate 削除 (Closes #291)

### DIFF
--- a/docker/production/django/start.sh
+++ b/docker/production/django/start.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 
 set -o errexit
-
 set -o pipefail
-
 set -o nounset
 
+# #291: migrate は cd-stg.yml の "Run Django migrations on ECS" step が
+# sns-stg-django-migrate task で実施する。container 起動時に重複実行すると
+# 多重起動レース + cold start を遅らせて healthcheck flapping を引き起こす
+# ため削除した。local 開発環境は docker compose の別 service / `manage.py
+# migrate` で個別に管理する。
 python /app/manage.py collectstatic --noinput
-python /app/manage.py migrate
 
 NUM_WORKERS=${GUNICORN_WORKERS:-3}
+GUNICORN_TIMEOUT=${GUNICORN_TIMEOUT:-60}
+GUNICORN_GRACEFUL_TIMEOUT=${GUNICORN_GRACEFUL_TIMEOUT:-30}
 
-exec /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:8000 --chdir=/app --workers $NUM_WORKERS
+# #291: --preload で fork 前に app を import し、worker 起動時の Aurora cold
+# connect を 1 回に集約する (起動時間短縮)。--timeout 60 は default 30 より
+# 緩く取って Aurora cold connect (~2s) や migration 直後の重い query を許容。
+exec /usr/local/bin/gunicorn config.wsgi \
+  --bind 0.0.0.0:8000 \
+  --chdir=/app \
+  --workers "$NUM_WORKERS" \
+  --timeout "$GUNICORN_TIMEOUT" \
+  --graceful-timeout "$GUNICORN_GRACEFUL_TIMEOUT" \
+  --preload

--- a/docs/issues/phase-3-followups.md
+++ b/docs/issues/phase-3-followups.md
@@ -1,0 +1,65 @@
+# Phase 3 フォローアップ Issues
+
+Phase 3 (DM) の stg 動作確認 + Phase 3 E2E spec 完走の過程で発覚した
+インフラ・型・UI wire-up 起因の不具合を追跡する。Phase 3 マイルストーン
+クローズ前に解消する想定 (一部は Phase 9 本番昇格まで持ち越し可)。
+
+## 一覧
+
+| Issue | 件名                                                                      | 状態   | 優先度 | 着手 Phase           |
+| ----- | ------------------------------------------------------------------------- | ------ | ------ | -------------------- |
+| #269  | useUserProfile を `/api/v1/users/me/` に修正                              | closed | high   | Phase 3              |
+| #275  | ALB から CloudFront 経由 WebSocket 経路の SSL 不整合                      | closed | high   | Phase 3              |
+| #276  | InvitationList の type drift + room_name field 追加                       | closed | high   | Phase 3              |
+| #281  | `COOKIE_DOMAIN` 設定 + spec WS-skip 解除                                  | closed | high   | Phase 3              |
+| #285  | グループ招待拒否時に list が refresh されず 403 を返す (CSRF Cookie 不在) | closed | high   | Phase 3              |
+| #273  | `/messages` に「+ 新規グループ」 button が wire-up されていない           | closed | medium | Phase 3              |
+| #274  | DM メッセージの削除 UI (hover delete + 楽観 UI + WS broadcast 受信)       | closed | medium | Phase 3              |
+| #277  | Phase 3 E2E spec を 8 シナリオに拡張 + API bootstrap helper 追加          | closed | medium | Phase 3              |
+| #291  | sns-stg-django ECS task が container health check 失敗で慢性 flapping     | open   | high   | **Phase 3 (進行中)** |
+
+## #291 の根本原因と対応方針
+
+PR #29X (本ファイルを含む同 PR) で fix する。
+
+### 根本原因 (architect 調査結果)
+
+`terraform/modules/services/main.tf:177` の Django container `healthCheck` が
+`curl -fsSL http://localhost:8000/api/health/` だが、base image
+`python:3.12.2-slim-bookworm` に curl が同梱されていない。`apt-get install`
+にも curl は含まれず、毎回 `curl: command not found` の exit 127 が ECS に
+返される。
+
+- ALB target group probe は別経路で /api/health/ を叩いているので 200 が
+  CloudWatch logs に残る (見かけ上 healthy)
+- container probe は startPeriod=60s 経過後に retries=3 × interval=30s = 90s
+  で UNHEALTHY 確定 → ECS が task を kill
+- 結果: deploy 完了直後の task が ~3 分で kill され、cd-stg の
+  `aws ecs wait services-stable` が 10 分タイムアウトする
+
+### 修正
+
+1. **healthCheck command を python urllib に置換** (curl 依存除去)
+2. **startPeriod=120s, retries=5 に緩和** (collectstatic + Aurora cold connect 余裕)
+3. **start.sh から `python manage.py migrate` を削除** (cd-stg.yml の
+   `sns-stg-django-migrate` task で実施しているので重複)
+4. **gunicorn flags 改善**:
+   - `--timeout 60` (default 30 → Aurora cold connect 許容)
+   - `--graceful-timeout 30` (ECS stopTimeout と整合)
+   - `--preload` (worker fork 前に app import → cold connect 1 回に集約)
+
+### 副次検討 (本 PR 外、future work)
+
+- `/api/health/` を `/health/live` (pure 200) と `/health/ready` (DB ping) に
+  分離し、container probe は live、ALB probe は ready を叩く分業
+- ALB `deployment_minimum_healthy_percent=100, maximum_percent=200` で
+  blue/green 寄り cutover にして deploy 中の 503 窓を縮める
+- gunicorn `--worker-class gthread --threads 4` への切替検討 (ALB + sticky
+  session 環境下での同時接続数余裕、Phase 4 以降のトラフィック増で再検討)
+
+## 受け入れ条件 (Phase 3 マイルストーン close 前)
+
+- [ ] PR #29X (#291 fix) が merge され cd-stg deploy が成功
+- [ ] /api/health/ が 30 分以上連続で 200
+- [ ] cd-stg deploy の `services-stable` が 5 分以内に成功
+- [ ] Phase 3 spec を 3 回連続実行して 8/8 が安定して green

--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -173,12 +173,23 @@ resource "aws_ecs_task_definition" "django" {
           awslogs-stream-prefix = "django"
         }
       }
+      # #291: container healthCheck は python urllib で実施する。slim-bookworm
+      # base image に curl は同梱されておらず、`curl: command not found` で
+      # exit 127 → ECS が UNHEALTHY 判定して起動 ~3 分で kill する慢性 flapping
+      # の原因だった。Dockerfile に curl を追加するより、既に存在する Python
+      # runtime で済ませる方が image size を増やさない。
+      # startPeriod=120s は collectstatic + gunicorn workers の Aurora cold
+      # connect (初回 ~2s) を見込んだ余裕。retries=5 で interval 30s × 5 =
+      # 150s の grace を取る。
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -fsSL http://localhost:8000/api/health/ || exit 1"]
+        command = [
+          "CMD-SHELL",
+          "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/api/health/', timeout=4).status==200 else 1)\""
+        ]
         interval    = 30
         timeout     = 5
-        retries     = 3
-        startPeriod = 60
+        retries     = 5
+        startPeriod = 120
       }
     }
   ])


### PR DESCRIPTION
## Summary

- **Root cause** (architect 調査): `terraform/modules/services/main.tf` の Django container `healthCheck` が `curl -fsSL http://localhost:8000/api/health/`。base image `python:3.12-slim-bookworm` に curl が同梱されておらず exit 127 → ECS が ~3 分で task kill する慢性 flapping
- healthCheck を Python urllib に置換 (image 既存)。startPeriod 60→120s, retries 3→5 に緩和
- `start.sh` から重複 migrate を削除 (cd-stg.yml の django-migrate task で実施済)、gunicorn `--timeout 60 --graceful-timeout 30 --preload` 追加
- `docs/issues/phase-3-followups.md` 新規 (Phase 3 stg 動作確認の follow-up 一覧)

## Test plan

- [x] `bash -n start.sh` syntax OK
- [x] `terraform fmt -check` clean
- [ ] CI 全 pass
- [ ] terraform apply (ハルナさん手動)
- [ ] cd-stg deploy 成功 (services-stable が 5 分以内)
- [ ] /api/health/ が 30 分連続で 200
- [ ] Phase 3 spec を 3 回連続実行して 8/8 安定 green

Closes #291