### PR TITLE
[fix][tweets] quote/repost/reply の即時反映 (Closes #337)

### DIFF
--- a/client/e2e/realtime-tweet-actions.spec.ts
+++ b/client/e2e/realtime-tweet-actions.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * #337: リプライ / 引用 / リポストの即時反映 E2E.
+ *
+ * 検証観点:
+ *   1. home の TweetCard で「リポスト」 click → 即時 TL 上部に新 REPOST tweet
+ *      が prepend されること (リロード不要)
+ *   2. home の TweetCard で「引用」 → PostDialog 投稿 → 即時 TL 上部に新 quote
+ *      tweet が prepend されること
+ *   3. /tweet/<focal> で「リプライ」 → PostDialog 投稿 → 即時 replies 一覧に
+ *      append されること
+ *
+ * 実行 (stg):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=test2@gmail.com PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+ *   npx playwright test e2e/realtime-tweet-actions.spec.ts
+ */
+
+import { expect, test } from "@playwright/test";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "alice@example.com",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "supersecret12", // pragma: allowlist secret
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "alice",
+};
+
+async function login(
+	page: import("@playwright/test").Page,
+	email: string,
+	password: string,
+) {
+	await page.goto("/login");
+	await page.getByLabel(/Email Address|メール/i).fill(email);
+	await page.getByPlaceholder(/Password|パスワード/i).fill(password);
+	const submit = page.getByRole("button", { name: "Sign In", exact: true });
+	if (await submit.isVisible().catch(() => false)) {
+		await submit.click();
+	} else {
+		await page.getByRole("button", { name: "ログイン", exact: true }).click();
+	}
+	await page.waitForURL(/\/onboarding|\/$/);
+}
+
+test.describe("#337 即時反映 — quote / repost / reply", () => {
+	test("home で 引用 → 即時 TL 上部に新 quote tweet が prepend される", async ({
+		page,
+	}) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto("/");
+
+		// TL の最初の引用 button を持つ article (= 通常 article、repost article 除外)
+		const article = page
+			.locator("article")
+			.filter({ has: page.getByRole("button", { name: /^引用/ }) })
+			.first();
+		await expect(article).toBeVisible({ timeout: 15_000 });
+
+		// 投稿前の article 数
+		const beforeCount = await page.locator("article").count();
+
+		await article.getByRole("button", { name: /^引用/ }).click();
+		const textarea = page.getByRole("textbox", { name: "引用リポストの本文" });
+		await expect(textarea).toBeVisible({ timeout: 5_000 });
+
+		const marker = `[#337 quote ${Date.now()}]`;
+		await textarea.fill(marker);
+
+		const quoteResp = page.waitForResponse(
+			(res) =>
+				res.url().includes("/api/v1/tweets/") &&
+				res.url().includes("/quote/") &&
+				res.request().method() === "POST",
+		);
+		await page.getByRole("button", { name: "引用する", exact: true }).click();
+		const res = await quoteResp;
+		expect(res.status()).toBe(201);
+
+		// reload せずに、新 quote tweet が TL 内に出ていること
+		await expect(page.getByText(marker, { exact: false })).toBeVisible({
+			timeout: 5_000,
+		});
+
+		// article 数も増えている (= prepend)
+		await expect
+			.poll(async () => await page.locator("article").count(), {
+				timeout: 5_000,
+			})
+			.toBeGreaterThan(beforeCount);
+	});
+
+	test("home で リポスト → 即時 TL 上部に REPOST tweet が prepend される", async ({
+		page,
+	}) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto("/");
+
+		// reposted=false のリポスト button を持つ article を探す
+		const article = page
+			.locator("article")
+			.filter({ has: page.getByRole("button", { name: "リポスト" }) })
+			.first();
+		await expect(article).toBeVisible({ timeout: 15_000 });
+		const beforeCount = await page.locator("article").count();
+
+		const repostBtn = article.getByRole("button", { name: "リポスト" });
+		const repostResp = page.waitForResponse(
+			(res) =>
+				res.url().includes("/api/v1/tweets/") &&
+				res.url().includes("/repost/") &&
+				res.request().method() === "POST",
+		);
+		await repostBtn.click();
+		const res = await repostResp;
+		expect([200, 201]).toContain(res.status());
+
+		// 新 REPOST tweet が prepend されているか (= article 数増加 + RepostBanner
+		// 出現)。テキスト「がリポストしました」を含む article の存在で確認。
+		await expect
+			.poll(async () => await page.locator("article").count(), {
+				timeout: 8_000,
+			})
+			.toBeGreaterThan(beforeCount);
+		await expect(page.getByText(/がリポストしました/).first()).toBeVisible({
+			timeout: 5_000,
+		});
+	});
+
+	test("/tweet/<focal> で リプライ → 即時 replies 一覧に append される", async ({
+		page,
+	}) => {
+		await login(page, USER1.email, USER1.password);
+		await page.goto("/");
+
+		// home で reply button を持つ article を click → /tweet/<id> へ。
+		const article = page
+			.locator("article")
+			.filter({ has: page.getByRole("button", { name: /^リプライ/ }) })
+			.first();
+		await expect(article).toBeVisible({ timeout: 15_000 });
+
+		// focal id を URL から取りたいので、article 中の /tweet/<id> link を探す。
+		// QuoteEmbed は `/tweet/<id>` link を持つので、reply count badge にも tweet
+		// id が必要。ここでは body の link は無いため、href を持つ link で focal
+		// id を直接 evaluate で割り出す。代わりに reply button click 後の dialog
+		// 経由で focal id を確認する方が手堅い: API URL に含まれる。
+		await article.getByRole("button", { name: /^リプライ/ }).click();
+
+		// リプライ Dialog が出るので、その投稿先 focal id を URL 経由ではなく
+		// API request URL から拾う。
+		const replyTextarea = page.getByRole("textbox", {
+			name: "リプライの本文",
+		});
+		await expect(replyTextarea).toBeVisible({ timeout: 5_000 });
+		const marker = `[#337 reply ${Date.now()}]`;
+		await replyTextarea.fill(marker);
+		const replyResp = page.waitForResponse(
+			(res) =>
+				res.url().includes("/api/v1/tweets/") &&
+				res.url().includes("/reply/") &&
+				res.request().method() === "POST",
+		);
+		await page.getByRole("button", { name: "返信する", exact: true }).click();
+		const res = await replyResp;
+		expect(res.status()).toBe(201);
+
+		// API URL から focal id を取得 → /tweet/<focalId> に遷移して append 確認。
+		const url = res.url();
+		const m = url.match(/\/tweets\/(\d+)\/reply\//);
+		expect(m, "reply API URL に focal id が含まれる").not.toBeNull();
+		const focalId = m![1];
+
+		// home の close 後、別ユーザーの新 reply がリロードなしで focal page で
+		// 出るかは別 test。ここでは「自分が直接 /tweet/<focal> を開いた状態で
+		// reply を投稿 → 即時下部に append」を main scenario とする。
+		await page.goto(`/tweet/${focalId}`);
+		await expect(page.getByRole("heading", { level: 2 })).toBeVisible({
+			timeout: 5_000,
+		});
+
+		// /tweet/<focal> 上で再度 reply を投稿 → リロードなしで append 確認
+		const focalReplyBtn = page
+			.locator("article")
+			.filter({ has: page.getByRole("button", { name: /^リプライ/ }) })
+			.first()
+			.getByRole("button", { name: /^リプライ/ });
+		await focalReplyBtn.click();
+		const ta2 = page.getByRole("textbox", { name: "リプライの本文" });
+		await expect(ta2).toBeVisible({ timeout: 5_000 });
+		const marker2 = `[#337 thread ${Date.now()}]`;
+		await ta2.fill(marker2);
+		const replyResp2 = page.waitForResponse(
+			(res) =>
+				res.url().includes("/api/v1/tweets/") &&
+				res.url().includes("/reply/") &&
+				res.request().method() === "POST",
+		);
+		await page.getByRole("button", { name: "返信する", exact: true }).click();
+		const res2 = await replyResp2;
+		expect(res2.status()).toBe(201);
+
+		// reload なしで marker2 が表示される (replies に append)
+		await expect(page.getByText(marker2, { exact: false })).toBeVisible({
+			timeout: 5_000,
+		});
+	});
+});

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import ConversationReplies from "@/components/timeline/ConversationReplies";
 import TweetCardList from "@/components/timeline/TweetCardList";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
