### PR TITLE
fix(test): pytest 同一 session 内 cross-test DB state leak を解消 (Closes #302)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -40,6 +40,94 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 # -----------------------------------------------------------------------------
+# orphan connection cleaner (Issue #302)
+# -----------------------------------------------------------------------------
+# 背景:
+#   `@pytest.mark.django_db(transaction=True)` を使うテストは、teardown で
+#   `flush` を呼んで TRUNCATE + post_migrate を発行する。前回 pytest run が
+#   abort (Ctrl-C / OOM / -x) すると、postgres 側に "idle in transaction" の
+#   死に connection が残り、次回 run の TRUNCATE で **AccessExclusiveLock 取得
+#   待ちのデッドロック** が発生 (`psycopg2.errors.DeadlockDetected`).
+#
+#   このデッドロックで TRUNCATE が失敗すると後続の post_migrate も実行されず、
+#   `auth_permission` / `django_content_type` が不整合 (UniqueViolation /
+#   ForeignKeyViolation) のまま残り、以降のテストが ERROR になる
+#   (Issue #302 の三症状: pagination count 13, csrf IntegrityError, reaction
+#   ERROR はすべて同じ root cause の派生).
+#
+# 対策:
+#   セッション開始時に `django_db_setup` よりも前で、test DB に居る前回 run の
+#   死に connection を `pg_terminate_backend` で全部叩き落とす。本セッションが
+#   実際に開く connection は対象外 (まだ存在しないので)。
+#
+#   psycopg2 を直接 import して短命 connection で実行する。Django の
+#   connections は `django_db_setup` 後でないと安全に使えない。
+@pytest.fixture(scope="session", autouse=True)
+def _terminate_orphan_test_db_connections() -> Iterator[None]:
+    """`test_<DB>` への前 run 由来の死に connection を session 開始時に終了させる.
+
+    autouse + session scope で **全 pytest run で必ず先頭に走る**.
+    pytest-django の `django_db_setup` よりも前に走らせたいので、
+    pytest が collection 直後に session fixture を解決する性質を利用する.
+    """
+    try:
+        import psycopg2  # type: ignore[import-not-found]
+    except ImportError:  # pragma: no cover - psycopg2 未導入環境では skip
+        yield
+        return
+
+    # 接続パラメータは pytest-django と同じ env を見る (run-tests-local.sh と CI の双方で同じ).
+    # pytest-django は `test_<NAME>` を test DB として使う既定。
+    db_name = os.environ.get("POSTGRES_DB", "")
+    test_db_name = f"test_{db_name}" if db_name else None
+    if not test_db_name:
+        yield
+        return
+
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    user = os.environ.get("POSTGRES_USER", "postgres")
+    password = os.environ.get("POSTGRES_PASSWORD", "")
+
+    # 管理用 DB (postgres) に接続して `pg_terminate_backend` を打つ。
+    # test DB 自体に接続すると自分の connection も対象になりかねないため別 DB から。
+    try:
+        admin_conn = psycopg2.connect(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            dbname="postgres",
+            connect_timeout=3,
+        )
+    except psycopg2.Error:  # pragma: no cover - DB 不到達なら skip (CI とは関係ない別環境)
+        yield
+        return
+
+    try:
+        admin_conn.autocommit = True
+        with admin_conn.cursor() as cur:
+            # `idle` / `idle in transaction` のみが対象。`active` (= 他の pytest が
+            # テスト実行中) は kill しない。state_change が古い (= 60 秒以上前)
+            # の `idle in transaction` を「死に connection」と見なす。
+            # 自身の bookend connection (admin_conn) は datname='postgres' なので
+            # `datname=test_<DB>` の filter で自動的に除外される。
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) "
+                "FROM pg_stat_activity "
+                "WHERE datname = %s "
+                "  AND pid <> pg_backend_pid() "
+                "  AND state IN ('idle', 'idle in transaction', 'idle in transaction (aborted)') "
+                "  AND state_change < now() - interval '60 seconds'",
+                (test_db_name,),
+            )
+    finally:
+        admin_conn.close()
+
+    yield
+
+
+# -----------------------------------------------------------------------------
 # 共通 API fixtures
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Issue #302 で報告された pytest cross-test leak の root cause を特定し、
最小修正で対処した。

