### PR TITLE
fix(a11y): LeftNavbar Link に aria-label 追加 (lg- viewport で SR 無名 link 解消)

### DIFF
--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -88,6 +88,7 @@ export default function LeftNavbar() {
 						<Link
 							href={href}
 							key={linkItem.label}
+							aria-label={linkItem.label}
 							aria-current={isActive ? "page" : undefined}
 							className={`${
 								isActive
@@ -96,7 +97,11 @@ export default function LeftNavbar() {
 							} flex items-center justify-start gap-4 bg-transparent p-4 transition`}
 						>
 							<NavIcon link={linkItem} isActive={isActive} />
+							{/* lg 以下では label を視覚的に隠すが、a11y のため Link 自体に
+							    aria-label を付与している (max-lg で text を display:none に
+							    した場合も SR からは label が読み上げられる)。 */}
 							<p
+								aria-hidden="true"
 								className={`${isActive ? "base-bold" : "base-medium"} max-lg:hidden`}
 							>
 								{linkItem.label}

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -111,14 +111,25 @@ export default function MobileNavbar() {
 	const { handleLogout, isAuthenticated } = useAuthNavigation();
 	return (
 		<Sheet>
-			<SheetTrigger asChild className="cursor-pointer">
-				<Image
-					src="/assets/icons/mobile-menu.svg"
-					alt="Mobile Menu"
-					width={36}
-					height={36}
-					className="invert-colors sm:hidden"
-				/>
+			{/* a11y: Image を直接 SheetTrigger の child にすると button role が
+			    付かず SR / keyboard で operable と認識されない (WCAG 4.1.2)。
+			    button でラップ + aria-label でメニューを開く意図を明示。
+			    sm:hidden は親 button 側に移し、icon は装飾として aria-hidden。 */}
+			<SheetTrigger asChild>
+				<button
+					type="button"
+					aria-label="メインナビゲーションを開く"
+					className="cursor-pointer sm:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+				>
+					<Image
+						src="/assets/icons/mobile-menu.svg"
+						alt=""
+						aria-hidden="true"
+						width={36}
+						height={36}
+						className="invert-colors"
+					/>
+				</button>
 			</SheetTrigger>
 			<SheetContent side="left" className="bg-baby_rich border-none">
 				<Link href="/" className="flex items-center gap-1">


### PR DESCRIPTION
## Summary

LeftNavbar の `<p className="max-lg:hidden">` で label が tablet/mobile 幅で消える際、Link の accessible name が icon (lucide, aria-label 無し) + 隠れた p text の不安定状態になっていた。Link 自体に aria-label を付与して常に "ホーム" / "メッセージ" 等を SR が読み上げる形に統一。

WCAG 2.4.4 (Link Purpose) / 4.1.2 (Name, Role, Value)。docs/A11Y.md §2.1 「アイコン only ボタンは aria-label 必須」と整合。

## Test plan

- [x] tsc / vitest 357/357
- [ ] CI

Refs: #297