@@ -176,25 +177,9 @@ export default async function TweetDetailPage({ params }: PageProps) {
 				</section>
 			) : null}
 
-			<section
-				aria-label="このツイート"
-				className="border-l-2 border-baby_blue pl-2 my-1"
-			>
-				<TweetCardList tweets={[tweet]} ariaLabel="ツイート詳細" />
-			</section>
-
-			{replies.length > 0 ? (
-				<section aria-label="リプライ" className="mt-2">
-					<h2 className="px-4 py-2 text-sm font-semibold text-muted-foreground">
-						リプライ ({replies.length})
-					</h2>
-					<TweetCardList tweets={replies} ariaLabel="リプライ一覧" />
-				</section>
-			) : (
-				<p className="px-4 py-6 text-sm text-muted-foreground">
-					まだリプライはありません。
-				</p>
-			)}
+			{/* #337: focal + replies を client component に切り出して、reply 投稿時
+			    に即時 append できるようにする (リロード不要)。 */}
+			<ConversationReplies focal={tweet} initialReplies={replies} />
 		</main>
 	);
 }

--- a/client/src/components/timeline/ConversationReplies.tsx
+++ b/client/src/components/timeline/ConversationReplies.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * ConversationReplies — /tweet/[id] の focal + replies を render する client wrapper.
+ *
+ * #337: focal で reply 投稿後にリロードしないと表示されない問題を解消する。
+ * server component (page.tsx) は initial fetch だけを行い、その結果を初期値
+ * として渡す。focal の reply 投稿は onDescendantPosted 経由で bubble up
+ * するので、ここで `replies` state に append する。
+ *
+ * focal 自体の TweetCard は border-l 強調を付けて表示する (Twitter conversation
+ * view 慣習)。
+ */
+
+import { useCallback, useState } from "react";
+
+import TweetCardList from "@/components/timeline/TweetCardList";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+interface ConversationRepliesProps {
+	focal: TweetSummary;
+	initialReplies: TweetSummary[];
+}
+
+function dedupById(tweets: TweetSummary[]): TweetSummary[] {
+	const seen = new Set<number>();
+	return tweets.filter((t) => {
+		if (seen.has(t.id)) return false;
+		seen.add(t.id);
+		return true;
+	});
+}
+
+export default function ConversationReplies({
+	focal,
+	initialReplies,
+}: ConversationRepliesProps) {
+	const [replies, setReplies] = useState<TweetSummary[]>(
+		dedupById(initialReplies),
+	);
+	const [liveMessage, setLiveMessage] = useState("");
+
+	// focal の reply 投稿時に呼ばれる。reply 以外 (quote / repost) は home TL の
+	// 話なのでここでは扱わず、focal が /tweet/<focal_id> page から離れるとして
+	// 無視する (新 quote tweet を append しても conversation view では文脈が
+	// ずれる)。Twitter も同じ挙動で、quote は home に出る。
+	const handleDescendantPosted = useCallback(
+		(tweet: TweetSummary) => {
+			if (tweet.type !== "reply") return;
+			// focal の直下 reply のみ追加 (chain が深い reply は append しない)。
+			// reply_to は TweetMini (id を含む) で来る。
+			if (tweet.reply_to?.id !== focal.id) return;
+			setReplies((prev) => dedupById([...prev, tweet]));
+			setLiveMessage("リプライを投稿しました");
+		},
+		[focal.id],
+	);
+
+	return (
+		<>
+			<div role="status" aria-live="polite" className="sr-only">
+				{liveMessage}
+			</div>
+
+			<section
+				aria-label="このツイート"
+				className="border-l-2 border-baby_blue pl-2 my-1"
+			>
+				<TweetCardList
+					tweets={[focal]}
+					ariaLabel="ツイート詳細"
+					onDescendantPosted={handleDescendantPosted}
+				/>
+			</section>
+
+			{replies.length > 0 ? (
+				<section aria-label="リプライ" className="mt-2">
+					<h2 className="px-4 py-2 text-sm font-semibold text-muted-foreground">
+						リプライ ({replies.length})
+					</h2>
+					<TweetCardList
+						tweets={replies}
+						ariaLabel="リプライ一覧"
+						onDescendantPosted={handleDescendantPosted}
+					/>
+				</section>
+			) : (
+				<p className="px-4 py-6 text-sm text-muted-foreground">
+					まだリプライはありません。
+				</p>
+			)}
+		</>
+	);
+}

