### PR TITLE
[fix][tweets+timeline] X 互換 — REPOST 起点の解決 + tombstone TL 除外 (Closes #346, #347)

### DIFF
--- a/apps/timeline/services.py
+++ b/apps/timeline/services.py
@@ -136,8 +136,12 @@ def _query_following(user, blocked_ids: set[int], limit: int) -> list[Tweet]:
             type__in=[TweetType.ORIGINAL, TweetType.REPOST, TweetType.QUOTE],
         )
         .exclude(author_id__in=blocked_ids)
-        # #347: 元 tweet が tombstone の REPOST 行は X 互換で TL から消す
+        # #347: 元 tweet が tombstone の REPOST 行は X 互換で TL から消す。
+        # repost_of__isnull は repost_of=NULL の broken data 対策 (JOIN 結果が
+        # NULL のとき is_deleted=True 比較は False を返すため、別 exclude で
+        # 明示的に弾く)。
         .exclude(type=TweetType.REPOST, repost_of__is_deleted=True)
+        .exclude(type=TweetType.REPOST, repost_of__isnull=True)
         .order_by("-created_at")[:limit]
     )
     return list(qs)

--- a/apps/timeline/services.py
+++ b/apps/timeline/services.py
@@ -120,6 +120,10 @@ def _query_following(user, blocked_ids: set[int], limit: int) -> list[Tweet]:
     #334: REPLY type は home TL に出さない (X 慣習)。reply は conversation
     view (/tweet/<parent>) からのみ閲覧可能、TL は ORIGINAL / REPOST / QUOTE
     のみ。
+
+    #347: 元 tweet が削除された REPOST 行は home TL から除外する (X 慣習)。
+    QUOTE は引用者本文が残るので除外しない (docs/specs/repost-quote-state-machine.md
+    §2.5 / §5.4 参照)。
     """
     cutoff = timezone.now() - timedelta(hours=24)
     qs = (
@@ -132,6 +136,8 @@ def _query_following(user, blocked_ids: set[int], limit: int) -> list[Tweet]:
             type__in=[TweetType.ORIGINAL, TweetType.REPOST, TweetType.QUOTE],
         )
         .exclude(author_id__in=blocked_ids)
+        # #347: 元 tweet が tombstone の REPOST 行は X 互換で TL から消す
+        .exclude(type=TweetType.REPOST, repost_of__is_deleted=True)
         .order_by("-created_at")[:limit]
     )
     return list(qs)

--- a/apps/timeline/tests/test_services.py
+++ b/apps/timeline/tests/test_services.py
@@ -218,6 +218,28 @@ def test_build_home_tl_excludes_repost_with_deleted_original() -> None:
 
 
 @pytest.mark.django_db(transaction=True)
+def test_build_home_tl_excludes_repost_with_null_repost_of() -> None:
+    """#347 (review HIGH-2): broken data — type=REPOST だが repost_of=NULL の
+    行も TL から除外する。repost_of__is_deleted=True の JOIN 比較は NULL を
+    False で評価するため、別 exclude で明示的に弾く必要がある.
+    """
+    from apps.tweets.models import Tweet, TweetType
+
+    actor = make_user()
+    target = make_user()
+    make_follow(actor, target)
+    # broken row: type=REPOST かつ repost_of=NULL
+    broken = Tweet.objects.create(author=target, body="", type=TweetType.REPOST, repost_of=None)
+    # alive original も 1 件用意 (TL が空にならない)
+    alive = make_tweet(author=target, body="alive")
+
+    result = build_home_tl(actor, limit=20)
+    pks = {t.pk for t in result}
+    assert broken.pk not in pks
+    assert alive.pk in pks
+
+
+@pytest.mark.django_db(transaction=True)
 def test_build_home_tl_keeps_quote_with_deleted_original() -> None:
     """#347: QUOTE は元 tweet が削除されても本文が残るので TL に残る (§2.5)."""
     from apps.tweets.models import Tweet, TweetType