- **Root cause**: 前回 pytest run の abort で `test_app_db` に残った
  `idle in transaction` 死に connection が、次回 run の `TRUNCATE` と
  deadlock (`psycopg2.errors.DeadlockDetected`) を起こし、
  `_post_teardown` の flush が rollback。`auth_permission` /
  `django_content_type` の不整合が以降のテストへ leak していた。
- **修正範囲**: ルート `conftest.py` に session-scope autouse fixture を 1 件
  追加 (88 行)。session 開始時に `pg_terminate_backend` で
  60 秒以上古い idle connection だけを掃除する。
- **active / 短命 idle (= 並走 pytest) は対象外**。別 PR #303 / #304 を巻き
  込まない。

## Root Cause 詳細

`@pytest.mark.django_db(transaction=True)` を使うテストは多数あり (reactions /
follows / dm / tweets/repost 等)、teardown で `flush` 経由の `TRUNCATE` +
`post_migrate` を発行する。

前回 pytest run が `Ctrl-C` / `-x` 早期停止 / OOM で abort すると postgres 側
に `idle in transaction` 状態の接続が残る。これが次回 run の `TRUNCATE
"users_user", "django_content_type", ...` の `AccessExclusiveLock` 取得を
妨害し、deadlock。Django の `transaction.atomic()` で flush 全体が rollback
される結果、

| 派生症状                                                            | 元の Issue 記述                                  |
|---------------------------------------------------------------------|--------------------------------------------------|
| `auth_permission_..._uniq` UniqueViolation @ teardown               | reaction `test_get_aggregate_..._zero` ERROR    |
| `Key (content_type_id)=N is not present in django_content_type`     | csrf `test_rejects_non_get_methods` IntegrityError |
| 前回 Tweet 行が残留 → `count == 11` が 13 を返す                    | tweets `test_pagination_default_page_size` FAIL  |

の 3 症状すべてが同じ root cause から生じていた。

## 修正検証

### 修正前 (主問題発生)

```bash
$ pytest apps/reactions/tests/test_reaction_api.py --reuse-db
8 passed, 2 errors  # teardown で IntegrityError
```

### 修正後

```bash
$ pytest apps/reactions/tests/test_reaction_api.py --reuse-db
8 passed
$ pytest "apps/tweets/.../TestListTweets::test_pagination_default_page_size" \
         "apps/common/.../test_rejects_non_get_methods" \
         "apps/reactions/.../test_get_aggregate_includes_all_kinds_zero" --create-db
3 passed
```

## Test plan

- [x] Issue #302 の 3 症状 (pagination / csrf / reaction aggregate) が修正後
      `--create-db` / `--reuse-db` 両方で pass
- [x] `apps/reactions/tests/test_reaction_api.py` 全 8 件 sequential pass
- [ ] CI 緑 (本 PR のみ・並走 PR の影響を排除した状態で確認)
- [ ] 修正前後で個別実行 (`pytest <id>`) の挙動は不変 (回帰なし)

## 補足: 並走 pytest との関係

別 PR #303 / #304 が同じ devcontainer 内で `pytest apps/` を並走させていると、
`test_app_db` を共有するため deadlock は依然として発生し得る。これは pytest-django
の test DB 分離の問題で **本 fix の対象外**。`active` 状態の他 pytest 接続は
明示的に kill しない設計にしてある。

## 関連

- Closes #302
- Follow-up to #280 (pre-push `--create-db` 強制) — そちらは workaround、本 PR が root cause 修正