### PR TITLE
fix(cache): Django CACHES に Redis backend を設定 (multi-worker 共有) (Refs #311)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 531
+        "line_number": 558
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-03T09:35:50Z"
+  "generated_at": "2026-05-03T15:20:30Z"
 }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -322,6 +322,33 @@ if _redis_url_clean.startswith("rediss://"):
     # 小文字 "required" で渡すこと (大文字 "CERT_REQUIRED" や int constant は invalid)。
     _channels_host["ssl_cert_reqs"] = "required"
 
+# #311: Django cache backend (P2-08 home TL cache 等の保存先).
+# 旧設定は CACHES 未定義 = default LocMemCache だったため、gunicorn workers
+# 間で cache が共有されず、worker A の `cache.delete(...)` が worker B に
+# 伝播しなかった (post → 別 worker での GET が stale を返す原因)。
+# REDIS_URL (Channels / Celery と同じ instance) を流用する。DB 分離より
+# KEY_PREFIX で衝突回避する方がシンプル (django-cache: "sns:cache:*" /
+# celery: "celery-task-meta-*" / channels: "asgi::*")。
+_cache_options: dict[str, object] = {
+    "CLIENT_CLASS": "django_redis.client.DefaultClient",
+    "IGNORE_EXCEPTIONS": True,
+}
+if _redis_url_clean.startswith("rediss://"):
+    _cache_options["CONNECTION_POOL_KWARGS"] = {"ssl_cert_reqs": "required"}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": _redis_url_clean,
+        "OPTIONS": _cache_options,
+        "KEY_PREFIX": "sns:cache",
+        "TIMEOUT": 300,
+    }
+}
+# cache backend エラーで request が落ちないように (silent log のみ)。
+DJANGO_REDIS_IGNORE_EXCEPTIONS = True
+DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
+
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ django-celery-email==3.0.0
 cloudinary==1.39.1
 django-celery-beat==2.6.0
 redis==5.0.3
+django-redis==5.4.0
 celery==5.4.0
 flower==2.0.1
 djangorestframework-simplejwt==5.3.0


### PR DESCRIPTION
CACHES 未設定 → LocMemCache (per-process) で worker 間 cache 不整合 → #311 の真因。django-redis backend に変更。Refs #311