### PR TITLE
fix(scripts): pre-push pytest を --create-db 既定化 + test isolation 暫定対策 (refs #302)

### DIFF
--- a/scripts/run-tests-local.sh
+++ b/scripts/run-tests-local.sh
@@ -157,9 +157,13 @@ run_pytest() {
 ensure_compose_services
 ensure_network_attached
 
-# 引数が無ければ default 引数 (1 件 fail で即 stop、coverage 切り)
+# 引数が無ければ default 引数 (1 件 fail で即 stop、coverage 切り)。
+# `--create-db` は `pyproject.toml` の `--reuse-db` を打ち消し、stale data
+# (前回 run で transactional rollback を escaped したコミット済 row 等) を
+# 持ち越して別 test の前提を破壊する事故を防ぐ。CI の `--create-db` と挙動
+# 整合させる。CLI から `scripts/run-tests-local.sh --reuse-db` で再利用も可。
 if [ $# -eq 0 ]; then
-  run_pytest --ff -x --no-cov -q
+  run_pytest --create-db --ff -x --no-cov -q
 else
-  run_pytest "$@"
+  run_pytest --create-db "$@"
 fi


### PR DESCRIPTION
## Summary

- \`scripts/run-tests-local.sh\` の pytest コマンドに \`--create-db\` を追加し、\`pyproject.toml\` の \`--reuse-db\` を打ち消す
- 効果: cross-run 持ち越し (前 run の commit 済 row が次 run に残って test を破壊する) を解消
- intra-session leak (#302) は別 issue で本腰調査、本 PR は暫定対策

## 背景

- pre-push hook の pytest が間欠 fail で PR push を block していた
- 失敗事例: \`test_pagination_default_page_size\` (count=13 should be 11) / \`test_csrf\` (IntegrityError) / \`test_reaction_api\` (ERROR)
- CI は \`--create-db\` 明示 + fresh container で問題なし

## Test plan

- [x] \`scripts/run-tests-local.sh apps/tweets/tests/test_crud_api.py\` 32/32 pass
- [ ] CI 全 pass
- [ ] full suite で残る leak は #302 で本腰調査

Refs: #302