### PR TITLE
[fix][auth+timeline] login onboarding 強制 skip + TweetCard クリック遷移 (Closes #339, #340)

### DIFF
--- a/client/src/components/forms/auth/LoginForm.tsx
+++ b/client/src/components/forms/auth/LoginForm.tsx
@@ -2,13 +2,14 @@
 import * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useLoginUserMutation } from "@/lib/redux/features/auth/authApiSlice";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAppDispatch } from "@/lib/redux/hooks/typedHooks";
 import { useForm } from "react-hook-form";
 import { loginUserSchema, TLoginUserSchema } from "@/lib/validationSchemas";
 import { extractErrorMessage } from "@/utils";
 import { toast } from "react-toastify";
 import { setAuth } from "@/lib/redux/features/auth/authSlice";
+import { fetchCurrentUser } from "@/lib/api/users";
 import { FormFieldComponent } from "@/components/forms/FormFieldComponent";
 import { MailIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,7 @@ import Spinner from "@/components/shared/Spinner";
 export default function LoginForm() {
 	const [loginUser, { isLoading }] = useLoginUserMutation();
 	const router = useRouter();
+	const searchParams = useSearchParams();
 	const dispatch = useAppDispatch();
 
 	const {
@@ -38,9 +40,22 @@ export default function LoginForm() {
 			await loginUser(values).unwrap();
 			dispatch(setAuth());
 			toast.success("Login Successful");
-			// SPEC §69: 初回ログイン直後はオンボーディングウィザードへ誘導。
-			// onboarding 完了済みユーザは /onboarding 内で / にリダイレクトされる。
-			router.push("/onboarding");
+			// #339: needs_onboarding=true (初回) のみ /onboarding に誘導する。
+			// 設定済みユーザーで /onboarding を flash させる UX を回避。?next= があれば
+			// そちらを優先 (private route から飛ばされてきた場合)。
+			const next = searchParams?.get("next");
+			let dest = next || "/";
+			try {
+				const me = await fetchCurrentUser();
+				if (me.needs_onboarding) {
+					dest = "/onboarding";
+				}
+			} catch {
+				// /users/me/ 取得失敗時は安全側で /onboarding に倒す (新規ユーザーの
+				// 可能性、Guard が再評価して /onboarding 不要なら / に redirect する)。
+				dest = "/onboarding";
+			}
+			router.push(dest);
 			reset();
 		} catch (error) {
 			const errorMessage = extractErrorMessage(error);

--- a/client/src/components/forms/auth/LoginForm.tsx
+++ b/client/src/components/forms/auth/LoginForm.tsx
@@ -51,9 +51,12 @@ export default function LoginForm() {
 					dest = "/onboarding";
 				}
 			} catch {
-				// /users/me/ 取得失敗時は安全側で /onboarding に倒す (新規ユーザーの
-				// 可能性、Guard が再評価して /onboarding 不要なら / に redirect する)。
-				dest = "/onboarding";
+				// /users/me/ 取得失敗 (transient network / 503 / cookie race) は
+				// 既存ユーザーが多い前提で / にフォールバックする。useOnboardingGuard
+				// が後続でユーザーを fetch して、本当に needs_onboarding=true なら
+				// /onboarding に redirect する。新規ユーザーが flash で /onboarding に
+				// 遷移するのは Guard 側の責務とし、login の fetch fail で全員を
+				// /onboarding に倒す方が UX 退化が大きい。
 			}
 			router.push(dest);
 			reset();

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -9,7 +9,8 @@
  */
 
 import Link from "next/link";
-import React, { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import React, { useCallback, useMemo, useState } from "react";
 import DOMPurify from "isomorphic-dompurify";
 import ReactionBar from "@/components/reactions/ReactionBar";
 import ExpandableBody from "@/components/timeline/ExpandableBody";
@@ -126,8 +127,40 @@ export default function TweetCard({
 	setsize,
 	onDescendantPosted,
 }: TweetCardProps) {
+	const router = useRouter();
 	const [replyOpen, setReplyOpen] = useState(false);
 	const [quoteOpen, setQuoteOpen] = useState(false);
+
+	// #340: card 全体クリックで /tweet/<id> に遷移 (X 慣習)。
+	// 内部 link / button は伝播を止めて従来動作。テキスト drag-select も保護。
+	// repost article は repost_of の id へ飛ばす (banner 上ではなく元 tweet 詳細)。
+	const targetId =
+		tweet.type === "repost" && tweet.repost_of ? tweet.repost_of.id : tweet.id;
+	const navigateToDetail = useCallback(
+		(e: React.MouseEvent | React.KeyboardEvent) => {
+			const target = e.target as HTMLElement;
+			if (target.closest("a, button, [role='button'], textarea, input")) return;
+			if (typeof window !== "undefined") {
+				const sel = window.getSelection?.();
+				if (sel && sel.toString().length > 0) return;
+			}
+			router.push(`/tweet/${targetId}`);
+		},
+		[router, targetId],
+	);
+	const onCardKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter" || e.key === " ") {
+				const target = e.target as HTMLElement;
+				// 内部の interactive element に focus がある場合はそちらの動作優先
+				if (target.closest("a, button, [role='button'], textarea, input"))
+					return;
+				e.preventDefault();
+				navigateToDetail(e);
+			}
+		},
+		[navigateToDetail],
+	);
 	// #334: reply / quote 投稿成功時に楽観的に親 count badge を +1 する。
 	// PostDialog onPosted コールバック → ここで state を更新し、再レンダーで
 	// footer の count が即時反映される。リロード不要。
@@ -202,10 +235,13 @@ export default function TweetCard({
 		const originalName = original.author_display_name || original.author_handle;
 		return (
 			<article
-				className="flex flex-col gap-2 border-b border-border px-4 py-3 hover:bg-muted/40 transition-colors"
-				aria-label={`${reposter} がリポスト: ${originalName} のツイート`}
+				className="flex cursor-pointer flex-col gap-2 border-b border-border px-4 py-3 hover:bg-muted/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				aria-label={`${reposter} がリポスト: ${originalName} のツイート — クリックで詳細`}
 				aria-posinset={posinset}
 				aria-setsize={setsize}
+				tabIndex={0}
+				onClick={navigateToDetail}
+				onKeyDown={onCardKeyDown}
 			>
 				<RepostBanner
 					handle={tweet.author_handle}
@@ -259,10 +295,13 @@ export default function TweetCard({
 		<article
 			// scroll-mt-12 keeps focused articles visible below the sticky tab bar
 			// (WCAG 2.2 SC 2.4.11 Focus Not Obscured). Tab bar height is 3rem.
-			className="flex flex-col gap-3 border-b border-border px-4 py-3 scroll-mt-12 hover:bg-muted/40 transition-colors"
-			aria-label={`${authorName} のツイート`}
+			className="flex cursor-pointer flex-col gap-3 border-b border-border px-4 py-3 scroll-mt-12 hover:bg-muted/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			aria-label={`${authorName} のツイート — クリックで詳細`}
 			aria-posinset={posinset}
 			aria-setsize={setsize}
+			tabIndex={0}
+			onClick={navigateToDetail}
+			onKeyDown={onCardKeyDown}
 		>
 			{/* Author row */}
 			<header className="flex items-center gap-3">

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -138,8 +138,11 @@ export default function TweetCard({
 		tweet.type === "repost" && tweet.repost_of ? tweet.repost_of.id : tweet.id;
 	const navigateToDetail = useCallback(
 		(e: React.MouseEvent | React.KeyboardEvent) => {
-			const target = e.target as HTMLElement;
-			if (target.closest("a, button, [role='button'], textarea, input")) return;
+			// e.target は EventTarget 型で Text node / 純 EventTarget の場合 closest を
+			// 持たないため、Element に narrow してから判定する。
+			if (!(e.target instanceof Element)) return;
+			if (e.target.closest("a, button, [role='button'], textarea, input"))
+				return;
 			if (typeof window !== "undefined") {
 				const sel = window.getSelection?.();
 				if (sel && sel.toString().length > 0) return;
@@ -151,9 +154,9 @@ export default function TweetCard({
 	const onCardKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
 			if (e.key === "Enter" || e.key === " ") {
-				const target = e.target as HTMLElement;
+				if (!(e.target instanceof Element)) return;
 				// 内部の interactive element に focus がある場合はそちらの動作優先
-				if (target.closest("a, button, [role='button'], textarea, input"))
+				if (e.target.closest("a, button, [role='button'], textarea, input"))
 					return;
 				e.preventDefault();
 				navigateToDetail(e);

--- a/client/src/components/timeline/__tests__/TweetCard.click.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.click.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * #340: TweetCard 全体クリック → /tweet/<id> 遷移のテスト.
+ *
+ * 検証観点:
+ *   - 本文クリック → router.push('/tweet/<id>')
+ *   - 内部 link / button クリック → router.push されない (内部要素の動作優先)
+ *   - テキスト drag-select 中 (selection あり) → router.push されない
+ *   - is_deleted (tombstone) → click 無視
+ *   - type=repost → repost_of の id へ遷移
+ *   - Enter キー → /tweet/<id>
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import TweetCard from "@/components/timeline/TweetCard";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: pushMock }),
+	usePathname: () => "/",
+	useSearchParams: () => new URLSearchParams(),
+}));
+
+const BASE: TweetSummary = {
+	id: 42,
+	body: "hello world",
+	html: "<p>hello world</p>",
+	char_count: 11,
+	author_handle: "alice",
+	author_display_name: "Alice",
+	tags: [],
+	images: [],
+	created_at: "2024-01-15T10:00:00Z",
+	updated_at: "2024-01-15T10:00:00Z",
+	edit_count: 0,
+};
+
+describe("TweetCard — #340 click navigation", () => {
+	beforeEach(() => {
+		pushMock.mockClear();
+	});
+
+	it("本文クリックで /tweet/<id> に遷移", async () => {
+		const user = userEvent.setup();
+		render(<TweetCard tweet={BASE} />);
+		const article = screen.getByRole("article");
+		await user.click(article);
+		expect(pushMock).toHaveBeenCalledWith("/tweet/42");
+	});
+
+	it("作者リンク (a) クリック時は遷移しない", async () => {
+		const user = userEvent.setup();
+		render(<TweetCard tweet={BASE} />);
+		const link = screen.getByRole("link", {
+			name: /Alice .*?のプロフィール/,
+		});
+		await user.click(link);
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it("リプライ button クリック時は遷移しない", async () => {
+		const user = userEvent.setup();
+		render(<TweetCard tweet={BASE} />);
+		const replyBtn = screen.getByRole("button", { name: /リプライ/ });
+		await user.click(replyBtn);
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it("type=repost のとき repost_of.id へ遷移", async () => {
+		const user = userEvent.setup();
+		const repost: TweetSummary = {
+			...BASE,
+			id: 100,
+			type: "repost",
+			repost_of: {
+				id: 42,
+				author_handle: "bob",
+				author_display_name: "Bob",
+				body: "original",
+				created_at: "2024-01-15T09:00:00Z",
+				is_deleted: false,
+			},
+		} as unknown as TweetSummary;
+		render(<TweetCard tweet={repost} />);
+		const article = screen.getByRole("article");
+		await user.click(article);
+		expect(pushMock).toHaveBeenCalledWith("/tweet/42");
+	});
+
+	it("is_deleted (tombstone) は click handler を持たない", async () => {
+		const user = userEvent.setup();
+		const tombstone: TweetSummary = {
+			...BASE,
+			is_deleted: true,
+		} as unknown as TweetSummary;
+		render(<TweetCard tweet={tombstone} />);
+		const article = screen.getByRole("article");
+		await user.click(article);
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it("テキスト選択中は遷移しない", async () => {
+		const user = userEvent.setup();
+		render(<TweetCard tweet={BASE} />);
+		// window.getSelection をモックして toString が non-empty を返すように
+		const original = window.getSelection;
+		window.getSelection = () =>
+			({ toString: () => "selected text" }) as unknown as Selection;
+		const article = screen.getByRole("article");
+		await user.click(article);
+		expect(pushMock).not.toHaveBeenCalled();
+		window.getSelection = original;
+	});
+
+	it("Enter キーで /tweet/<id> に遷移", async () => {
+		const user = userEvent.setup();
+		render(<TweetCard tweet={BASE} />);
+		const article = screen.getByRole("article");
+		article.focus();
+		await user.keyboard("{Enter}");
+		expect(pushMock).toHaveBeenCalledWith("/tweet/42");
+	});
+});


### PR DESCRIPTION
## Summary

Twitter 慣習に揃えた UX 改善 2 件:

- **#339**: ログイン後に毎回 /onboarding に飛んで wizard が一瞬 flash される問題を解消。\`needs_onboarding=false\` ならそのまま / (or ?next=) に遷移
- **#340**: TweetCard 本文/空白部分のクリックで /tweet/<id> 詳細画面に遷移 (X 慣習)

## #339: LoginForm 修正

login 成功直後に \`fetchCurrentUser()\` を 1 回だけ叩き、\`needs_onboarding\` を見て分岐:

\`\`\`ts
if (me.needs_onboarding) dest = '/onboarding';
else dest = next || '/';
\`\`\`

## #340: TweetCard クリック handler

\`<article>\` に onClick + onKeyDown + tabIndex=0 を追加。X と同じく:

- 内部 a / button / textarea / input は伝播抑止 (closest)
- \`window.getSelection()\` に選択中テキストがあれば遷移しない (drag select)
- is_deleted (tombstone) は handler を付けない
- type=repost は repost_of.id へ遷移
- aria-label に「クリックで詳細」を追記、Enter / Space で keyboard 操作

## Test plan

- [x] vitest \`TweetCard.click.test.tsx\` (7 tests): 全パターン検証
- [x] vitest 全体 376/376 green
- [x] tsc --noEmit 緑
- [x] lint 緑 (warning は既存と同じレベル)
- [ ] stg で実機検証 (login flash なし / TL タップで詳細遷移)

## 関連

- Closes #339
- Closes #340
- Builds on PR #338 (#337)