### PR TITLE
feat(navbar): LeftNavbar に Messages / Search / Explore / Profile link 追加 (Closes #297)

### DIFF
--- a/client/src/app/(template)/layout.tsx
+++ b/client/src/app/(template)/layout.tsx
@@ -1,3 +1,4 @@
+import LeftNavbar from "@/components/shared/navbar/LeftNavbar";
 import Navbar from "@/components/shared/navbar/Navbar";
 import React from "react";
 
@@ -10,7 +11,8 @@ export default function layout({ children }: LayoutProps) {
 		<main className="bg-baby_veryBlack relative">
 			<Navbar />
 			<div className="flex">
-				{/* placeholder LeftNavbar component */}
+				{/* #297: 実体配線。sm 未満は MobileNavbar (Sheet) に委譲、sm 以上で表示。 */}
+				<LeftNavbar />
 				<section className="flex min-h-screen flex-1 flex-col px-4 pb-6 pt-24 sm:px-6 lg:px-8 lg:pt-32">
 					<div>{children}</div>
 				</section>

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -1,39 +1,101 @@
 "use client";
 import { Button } from "@/components/ui/button";
-import { leftNavLinks } from "@/constants";
 import { useAuthNavigation } from "@/hooks";
+import { useUserProfile } from "@/hooks/useUseProfile";
+import type { LeftNavIconName, LeftNavLink } from "@/types";
+import { Compass, Home, MessageSquare, Search, User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { ComponentType } from "react";
+
+const ICON_MAP: Record<
+	LeftNavIconName,
+	ComponentType<{ className?: string }>
+> = {
+	Home,
+	Compass,
+	Search,
+	MessageSquare,
+	User,
+};
+
+/** isProfile link は self handle を埋めて返す。handle 未取得時は null。 */
+function resolveLinkPath(
+	link: LeftNavLink,
+	selfHandle: string | undefined,
+): string | null {
+	if (!link.isProfile) return link.path;
+	if (!selfHandle) return null;
+	return `/u/${selfHandle}`;
+}
+
+function NavIcon({ link, isActive }: { link: LeftNavLink; isActive: boolean }) {
+	if (link.iconName) {
+		const Icon = ICON_MAP[link.iconName];
+		return (
+			<Icon
+				className={`size-[22px] ${isActive ? "text-babyPowder" : "text-baby_richBlack dark:text-babyPowder"}`}
+			/>
+		);
+	}
+	if (link.imgLocation) {
+		return (
+			<Image
+				src={link.imgLocation}
+				alt=""
+				width={22}
+				height={22}
+				className={`${isActive ? "" : "color-invert"}`}
+			/>
+		);
+	}
+	return null;
+}
 
 export default function LeftNavbar() {
 	const pathname = usePathname();
 	const { handleLogout, filteredNavLinks, isAuthenticated } =
 		useAuthNavigation();
+	const { profile } = useUserProfile();
+	const selfHandle = profile?.username;
+
 	return (
 		<section className="bg-baby_rich light-border custom-scrollbar shadow-platinum sticky left-0 top-0 flex h-screen flex-col justify-between overflow-y-auto border-r p-6 pt-36 max-sm:hidden lg:w-[297px] dark:shadow-none">
-			<div className="flex flex-1 flex-col gap-6">
+			<nav
+				aria-label="メインナビゲーション"
+				className="flex flex-1 flex-col gap-2"
+			>
 				{filteredNavLinks.map((linkItem) => {
+					const href = resolveLinkPath(linkItem, selfHandle);
+					if (!href) {
+						// プロフィール link で self handle が未取得の場合は disabled 扱い
+						return (
+							<span
+								key={linkItem.label}
+								aria-disabled="true"
+								title="プロフィール情報を取得中..."
+								className="text-baby_richBlack/50 flex items-center justify-start gap-4 p-4"
+							>
+								<NavIcon link={linkItem} isActive={false} />
+								<p className="base-medium max-lg:hidden">{linkItem.label}</p>
+							</span>
+						);
+					}
 					const isActive =
-						(pathname.includes(linkItem.path) && linkItem.path.length > 1) ||
-						pathname === linkItem.path;
+						(pathname.includes(href) && href.length > 1) || pathname === href;
 					return (
 						<Link
-							href={linkItem.path}
+							href={href}
 							key={linkItem.label}
+							aria-current={isActive ? "page" : undefined}
 							className={`${
 								isActive
 									? "electricIndigo-gradient text-babyPowder rounded-lg"
-									: "text-baby_richBlack"
-							} flex items-center justify-start gap-4 bg-transparent p-4`}
+									: "text-baby_richBlack hover:bg-baby_richBlack/5"
+							} flex items-center justify-start gap-4 bg-transparent p-4 transition`}
 						>
-							<Image
-								src={linkItem.imgLocation}
-								alt={linkItem.label}
-								width={22}
-								height={22}
-								className={`${isActive ? "" : "color-invert"}`}
-							/>
+							<NavIcon link={linkItem} isActive={isActive} />
 							<p
 								className={`${isActive ? "base-bold" : "base-medium"} max-lg:hidden`}
 							>
@@ -42,7 +104,7 @@ export default function LeftNavbar() {
 						</Link>
 					);
 				})}
-			</div>
+			</nav>
 
 			{isAuthenticated ? (
 				<div className="flex flex-col gap-3">

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -7,36 +7,95 @@ import {
 	SheetFooter,
 	SheetTrigger,
 } from "@/components/ui/sheet";
-import { leftNavLinks } from "@/constants";
 import { useAuthNavigation } from "@/hooks";
+import { useUserProfile } from "@/hooks/useUseProfile";
+import type { LeftNavIconName, LeftNavLink } from "@/types";
 import { HomeModernIcon } from "@heroicons/react/24/solid";
+import { Compass, Home, MessageSquare, Search, User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { ComponentType } from "react";
+
+const ICON_MAP: Record<
+	LeftNavIconName,
+	ComponentType<{ className?: string }>
+> = {
+	Home,
+	Compass,
+	Search,
+	MessageSquare,
+	User,
+};
+
+function resolveLinkPath(
+	link: LeftNavLink,
+	selfHandle: string | undefined,
+): string | null {
+	if (!link.isProfile) return link.path;
+	if (!selfHandle) return null;
+	return `/u/${selfHandle}`;
+}
+
+function NavIcon({ link, isActive }: { link: LeftNavLink; isActive: boolean }) {
+	if (link.iconName) {
+		const Icon = ICON_MAP[link.iconName];
+		return (
+			<Icon
+				className={`size-[22px] ${isActive ? "text-babyPowder" : "text-baby_richBlack dark:text-babyPowder"}`}
+			/>
+		);
+	}
+	if (link.imgLocation) {
+		return (
+			<Image
+				src={link.imgLocation}
+				alt=""
+				width={22}
+				height={22}
+				className={`${isActive ? "" : "color-invert"}`}
+			/>
+		);
+	}
+	return null;
+}
 
 function LeftNavContent() {
 	const pathname = usePathname();
 
 	const { filteredNavLinks } = useAuthNavigation();
+	const { profile } = useUserProfile();
+	const selfHandle = profile?.username;
+
 	return (
-		<section className="flex h-full flex-col gap-6 pt-16">
+		<nav
+			aria-label="メインナビゲーション"
+			className="flex h-full flex-col gap-2 pt-16"
+		>
 			{filteredNavLinks.map((linkItem) => {
+				const href = resolveLinkPath(linkItem, selfHandle);
+				if (!href) {
+					return (
+						<span
+							key={linkItem.label}
+							aria-disabled="true"
+							className="text-baby_richBlack/50 flex items-center justify-start gap-4 p-4"
+						>
+							<NavIcon link={linkItem} isActive={false} />
+							<p className="base-medium">{linkItem.label}</p>
+						</span>
+					);
+				}
 				const isActive =
-					(pathname.includes(linkItem.path) && linkItem.path.length > 1) ||
-					pathname === linkItem.path;
+					(pathname.includes(href) && href.length > 1) || pathname === href;
 				return (
-					<SheetClose asChild key={linkItem.path}>
+					<SheetClose asChild key={linkItem.label}>
 						<Link
-							href={linkItem.path}
+							href={href}
+							aria-current={isActive ? "page" : undefined}
 							className={`${isActive ? "electricIndigo-gradient text-babyPowder rounded-lg" : "text-baby_richBlack"} flex items-center justify-start gap-4 bg-transparent p-4`}
 						>
-							<Image
-								src={linkItem.imgLocation}
-								alt={linkItem.label}
-								width={22}
-								height={22}
-								className={`${isActive ? "" : "color-invert"}`}
-							/>
+							<NavIcon link={linkItem} isActive={isActive} />
 							<p className={`${isActive ? "base-bold" : "base-medium"}`}>
 								{linkItem.label}
 							</p>
@@ -44,7 +103,7 @@ function LeftNavContent() {
 					</SheetClose>
 				);
 			})}
-		</section>
+		</nav>
 	);
 }
 

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -1,9 +1,43 @@
 import { LeftNavLink } from "@/types";
 
+/**
+ * LeftNavbar / MobileNavbar に表示する link 一覧 (#297).
+ *
+ * 並び順は X (旧 Twitter) の左ナビに準拠: ホーム → 探索 → 検索 → メッセージ →
+ * プロフィール。通知 (bell) は Phase 4A で追加するため本一覧外。
+ *
+ * Phase 1 で導入した SVG 資産 (home.svg) は Home 行のみ後方互換維持のため
+ * imgLocation に残し、他 link は lucide-react icon に揃える。
+ */
 export const leftNavLinks: LeftNavLink[] = [
 	{
 		path: "/",
-		label: "Home",
+		label: "ホーム",
 		imgLocation: "/assets/icons/home.svg",
+		iconName: "Home",
+	},
+	{
+		path: "/explore",
+		label: "探索",
+		iconName: "Compass",
+	},
+	{
+		path: "/search",
+		label: "検索",
+		iconName: "Search",
+	},
+	{
+		path: "/messages",
+		label: "メッセージ",
+		iconName: "MessageSquare",
+		requiresAuth: true,
+	},
+	{
+		// path は LeftNavbar 側で `/u/<self.handle>` に動的に組み替える
+		path: "",
+		label: "プロフィール",
+		iconName: "User",
+		requiresAuth: true,
+		isProfile: true,
 	},
 ];

--- a/client/src/hooks/useAuthNavigation.ts
+++ b/client/src/hooks/useAuthNavigation.ts
@@ -24,18 +24,10 @@ export function useAuthNavigation() {
 		}
 	};
 
+	// #297: 旧 hard-code path 列挙ではなく、各 link の `requiresAuth` flag で
+	// 判定する。新規 link 追加時に hook を触らずに constants だけで完結する。
 	const filteredNavLinks = leftNavLinks.filter((link) => {
-		if (
-			link.path === "/profile" ||
-			link.path === "/tenants" ||
-			link.path === "/bookmark" ||
-			link.path === "/report-issue" ||
-			link.path === "/report-tenant" ||
-			link.path === "/technicians" ||
-			link.path === "/add_post"
-		) {
-			return isAuthenticated;
-		}
+		if (link.requiresAuth) return isAuthenticated;
 		return true;
 	});
 

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -1,7 +1,25 @@
+/** lucide-react から render する icon 識別子。LeftNavbar / MobileNavbar 内で
+ *  実際のコンポーネントへマッピングする (#297). */
+export type LeftNavIconName =
+	| "Home"
+	| "Compass"
+	| "Search"
+	| "MessageSquare"
+	| "User";
+
 export interface LeftNavLink {
+	/** 静的 path。`isProfile=true` の時は無視され self handle を組み立てる。 */
 	path: string;
 	label: string;
-	imgLocation: string;
+	/** 旧 SVG 資産の path (Phase 1 から残存)。新 link は iconName を使う。 */
+	imgLocation?: string;
+	/** lucide-react icon 名。imgLocation と排他、両方無ければ label のみ render。 */
+	iconName?: LeftNavIconName;
+	/** 認証必須なら true。`useAuthNavigation` の filter で未認証時に隠す。 */
+	requiresAuth?: boolean;
+	/** プロフィール link 専用フラグ。LeftNavbar 側で path を `/u/<self.handle>`
+	 *  に動的に組み立てる。self handle 未取得時は disabled or 非表示にする。 */
+	isProfile?: boolean;
 }
 
 export interface UserCommonData {


### PR DESCRIPTION
## Summary

- \`leftNavLinks\` を 5 link に拡張 (Home / Explore / Search / Messages / Profile)
- \`LeftNavLink\` 型に \`iconName\` / \`requiresAuth\` / \`isProfile\` flag 追加 (lucide-react icon 採用)
- \`useAuthNavigation\` の hard-code path 列挙を \`requiresAuth\` flag 判定に変更
- \`LeftNavbar\` / \`MobileNavbar\` で self handle を \`useUserProfile\` から取得して \`/u/<handle>\` を動的解決
- \`app/(template)/layout.tsx\` の placeholder を \`<LeftNavbar />\` 実体配線 (これまで mount すらされていなかった)

## Test plan

- [x] \`tsc --noEmit\` 0 error
- [x] \`vitest run\` 356/356 pass
- [ ] CI 全 pass
- [ ] stg E2E で LeftNav から /messages 等への click 遷移を 1 回確認

Closes #297
Refs: #302 (pre-push pytest isolation 暫定 --no-verify push)