### PR TITLE
feat(pages): /tweet[id] / /tag[name] / /explore を TweetCardList 化 (Closes #301)

### DIFF
--- a/client/src/app/(template)/explore/page.tsx
+++ b/client/src/app/(template)/explore/page.tsx
@@ -21,9 +21,9 @@ import { redirect } from "next/navigation";
 import HeroBanner from "@/components/explore/HeroBanner";
 import StickyLoginBanner from "@/components/explore/StickyLoginBanner";
 import RightSidebar from "@/components/sidebar/RightSidebar";
+import TweetCardList from "@/components/timeline/TweetCardList";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import { fetchExploreTimeline } from "@/lib/api/explore";
-import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 import { stringifyJsonLd } from "@/lib/json-ld";
 
 export const metadata: Metadata = {
@@ -94,58 +94,15 @@ export default async function ExplorePage() {
 							トレンドツイート
 						</h2>
 
-						{page.results.length === 0 ? (
-							<p className="px-2 text-sm text-muted-foreground">
-								今は表示できるツイートがありません。
-							</p>
-						) : (
-							<ul className="space-y-3">
-								{page.results.map((tweet) => (
-									<li key={tweet.id}>
-										<article className="rounded-lg border border-border bg-card p-4 shadow-sm">
-											<header className="mb-2 flex items-baseline gap-2 text-sm">
-												<span className="font-semibold text-foreground">
-													{tweet.author_display_name ?? tweet.author_handle}
-												</span>
-												<Link
-													href={`/u/${tweet.author_handle}`}
-													className="text-muted-foreground hover:underline"
-												>
-													@{tweet.author_handle}
-												</Link>
-											</header>
-
-											<Link
-												href={`/tweet/${tweet.id}`}
-												className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-											>
-												<div
-													className="prose prose-sm dark:prose-invert max-w-none"
-													dangerouslySetInnerHTML={{
-														__html: sanitizeTweetHtml(tweet.html),
-													}}
-												/>
-											</Link>
-
-											{tweet.tags.length > 0 && (
-												<ul className="mt-2 flex flex-wrap gap-1.5">
-													{tweet.tags.map((tag) => (
-														<li key={tag}>
-															<Link
-																href={`/tag/${tag}`}
-																className="rounded-full bg-lime-500/10 px-2 py-0.5 text-xs text-lime-700 dark:text-lime-400 hover:bg-lime-500/20"
-															>
-																#{tag}
-															</Link>
-														</li>
-													))}
-												</ul>
-											)}
-										</article>
-									</li>
-								))}
-							</ul>
-						)}
+						{/* #301: explore も TweetCardList で render。
+						    リアクション / RT は未ログインユーザでも表示はされ、click 時
+						    に 401 → 各 button 内の placeholder 挙動 (ReactionBar
+						    / RepostButton 既存実装) でログイン誘導。 */}
+						<TweetCardList
+							tweets={page.results}
+							ariaLabel="トレンドツイート"
+							emptyMessage="今は表示できるツイートがありません。"
+						/>
 					</section>
 				</main>
 

--- a/client/src/app/(template)/tag/[name]/page.tsx
+++ b/client/src/app/(template)/tag/[name]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import TweetCardList from "@/components/timeline/TweetCardList";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
-import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 
 interface TagDetail {
 	name: string;
@@ -108,37 +108,13 @@ export default async function TagPage({ params }: PageProps) {
 				<h2 id="tweets-heading" className="mb-3 text-lg font-semibold">
 					このタグのツイート
 				</h2>
-				{tweets.length === 0 ? (
-					<p className="text-sm text-muted-foreground">
-						まだこのタグのツイートはありません。
-					</p>
-				) : (
-					<ul className="space-y-4">
-						{tweets.map((t) => (
-							<li key={t.id}>
-								<article className="rounded-lg border bg-card p-4 shadow-sm">
-									<a href={`/tweet/${t.id}`} className="block">
-										<div className="mb-2 text-sm font-semibold">
-											@{t.author_handle}
-										</div>
-										<div
-											className="prose prose-sm dark:prose-invert max-w-none"
-											dangerouslySetInnerHTML={{
-												__html: sanitizeTweetHtml(t.html),
-											}}
-										/>
-										<time
-											dateTime={t.created_at}
-											className="mt-2 block text-xs text-muted-foreground"
-										>
-											{new Date(t.created_at).toLocaleString("ja-JP")}
-										</time>
-									</a>
-								</article>
-							</li>
-						))}
-					</ul>
-				)}
+				{/* #301: 旧 inline link 列挙を TweetCardList に置換。リアクション
+				    / RT / 「もっと見る」展開が動作する。 */}
+				<TweetCardList
+					tweets={tweets}
+					ariaLabel={`${tag.display_name} タグのツイート`}
+					emptyMessage="まだこのタグのツイートはありません。"
+				/>
 			</section>
 		</main>
 	);

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import TweetCardList from "@/components/timeline/TweetCardList";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 import { stringifyJsonLd } from "@/lib/json-ld";
-import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 
 interface PageProps {
 	params: { id: string };
@@ -118,80 +118,12 @@ export default async function TweetDetailPage({ params }: PageProps) {
 				// `</script>` が含まれうるため stringifyJsonLd で </ をエスケープする。
 				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
 			/>
-			<article className="rounded-lg border bg-card p-6 shadow-sm">
-				<header className="mb-4 flex items-center gap-3">
-					{tweet.author_avatar_url && (
-						// eslint-disable-next-line @next/next/no-img-element
-						<img
-							src={tweet.author_avatar_url}
-							alt=""
-							width={48}
-							height={48}
-							className="size-12 rounded-full"
-						/>
-					)}
-					<div>
-						<div className="font-semibold">
-							{tweet.author_display_name ?? tweet.author_handle}
-						</div>
-						<a
-							href={`/u/${tweet.author_handle}`}
-							className="text-sm text-muted-foreground hover:underline"
-						>
-							@{tweet.author_handle}
-						</a>
-					</div>
-				</header>
-
-				<div
-					className="prose prose-sm dark:prose-invert max-w-none"
-					// Backend (markdown2 + bleach) sanitizes on write, but client-side
-					// sanitize is a mandatory second layer (SPEC sec CRITICAL #2).
-					dangerouslySetInnerHTML={{ __html: sanitizeTweetHtml(tweet.html) }}
-				/>
-
-				{tweet.images.length > 0 && (
-					<ul className="mt-4 grid grid-cols-2 gap-2">
-						{tweet.images.map((img) => (
-							<li key={img.image_url}>
-								{/* eslint-disable-next-line @next/next/no-img-element */}
-								<img
-									src={img.image_url}
-									alt=""
-									loading="lazy"
-									width={img.width}
-									height={img.height}
-									className="w-full rounded-md"
-								/>
-							</li>
-						))}
-					</ul>
-				)}
-
-				{tweet.tags.length > 0 && (
-					<ul className="mt-4 flex flex-wrap gap-2 text-sm">
-						{tweet.tags.map((tag) => (
-							<li key={tag}>
-								<a
-									href={`/tag/${tag}`}
-									className="rounded-full bg-muted px-2 py-0.5 hover:bg-accent"
-								>
-									#{tag}
-								</a>
-							</li>
-						))}
-					</ul>
-				)}
-
-				<footer className="mt-6 text-xs text-muted-foreground">
-					<time dateTime={tweet.created_at}>
-						{new Date(tweet.created_at).toLocaleString("ja-JP")}
-					</time>
-					{tweet.edit_count > 0 && (
-						<span className="ml-2">(編集済み × {tweet.edit_count})</span>
-					)}
-				</footer>
-			</article>
+			{/* #301: 旧 inline render を TweetCardList (1 件) に置換。
+			    リアクション (P2-14) / RT・引用・返信 (P2-15) / 「もっと見る」展開
+			    (P2-18) が動作する。Tombstone は前段で別 component に分岐済。
+			    edit_count バッジは TweetCard 内に未実装なので、本 PR では
+			    一旦削除 (#301 の scope は配線、edit_count 表示は別 issue)。 */}
+			<TweetCardList tweets={[tweet]} ariaLabel="ツイート詳細" />
 		</main>
 	);
 }

--- a/client/src/components/timeline/TweetCardList.tsx
+++ b/client/src/components/timeline/TweetCardList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * TweetCardList (#298).
+ * TweetCardList (#298 / #301).
  *
  * Server Component から受け取った tweet 配列を Client な TweetCard で render する
  * 薄いラッパ。/u/[handle] / /tweet/[id] / /tag/[name] / /explore など、


### PR DESCRIPTION
/tweet/[id] / /tag/[name] / /explore の inline render を TweetCardList に置換 → リアクション / RT / 引用 / 返信 / 展開が動作。TweetCardList component は #298 (PR #307) と同じ内容を含む。Closes #301