### PR TITLE
[fix][tweets] RepostButton を DropdownMenu 化 + 独立「引用」button 撤去 (Closes #342)

### DIFF
--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -459,13 +459,21 @@ export default function TweetCard({
 						const repostCount = tweet.repost_count ?? 0;
 						const total = repostCount + quoteCountOptimistic;
 						if (total === 0) return null;
+						// a11y CRITICAL-2 (#343 review): aria-label と visible text の
+						// double-announcement を防ぐため、visible 数字は aria-hidden、
+						// SR 用の文言は sr-only span で別出しにする。
 						return (
-							<span
-								className="text-xs text-muted-foreground font-semibold"
-								aria-label={`リポスト ${repostCount} 件 (引用 ${quoteCountOptimistic} 件含む)`}
-							>
-								{total}
-							</span>
+							<>
+								<span
+									aria-hidden="true"
+									className="text-xs text-muted-foreground font-semibold"
+								>
+									{total}
+								</span>
+								<span className="sr-only">
+									リポスト {repostCount} 件 (うち引用 {quoteCountOptimistic} 件)
+								</span>
+							</>
 						);
 					})()}
 				</div>

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -446,36 +446,29 @@ export default function TweetCard({
 					) : null}
 				</button>
 
+				{/* #342: 独立「引用」 button を撤去し、RepostButton の DropdownMenu に
+				    「引用」項目を吸収 (X 準拠)。count は repost / quote 合算で 1 つの
+				    badge として表示する (X TL の慣習)。 */}
 				<div className="flex items-center gap-1">
-					<RepostButton tweetId={tweet.id} onPosted={onDescendantPosted} />
-					{tweet.repost_count ? (
-						<span
-							className="text-xs text-muted-foreground"
-							aria-label={`リポスト ${tweet.repost_count} 件`}
-						>
-							{tweet.repost_count}
-						</span>
-					) : null}
+					<RepostButton
+						tweetId={tweet.id}
+						onPosted={onDescendantPosted}
+						onQuoteRequest={() => setQuoteOpen(true)}
+					/>
+					{(() => {
+						const repostCount = tweet.repost_count ?? 0;
+						const total = repostCount + quoteCountOptimistic;
+						if (total === 0) return null;
+						return (
+							<span
+								className="text-xs text-muted-foreground font-semibold"
+								aria-label={`リポスト ${repostCount} 件 (引用 ${quoteCountOptimistic} 件含む)`}
+							>
+								{total}
+							</span>
+						);
+					})()}
 				</div>
-
-				<button
-					type="button"
-					aria-label={
-						quoteCountOptimistic
-							? `引用 ${quoteCountOptimistic} 件`
-							: "引用リポスト"
-					}
-					onClick={() => setQuoteOpen(true)}
-					className="flex items-center gap-1 min-h-[32px] px-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-				>
-					<span aria-hidden="true">”</span>
-					<span>引用</span>
-					{quoteCountOptimistic ? (
-						<span aria-hidden="true" className="font-semibold">
-							{quoteCountOptimistic}
-						</span>
-					) : null}
-				</button>
 
 				<ReactionBar tweetId={tweet.id} />
 			</footer>

--- a/client/src/components/timeline/__tests__/TweetCard.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.test.tsx
@@ -204,19 +204,18 @@ describe("TweetCard — action buttons (placeholder)", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders the RepostButton (P2-15 wires the action)", () => {
+	it("renders the RepostButton menu trigger (#342)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
-		// "リポスト" exact-match (avoid catching "引用リポスト")
 		expect(
-			screen.getByRole("button", { name: "リポスト" }),
+			screen.getByRole("button", { name: /リポストメニュー/ }),
 		).toBeInTheDocument();
 	});
 
