### PR TITLE
feat(dm): /u/[handle] に「メッセージ」 button + /messages に招待リンク追加 (Closes #299, #300)

### DIFF
--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -21,7 +21,9 @@ import {
 	DialogTrigger,
 } from "@/components/ui/dialog";
 import { useUserProfile } from "@/hooks/useUseProfile";
+import { useListInvitationsQuery } from "@/lib/redux/features/dm/dmApiSlice";
 import { useAppSelector } from "@/lib/redux/hooks/typedHooks";
+import Link from "next/link";
 
 export default function MessagesPage() {
 	const router = useRouter();
@@ -31,6 +33,11 @@ export default function MessagesPage() {
 	// 作成成功時は GroupCreateForm 側で `/messages/<id>` に遷移するため、
 	// open state は cancel button と外クリックで false に戻す。
 	const [groupDialogOpen, setGroupDialogOpen] = useState(false);
+	// #300: 招待 link の badge 用に pending invitation 件数を取得する。
+	// 0 件の時は link は出すが badge を非表示にする。RTK Query は
+	// invalidatesTags 経由で承諾/拒否後に auto refetch される。
+	const invitationsQuery = useListInvitationsQuery({ status: "pending" });
+	const pendingCount = invitationsQuery.data?.count ?? 0;
 
 	// 認証チェック (#269): cookie (`logged_in`) を直接読んで判定する。
 	// PersistAuth (app/layout.tsx) の useEffect は本ページ useEffect より「後」に
@@ -71,27 +78,49 @@ export default function MessagesPage() {
 
 	return (
 		<section className="mx-auto max-w-2xl">
-			<header className="mb-6 flex items-baseline justify-between">
+			<header className="mb-6 flex items-baseline justify-between gap-3">
 				<h1 className="text-baby_white text-xl font-bold">メッセージ</h1>
-				{/* #273: 新規グループ作成 button + Dialog wire-up。
-				    GroupCreateForm 自体は P3-11 (#236) で実装済。 */}
-				<Dialog open={groupDialogOpen} onOpenChange={setGroupDialogOpen}>
-					<DialogTrigger asChild>
-						<button
-							type="button"
-							aria-label="新規グループ作成"
-							className="bg-baby_blue text-baby_white focus-visible:ring-baby_white rounded-md px-3 py-1.5 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2"
-						>
-							＋ 新規グループ
-						</button>
-					</DialogTrigger>
-					<DialogContent>
-						<DialogHeader>
-							<DialogTitle>新規グループ作成</DialogTitle>
-						</DialogHeader>
-						<GroupCreateForm onCancel={() => setGroupDialogOpen(false)} />
-					</DialogContent>
-				</Dialog>
+				<div className="flex items-center gap-2">
+					{/* #300: 招待リスト導線。pending 0 件でも link は表示 (Phase 3
+					    spec が /messages/invitations 直リンクを使うため)、badge は
+					    1 件以上のときだけ。 */}
+					<Link
+						href="/messages/invitations"
+						aria-label={
+							pendingCount > 0 ? `招待 ${pendingCount} 件` : "招待リストを開く"
+						}
+						className="text-baby_white inline-flex items-center gap-1 rounded-md border border-border px-3 py-1.5 text-sm font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					>
+						招待
+						{pendingCount > 0 ? (
+							<span
+								aria-hidden="true"
+								className="bg-baby_red text-baby_white inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1.5 py-0 text-xs font-semibold"
+							>
+								{pendingCount}
+							</span>
+						) : null}
+					</Link>
+					{/* #273: 新規グループ作成 button + Dialog wire-up。
+					    GroupCreateForm 自体は P3-11 (#236) で実装済。 */}
+					<Dialog open={groupDialogOpen} onOpenChange={setGroupDialogOpen}>
+						<DialogTrigger asChild>
+							<button
+								type="button"
+								aria-label="新規グループ作成"
+								className="bg-baby_blue text-baby_white focus-visible:ring-baby_white rounded-md px-3 py-1.5 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2"
+							>
+								＋ 新規グループ
+							</button>
+						</DialogTrigger>
+						<DialogContent>
+							<DialogHeader>
+								<DialogTitle>新規グループ作成</DialogTitle>
+							</DialogHeader>
+							<GroupCreateForm onCancel={() => setGroupDialogOpen(false)} />
+						</DialogContent>
+					</Dialog>
+				</div>
 			</header>
 			<RoomList currentUserId={profile.pkid} />
 		</section>

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import StartDMButton from "@/components/dm/StartDMButton";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -135,13 +136,19 @@ export default async function ProfilePage({ params }: PageProps) {
 						aria-hidden
 					/>
 				)}
-				<div className="pb-2">
+				<div className="pb-2 flex-1">
 					<h1 className="text-xl font-bold sm:text-2xl">
 						{profile.display_name || profile.username}
 					</h1>
 					<div className="text-sm text-muted-foreground">
 						@{profile.username}
 					</div>
+				</div>
+				{/* #299: 認証済 & 自分以外の profile に対して「メッセージ」 button。
+				    click で direct DM room を取得 / 作成して /messages/<id> 遷移。
+				    self / 未ログイン判定は StartDMButton 内で行う。 */}
+				<div className="pb-2">
+					<StartDMButton targetHandle={profile.username} />
 				</div>
 			</header>
 

--- a/client/src/components/dm/StartDMButton.tsx
+++ b/client/src/components/dm/StartDMButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * StartDMButton (#299).
+ *
+ * /u/[handle] で表示、click で direct DM room を作成 or 既存 room を取得し
+ * /messages/<id> へ遷移する。selfHandle === targetHandle なら non-render。
+ *
+ * - POST /api/v1/dm/rooms/ (kind=direct, member_handle=<handle>)
+ *   - 既存 direct room があれば 200 で同じ id 返る (backend 側 idempotent)
+ *   - 新規 201
+ * - 失敗時は inline alert
+ */
+
+import { Button } from "@/components/ui/button";
+import { useUserProfile } from "@/hooks/useUseProfile";
+import { useCreateDMRoomMutation } from "@/lib/redux/features/dm/dmApiSlice";
+import { cn } from "@/lib/utils";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface StartDMButtonProps {
+	targetHandle: string;
+	size?: "sm" | "md";
+}
+
+export default function StartDMButton({
+	targetHandle,
+	size = "md",
+}: StartDMButtonProps) {
+	const router = useRouter();
+	const { profile } = useUserProfile();
+	const selfHandle = profile?.username;
+	const [createRoom, { isLoading }] = useCreateDMRoomMutation();
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	if (selfHandle && selfHandle === targetHandle) return null;
+	// 未ログイン時は非表示 (401 を起こさない)。useUserProfile が profile を
+	// 持つ = 認証済みと判定。
+	if (!profile) return null;
+
+	const handleClick = async () => {
+		setErrorMessage(null);
+		try {
+			const room = await createRoom({
+				kind: "direct",
+				member_handle: targetHandle,
+			}).unwrap();
+			router.push(`/messages/${room.id}`);
+		} catch (err) {
+			const status = (err as { status?: number })?.status;
+			if (status === 401) {
+				setErrorMessage("ログインが必要です");
+			} else if (status === 403) {
+				setErrorMessage("このユーザーにはメッセージを送れません");
+			} else {
+				setErrorMessage("DM 開始に失敗しました");
+			}
+		}
+	};
+
+	const sizeClass = size === "sm" ? "px-3 py-1 text-xs" : "px-4 py-1.5 text-sm";
+
+	return (
+		<div className="inline-flex flex-col items-end gap-1">
+			<Button
+				type="button"
+				onClick={handleClick}
+				disabled={isLoading}
+				aria-label={`@${targetHandle} にメッセージを送る`}
+				className={cn(
+					"rounded-full border border-border bg-transparent font-semibold text-foreground transition hover:bg-muted disabled:opacity-50",
+					sizeClass,
+				)}
+			>
+				{isLoading ? "開始中..." : "メッセージ"}
+			</Button>
+			{errorMessage ? (
+				<span role="alert" className="text-baby_red text-xs">
+					{errorMessage}
+				</span>
+			) : null}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- #299: `StartDMButton` 新規。/u/[handle] header から POST /api/v1/dm/rooms/ → /messages/<id> 遷移
- #300: /messages header に「招待」 link + pending count badge

## Test plan

- [x] tsc clean
- [x] vitest 356/356
- [ ] CI 全 pass
- [ ] stg E2E

Closes #299
Closes #300
Refs: #302