--- a/apps/timeline/tests/test_services.py
+++ b/apps/timeline/tests/test_services.py
@@ -182,3 +182,61 @@ def test_build_home_tl_excludes_self_reply_type() -> None:
     pks = {t.pk for t in result}
     assert parent.pk in pks
     assert own_reply.pk not in pks  # ← REPLY は除外
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_home_tl_excludes_repost_with_deleted_original() -> None:
+    """#347: 元 tweet が削除された REPOST 行は home TL から消す (X 慣習).
+
+    docs/specs/repost-quote-state-machine.md §2.5 / §5.4 と整合.
+    """
+    from apps.tweets.models import Tweet, TweetType
+
+    actor = make_user()
+    target = make_user()
+    make_follow(actor, target)
+
+    # フォロイーが他人 tweet をリポスト → その後元 tweet が削除される
+    original_author = make_user()
+    original = make_tweet(author=original_author, body="will be deleted")
+    repost = Tweet.objects.create(
+        author=target,
+        body="",
+        type=TweetType.REPOST,
+        repost_of=original,
+    )
+    original.soft_delete()  # tombstone 化
+
+    # 同一フォロイーの alive original も用意 (TL は空にならない)
+    alive_tweet = make_tweet(author=target, body="alive original")
+
+    result = build_home_tl(actor, limit=20)
+    pks = {t.pk for t in result}
+    # alive original は出る、tombstone repost は出ない
+    assert alive_tweet.pk in pks
+    assert repost.pk not in pks
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_home_tl_keeps_quote_with_deleted_original() -> None:
+    """#347: QUOTE は元 tweet が削除されても本文が残るので TL に残る (§2.5)."""
+    from apps.tweets.models import Tweet, TweetType
+
+    actor = make_user()
+    target = make_user()
+    make_follow(actor, target)
+
+    original_author = make_user()
+    original = make_tweet(author=original_author, body="quoted source")
+    quote = Tweet.objects.create(
+        author=target,
+        body="my comment",
+        type=TweetType.QUOTE,
+        quote_of=original,
+    )
+    original.soft_delete()
+
+    result = build_home_tl(actor, limit=20)
+    pks = {t.pk for t in result}
+    # QUOTE は引用者の本文があるので残す (placeholder embed は frontend 描画責務)
+    assert quote.pk in pks

--- a/apps/tweets/tests/test_actions_api.py
+++ b/apps/tweets/tests/test_actions_api.py
@@ -185,6 +185,29 @@ class TestResolveTargetRepostFallthrough:
         quote = Tweet.objects.get(pk=res.json()["id"])
         assert quote.quote_of_id == original.pk
 
+    def test_repost_chain_violation_returns_404(self, api_client: APIClient) -> None:
+        """broken data: REPOST → REPOST のチェーンが残っていた場合、404 で拒否。
+
+        §2.4 で深さ 1 が保証されているが、過去データに chain が混入していたら
+        wrong-result を返す代わりに 404 + structlog で気づけるようにする。
+        """
+        author_a = make_user()
+        original = make_tweet(author=author_a, body="original")
+        # 通常は _resolve_target で防がれるが、テスト用に DB 直書きで chain を作る
+        repost_b = Tweet.objects.create(
+            author=make_user(), body="", type=TweetType.REPOST, repost_of=original
+        )
+        # broken: type=REPOST だが repost_of が REPOST を指す (深さ 2)
+        chain = Tweet.objects.create(
+            author=make_user(), body="", type=TweetType.REPOST, repost_of=repost_b
+        )
+        actor_c = make_user()
+        api_client.force_authenticate(user=actor_c)
+
+        res = api_client.post(repost_url(chain.pk))
+
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
     def test_repost_target_is_repost_with_deleted_original_404(self, api_client: APIClient) -> None:
         """REPOST tweet を target に渡したが元 tweet が削除済みなら 404."""
         author_a = make_user()

--- a/apps/tweets/tests/test_actions_api.py
+++ b/apps/tweets/tests/test_actions_api.py
@@ -142,3 +142,62 @@ class TestQuoteAndReply:
         # body 必須 (TweetCreateSerializer のバリデーション)
         res = api_client.post(quote_url(target.pk), {"body": ""}, format="json")
         assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.integration