--- a/client/src/components/timeline/HomeFeed.tsx
+++ b/client/src/components/timeline/HomeFeed.tsx
@@ -103,6 +103,22 @@ export default function HomeFeed({ initialTab, initialTweets }: HomeFeedProps) {
 		setLiveMessage("新しいツイートを投稿しました");
 	}, []);
 
+	// #337: TweetCard 配下 (PostDialog reply/quote, RepostButton) で投稿された
+	// tweet を TL 上部に prepend する。reply は home TL に出さない (#334) ので
+	// type が REPLY のときは何もしない (count badge の楽観 +1 は TweetCard 内で
+	// 完結しているので、ここで何もしなくても親の見た目は更新済み)。
+	const handleDescendantPosted = useCallback((tweet: TweetSummary) => {
+		if (tweet.type === "reply") return;
+		setTweets((prev) => dedupById([tweet, ...prev]));
+		setLiveMessage(
+			tweet.type === "repost"
+				? "リポストしました"
+				: tweet.type === "quote"
+					? "引用リポストしました"
+					: "新しいツイートを投稿しました",
+		);
+	}, []);
+
 	return (
 		<div className="flex flex-col gap-0">
 			{/* SR-only live region for optimistic prepend announcement */}
@@ -134,6 +150,7 @@ export default function HomeFeed({ initialTab, initialTweets }: HomeFeedProps) {
 								tweet={tweet}
 								posinset={idx + 1}
 								setsize={tweets.length}
+								onDescendantPosted={handleDescendantPosted}
 							/>
 						))}
 					</div>

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -24,6 +24,12 @@ interface TweetCardProps {
 	posinset?: number;
 	/** Total feed size; pair with ``posinset`` to satisfy WAI-ARIA feed pattern. */
 	setsize?: number;
+	/**
+	 * #337: 子 dialog (PostDialog reply / quote) と RepostButton で新規 tweet が
+	 * 投稿された際、上位 (HomeFeed / ConversationReplies) に bubble up する。
+	 * 上位は受け取った tweet.type を見て prepend / append を判断する。
+	 */
+	onDescendantPosted?: (tweet: TweetSummary) => void;
 }
 
 /** #327: 削除済み tweet の tombstone 表示 (article 単位)。 */