-	it("renders the quote button (P2-15)", () => {
+	it("does NOT render an independent 引用 button (#342: 引用は menu に統合)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
 		expect(
-			screen.getByRole("button", { name: "引用リポスト" }),
-		).toBeInTheDocument();
+			screen.queryByRole("button", { name: "引用リポスト" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders ReactionBar trigger in the footer (P2-14 wires the bar)", () => {
@@ -310,13 +309,12 @@ describe("TweetCard — accessibility (review fixes)", () => {
 		expect(img?.getAttribute("height")).toBe("600");
 	});
 
-	it("all action buttons are interactive after P2-14/P2-15 wiring", () => {
+	it("all action buttons are interactive after #342 menu rewrite", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
 		const reply = screen.getByRole("button", { name: "リプライ" });
-		const repost = screen.getByRole("button", { name: "リポスト" });
-		const quote = screen.getByRole("button", { name: "引用リポスト" });
+		const repost = screen.getByRole("button", { name: /リポストメニュー/ });
 		const reaction = screen.getByRole("button", { name: /リアクション/ });
-		[reply, repost, quote, reaction].forEach((btn) => {
+		[reply, repost, reaction].forEach((btn) => {
 			expect(btn.getAttribute("aria-disabled")).toBeNull();
 		});
 	});
@@ -401,8 +399,11 @@ describe("TweetCard — #327 extensions", () => {
 		render(<TweetCard tweet={tweet} />);
 		const replyBtn = screen.getByRole("button", { name: /リプライ 5 件/ });
 		expect(replyBtn).toHaveTextContent("5");
-		const quoteBtn = screen.getByRole("button", { name: /引用 2 件/ });
-		expect(quoteBtn).toHaveTextContent("2");
+		// #342: 引用は menu に統合され、count は repost_count + quote_count の
+		// 合算 badge で表示される。aria-label は "リポスト 3 件 (引用 2 件含む)"。
+		expect(
+			screen.getByLabelText(/リポスト 3 件 \(引用 2 件含む\)/),
+		).toHaveTextContent("5");
 	});
 
 	it("does not display count when 0", () => {

--- a/client/src/components/timeline/__tests__/TweetCard.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.test.tsx
@@ -207,7 +207,7 @@ describe("TweetCard — action buttons (placeholder)", () => {
 	it("renders the RepostButton menu trigger (#342)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
 		expect(
-			screen.getByRole("button", { name: /リポストメニュー/ }),
+			screen.getByRole("button", { name: /^リポスト(済み)?$/ }),
 		).toBeInTheDocument();
 	});
 
@@ -312,7 +312,7 @@ describe("TweetCard — accessibility (review fixes)", () => {
 	it("all action buttons are interactive after #342 menu rewrite", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
 		const reply = screen.getByRole("button", { name: "リプライ" });
-		const repost = screen.getByRole("button", { name: /リポストメニュー/ });
+		const repost = screen.getByRole("button", { name: /^リポスト(済み)?$/ });
 		const reaction = screen.getByRole("button", { name: /リアクション/ });
 		[reply, repost, reaction].forEach((btn) => {
 			expect(btn.getAttribute("aria-disabled")).toBeNull();
@@ -400,10 +400,12 @@ describe("TweetCard — #327 extensions", () => {
 		const replyBtn = screen.getByRole("button", { name: /リプライ 5 件/ });
 		expect(replyBtn).toHaveTextContent("5");
 		// #342: 引用は menu に統合され、count は repost_count + quote_count の
-		// 合算 badge で表示される。aria-label は "リポスト 3 件 (引用 2 件含む)"。
+		// 合算 (= 5) を視覚表示。SR 用には sr-only span で内訳を読ませる
+		// (#343 a11y review CRITICAL-2: visible text と aria-label の double-
+		// announcement を回避するため visible 数字は aria-hidden、SR 用は別 span)。
 		expect(
-			screen.getByLabelText(/リポスト 3 件 \(引用 2 件含む\)/),
-		).toHaveTextContent("5");
+			screen.getByText("リポスト 3 件 (うち引用 2 件)"),
+		).toBeInTheDocument();
 	});
 
 	it("does not display count when 0", () => {

--- a/client/src/components/tweets/RepostButton.tsx
+++ b/client/src/components/tweets/RepostButton.tsx
@@ -50,6 +50,9 @@ export default function RepostButton({
 }: RepostButtonProps) {
 	const [reposted, setReposted] = useState(initialReposted);
 	const [busy, setBusy] = useState(false);
+	// a11y CRITICAL-2 (PR #343 review): toast は visible UX のみで SR には届きにくい。
+	// state 変化を sr-only な polite live region で announce する。
+	const [statusMsg, setStatusMsg] = useState("");
 
 	const handleRepost = async () => {
 		if (busy) return;
@@ -57,6 +60,7 @@ export default function RepostButton({
 		setReposted(true);
 		try {
 			const result = await repostTweet(tweetId);
+			setStatusMsg("リポストしました");
 			if (onPosted) {
 				try {
 					const full = await fetchTweet(result.id);
@@ -81,6 +85,7 @@ export default function RepostButton({
 		setReposted(false);
 		try {
 			await unrepostTweet(tweetId);
+			setStatusMsg("リポストを取り消しました");
 		} catch {
 			setReposted(true);
 			toast.error("リポストを取り消せませんでした");
@@ -91,11 +96,17 @@ export default function RepostButton({
 
 	return (
 		<DropdownMenu>
+			{/* a11y CRITICAL-2: 状態変化を sr-only polite live region で announce */}
+			<span role="status" aria-live="polite" className="sr-only">
+				{statusMsg}
+			</span>
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
-					aria-label="リポストメニュー"
-					aria-pressed={reposted}
+					// a11y CRITICAL-1: aria-pressed は menu trigger に不適切 (Radix が
+					// 自動付与する aria-haspopup="menu"/aria-expanded と意味衝突)。
+					// 状態は accessible name に直接含める (X 公式日本語版に準拠)。
+					aria-label={reposted ? "リポスト済み" : "リポスト"}
 					disabled={busy}
 					className={`flex items-center gap-1 min-h-[32px] px-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded ${
 						reposted

--- a/client/src/components/tweets/RepostButton.tsx
+++ b/client/src/components/tweets/RepostButton.tsx
@@ -136,7 +136,7 @@ export default function RepostButton({
 					<DropdownMenuItem
 						onSelect={(e) => {
 							e.preventDefault();
-							void handleUnrepost();
+							handleUnrepost();
 						}}
 					>
 						リポストを取り消す
@@ -145,7 +145,7 @@ export default function RepostButton({
 					<DropdownMenuItem
 						onSelect={(e) => {
 							e.preventDefault();
-							void handleRepost();
+							handleRepost();
 						}}
 					>
 						リポスト

--- a/client/src/components/tweets/RepostButton.tsx
+++ b/client/src/components/tweets/RepostButton.tsx
@@ -1,17 +1,29 @@
 "use client";
 
 /**
- * RepostButton — toggle repost on a tweet (P2-15 / Issue #188).
+ * RepostButton — repost / unrepost / quote の menu trigger (Issue #342, X 準拠).
  *
- * Optimistic UX:
- *   - Click while not reposted → immediately mark active, POST /repost/
- *   - Click while reposted → immediately mark inactive, DELETE /repost/
- *   - On API error: rollback + toast
+ * 旧仕様 (#188): 即時 toggle button だったが、Twitter UX に合わせて
+ * Click → DropdownMenu で「リポスト / 引用」を選ばせる形に変更。
+ *
+ * State machine: docs/specs/repost-quote-state-machine.md §3 を参照.
+ *   not_reposted → menu: [リポスト] [引用]
+ *   reposted     → menu: [リポストを取り消す] [引用]
+ *
+ * 引用は本 component では PostDialog を直接 open せず、`onQuoteRequest`
+ * callback で親 (TweetCard) に依頼する。これは parentTweet preview のために
+ * PostDialog 自体は TweetCard で持つ必要があり、ここで重複生成しないため。
  */
 
 import { useState } from "react";
 import { toast } from "react-toastify";
 
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { repostTweet, unrepostTweet } from "@/lib/api/repost";
 import { fetchTweet, type TweetSummary } from "@/lib/api/tweets";
 
@@ -23,78 +35,120 @@ interface RepostButtonProps {
 	 * 上位 (HomeFeed 等) で TL に prepend して即時反映するために使う。
 	 */
 	onPosted?: (tweet: TweetSummary) => void;
+	/**
+	 * #342: menu「引用」 を選択したときに親に通知。親 (TweetCard) は
+	 * PostDialog mode="quote" を open する。
+	 */
+	onQuoteRequest?: () => void;
 }
 
 export default function RepostButton({
 	tweetId,
 	initialReposted = false,
 	onPosted,
+	onQuoteRequest,
 }: RepostButtonProps) {
 	const [reposted, setReposted] = useState(initialReposted);
 	const [busy, setBusy] = useState(false);
 
-	const handleClick = async () => {
+	const handleRepost = async () => {
 		if (busy) return;
-		const previous = reposted;
 		setBusy(true);
-		setReposted(!previous);
-
+		setReposted(true);
 		try {
-			if (previous) {
-				await unrepostTweet(tweetId);
-			} else {
-				const result = await repostTweet(tweetId);
-				// repost 自体は成功。後続の fetchTweet が失敗しても reposted state は
-				// rollback しない (DB 上は created 済み)。ただし TL の即時反映は
-				// 行えないので、ユーザーには「TL 反映に失敗、リロードで確認」を
-				// toast で伝える。silent fail は禁止。
-				if (onPosted) {
-					try {
-						const full = await fetchTweet(result.id);
-						onPosted(full);
-					} catch {
-						toast.warn(
-							"リポストは完了しましたが、画面更新に失敗しました。リロードしてください。",
-						);
-					}
+			const result = await repostTweet(tweetId);
+			if (onPosted) {
+				try {
+					const full = await fetchTweet(result.id);
+					onPosted(full);
+				} catch {
+					toast.warn(
+						"リポストは完了しましたが、画面更新に失敗しました。リロードしてください。",
+					);
 				}
 			}
 		} catch {
-			setReposted(previous);
+			setReposted(false);
 			toast.error("リポストを更新できませんでした");
 		} finally {
 			setBusy(false);
 		}
 	};
 
+	const handleUnrepost = async () => {
+		if (busy) return;
+		setBusy(true);
+		setReposted(false);
+		try {
+			await unrepostTweet(tweetId);
+		} catch {
+			setReposted(true);
+			toast.error("リポストを取り消せませんでした");
+		} finally {
+			setBusy(false);
+		}
+	};
+
 	return (
-		<button
-			type="button"
-			aria-label={reposted ? "リポストを取消" : "リポスト"}
-			aria-pressed={reposted}
-			disabled={busy}
-			onClick={handleClick}
-			className={`flex items-center gap-1 min-h-[32px] px-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded ${
-				reposted
-					? "text-lime-600 dark:text-lime-400"
-					: "text-muted-foreground hover:text-foreground"
-			} disabled:opacity-50`}
-		>
-			<svg
-				className="size-4"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke="currentColor"
-				strokeWidth={1.5}
-				aria-hidden="true"
-			>
-				<path
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 3M21 7.5H7.5"
-				/>
-			</svg>
-			<span>リポスト</span>
-		</button>
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					aria-label="リポストメニュー"
+					aria-pressed={reposted}
+					disabled={busy}
+					className={`flex items-center gap-1 min-h-[32px] px-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded ${
+						reposted
+							? "text-lime-600 dark:text-lime-400"
+							: "text-muted-foreground hover:text-foreground"
+					} disabled:opacity-50`}
+				>
+					<svg
+						className="size-4"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						strokeWidth={1.5}
+						aria-hidden="true"
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 3M21 7.5H7.5"
+						/>
+					</svg>
+					<span>リポスト</span>
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="min-w-[10rem]">
+				{reposted ? (
+					<DropdownMenuItem
+						onSelect={(e) => {
+							e.preventDefault();
+							void handleUnrepost();
+						}}
+					>
+						リポストを取り消す
+					</DropdownMenuItem>
+				) : (
+					<DropdownMenuItem
+						onSelect={(e) => {
+							e.preventDefault();
+							void handleRepost();
+						}}
+					>
+						リポスト
+					</DropdownMenuItem>
+				)}
+				<DropdownMenuItem
+					onSelect={(e) => {
+						e.preventDefault();
+						onQuoteRequest?.();
+					}}
+				>
+					引用
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }

--- a/client/src/components/tweets/__tests__/RepostButton.test.tsx
+++ b/client/src/components/tweets/__tests__/RepostButton.test.tsx
@@ -36,12 +36,21 @@ describe("RepostButton (#342 menu)", () => {
 		vi.clearAllMocks();
 	});
 
-	const triggerName = /リポストメニュー/;
+	const triggerName = /^リポスト(済み)?$/;
 
-	it("renders inactive state by default (aria-pressed=false)", () => {
+	it("renders inactive state by default (aria-label='リポスト')", () => {
 		render(<RepostButton tweetId={1} />);
-		const btn = screen.getByRole("button", { name: triggerName });
-		expect(btn.getAttribute("aria-pressed")).toBe("false");
+		const btn = screen.getByRole("button", { name: "リポスト" });
+		expect(btn).toBeInTheDocument();
+		// a11y: aria-pressed は menu trigger に付与しない (CRITICAL-1, #343)
+		expect(btn.getAttribute("aria-pressed")).toBeNull();
+	});
+
+	it("renders reposted state with aria-label='リポスト済み'", () => {
+		render(<RepostButton tweetId={1} initialReposted />);
+		expect(
+			screen.getByRole("button", { name: "リポスト済み" }),
+		).toBeInTheDocument();
 	});
 
 	it("opens menu with [リポスト, 引用] when not reposted", async () => {
@@ -76,12 +85,12 @@ describe("RepostButton (#342 menu)", () => {
 		await waitFor(() => {
 			expect(repostTweet).toHaveBeenCalledWith(1);
 		});
-		// Radix DropdownMenu は menu open 中 body に scroll-lock + pointer-events:none
-		// を付与し、jsdom 上 trigger button が role=button で取得できなくなる。
-		// aria-pressed の検証は DOM 直接 query で行う (実 brower では問題なし)。
+		// reposted=true 状態では aria-label が「リポスト済み」に切り替わる (DOM 直接
+		// query を使うのは Radix が menu open 中 body を scroll-lock するため)。
 		await waitFor(() => {
-			const trigger = document.querySelector("[aria-label='リポストメニュー']");
-			expect(trigger?.getAttribute("aria-pressed")).toBe("true");
+			expect(
+				document.querySelector("[aria-label='リポスト済み']"),
+			).not.toBeNull();
 		});
 	});
 
@@ -121,9 +130,9 @@ describe("RepostButton (#342 menu)", () => {
 				expect.stringContaining("更新できませんでした"),
 			);
 		});
+		// rollback 後は aria-label が「リポスト」(未) に戻る
 		await waitFor(() => {
-			const trigger = document.querySelector("[aria-label='リポストメニュー']");
-			expect(trigger?.getAttribute("aria-pressed")).toBe("false");
+			expect(document.querySelector("[aria-label='リポスト']")).not.toBeNull();
 		});
 	});
 });

--- a/client/src/components/tweets/__tests__/RepostButton.test.tsx
+++ b/client/src/components/tweets/__tests__/RepostButton.test.tsx
@@ -1,5 +1,11 @@
 /**
- * Tests for RepostButton (P2-15 / Issue #188).
+ * Tests for RepostButton (#342: DropdownMenu trigger 化以降).
+ *
+ * X UX:
+ *   - trigger button click → menu open
+ *   - not_reposted: menu に「リポスト」「引用」
+ *   - reposted    : menu に「リポストを取り消す」「引用」
+ *   - menu「引用」 を選んだら onQuoteRequest が呼ばれる (open は親の責務)
  */
 
 import { render, screen, waitFor } from "@testing-library/react";
@@ -13,69 +19,111 @@ vi.mock("@/lib/api/repost", () => ({
 	unrepostTweet: vi.fn(),
 }));
 
+vi.mock("@/lib/api/tweets", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/tweets")>(
+			"@/lib/api/tweets",
+		);
+	return { ...actual, fetchTweet: vi.fn() };
+});
+
 vi.mock("react-toastify", () => ({
-	toast: { error: vi.fn() },
+	toast: { error: vi.fn(), warn: vi.fn() },
 }));
 
-describe("RepostButton", () => {
+describe("RepostButton (#342 menu)", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("renders inactive state by default", () => {
+	const triggerName = /リポストメニュー/;
+
+	it("renders inactive state by default (aria-pressed=false)", () => {
 		render(<RepostButton tweetId={1} />);
-		const btn = screen.getByRole("button", { name: /リポスト$/ });
+		const btn = screen.getByRole("button", { name: triggerName });
 		expect(btn.getAttribute("aria-pressed")).toBe("false");
 	});
 
-	it("optimistically activates and POSTs on first click", async () => {
+	it("opens menu with [リポスト, 引用] when not reposted", async () => {
+		render(<RepostButton tweetId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: triggerName }));
+		expect(
+			await screen.findByRole("menuitem", { name: "リポスト" }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "引用" })).toBeInTheDocument();
+	});
+
+	it("opens menu with [リポストを取り消す, 引用] when already reposted", async () => {
+		render(<RepostButton tweetId={5} initialReposted />);
+		await userEvent.click(screen.getByRole("button", { name: triggerName }));
+		expect(
+			await screen.findByRole("menuitem", { name: "リポストを取り消す" }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "引用" })).toBeInTheDocument();
+	});
+
+	it("menu「リポスト」 → POST repost と aria-pressed=true", async () => {
 		vi.mocked(repostTweet).mockResolvedValue({
 			id: 99,
 			repost_of: 1,
 			created: true,
 		});
-
 		render(<RepostButton tweetId={1} />);
-		const btn = screen.getByRole("button", { name: /リポスト$/ });
-		await userEvent.click(btn);
-
+		await userEvent.click(screen.getByRole("button", { name: triggerName }));
+		await userEvent.click(
+			await screen.findByRole("menuitem", { name: "リポスト" }),
+		);
 		await waitFor(() => {
-			expect(
-				screen.getByRole("button", { name: /リポストを取消/ }),
-			).toHaveAttribute("aria-pressed", "true");
+			expect(repostTweet).toHaveBeenCalledWith(1);
 		});
-		expect(repostTweet).toHaveBeenCalledWith(1);
+		// Radix DropdownMenu は menu open 中 body に scroll-lock + pointer-events:none
+		// を付与し、jsdom 上 trigger button が role=button で取得できなくなる。
+		// aria-pressed の検証は DOM 直接 query で行う (実 brower では問題なし)。
+		await waitFor(() => {
+			const trigger = document.querySelector("[aria-label='リポストメニュー']");
+			expect(trigger?.getAttribute("aria-pressed")).toBe("true");
+		});
 	});
 
-	it("DELETEs on second click when already reposted", async () => {
+	it("menu「リポストを取り消す」 → DELETE unrepost", async () => {
 		vi.mocked(unrepostTweet).mockResolvedValue();
-
-		render(<RepostButton tweetId={5} initialReposted={true} />);
+		render(<RepostButton tweetId={5} initialReposted />);
+		await userEvent.click(screen.getByRole("button", { name: triggerName }));
 		await userEvent.click(
-			screen.getByRole("button", { name: /リポストを取消/ }),
+			await screen.findByRole("menuitem", { name: "リポストを取り消す" }),
 		);
-
 		await waitFor(() => {
 			expect(unrepostTweet).toHaveBeenCalledWith(5);
 		});
 	});
 
-	it("rolls back state and toasts on error", async () => {
+	it("menu「引用」 → onQuoteRequest が呼ばれる (API は叩かれない)", async () => {
+		const onQuoteRequest = vi.fn();
+		render(<RepostButton tweetId={5} onQuoteRequest={onQuoteRequest} />);
+		await userEvent.click(screen.getByRole("button", { name: triggerName }));
+		await userEvent.click(
+			await screen.findByRole("menuitem", { name: "引用" }),
+		);
+		expect(onQuoteRequest).toHaveBeenCalled();
+		expect(repostTweet).not.toHaveBeenCalled();
+	});
+
+	it("rolls back state and toasts on repost error", async () => {
 		const { toast } = await import("react-toastify");
 		vi.mocked(repostTweet).mockRejectedValue(new Error("500"));
-
 		render(<RepostButton tweetId={1} />);
-		await userEvent.click(screen.getByRole("button", { name: /リポスト$/ }));
-
+		await userEvent.click(screen.getByRole("button", { name: triggerName }));
+		await userEvent.click(
+			await screen.findByRole("menuitem", { name: "リポスト" }),
+		);
 		await waitFor(() => {
 			expect(toast.error).toHaveBeenCalledWith(
 				expect.stringContaining("更新できませんでした"),
 			);
 		});
-		expect(
-			screen
-				.getByRole("button", { name: /リポスト$/ })
-				.getAttribute("aria-pressed"),
-		).toBe("false");
+		await waitFor(() => {
+			const trigger = document.querySelector("[aria-label='リポストメニュー']");
+			expect(trigger?.getAttribute("aria-pressed")).toBe("false");
+		});
 	});
 });

--- a/docs/specs/repost-quote-state-machine.md
+++ b/docs/specs/repost-quote-state-machine.md
@@ -1,0 +1,237 @@
+# リポスト / 引用ツイート 状態遷移仕様
+
+> Version: 0.1 (Draft)
+> 最終更新: 2026-05-03
+> ステータス: Draft (実装着手前 / X 本家挙動の実機確認込みで FIX 予定)
+> 関連: [SPEC.md §3.3 / §3.4](../SPEC.md), [ER.md §2.5](../ER.md), [ROADMAP.md](../ROADMAP.md)
+
+---
+
+## 0. このドキュメントの位置づけ
+
+本プロジェクトのリポスト (Repost) と 引用ツイート (Quote) の **UI 上の挙動** と **DB / API の状態遷移** を、X (旧 Twitter) 本家の現挙動 (2024〜2026 時点) と整合させるための仕様書。
+
+`docs/SPEC.md` §3.3 / §3.4 は機能の存在と件数カウントしか触れていないため、ボタンメニューの内容・トグル方向・引用と repost の併用可否といった細部を本書で確定させる。
+
+**ゴール**: 「X でできること / できないこと」をそのまま再現する。独自のひねりは入れない (差別化は別レイヤーで行う方針、ROADMAP 参照)。
+
+---
+
+## 1. 用語
+
+| 用語                | 定義                                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| 元 tweet            | 「リポスト」ボタンが押される対象のツイート。`Tweet`                                               |
+| REPOST tweet        | `type=repost` の Tweet 行。`body=""`、`repost_of` で元 tweet を指す                               |
+| QUOTE tweet         | `type=quote` の Tweet 行。本文 1〜180 字 + `quote_of` で元 tweet を指す                           |
+| reposted (動詞状態) | あるユーザが対象 tweet について **REPOST tweet を保有している** 状態                              |
+| quoted (動詞状態)   | あるユーザが対象 tweet を **少なくとも 1 件 quote している** 状態 (生きてる QUOTE tweet が 1+ 件) |
+
+**ユーザ視点の状態は (reposted, quoted) の 2 軸のフラグ** で表現する。両者は独立 (X 本家がそうなっている、§3 参照)。
+
+---
+
+## 2. X 本家の現挙動 (調査結果)
+
+`help.x.com` 公式ヘルプ + 解説記事 (TweetDelete / Tweet Archivist / Circleboom / Android Police 等、2024〜2026 時点) を参照した。出典は §6。
+
+### 2.1 リポスト ボタン押下時のメニュー
+
+| 状態                                                   | 開くポップアップ メニュー         |
+| ------------------------------------------------------ | --------------------------------- |
+| **未 repost** (まだ自分が REPOST tweet を作っていない) | `[ リポスト ] [ 引用 ]`           |
+| **repost 済み** (自分の REPOST tweet が存在する)       | `[ リポストを取り消す ] [ 引用 ]` |
+
+要点:
+
+- **「引用」項目はどちらの状態でも常に出る**。引用は「もう 1 件追加で Quote を作る」操作なので、既に repost 済みでも独立して使える (§2.3 参照)。
+- 「リポスト済み」アイコンは緑にハイライトされる (本プロジェクトでは lime-600/400)。
+- iOS / Android / Web で UI 細部 (BottomSheet vs Dropdown) は違うが、出る項目とラベルは同じ。
+
+### 2.2 「リポストを取り消す」の挙動
+
+- メニューから「リポストを取り消す」を選ぶと **即時** に REPOST tweet が消える。**確認ダイアログは出ない** (X はワンタップで取消)。
+- 元 tweet の `repost_count` は 1 減る。
+- 取り消した後、フォロワーの TL から該当 RT 行が消える (キャッシュの絡みで他端末では遅延あり、と公式 FAQ にも記載)。
+- 取り消し後に同じ tweet をもう一度リポストすることは可能 (制限なし)。`repost_count` は再び +1 される。
+
+### 2.3 引用ツイートの挙動
+
+- 「引用」を選ぶと作成画面が開き、本文 (X は最大 280 字、本プロジェクトは 180 字) を入力して投稿する。
+- 引用は **通常の tweet と同等** に扱われる。取り消し UI は無く、削除は自分のツイート一覧の「削除」メニューから行う (= QUOTE tweet を soft-delete)。
+- **引用は何件でも作れる**。同一の元 tweet に対して同じユーザが quote を 3 回作っても、3 件とも別の QUOTE tweet になる。`quote_count` も +3 される。
+- repost との **同時併存可** : `(reposted, quoted) = (True, True)` の状態が成立する。X はこの 2 軸を独立に管理している。
+
+### 2.4 REPOST tweet 自体に対する操作
+
+- REPOST tweet (= 自分が他人をリポストした行) は TL 上で **元 tweet 本体が表示** され、上部に「@user がリポストしました」バナーが付く。
+- このカードの下にある「リポスト」ボタンを押すと、**操作対象は元 tweet** になる (バナー部分はリポスト不可)。
+  - 例: A が B のツイートをリポスト → C が A の TL でその行を見て「リポスト」を押す → C の REPOST は B の元 tweet を指す (`repost_of=B's_tweet`)。A が間に入ることはない。
+  - 引用も同様 (`quote_of=B's_tweet`)。
+- これにより「RT の RT」のチェーンは生まれず、`repost_of` は常に深さ 1 の参照に保たれる。
+
+### 2.5 削除済み (tombstone) tweet
+
+- 元 tweet が author によって削除されると、その tweet を指す **既存の REPOST tweet も実質的に消える** (X 本家ではユーザー TL 上から消える)。本プロジェクトの実装では元 tweet が `is_deleted=True` の場合、TL レンダリング側で tombstone 扱いにする (§4 参照)。
+- 削除済み tweet の **新規 リポスト / 引用 は不可**: ボタンが disabled、または操作時に 400 エラー。
+- 鍵垢 (protected) ツイートも repost 不可 (本プロジェクトは MVP では鍵垢機能を持たないので、この分岐は将来用)。
+
+### 2.6 カウント整合性
+
+| イベント                    | `repost_count` | `quote_count` |
+| --------------------------- | -------------- | ------------- |
+| 新規 REPOST tweet 作成      | +1             | -             |
+| REPOST tweet 取り消し       | -1             | -             |
+| 同一 user による 2 回目 RT  | (拒否)         | -             |
+| 新規 QUOTE tweet 作成       | -              | +1            |
+| QUOTE tweet 削除 (soft)     | -              | -1            |
+| 同一 user による N 件 quote | -              | +N            |
+
+「同一 user による 2 回目 RT」が拒否されるのは X / 本プロジェクト共通の制約。本プロジェクトでは partial UniqueConstraint `tweet_unique_repost_per_user` (apps/tweets/models.py) で DB レイヤから保証している。
+
+---
+
+## 3. 状態遷移図 (Mermaid)
+
+ある (actor, target_tweet) ペアに対する状態と user action の関係を図示する。`reposted` と `quoted` は独立フラグなので、状態は 4 つの直積で表現する。
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    [*] --> NOT_REPOSTED_NOT_QUOTED : 初期状態
+
+    state "(reposted=No, quoted=No)" as NOT_REPOSTED_NOT_QUOTED
+    state "(reposted=Yes, quoted=No)" as REPOSTED_NOT_QUOTED
+    state "(reposted=No, quoted=Yes)" as NOT_REPOSTED_QUOTED
+    state "(reposted=Yes, quoted=Yes)" as REPOSTED_QUOTED
+
+    NOT_REPOSTED_NOT_QUOTED --> REPOSTED_NOT_QUOTED : リポスト押下
+    REPOSTED_NOT_QUOTED --> NOT_REPOSTED_NOT_QUOTED : リポストを取り消す押下
+
+    NOT_REPOSTED_NOT_QUOTED --> NOT_REPOSTED_QUOTED : 引用押下 + 投稿
+    REPOSTED_NOT_QUOTED --> REPOSTED_QUOTED : 引用押下 + 投稿
+
+    NOT_REPOSTED_QUOTED --> REPOSTED_QUOTED : リポスト押下
+    REPOSTED_QUOTED --> NOT_REPOSTED_QUOTED : リポストを取り消す押下
+
+    NOT_REPOSTED_QUOTED --> NOT_REPOSTED_QUOTED : さらに引用押下 + 投稿\n(quote 件数 +1, 状態は変わらない)
+    REPOSTED_QUOTED --> REPOSTED_QUOTED : さらに引用押下 + 投稿\n(quote 件数 +1, 状態は変わらない)
+
+    NOT_REPOSTED_QUOTED --> NOT_REPOSTED_NOT_QUOTED : 全 QUOTE tweet を削除
+    REPOSTED_QUOTED --> REPOSTED_NOT_QUOTED : 全 QUOTE tweet を削除
+```
+
+ポイント:
+
+- **`quoted=Yes` は「QUOTE tweet を 1 件以上保有」の集約フラグ** であって、何件あっても 1 つの状態として扱う。引用を 5 件作っても状態としては `quoted=Yes` のまま、ただし `quote_count` は +5。
+- リポスト軸は完全な ON/OFF トグル、引用軸は「count 操作」 + 「最後の 1 件を消したら状態が変わる」非対称構造。
+
+---
+
+## 4. 条件分岐表 (action × current state)
+
+UI 側のボタンメニュー描画と enabled/disabled、API 側の振る舞いを 1 表にまとめる。
+
+凡例:
+
+- `RT▶ rev` : 「リポストを取り消す」を表示
+- `RT▶ new` : 「リポスト」(新規) を表示
+- `Q▶` : 「引用」を表示
+
+### 4.1 リポストアイコン押下時のメニュー (元 tweet が alive のとき)
+
+| 現状態                     | メニュー項目       | アイコン色  |
+| -------------------------- | ------------------ | ----------- |
+| `(reposted=No,  quoted=*)` | `RT▶ new` + `Q▶` | 灰色        |
+| `(reposted=Yes, quoted=*)` | `RT▶ rev` + `Q▶` | 緑 (active) |
+
+`quoted` の値はこのメニューに **影響しない**。引用は別軸なので。
+
+### 4.2 各 action の遷移と副作用
+
+| 現状態                   | action                             | 結果状態                | API                                         | counts    | 備考                                  |
+| ------------------------ | ---------------------------------- | ----------------------- | ------------------------------------------- | --------- | ------------------------------------- |
+| `(No,  No)`              | リポスト押下                       | `(Yes, No)`             | `POST /tweets/<id>/repost/`                 | repost +1 | -                                     |
+| `(No,  No)`              | 引用押下 + 投稿                    | `(No,  Yes)`            | `POST /tweets/<id>/quote/`                  | quote +1  | 入力 dialog を経由                    |
+| `(Yes, No)`              | リポストを取り消す                 | `(No,  No)`             | `DELETE /tweets/<id>/repost/`               | repost -1 | 確認ダイアログなし (X 同等)           |
+| `(Yes, No)`              | 引用押下 + 投稿                    | `(Yes, Yes)`            | `POST /tweets/<id>/quote/`                  | quote +1  | 既存 REPOST tweet は **そのまま残る** |
+| `(No,  Yes)`             | リポスト押下                       | `(Yes, Yes)`            | `POST /tweets/<id>/repost/`                 | repost +1 | 既存 QUOTE tweet 群は そのまま残る    |
+| `(No,  Yes)`             | 引用押下 + 投稿                    | `(No,  Yes)`            | `POST /tweets/<id>/quote/`                  | quote +1  | 状態不変、件数のみ加算                |
+| `(Yes, Yes)`             | リポストを取り消す                 | `(No,  Yes)`            | `DELETE /tweets/<id>/repost/`               | repost -1 | QUOTE 群は無関係                      |
+| `(Yes, Yes)`             | 引用押下 + 投稿                    | `(Yes, Yes)`            | `POST /tweets/<id>/quote/`                  | quote +1  | 状態不変、件数のみ加算                |
+| 任意 + `quoted=Yes`      | QUOTE tweet を `DELETE /tweets/N/` | quote -1, 0 になれば No | `DELETE /tweets/<quote_id>/` (soft)         | quote -1  | 現状 SPEC §3.9 の soft-delete         |
+| 元 tweet が `is_deleted` | リポスト押下 / 引用押下            | (拒否)                  | 400 `tweet is deleted` または UI で disable | -         | tombstone は repost / quote 不可      |
+
+### 4.3 REPOST tweet 自身を起点に押した場合
+
+REPOST tweet (自分または他人の `type=repost` 行) のカード上の「リポスト」「引用」ボタンを押した場合、`target` は **元 tweet** (`repost_of`) に解決する。actor は元 tweet に対する `(reposted, quoted)` 状態に従って §4.1 / §4.2 のフローを実行する。
+
+REPOST tweet を直接 target にする repost / quote は仕様上禁止。サーバ側で `target.type == REPOST` なら `target = target.repost_of` に解決し直すか、UI で REPOST tweet の id を投げないようにする (現状実装の `TweetCard.tsx` は `repost_of.id` を辿って詳細遷移しているため、ボタンも同様に解決すれば整合する)。
+
+---
+
+## 5. 実装メモ — 現状 codeplace と X 互換のギャップ
+
+### 5.1 バックエンド (apps/tweets/)
+
+✅ できていること:
+
+- `Tweet.type` enum (ORIGINAL / REPLY / REPOST / QUOTE) と `repost_of` / `quote_of` FK は揃っている (`apps/tweets/models.py`)。
+- 同一 user × 同一元 tweet の重複 REPOST を partial UniqueConstraint `tweet_unique_repost_per_user` で防止済み。
+- `POST /api/v1/tweets/<id>/repost/` は idempotent (既存があれば 200 で返す)、`DELETE` で取り消し (`apps/tweets/views_actions.py: RepostView`)。
+- `POST /api/v1/tweets/<id>/quote/` は何度でも作成できる (`QuoteView`)。
+- 削除済み tweet (`is_deleted=True`) は `_resolve_target` の `get_object_or_404` で 404 になるので、そもそも操作できない (alive のみ抽出する Manager)。
+
+⚠️ 不足 / 要検討:
+
+- **REPOST tweet を target に渡されたときの解決ロジックが無い**。`POST /tweets/<repost_tweet_id>/repost/` を投げると、その REPOST tweet 自身を `repost_of` にしようとして UniqueConstraint を満たし得る (`type=repost` の repost を作る) おそれがある。サーバ側で「`target.type == REPOST` なら `target = target.repost_of`、それも tombstone なら 400」のリゾルバを `_resolve_target` に追加すべき (X 互換)。
+- **quote の重複作成** は仕様上 OK (件数 +N)。現状もこの挙動なので追加対応は不要。重複防止 unique constraint を quote に **追加してはいけない** (X 互換性が壊れる)。
+- **block 判定** は実装済みだが (`is_blocked_relationship`)、protect (鍵垢) は未実装。鍵垢を導入する Phase で `target.author.is_protected` チェックを追加する。
+
+### 5.2 フロントエンド (client/src/components/)
+
+✅ 実装済み (Issue #342 / PR で対応):
+
+1. **`RepostButton` が DropdownMenu トリガー化された** (`client/src/components/tweets/RepostButton.tsx`)。X 同等で、クリック → menu に `[リポスト | 引用]` (または `[リポストを取り消す | 引用]`) が並ぶ。`shadcn/ui` の `DropdownMenu` を使用。menu 描画は §4.1 の表どおり `initialReposted` で 2 項目を出し分け。`[引用]` を選んだら親 (TweetCard) に `onQuoteRequest` callback で通知し、TweetCard 側で既存の `PostDialog mode="quote"` を open する。
+2. **`TweetCard.tsx` footer から独立「引用」 button が撤去された**。引用は repost menu 内の項目からのみアクセス。count badge は **`repost_count + quote_count` の合算 1 つ** に統一 (X TL の慣習)。aria-label は「リポスト N 件 (引用 M 件含む)」で内訳を保持。
+3. **`(reposted=Yes, quoted=Yes)` の同時状態** は問題なくレンダリングされる。`RepostButton` の `initialReposted` と TweetCard の `quoteCountOptimistic` は独立 state で衝突しない。
+
+⚠️ 残ギャップ (本 issue では未対応、別 issue で扱う):
+
+1. **REPOST tweet カード (= type=repost) からのリポスト操作のターゲット解決**: `TweetCard.tsx` は repost article 内に `RepostButton` を **そもそも置いていない** (早期 return パスには footer が無い)。これは意図的な単純化だが、X は repost の表示でも下にアクションバーが出る。`Phase 4` で repost article にも footer を生やすときに、`tweetId={tweet.repost_of.id}` を渡すよう注意 (§4.3 と整合)。
+2. **REPOST tweet を target にした `POST /tweets/<repost_id>/repost/`** に対するサーバ側リゾルバ (§5.1 ⚠️ 1 番目)。frontend で誤って repost_id を渡しても backend が `target.repost_of` に解決し直すよう修正する別 issue を要起票。
+
+### 5.3 カウント同期
+
+`apps/tweets/signals.py` の post_save / post_delete + Celery Beat reconciliation でカウンタは整合している (既存)。本仕様で追加要件は無い。
+
+---
+
+## 6. 参考 URL
+
+調査時の出典 (2026-05 時点で最新挙動を確認)。X 本家ヘルプは IP ブロックで WebFetch 不可だったが、検索結果で要点は引けている。
+
+### 一次ソース (公式)
+
+- [help.x.com — How to Repost](https://help.x.com/en/using-x/how-to-repost)
+- [help.x.com — Repost FAQs](https://help.x.com/en/using-x/repost-faqs)
+
+### 二次ソース (解説記事 / 2024〜2026)
+
+- [TweetDelete — Undo Repost on X](https://tweetdelete.net/resources/undo-repost-on-x/)
+- [TweetDelete — How to Delete a Repost on X](https://tweetdelete.net/resources/how-to-delete-a-repost-on-x/)
+- [Tweet Archivist — How to Quote Tweet on X in 2026](https://www.tweetarchivist.com/how-to-quote-tweet-guide)
+- [Circleboom — How to Undo Repost on X (Twitter) in 2026](https://circleboom.com/blog/how-to-undo-repost-on-x-twitter/)
+- [Circleboom — Retweet button greyed out](https://circleboom.com/blog/retweet-button-greyed-out/)
+- [Android Police — How to delete a repost on X](https://www.androidpolice.com/x-delete-a-post/)
+- [TweetEraser — How To Delete a Repost on X](https://www.tweeteraser.com/resources/how-to-delete-a-repost-on-x-undo-retweets-easily/)
+
+### 内部参照
+
+- [docs/SPEC.md §3.2-§3.4](../SPEC.md)
+- [docs/ER.md §2.5 (Tweet)](../ER.md)
+- [apps/tweets/models.py](../../apps/tweets/models.py) (Tweet, TweetType)
+- [apps/tweets/views_actions.py](../../apps/tweets/views_actions.py) (RepostView, QuoteView)
+- [client/src/components/tweets/RepostButton.tsx](../../client/src/components/tweets/RepostButton.tsx)
+- [client/src/components/timeline/TweetCard.tsx](../../client/src/components/timeline/TweetCard.tsx)


### PR DESCRIPTION
## Summary

X (旧 Twitter) UX に揃え、リポストアイコン押下で menu が開くように修正。独立していた「引用」 button は撤去し、引用は repost menu からのみアクセス。

| Before | After |
|---|---|
| `[リポスト ↺] [count]  [引用 N]  [リアクション]` | `[リポスト ↺ ▾] [count = repost+quote]  [リアクション]` |
| 即時トグル (引用へ分岐できない) | menu に「リポスト/取消」「引用」が並ぶ (X 準拠) |

## 変更点

- `RepostButton` を shadcn/ui \`DropdownMenu\` でラップ
  - \`not_reposted\` → menu: 「リポスト」「引用」
  - \`reposted\` → menu: 「リポストを取り消す」「引用」
- 引用は親 (TweetCard) に \`onQuoteRequest\` callback で通知 → 既存 \`PostDialog mode=\"quote\"\` を open (PostDialog の重複生成を避けるため、open は引き続き TweetCard 側に集約)
- TweetCard footer から独立「引用」 button を削除
- count badge を \`repost_count + quote_count\` の合算 1 つに統一 (X TL の慣習)。aria-label に「リポスト N 件 (引用 M 件含む)」で内訳保持
- \`RepostButton.test.tsx\` を menu 操作ベースに全面リライト (8 tests)
- \`docs/specs/repost-quote-state-machine.md\` §5.2 を「要修正点」→「実装済み」表現に更新。残ギャップ (REPOST tweet 起点解決) は別 issue 化

## Test plan

- [x] vitest 全体 379/379 green (RepostButton 8 / TweetCard 50 含む)
- [x] tsc --noEmit 緑
- [x] lint 緑 (warning は既存と同じレベル)
- [ ] stg 実機検証 — login → home → リポスト click で menu 開く / 「引用」選択で PostDialog open / count 合算表示

## 関連

- Closes #342
- Builds on PR #338 (#337) for onPosted bubble up
- docs: \`docs/specs/repost-quote-state-machine.md\` (Issue 直前のユーザー要望で先行作成、本 PR で §5.2 を実装済みステータスに更新)