+class TestResolveTargetRepostFallthrough:
+    """#346: REPOST tweet を target に渡されたら repost_of に解決する."""
+
+    def test_repost_of_repost_falls_through_to_original(self, api_client: APIClient) -> None:
+        """A→B→C を順に追って、C が B (REPOST tweet) を repost しても A の REPOST が作られる."""
+        author_a = make_user()
+        original = make_tweet(author=author_a, body="original")
+        actor_b = make_user()
+        repost_b = Tweet.objects.create(
+            author=actor_b, body="", type=TweetType.REPOST, repost_of=original
+        )
+        actor_c = make_user()
+        api_client.force_authenticate(user=actor_c)
+
+        # C が B の REPOST 行 (= repost_b) を target に repost を投げる
+        res = api_client.post(repost_url(repost_b.pk))
+
+        assert res.status_code == status.HTTP_201_CREATED
+        c_repost = Tweet.objects.get(author=actor_c, type=TweetType.REPOST)
+        # C の REPOST は B ではなく A の original を指す (RT のチェーンを許さない)
+        assert c_repost.repost_of_id == original.pk
+        assert c_repost.repost_of_id != repost_b.pk
+
+    def test_quote_of_repost_falls_through_to_original(self, api_client: APIClient) -> None:
+        author_a = make_user()
+        original = make_tweet(author=author_a, body="original")
+        actor_b = make_user()
+        repost_b = Tweet.objects.create(
+            author=actor_b, body="", type=TweetType.REPOST, repost_of=original
+        )
+        actor_c = make_user()
+        api_client.force_authenticate(user=actor_c)
+
+        res = api_client.post(quote_url(repost_b.pk), {"body": "コメント"}, format="json")
+
+        assert res.status_code == status.HTTP_201_CREATED
+        quote = Tweet.objects.get(pk=res.json()["id"])
+        assert quote.quote_of_id == original.pk
+
+    def test_repost_target_is_repost_with_deleted_original_404(self, api_client: APIClient) -> None:
+        """REPOST tweet を target に渡したが元 tweet が削除済みなら 404."""
+        author_a = make_user()
+        original = make_tweet(author=author_a)
+        actor_b = make_user()
+        repost_b = Tweet.objects.create(
+            author=actor_b, body="", type=TweetType.REPOST, repost_of=original
+        )
+        # 元 tweet を soft-delete (alive Manager から外す)
+        original.soft_delete()
+        actor_c = make_user()
+        api_client.force_authenticate(user=actor_c)
+
+        res = api_client.post(repost_url(repost_b.pk))
+
+        assert res.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/tweets/views_actions.py
+++ b/apps/tweets/views_actions.py
@@ -22,6 +22,7 @@ import logging
 from typing import Any
 
 from django.db import IntegrityError, transaction
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from rest_framework import serializers as drf_serializers
 from rest_framework import status
@@ -53,12 +54,29 @@ def _resolve_target(tweet_id: int) -> Tweet:
     ではなく **元 tweet (``repost_of``)** に解決し直す。これは X が
     「RT の RT」のチェーンを許容しないため (docs/specs/repost-quote-state-machine.md
     §4.3 / §2.4 参照)。元 tweet が削除済みなら ``Http404`` (alive Manager)。
