### PR TITLE
fix(timeline): home TL global query を 2 段 fallback で reaction=0 も補充 (Closes #317)

### DIFF
--- a/apps/timeline/services.py
+++ b/apps/timeline/services.py
@@ -132,18 +132,41 @@ def _query_following(user, blocked_ids: set[int], limit: int) -> list[Tweet]:
 
 
 def _query_global(blocked_ids: set[int], exclude_author_id: int | None, limit: int) -> list[Tweet]:
-    """全体候補 (30%): 24h 以内の reaction 数上位 (original / quote のみ、repost は重複防止のため除外)."""
+    """全体候補 (30%): 24h 以内の original / quote (repost は重複防止のため除外).
+
+    #317: 旧実装は ``reaction_count > 0`` only だったため、サービス開始期
+    (誰もリアクションしていない) や少人数 stg では global 候補が空になり、
+    フォロー 0 人ユーザーの home TL が完全に空になっていた。
+
+    本実装は 2 段 fallback:
+      1) reaction_count > 0 を高優先 (旧挙動)、(reaction_count, created_at) で sort
+      2) limit に満たない場合のみ reaction_count == 0 から最新順で補充
+    reaction が活発になれば自然に primary が limit を埋め、旧挙動に収束する。
+    """
     cutoff = timezone.now() - timedelta(hours=24)
-    qs = Tweet.objects.select_related("author").filter(
+    base_qs = Tweet.objects.select_related("author").filter(
         created_at__gte=cutoff,
         type__in=[TweetType.ORIGINAL, TweetType.QUOTE],
-        reaction_count__gt=0,
     )
     if blocked_ids:
-        qs = qs.exclude(author_id__in=blocked_ids)
+        base_qs = base_qs.exclude(author_id__in=blocked_ids)
     if exclude_author_id is not None:
-        qs = qs.exclude(author_id=exclude_author_id)
-    return list(qs.order_by("-reaction_count", "-created_at")[:limit])
+        base_qs = base_qs.exclude(author_id=exclude_author_id)
+
+    # 1st: reaction>0 を優先取得
+    primary = list(
+        base_qs.filter(reaction_count__gt=0).order_by("-reaction_count", "-created_at")[:limit]
+    )
+    if len(primary) >= limit:
+        return primary
+
+    # 2nd: 不足分を reaction=0 から最新順で補充 (重複除外)
+    needed = limit - len(primary)
+    seen = {t.pk for t in primary}
+    fallback = list(
+        base_qs.filter(reaction_count=0).exclude(pk__in=seen).order_by("-created_at")[:needed]
+    )
+    return primary + fallback
 
 
 def _interleave_70_30(following: list[Tweet], global_: list[Tweet]) -> list[Tweet]:

--- a/apps/timeline/tests/test_services.py
+++ b/apps/timeline/tests/test_services.py
@@ -90,6 +90,43 @@ def test_build_home_tl_works_for_user_with_no_follows() -> None:
 
 
 @pytest.mark.django_db(transaction=True)
+def test_build_home_tl_includes_others_recent_tweets_when_no_reactions() -> None:
+    """#317: フォロー 0 人 + reaction 全て 0 件 でも他人の最新ツイートが
+    home TL に出る (global query の fallback)。"""
+    actor = make_user()
+    other = make_user()
+    # actor は other を follow していない & 誰もリアクションしていない
+    others_tweet = make_tweet(author=other, body="hello from other")
+
+    result = build_home_tl(actor, limit=20)
+    pks = {t.pk for t in result}
+    assert others_tweet.pk in pks
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_home_tl_prefers_reaction_count_over_recent_in_global() -> None:
+    """#317: reaction>0 ツイートが limit を埋められる時は旧挙動 (reaction 優先)
+    に収束する。reaction=0 fallback は不足分のみ。"""
+    actor = make_user()
+    a = make_user()
+    b = make_user()
+    # actor は誰もフォローしていない
+    popular = make_tweet(author=a, body="popular")
+    Tweet.objects.filter(pk=popular.pk).update(reaction_count=5)
+    no_reaction = make_tweet(author=b, body="recent but no reaction")
+
+    # limit=1 で primary (popular) のみが返ってくることを確認
+    result = build_home_tl(actor, limit=1)
+    pks = {t.pk for t in result}
+    assert popular.pk in pks
+    # limit=20 (余裕あり) で fallback も含む
+    result_all = build_home_tl(actor, limit=20)
+    pks_all = {t.pk for t in result_all}
+    assert popular.pk in pks_all
+    assert no_reaction.pk in pks_all
+
+
+@pytest.mark.django_db(transaction=True)
 def test_build_explore_tl_returns_only_with_reactions() -> None:
     """explore は reaction_count > 0 のツイートのみ."""
     a = make_user()


### PR DESCRIPTION
新規環境で他人ツイートが home TL に出ない UX バグを修正。reaction>0 を高優先で埋め、不足分を reaction=0 から最新順で補充。Closes #317