### PR TITLE
feat(profile): /u/[handle] tweet 一覧を TweetCard 化 (Closes #298)

### DIFF
--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -2,10 +2,10 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import StartDMButton from "@/components/dm/StartDMButton";
+import TweetCardList from "@/components/timeline/TweetCardList";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 import { stringifyJsonLd } from "@/lib/json-ld";
-import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 
 interface PublicProfile {
 	username: string;
@@ -175,34 +175,14 @@ export default async function ProfilePage({ params }: PageProps) {
 				<h2 id="tweets-heading" className="mb-3 text-lg font-semibold">
 					ツイート
 				</h2>
-				{tweets.length === 0 ? (
-					<p className="text-sm text-muted-foreground">
-						まだツイートがありません。
-					</p>
-				) : (
-					<ul className="space-y-4">
-						{tweets.map((t) => (
-							<li key={t.id}>
-								<article className="rounded-lg border bg-card p-4 shadow-sm">
-									<a href={`/tweet/${t.id}`} className="block">
-										<div
-											className="prose prose-sm dark:prose-invert max-w-none"
-											dangerouslySetInnerHTML={{
-												__html: sanitizeTweetHtml(t.html),
-											}}
-										/>
-										<time
-											dateTime={t.created_at}
-											className="mt-2 block text-xs text-muted-foreground"
-										>
-											{new Date(t.created_at).toLocaleString("ja-JP")}
-										</time>
-									</a>
-								</article>
-							</li>
-						))}
-					</ul>
-				)}
+				{/* #298: 旧 plain link 列挙を TweetCard ベースに置換。
+				    リアクション (P2-14) / RT (P2-15) / 「もっと見る」展開 (P2-18)
+				    が本配線される。HomeFeed と同 ARIA feed pattern。 */}
+				<TweetCardList
+					tweets={tweets}
+					ariaLabel={`@${profile.username} のツイート`}
+					emptyMessage="まだツイートがありません。"
+				/>
 			</section>
 		</main>
 	);

--- a/client/src/components/timeline/TweetCardList.tsx
+++ b/client/src/components/timeline/TweetCardList.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * TweetCardList (#298).
+ *
+ * Server Component から受け取った tweet 配列を Client な TweetCard で render する
+ * 薄いラッパ。/u/[handle] / /tweet/[id] / /tag/[name] / /explore など、
+ * 既存の plain `<a>` link で render していたページが共通でリアクション / RT
+ * / 「もっと見る」展開を享受できるようにする。
+ *
+ * Server からは JSON-serializable な TweetSummary 配列を渡すだけで済む。
+ * ARIA feed pattern に揃えるため `role="feed"` + posinset/setsize を付与する
+ * (HomeFeed と同じ pattern)。
+ */
+
+import TweetCard from "@/components/timeline/TweetCard";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+interface TweetCardListProps {
+	tweets: TweetSummary[];
+	/**
+	 * a11y label。/u/<handle> なら "<display> のツイート" 等、文脈に応じた
+	 * 説明を渡す (HomeFeed は "ホームタイムライン" 等)。
+	 */
+	ariaLabel: string;
+	/**
+	 * 空配列のときに表示する文言。default は "ツイートがありません。"。
+	 */
+	emptyMessage?: string;
+}
+
+export default function TweetCardList({
+	tweets,
+	ariaLabel,
+	emptyMessage = "ツイートがありません。",
+}: TweetCardListProps) {
+	if (tweets.length === 0) {
+		return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+	}
+	return (
+		<section
+			role="feed"
+			aria-label={ariaLabel}
+			aria-busy="false"
+			className="flex flex-col gap-3"
+		>
+			{tweets.map((tweet, index) => (
+				<TweetCard
+					key={tweet.id}
+					tweet={tweet}
+					posinset={index + 1}
+					setsize={tweets.length}
+				/>
+			))}
+		</section>
+	);
+}


### PR DESCRIPTION
TweetCardList 新規 + /u/[handle] の plain link 列挙を置換 → リアクション / RT / 展開が動作する。Closes #298