+
+    防御的不変条件: §2.4 で「``repost_of`` は常に深さ 1」と保証されているため、
+    解決後の target は ORIGINAL / QUOTE / REPLY のいずれかになる。万一壊れた
+    データでチェーン (REPOST→REPOST) が残っていた場合は wrong-result を返す
+    リスクがあるため、解決後の type を再チェックして 404 にする。
     """
     target = get_object_or_404(Tweet, pk=tweet_id)
-    if target.type == TweetType.REPOST and target.repost_of_id is not None:
-        # alive のみを引く既定 Manager (Tweet.objects) を使うので、元が
-        # is_deleted=True なら自動的に 404 になる。
-        return get_object_or_404(Tweet, pk=target.repost_of_id)
+    if target.type == TweetType.REPOST:
+        if target.repost_of_id is None:
+            # broken data: type=REPOST なのに repost_of=NULL
+            logger.error(
+                "repost_with_null_repost_of",
+                extra={"tweet_id": tweet_id},
+            )
+            raise Http404("REPOST tweet に元 tweet がありません")
+        target = get_object_or_404(Tweet, pk=target.repost_of_id)
+        if target.type == TweetType.REPOST:
+            # data invariant §2.4 違反: チェーン深さ > 1
+            logger.error(
+                "repost_chain_violation",
+                extra={"original_id": tweet_id, "resolved_id": target.pk},
+            )
+            raise Http404("リポストのチェーンは許容されません")
     return target
 
 

--- a/apps/tweets/views_actions.py
+++ b/apps/tweets/views_actions.py
@@ -47,8 +47,19 @@ class _RepostResponseSerializer(drf_serializers.Serializer):
 
 
 def _resolve_target(tweet_id: int) -> Tweet:
-    """元ツイートを取得する (alive のみ、削除済み / 存在しないなら 404)."""
-    return get_object_or_404(Tweet, pk=tweet_id)
+    """元ツイートを取得する (alive のみ、削除済み / 存在しないなら 404)。
+
+    #346 (X 互換): tweet_id が REPOST tweet を指している場合、その REPOST 自身
+    ではなく **元 tweet (``repost_of``)** に解決し直す。これは X が
+    「RT の RT」のチェーンを許容しないため (docs/specs/repost-quote-state-machine.md
+    §4.3 / §2.4 参照)。元 tweet が削除済みなら ``Http404`` (alive Manager)。
+    """
+    target = get_object_or_404(Tweet, pk=tweet_id)
+    if target.type == TweetType.REPOST and target.repost_of_id is not None:
+        # alive のみを引く既定 Manager (Tweet.objects) を使うので、元が
+        # is_deleted=True なら自動的に 404 になる。
+        return get_object_or_404(Tweet, pk=target.repost_of_id)
+    return target
 
 
 def _check_block_or_403(actor: Any, target: Tweet) -> Response | None:


### PR DESCRIPTION
## Summary

\`docs/specs/repost-quote-state-machine.md\` の残ギャップ 2 件を実装。

| Issue | 概要 |
|---|---|
| #346 | \`_resolve_target\` が target=REPOST のとき \`repost_of\` に解決し直す (RT の RT を防ぐ) |
| #347 | home TL から元 tweet 削除済みの REPOST 行を除外 (X 慣習: 行ごと消す) |

## #346: \`apps/tweets/views_actions.py\`

\`\`\`python
def _resolve_target(tweet_id: int) -> Tweet:
    target = get_object_or_404(Tweet, pk=tweet_id)
    if target.type == TweetType.REPOST and target.repost_of_id is not None:
        # alive Manager で元 tweet が tombstone なら自動 404
        return get_object_or_404(Tweet, pk=target.repost_of_id)
    return target
\`\`\`

これにより以下が成立:
- C が「B が A をリポストした行」をリポストすると、C の REPOST は A を指す (深さ 1 維持)
- 元 tweet が削除済みの REPOST 行に対する操作は 404 で拒否

## #347: \`apps/timeline/services.py\`

\`\`\`python
qs = (...).exclude(type=TweetType.REPOST, repost_of__is_deleted=True)
\`\`\`

QUOTE は引用者本文が残るので除外しない (docs §2.5)。frontend の \`QuoteEmbed\` が is_deleted を拾って placeholder 描画する責務。

## Test plan

- [x] 新規 pytest 5 件追加 (\`test_repost_of_repost_falls_through_to_original\` ほか)
- [x] pre-push pytest hook 通過
- [ ] CI で apps/ pytest 緑

## 関連

- Closes #346
- Closes #347
- Builds on PR #345 (docs v0.2)