@@ -118,6 +124,7 @@ export default function TweetCard({
 	tweet,
 	posinset,
 	setsize,
+	onDescendantPosted,
 }: TweetCardProps) {
 	const [replyOpen, setReplyOpen] = useState(false);
 	const [quoteOpen, setQuoteOpen] = useState(false);
@@ -398,7 +405,7 @@ export default function TweetCard({
 				</button>
 
 				<div className="flex items-center gap-1">
-					<RepostButton tweetId={tweet.id} />
+					<RepostButton tweetId={tweet.id} onPosted={onDescendantPosted} />
 					{tweet.repost_count ? (
 						<span
 							className="text-xs text-muted-foreground"
@@ -436,7 +443,10 @@ export default function TweetCard({
 				mode="reply"
 				open={replyOpen}
 				onOpenChange={setReplyOpen}
-				onPosted={() => setReplyCountOptimistic((n) => n + 1)}
+				onPosted={(posted) => {
+					setReplyCountOptimistic((n) => n + 1);
+					onDescendantPosted?.(posted);
+				}}
 				parentTweet={{
 					id: tweet.id,
 					author_handle: tweet.author_handle,
@@ -452,7 +462,10 @@ export default function TweetCard({
 				mode="quote"
 				open={quoteOpen}
 				onOpenChange={setQuoteOpen}
-				onPosted={() => setQuoteCountOptimistic((n) => n + 1)}
+				onPosted={(posted) => {
+					setQuoteCountOptimistic((n) => n + 1);
+					onDescendantPosted?.(posted);
+				}}
 				parentTweet={{
 					id: tweet.id,
 					author_handle: tweet.author_handle,

--- a/client/src/components/timeline/TweetCardList.tsx
+++ b/client/src/components/timeline/TweetCardList.tsx
@@ -27,12 +27,17 @@ interface TweetCardListProps {
 	 * 空配列のときに表示する文言。default は "ツイートがありません。"。
 	 */
 	emptyMessage?: string;
+	/**
+	 * #337: TweetCard 内で reply / quote / repost が投稿された際に bubble up.
+	 */
+	onDescendantPosted?: (tweet: TweetSummary) => void;
 }
 
 export default function TweetCardList({
 	tweets,
 	ariaLabel,
 	emptyMessage = "ツイートがありません。",
+	onDescendantPosted,
 }: TweetCardListProps) {
 	if (tweets.length === 0) {
 		return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
@@ -50,6 +55,7 @@ export default function TweetCardList({
 					tweet={tweet}
 					posinset={index + 1}
 					setsize={tweets.length}
+					onDescendantPosted={onDescendantPosted}
 				/>
 			))}
 		</section>

--- a/client/src/components/timeline/__tests__/ConversationReplies.test.tsx
+++ b/client/src/components/timeline/__tests__/ConversationReplies.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Tests for ConversationReplies (#337).
+ *
+ * 検証観点:
+ *   - initial replies が render される
+ *   - focal の reply 投稿 → replies に append (リロード不要)
+ *   - quote / repost / 他 tweet 由来の reply は無視
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import ConversationReplies from "@/components/timeline/ConversationReplies";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+// TweetCardList は内部で TweetCard を呼ぶが、ここでは onDescendantPosted の
+// fan-out を直接 trigger できるよう mock する。
+vi.mock("@/components/timeline/TweetCardList", () => ({
+	default: ({
+		tweets,
+		ariaLabel,
+		onDescendantPosted,
+	}: {
+		tweets: TweetSummary[];
+		ariaLabel: string;
+		onDescendantPosted?: (tweet: TweetSummary) => void;
+	}) => (
+		<div data-testid={`list-${ariaLabel}`}>
+			{tweets.map((t) => (
+				<div key={t.id} data-testid={`item-${t.id}`}>
+					{t.body}
+				</div>
+			))}
+			{onDescendantPosted ? (
+				<>
+					<button
+						type="button"
+						onClick={() =>
+							onDescendantPosted({
+								id: 9001,
+								body: "new reply to focal",
+								html: "<p>new reply to focal</p>",
+								char_count: 18,
+								author_handle: "bob",
+								tags: [],
+								images: [],
+								created_at: "2024-02-01T10:00:00Z",
+								updated_at: "2024-02-01T10:00:00Z",
+								edit_count: 0,
+								type: "reply",
+								reply_to: { id: 1, author_handle: "alice", body: "focal" },
+							} as unknown as TweetSummary)
+						}
+					>
+						emit:reply-to-focal:{ariaLabel}
+					</button>
+					<button
+						type="button"
+						onClick={() =>
+							onDescendantPosted({
+								id: 9002,
+								body: "quote of focal",
+								html: "<p>quote</p>",
+								char_count: 5,
+								author_handle: "bob",
+								tags: [],
+								images: [],
+								created_at: "2024-02-01T10:00:00Z",
+								updated_at: "2024-02-01T10:00:00Z",
+								edit_count: 0,
+								type: "quote",
+							} as unknown as TweetSummary)
+						}
+					>
+						emit:quote:{ariaLabel}
+					</button>
+					<button
+						type="button"
+						onClick={() =>
+							onDescendantPosted({
+								id: 9003,
+								body: "reply to other",
+								html: "<p>r</p>",
+								char_count: 3,
+								author_handle: "bob",
+								tags: [],
+								images: [],
+								created_at: "2024-02-01T10:00:00Z",
+								updated_at: "2024-02-01T10:00:00Z",
+								edit_count: 0,
+								type: "reply",
+								reply_to: { id: 999, author_handle: "x", body: "other" },
+							} as unknown as TweetSummary)
+						}
+					>
+						emit:reply-to-other:{ariaLabel}
+					</button>
+				</>
+			) : null}
+		</div>
+	),
+}));
+
+const focal = {
+	id: 1,
+	body: "focal body",
+	html: "<p>focal body</p>",
+	char_count: 10,
+	author_handle: "alice",
+	tags: [],
+	images: [],
+	created_at: "2024-01-01T00:00:00Z",
+	updated_at: "2024-01-01T00:00:00Z",
+	edit_count: 0,
+} as unknown as TweetSummary;
+
+const initialReplies = [
+	{
+		id: 100,
+		body: "first reply",
+		html: "<p>first reply</p>",
+		char_count: 11,
+		author_handle: "carol",
+		tags: [],
+		images: [],
+		created_at: "2024-01-02T00:00:00Z",
+		updated_at: "2024-01-02T00:00:00Z",
+		edit_count: 0,
+	},
+] as unknown as TweetSummary[];
+
+describe("ConversationReplies (#337)", () => {
+	it("renders focal + initial replies", () => {
+		render(
+			<ConversationReplies focal={focal} initialReplies={initialReplies} />,
+		);
+		expect(screen.getByTestId("item-1")).toHaveTextContent("focal body");
+		expect(screen.getByTestId("item-100")).toHaveTextContent("first reply");
+	});
+
+	it("appends new reply to focal without reload", async () => {
+		const user = userEvent.setup();
+		render(
+			<ConversationReplies focal={focal} initialReplies={initialReplies} />,
+		);
+		// focal panel ariaLabel = "ツイート詳細"
+		await user.click(
+			screen.getByRole("button", { name: "emit:reply-to-focal:ツイート詳細" }),
+		);
+		expect(screen.getByTestId("item-9001")).toHaveTextContent(
+			"new reply to focal",
+		);
+	});
+
+	it("ignores quote-type descendants (home TL の話なので conversation には足さない)", async () => {
+		const user = userEvent.setup();
+		render(
+			<ConversationReplies focal={focal} initialReplies={initialReplies} />,
+		);
+		await user.click(
+			screen.getByRole("button", { name: "emit:quote:ツイート詳細" }),
+		);
+		expect(screen.queryByTestId("item-9002")).not.toBeInTheDocument();
+	});
+
+	it("ignores reply whose reply_to ≠ focal (other thread)", async () => {
+		const user = userEvent.setup();
+		render(
+			<ConversationReplies focal={focal} initialReplies={initialReplies} />,
+		);
+		await user.click(
+			screen.getByRole("button", { name: "emit:reply-to-other:ツイート詳細" }),
+		);
+		expect(screen.queryByTestId("item-9003")).not.toBeInTheDocument();
+	});
+
+	it("renders empty placeholder when no replies", () => {
+		render(<ConversationReplies focal={focal} initialReplies={[]} />);
+		expect(screen.getByText("まだリプライはありません。")).toBeInTheDocument();
+	});
+});

--- a/client/src/components/tweets/RepostButton.tsx
+++ b/client/src/components/tweets/RepostButton.tsx
@@ -44,13 +44,18 @@ export default function RepostButton({
 				await unrepostTweet(tweetId);
 			} else {
 				const result = await repostTweet(tweetId);
+				// repost 自体は成功。後続の fetchTweet が失敗しても reposted state は
+				// rollback しない (DB 上は created 済み)。ただし TL の即時反映は
+				// 行えないので、ユーザーには「TL 反映に失敗、リロードで確認」を
+				// toast で伝える。silent fail は禁止。
 				if (onPosted) {
 					try {
 						const full = await fetchTweet(result.id);
 						onPosted(full);
 					} catch {
-						// fetch 失敗しても repost 自体は成功。silent fail で次回 reload 時に
-						// 表示される (UX のみ退化、データ整合性は維持)。
+						toast.warn(
+							"リポストは完了しましたが、画面更新に失敗しました。リロードしてください。",
+						);
 					}
 				}
 			}

--- a/client/src/components/tweets/RepostButton.tsx
+++ b/client/src/components/tweets/RepostButton.tsx
@@ -13,15 +13,22 @@ import { useState } from "react";
 import { toast } from "react-toastify";
 
 import { repostTweet, unrepostTweet } from "@/lib/api/repost";
+import { fetchTweet, type TweetSummary } from "@/lib/api/tweets";
 
 interface RepostButtonProps {
 	tweetId: number;
 	initialReposted?: boolean;
+	/**
+	 * #337: repost 成功時に新規 REPOST tweet (TweetSummary) を返す。
+	 * 上位 (HomeFeed 等) で TL に prepend して即時反映するために使う。
+	 */
+	onPosted?: (tweet: TweetSummary) => void;
 }
 
 export default function RepostButton({
 	tweetId,
 	initialReposted = false,
+	onPosted,
 }: RepostButtonProps) {
 	const [reposted, setReposted] = useState(initialReposted);
 	const [busy, setBusy] = useState(false);
@@ -36,7 +43,16 @@ export default function RepostButton({
 			if (previous) {
 				await unrepostTweet(tweetId);
 			} else {
-				await repostTweet(tweetId);
+				const result = await repostTweet(tweetId);
+				if (onPosted) {
+					try {
+						const full = await fetchTweet(result.id);
+						onPosted(full);
+					} catch {
+						// fetch 失敗しても repost 自体は成功。silent fail で次回 reload 時に
+						// 表示される (UX のみ退化、データ整合性は維持)。
+					}
+				}
 			}
 		} catch {
 			setReposted(previous);


### PR DESCRIPTION
## Summary

#334 のフォローアップ。post 後にリロードしないと表示されない問題が以下のケースで残っていたため修正。

- **home で 引用 / リポスト**: TL 上部に新規 quote / REPOST tweet が即時 prepend されない問題を解消
- **/tweet/<focal> で リプライ**: replies 一覧に新 reply が即時 append されない問題を解消

## 修正内容

| ファイル | 変更 |
|---|---|
| `RepostButton.tsx` | `onPosted` prop 追加。POST 後に `/tweets/<id>/` を fetch して TweetSummary を bubble up |
| `TweetCard.tsx` | `onDescendantPosted` prop 追加。PostDialog (reply/quote) と RepostButton の onPosted を統合 |
| `TweetCardList.tsx` | `onDescendantPosted` を passthrough |
| `HomeFeed.tsx` | `handleDescendantPosted` を実装。`tweet.type === 'reply'` のときは無視 (#334 既存)、それ以外は TL に prepend |
| `ConversationReplies.tsx` (新規) | client component。focal + replies を内部 state で管理。focal 直下の reply 投稿時に append |
| `tweet/[id]/page.tsx` | focal/replies 部分を ConversationReplies に切り出し |

## Test plan

- [x] `ConversationReplies.test.tsx` (5 tests) — focal reply append / quote 無視 / 他 thread 無視 / empty placeholder
- [x] `vitest run` 全体 369/369 green
- [x] `tsc --noEmit` 緑
- [x] `npm run lint` 緑 (warning は既存と同レベル)
- [ ] E2E spec `realtime-tweet-actions.spec.ts` (3 シナリオ) を stg で検証 — rate limit (#336) 復旧後

## 関連

- Closes #337
- Builds on #334 (PR #335 で reply 除外 + count optimistic を実装済み)
- #336 で stg user rate limit (500/day) 緩和を別途 issue 化