### PR TITLE
fix(timeline): home TL に self tweet を含める + post 時 cache invalidate (Closes #311)

### DIFF
--- a/apps/timeline/services.py
+++ b/apps/timeline/services.py
@@ -111,16 +111,21 @@ def _dedup_repost_originals(tweets: Iterable[Tweet]) -> list[Tweet]:
 
 
 def _query_following(user, blocked_ids: set[int], limit: int) -> list[Tweet]:
-    """フォロー候補 (70%): 24h 以内のフォロイーのツイート (original / repost / reply / quote)."""
+    """フォロー候補 (70%): 24h 以内のフォロイー OR 自分のツイート.
+
+    #311: 旧実装は `.exclude(author=user)` で self を除外していたが、
+    X / Twitter の慣習に合わせて home TL に self tweet を含める。新規ユーザー
+    (フォロー 0 人) も投稿後すぐに自 TL で確認できる UX を保証する。
+    """
     cutoff = timezone.now() - timedelta(hours=24)
     qs = (
         Tweet.objects.select_related("author", "repost_of")
         .filter(
-            author__follower_set__follower=user,  # フォロイーのツイート
+            # フォロイーのツイート OR 自分のツイート
+            Q(author__follower_set__follower=user) | Q(author=user),
             created_at__gte=cutoff,
         )
         .exclude(author_id__in=blocked_ids)
-        .exclude(author=user)  # 自分のツイートは TL に出さない
         .order_by("-created_at")[:limit]
     )
     return list(qs)

--- a/apps/timeline/tests/test_services.py
+++ b/apps/timeline/tests/test_services.py
@@ -55,7 +55,12 @@ def test_dedup_repost_originals_collapses_to_one_logical_id() -> None:
 
 
 @pytest.mark.django_db(transaction=True)
-def test_build_home_tl_returns_following_tweets() -> None:
+def test_build_home_tl_returns_following_and_self_tweets() -> None:
+    """#311: home TL は フォロイー + **自分** のツイートを含む。
+
+    旧仕様 (`.exclude(author=user)`) では新規ユーザーが投稿しても自 TL に
+    何も出ず UX が壊れていた。X / Twitter 慣習に合わせて self を含める。
+    """
     actor = make_user()
     target = make_user()
     make_follow(actor, target)
@@ -63,15 +68,25 @@ def test_build_home_tl_returns_following_tweets() -> None:
     # フォロイーがツイート
     t1 = make_tweet(author=target, body="hello1")
     t2 = make_tweet(author=target, body="hello2")
-    # 自分のツイートは TL に出ない
-    make_tweet(author=actor, body="my own tweet")
+    # 自分のツイートも TL に出る
+    own = make_tweet(author=actor, body="my own tweet")
 
     result = build_home_tl(actor, limit=20)
     pks = {t.pk for t in result}
     assert t1.pk in pks
     assert t2.pk in pks
-    # 自分のツイートが出ないこと
-    assert all(t.author_id != actor.pk for t in result)
+    assert own.pk in pks  # #311: self tweet が含まれる
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_home_tl_works_for_user_with_no_follows() -> None:
+    """#311: フォロー 0 人の新規ユーザーが投稿した直後に self tweet が見える。"""
+    actor = make_user()
+    own = make_tweet(author=actor, body="first tweet")
+
+    result = build_home_tl(actor, limit=20)
+    pks = {t.pk for t in result}
+    assert own.pk in pks
 
 
 @pytest.mark.django_db(transaction=True)

--- a/apps/tweets/signals.py
+++ b/apps/tweets/signals.py
@@ -77,6 +77,14 @@ def on_tweet_created(sender: type[Tweet], instance: Tweet, created: bool, **kwar
 
                 fetch_ogp_for_tweet.delay(tweet_pk)
 
+        # #311: 投稿者の home TL cache を invalidate。これがないと cache TTL
+        # (10 min) 経過まで自分の新規投稿が home に出ない。フォロワーの cache
+        # invalidate は fan-out コストが大きいので Phase 4 で fan-out-on-write
+        # を検討する際にまとめて対応 (本 PR では author 自身のみ)。
+        from apps.timeline.services import invalidate_home_tl
+
+        invalidate_home_tl(actor)
+
     transaction.on_commit(_bump)
 
 

--- a/client/e2e/phase2-extended.spec.ts
+++ b/client/e2e/phase2-extended.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Phase 2 拡張 E2E (#311 + #294 + 各種 UI 導線).
+ *
+ * 既存 phase2.spec.ts は alice/bob hard-code + 日本語 hard-code selector で
+ * stg 環境では動かなかった。本 spec は env-driven で stg / local 双方で動く。
+ *
+ * カバーする観点:
+ *   1. ホーム composer で投稿 → リロード後も自分の投稿が visible (#311)
+ *   2. LeftNav から /search /explore /messages /u/<self> へ click 遷移
+ *   3. ログアウト → /login redirect
+ *   4. /u/[handle] で TweetCard が render され リアクション button が見える (#298)
+ *   5. /u/[handle] header に Follow + メッセージ button が両方 render される (#296 + #299)
+ *
+ * 実行 (stg):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=test2@gmail.com PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+ *     PLAYWRIGHT_USER1_HANDLE=test2 \
+ *   PLAYWRIGHT_USER2_EMAIL=test3@gmail.com PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
+ *     PLAYWRIGHT_USER2_HANDLE=test3 \
+ *   npx playwright test e2e/phase2-extended.spec.ts
+ */
+
+import { expect, test } from "@playwright/test";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "alice@example.com",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "supersecret12", // pragma: allowlist secret
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "alice",
+};
+
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "bob@example.com",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "supersecret12", // pragma: allowlist secret
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "bob",
+};
+
+async function login(
+	page: import("@playwright/test").Page,
+	email: string,
+	password: string,
+) {
+	await page.goto("/login");
+	// 日英 fallback (#294)
+	await page.getByLabel(/Email Address|メール/i).fill(email);
+	await page.getByPlaceholder(/Password|パスワード/i).fill(password);
+	await page.getByRole("button", { name: /Sign In|ログイン/i }).click();
+	await page.waitForURL(/\/onboarding|\/$/);
+}
+
+test.describe("Phase 2 拡張 — post-reload / LeftNav / profile 導線", () => {
+	test("ホームで投稿 → リロード → 自分の tweet が依然 visible (#311)", async ({
+		page,
+	}) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto("/");
+
+		const composer = page.getByRole("textbox", { name: "ツイート本文" });
+		await expect(composer).toBeVisible({ timeout: 15_000 });
+
+		const marker = `tl-self-${Date.now()}`;
+		await composer.fill(marker);
+		await page.getByRole("button", { name: "投稿", exact: true }).click();
+
+		// 投稿直後に visible
+		await expect(page.getByText(marker)).toBeVisible({ timeout: 10_000 });
+
+		// リロード後も依然 visible (#311 home TL に self が含まれる)
+		await page.reload();
+		await expect(page.getByText(marker)).toBeVisible({ timeout: 15_000 });
+	});
+
+	test("LeftNav から /search /explore /messages /u/<self> に遷移できる (#297)", async ({
+		page,
+	}) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto("/");
+
+		// nav は aria-label で scope する (sidebar の他リンクと衝突回避)
+		const nav = page.getByRole("navigation", { name: "メインナビゲーション" });
+		await expect(nav).toBeVisible({ timeout: 10_000 });
+
+		// 検索
+		await nav.getByRole("link", { name: "検索" }).click();
+		await page.waitForURL(/\/search/);
+		await expect(page).toHaveURL(/\/search/);
+
+		// 探索
+		await nav.getByRole("link", { name: "探索" }).click();
+		await page.waitForURL(/\/explore/);
+		await expect(page).toHaveURL(/\/explore/);
+
+		// メッセージ
+		await nav.getByRole("link", { name: "メッセージ" }).click();
+		await page.waitForURL(/\/messages/);
+		await expect(page).toHaveURL(/\/messages/);
+
+		// プロフィール (/u/<self.handle>)
+		await nav.getByRole("link", { name: "プロフィール" }).click();
+		await page.waitForURL(new RegExp(`/u/${USER1.handle}`));
+		await expect(page).toHaveURL(new RegExp(`/u/${USER1.handle}`));
+
+		// ホーム
+		await nav.getByRole("link", { name: "ホーム" }).click();
+		await page.waitForURL(/\/$|\/(\?|#|$)/);
+	});
+
+	test("/u/[handle] (他人) に Follow + メッセージ button が両方表示 (#296 + #299)", async ({
+		page,
+	}) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto(`/u/${USER2.handle}`);
+
+		// header の右端に 2 button が並ぶ想定
+		const followBtn = page.getByRole("button", {
+			name: new RegExp(
+				`@${USER2.handle} をフォロー|@${USER2.handle} のフォローを解除`,
+			),
+		});
+		const dmBtn = page.getByRole("button", {
+			name: `@${USER2.handle} にメッセージを送る`,
+		});
+		await expect(followBtn).toBeVisible({ timeout: 10_000 });
+		await expect(dmBtn).toBeVisible();
+	});
+
+	test("/u/[handle] (他人) で TweetCard リアクション button が render される (#298)", async ({
+		page,
+	}) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto(`/u/${USER2.handle}`);
+
+		// 投稿が無い場合もあるので、tweet 列が render されている時のみ assert する
+		const feed = page.getByRole("feed", {
+			name: new RegExp(`@${USER2.handle} のツイート`),
+		});
+		const feedExists = await feed
+			.isVisible({ timeout: 5_000 })
+			.catch(() => false);
+		if (!feedExists) {
+			test.info().annotations.push({
+				type: "skip-reason",
+				description: `${USER2.handle} に tweet が無いので TweetCard 表示確認 skip`,
+			});
+			return;
+		}
+
+		// リアクション or RT button のいずれかが少なくとも 1 つあれば配線 OK
+		const interactionButton = feed
+			.getByRole("button", {
+				name: /リアクション|いいね|RT|repost|引用|reply|返信/i,
+			})
+			.first();
+		await expect(interactionButton).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("ログアウト → /login にリダイレクト", async ({ page }) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto("/");
+
+		// LeftNavbar の Log Out button (sm 以上で sidebar 内に表示)
+		const logout = page
+			.getByRole("button", { name: /Log Out|Logout|ログアウト/i })
+			.first();
+		await expect(logout).toBeVisible({ timeout: 10_000 });
+		await logout.click();
+		await page.waitForURL(/\/login/);
+		await expect(page).toHaveURL(/\/login/);
+	});
+});


### PR DESCRIPTION
ホーム投稿後リロードで消える UX バグを修正。`_query_following` の self 除外撤廃、tweet post で cache invalidate、E2E spec 5 観点追加。Closes #311