### PR TITLE
[fix+test][tweets] PostDialog 即時 close 修正 + 状態遷移 E2E spec (Closes #349)

### DIFF
--- a/client/e2e/repost-quote-state-machine.spec.ts
+++ b/client/e2e/repost-quote-state-machine.spec.ts
@@ -1,0 +1,354 @@
+/**
+ * #349: docs/specs/repost-quote-state-machine.md §4.2 全シナリオの E2E.
+ *
+ * 検証する状態遷移 (actor=USER1 から target tweet (USER2 作成) に対する操作):
+ *
+ *   1. (No,  No)  → リポスト          → (Yes, No)
+ *   2. (No,  No)  → 引用 + 投稿       → (No,  Yes)
+ *   3. (Yes, No)  → リポストを取り消す → (No,  No)
+ *   4. (Yes, No)  → 引用 + 投稿       → (Yes, Yes)  ← ハルナさん指摘ポイント
+ *   5. (No,  Yes) → リポスト          → (Yes, Yes)
+ *   6. (No,  Yes) → 引用 + 投稿       → (No,  Yes)  (件数のみ +1)
+ *   7. (Yes, Yes) → リポストを取り消す → (No,  Yes)
+ *   8. (Yes, Yes) → 引用 + 投稿       → (Yes, Yes)
+ *
+ * 加えて:
+ *   - PostDialog 即時 close 不具合 (#349 fix verify)
+ *   - REPOST tweet 起点の repost が repost_of に解決される (#346)
+ *   - 削除済み tweet を target にすると 404 (#347 関連)
+ *
+ * 直接 API call (axios) で状態遷移を作り、間に UI からの操作を挟むハイブリッド
+ * 戦略を採る。これにより stg の rate limit (#336) を抑えつつ、UI の挙動 (menu
+ * 描画、Dialog open、icon 色変化) を実機で確認できる。
+ *
+ * 実行:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=test3@gmail.com PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+ *   PLAYWRIGHT_USER1_HANDLE=test3 \
+ *   PLAYWRIGHT_USER2_EMAIL=test2@gmail.com PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
+ *   PLAYWRIGHT_USER2_HANDLE=test2 \
+ *   npx playwright test e2e/repost-quote-state-machine.spec.ts
+ */
+
+import {
+	type APIRequestContext,
+	expect,
+	type Page,
+	test,
+} from "@playwright/test";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "alice@example.com",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "supersecret12", // pragma: allowlist secret
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "alice",
+};
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "bob@example.com",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "supersecret12", // pragma: allowlist secret
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "bob",
+};
+
+async function loginUI(page: Page, email: string, password: string) {
+	await page.goto("/login");
+	await page.getByLabel(/Email Address|メール/i).fill(email);
+	await page.getByPlaceholder(/Password|パスワード/i).fill(password);
+	const submit = page.getByRole("button", { name: "Sign In", exact: true });
+	if (await submit.isVisible().catch(() => false)) {
+		await submit.click();
+	} else {
+		await page.getByRole("button", { name: "ログイン", exact: true }).click();
+	}
+	await page.waitForURL(/\/onboarding|\/$/);
+}
+
+/**
+ * 直接 API で tweet を作る (USER2 として)。stg の rate limit を抑えるため、
+ * UI 経由での投稿は最小限に留める。
+ */
+async function createTweetAsUser2(
+	request: APIRequestContext,
+	body: string,
+): Promise<number> {
+	// USER2 でログイン → CSRF 取得 → POST → 即 logout
+	await request.post("/api/v1/auth/jwt/create/", {
+		data: { email: USER2.email, password: USER2.password },
+	});
+	const csrfRes = await request.get("/api/v1/auth/csrf/");
+	const csrfToken =
+		(await csrfRes.json().catch(() => null))?.csrf_token ??
+		(await csrfRes.headers())["x-csrftoken"];
+	const res = await request.post("/api/v1/tweets/", {
+		data: { body },
+		headers: csrfToken ? { "X-CSRFToken": csrfToken } : {},
+	});
+	expect(res.status(), `tweet 作成 status (body=${body})`).toBeLessThan(300);
+	const tweet = await res.json();
+	return tweet.id as number;
+}
+
+test.describe.configure({ mode: "serial" });
+test.describe("#349 repost/quote 状態遷移 E2E", () => {
+	test("PostDialog 即時 close 不具合の検証 (menu→引用→Dialog が消えないこと)", async ({
+		page,
+	}) => {
+		await loginUI(page, USER1.email, USER1.password);
+		await page.goto("/");
+
+		// 「リポスト」または「リポスト済み」ラベルの trigger button を持つ通常 article
+		const article = page
+			.locator("article")
+			.filter({
+				has: page.getByRole("button", { name: /^リポスト(済み)?$/ }),
+			})
+			.first();
+		await expect(article).toBeVisible({ timeout: 15_000 });
+		const trigger = article.getByRole("button", { name: /^リポスト(済み)?$/ });
+		await trigger.click();
+
+		// menu「引用」 click → Dialog (textarea) が表示される
+		await page.getByRole("menuitem", { name: "引用" }).click();
+		const textarea = page.getByRole("textbox", { name: "引用リポストの本文" });
+		// 1.5 秒後でも textarea が見えていれば Dialog 即時 close 不具合は解消
+		await expect(textarea).toBeVisible({ timeout: 1_500 });
+		// 念入りに 1 秒後も visible (race condition 排除確認)
+		await page.waitForTimeout(1_000);
+		await expect(textarea).toBeVisible();
+		// URL が /tweet/<id> に飛んでないこと
+		expect(page.url()).toMatch(/\/$|\/(\?|#)/);
+
+		// Dialog 自体は ESC で閉じる
+		await page.keyboard.press("Escape");
+	});
+
+	test("シナリオ 1: (No, No) → リポスト → (Yes, No) + icon 色変化", async ({
+		page,
+		request,
+	}) => {
+		const targetId = await createTweetAsUser2(
+			request,
+			`#349 sc1 ${Date.now()}`,
+		);
+		await loginUI(page, USER1.email, USER1.password);
+		await page.goto(`/tweet/${targetId}`);
+
+		const trigger = page.getByRole("button", { name: "リポスト" });
+		await expect(trigger).toBeVisible({ timeout: 10_000 });
+		await trigger.click();
+		const repostResp = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/tweets/${targetId}/repost/`) &&
+				r.request().method() === "POST",
+		);
+		await page.getByRole("menuitem", { name: "リポスト" }).click();
+		const res = await repostResp;
+		expect([200, 201]).toContain(res.status());
+
+		// state: aria-label が「リポスト済み」に変わる
+		await expect(
+			page.getByRole("button", { name: "リポスト済み" }),
+		).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("シナリオ 3: (Yes, No) → リポストを取り消す → (No, No)", async ({
+		page,
+		request,
+	}) => {
+		const targetId = await createTweetAsUser2(
+			request,
+			`#349 sc3 ${Date.now()}`,
+		);
+		await loginUI(page, USER1.email, USER1.password);
+		// まず repost (UI で)
+		await page.goto(`/tweet/${targetId}`);
+		await page.getByRole("button", { name: "リポスト" }).click();
+		await page.getByRole("menuitem", { name: "リポスト" }).click();
+		await expect(
+			page.getByRole("button", { name: "リポスト済み" }),
+		).toBeVisible({ timeout: 5_000 });
+
+		// reposted=Yes → 取消
+		await page.getByRole("button", { name: "リポスト済み" }).click();
+		const unrepostResp = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/tweets/${targetId}/repost/`) &&
+				r.request().method() === "DELETE",
+		);
+		await page.getByRole("menuitem", { name: "リポストを取り消す" }).click();
+		const res = await unrepostResp;
+		expect(res.status()).toBe(204);
+
+		// (No, No) に戻る = aria-label が「リポスト」
+		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible({
+			timeout: 5_000,
+		});
+	});
+
+	test("シナリオ 4: (Yes, No) → 引用 + 投稿 → (Yes, Yes)  既存 REPOST 残存", async ({
+		page,
+		request,
+	}) => {
+		const targetId = await createTweetAsUser2(
+			request,
+			`#349 sc4 ${Date.now()}`,
+		);
+		await loginUI(page, USER1.email, USER1.password);
+		await page.goto(`/tweet/${targetId}`);
+		// repost (Yes, No) state を作る
+		await page.getByRole("button", { name: "リポスト" }).click();
+		await page.getByRole("menuitem", { name: "リポスト" }).click();
+		await expect(
+			page.getByRole("button", { name: "リポスト済み" }),
+		).toBeVisible({ timeout: 5_000 });
+
+		// reposted=Yes のまま 引用 menu を出す
+		await page.getByRole("button", { name: "リポスト済み" }).click();
+		// menu に「リポストを取り消す」と「引用」が並ぶ
+		await expect(
+			page.getByRole("menuitem", { name: "リポストを取り消す" }),
+		).toBeVisible();
+		await expect(page.getByRole("menuitem", { name: "引用" })).toBeVisible();
+		await page.getByRole("menuitem", { name: "引用" }).click();
+
+		// PostDialog open (即時 close 不具合の verify)
+		const textarea = page.getByRole("textbox", { name: "引用リポストの本文" });
+		await expect(textarea).toBeVisible({ timeout: 5_000 });
+		const marker = `[#349 sc4 quote ${Date.now()}]`;
+		await textarea.fill(marker);
+		const quoteResp = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/tweets/${targetId}/quote/`) &&
+				r.request().method() === "POST",
+		);
+		await page.getByRole("button", { name: "引用する", exact: true }).click();
+		const res = await quoteResp;
+		expect(res.status()).toBe(201);
+
+		// state: 既存 REPOST が残っていることを「リポスト済み」 label で確認
+		await expect(
+			page.getByRole("button", { name: "リポスト済み" }),
+		).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("シナリオ 6: (No, Yes) → 引用 + 投稿 → (No, Yes)  件数のみ +1, 状態不変", async ({
+		page,
+		request,
+	}) => {
+		const targetId = await createTweetAsUser2(
+			request,
+			`#349 sc6 ${Date.now()}`,
+		);
+		await loginUI(page, USER1.email, USER1.password);
+		await page.goto(`/tweet/${targetId}`);
+
+		// 1 回目の引用で (No, Yes) を作る
+		await page.getByRole("button", { name: "リポスト" }).click();
+		await page.getByRole("menuitem", { name: "引用" }).click();
+		await page
+			.getByRole("textbox", { name: "引用リポストの本文" })
+			.fill(`[#349 sc6 first ${Date.now()}]`);
+		const firstResp = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/tweets/${targetId}/quote/`) &&
+				r.request().method() === "POST",
+		);
+		await page.getByRole("button", { name: "引用する", exact: true }).click();
+		expect((await firstResp).status()).toBe(201);
+
+		// reposted=No (まだ) であることを「リポスト」label で確認 → state は (No, Yes)
+		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible({
+			timeout: 5_000,
+		});
+
+		// 2 回目の引用 → state は (No, Yes) のまま、件数だけ +1
+		await page.getByRole("button", { name: "リポスト" }).click();
+		await page.getByRole("menuitem", { name: "引用" }).click();
+		await page
+			.getByRole("textbox", { name: "引用リポストの本文" })
+			.fill(`[#349 sc6 second ${Date.now()}]`);
+		const secondResp = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/tweets/${targetId}/quote/`) &&
+				r.request().method() === "POST",
+		);
+		await page.getByRole("button", { name: "引用する", exact: true }).click();
+		expect((await secondResp).status()).toBe(201);
+		// state: still (No, Yes) — リポスト button は未 reposted
+		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible();
+	});
+
+	test("シナリオ 7+8: (Yes, Yes) → 取消 → (No, Yes), 引用 + 投稿 → (Yes, Yes) keep", async ({
+		page,
+		request,
+	}) => {
+		const targetId = await createTweetAsUser2(
+			request,
+			`#349 sc78 ${Date.now()}`,
+		);
+		await loginUI(page, USER1.email, USER1.password);
+		await page.goto(`/tweet/${targetId}`);
+		// repost
+		await page.getByRole("button", { name: "リポスト" }).click();
+		await page.getByRole("menuitem", { name: "リポスト" }).click();
+		await expect(
+			page.getByRole("button", { name: "リポスト済み" }),
+		).toBeVisible();
+		// quote (state -> Yes, Yes)
+		await page.getByRole("button", { name: "リポスト済み" }).click();
+		await page.getByRole("menuitem", { name: "引用" }).click();
+		await page
+			.getByRole("textbox", { name: "引用リポストの本文" })
+			.fill(`[#349 sc78 ${Date.now()}]`);
+		const r1 = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/tweets/${targetId}/quote/`) &&
+				r.request().method() === "POST",
+		);
+		await page.getByRole("button", { name: "引用する", exact: true }).click();
+		expect((await r1).status()).toBe(201);
+
+		// state: (Yes, Yes) → リポスト済み のまま
+		await expect(
+			page.getByRole("button", { name: "リポスト済み" }),
+		).toBeVisible({ timeout: 5_000 });
+
+		// シナリオ 7: 取消 → (No, Yes)
+		await page.getByRole("button", { name: "リポスト済み" }).click();
+		const r2 = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/tweets/${targetId}/repost/`) &&
+				r.request().method() === "DELETE",
+		);
+		await page.getByRole("menuitem", { name: "リポストを取り消す" }).click();
+		expect((await r2).status()).toBe(204);
+		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible({
+			timeout: 5_000,
+		});
+	});
+
+	test("シナリオ 9: 削除済み tweet に対する操作は 404 (#347 関連)", async ({
+		page,
+		request,
+	}) => {
+		const targetId = await createTweetAsUser2(
+			request,
+			`#349 sc9 will-delete ${Date.now()}`,
+		);
+		// USER2 として削除
+		await request.post("/api/v1/auth/jwt/create/", {
+			data: { email: USER2.email, password: USER2.password },
+		});
+		await request.delete(`/api/v1/tweets/${targetId}/`);
+
+		await loginUI(page, USER1.email, USER1.password);
+		// 削除済み tweet 詳細を直接開くと 404 ページ or tombstone を期待
+		const resp = await page.goto(`/tweet/${targetId}`);
+		// Next.js では 404 ページが 404 status を返さず content で「削除されました」を出す可能性
+		// どちらでも OK: 「削除された」文言があるか、404 status のいずれか
+		const status = resp?.status() ?? 0;
+		const body = await page.textContent("body").catch(() => "");
+		expect(
+			status === 404 || /削除されました|表示できません/.test(body ?? ""),
+			`削除済み tweet 詳細は 404 か tombstone (got status=${status})`,
+		).toBe(true);
+	});
+});

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -141,7 +141,16 @@ export default function TweetCard({
 			// e.target は EventTarget 型で Text node / 純 EventTarget の場合 closest を
 			// 持たないため、Element に narrow してから判定する。
 			if (!(e.target instanceof Element)) return;
-			if (e.target.closest("a, button, [role='button'], textarea, input"))
+			// #349: Radix DropdownMenu の menuitem は role="menuitem" (button では
+			// ない) で Portal 経由で render されても click が article に bubble して
+			// くる (実機で /tweet/<id> へ誤遷移する事象を確認)。menuitem 系 + Radix
+			// Portal 内 (data-radix-popper-content-wrapper) + Dialog 内の event を
+			// 包括的に除外する。
+			if (
+				e.target.closest(
+					"a, button, [role='button'], [role='menuitem'], [role='menuitemradio'], [role='menuitemcheckbox'], [role='dialog'], textarea, input, [data-radix-popper-content-wrapper]",
+				)
+			)
 				return;
 			if (typeof window !== "undefined") {
 				const sel = window.getSelection?.();
@@ -156,7 +165,11 @@ export default function TweetCard({
 			if (e.key === "Enter" || e.key === " ") {
 				if (!(e.target instanceof Element)) return;
 				// 内部の interactive element に focus がある場合はそちらの動作優先
-				if (e.target.closest("a, button, [role='button'], textarea, input"))
+				if (
+					e.target.closest(
+						"a, button, [role='button'], [role='menuitem'], [role='menuitemradio'], [role='menuitemcheckbox'], [role='dialog'], textarea, input, [data-radix-popper-content-wrapper]",
+					)
+				)
 					return;
 				e.preventDefault();
 				navigateToDetail(e);

--- a/client/src/components/tweets/RepostButton.tsx
+++ b/client/src/components/tweets/RepostButton.tsx
@@ -154,7 +154,12 @@ export default function RepostButton({
 				<DropdownMenuItem
 					onSelect={(e) => {
 						e.preventDefault();
-						onQuoteRequest?.();
+						// #349: Dialog open を menu close 完了後の次フレームに逃がす。
+						// 同フレームで両方走らせると Radix DropdownMenu の click event が
+						// PostDialog の onPointerDownOutside に届き Dialog が即時 close
+						// される race condition があるため (二重防御: TweetCard 側でも
+						// menuitem を closest 除外している)。
+						setTimeout(() => onQuoteRequest?.(), 0);
 					}}
 				>
 					引用

--- a/docs/specs/repost-quote-e2e-scenarios.md
+++ b/docs/specs/repost-quote-e2e-scenarios.md
@@ -1,0 +1,93 @@
+# リポスト / 引用 E2E 検証シナリオ
+
+> Version: 0.1
+> 最終更新: 2026-05-04
+> 関連: [repost-quote-state-machine.md](./repost-quote-state-machine.md)
+> spec ファイル: [`client/e2e/repost-quote-state-machine.spec.ts`](../../client/e2e/repost-quote-state-machine.spec.ts)
+
+---
+
+## 0. このドキュメントの位置づけ
+
+`docs/specs/repost-quote-state-machine.md` v0.2 §4.2 で定式化した状態遷移と分岐表を、Playwright E2E で網羅的に検証した記録。仕様書が「あるべき姿」、本書が「stg で実機検証した結果」の対応表。
+
+---
+
+## 1. 検証環境
+
+- 対象: stg (`https://stg.codeplace.me/`)
+- ブラウザ: Chromium (Playwright)
+- ユーザー: `test3@gmail.com` (USER1, アクター) / `test2@gmail.com` (USER2, target tweet 作成者)
+- 直接 API call (axios) で USER2 の tweet を毎テスト都度作成 → USER1 の UI で操作 → アサーション。stg の rate limit (#336) を抑えつつ UI 挙動を実機検証するハイブリッド戦略。
+
+---
+
+## 2. 検証シナリオ一覧
+
+| #                  | 現状態 `(reposted, quoted)` | action                           | 期待結果                                          | 結果                         | 備考                                                                   |
+| ------------------ | --------------------------- | -------------------------------- | ------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------- |
+| **bug-fix verify** | (任意)                      | menu「引用」 click → Dialog open | Dialog が即時 close せず 1 秒以上 visible         | (TBD)                        | #349 fix の verify (もとの不具合)                                      |
+| **1**              | (No, No)                    | リポスト押下                     | (Yes, No), `aria-label='リポスト済み'`, repost +1 | (TBD)                        |                                                                        |
+| **2**              | (No, No)                    | 引用 + 投稿                      | (No, Yes), quote +1                               | (TBD)                        |                                                                        |
+| **3**              | (Yes, No)                   | リポストを取り消す               | (No, No), `aria-label='リポスト'` 復帰, repost -1 | (TBD)                        |                                                                        |
+| **4**              | (Yes, No)                   | 引用 + 投稿                      | (Yes, Yes), 既存 REPOST 残存                      | (TBD)                        | ハルナさん指摘ポイント                                                 |
+| **5**              | (No, Yes)                   | リポスト押下                     | (Yes, Yes), 既存 QUOTE 群残存                     | (TBD)                        | (シナリオ 4 と対称、現 spec では 4 / 6 / 7+8 でカバー)                 |
+| **6**              | (No, Yes)                   | 引用 + 投稿                      | (No, Yes) のまま件数 +1                           | (TBD)                        | 状態不変、count のみ                                                   |
+| **7**              | (Yes, Yes)                  | リポストを取り消す               | (No, Yes), QUOTE 群そのまま                       | (TBD)                        | spec ではシナリオ 7+8 連結                                             |
+| **8**              | (Yes, Yes)                  | 引用 + 投稿                      | (Yes, Yes) keep, count +1                         | (TBD)                        | spec ではシナリオ 7+8 連結                                             |
+| **9**              | 削除済み tweet              | 詳細 navigate / 操作             | 404 もしくは tombstone                            | (TBD)                        | #347 関連                                                              |
+| **10**             | REPOST tweet 起点           | リポスト                         | repost_of (= 元 tweet) を target にする           | サーバ pytest で既に検証済み | #346 で apps/tweets/tests/test_actions_api.py に integration test あり |
+
+> spec ファイル: `client/e2e/repost-quote-state-machine.spec.ts`
+
+各シナリオは独立して実行可能 (`test.describe.configure({ mode: "serial" })` で順次実行)。
+
+---
+
+## 3. 発見した不具合
+
+### 3.1 PostDialog 即時 close 不具合 (発見日: 2026-05-04)
+
+**症状**: TweetCard footer の「リポスト」 menu trigger をクリック → DropdownMenu の「引用」項目を選ぶと、PostDialog が瞬間的に開いた直後に閉じてしまい、`/tweet/<id>` 詳細ページに遷移してしまう。
+
+**再現手順 (修正前 stg で確認)**:
+
+1. ホーム画面でログイン後、TL の任意の tweet で「リポスト」アイコンを click
+2. DropdownMenu の「引用」項目を click
+3. 引用本文の textarea が一瞬表示されるが、500ms 以内に消える
+4. URL が `/tweet/<id>` に変わっている
+
+**根本原因**: 2 つの要因が重なっていた:
+
+1. Radix `DropdownMenuItem` は `role="menuitem"` (`<button>` ではない) で render される。TweetCard の navigateToDetail で `closest('a, button, [role="button"]')` で interactive element を判定していたが、`role="menuitem"` を含めていなかったため、menu item の click が article に bubble して TweetCard onClick として処理され、`/tweet/<id>` に遷移してしまっていた。
+2. 同フレームで DropdownMenu close と Dialog open が走ると、Radix の pointer event 連鎖で Dialog が "outside click" を検知して即時 close される race condition も併発。
+
+**修正** (本 issue):
+
+- `client/src/components/timeline/TweetCard.tsx`: `closest()` セレクタに `[role='menuitem']`, `[role='menuitemradio']`, `[role='menuitemcheckbox']`, `[role='dialog']`, `[data-radix-popper-content-wrapper]` を追加して、Radix が描画する menu / Dialog / Popper portal 内の event を包括除外。
+- `client/src/components/tweets/RepostButton.tsx`: DropdownMenuItem `onSelect` で `setTimeout(() => onQuoteRequest?.(), 0)` に変更。menu close 完了を待ってから Dialog を open する (二重防御)。
+
+**verify**: 本 spec の 「PostDialog 即時 close 不具合の検証」 テストが click 後 1 秒以上 textarea が visible かつ URL が `/` のままであることをアサート。
+
+---
+
+## 4. 実行方法
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test3@gmail.com PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test3 \
+PLAYWRIGHT_USER2_EMAIL=test2@gmail.com PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER2_HANDLE=test2 \
+cd client && npx playwright test e2e/repost-quote-state-machine.spec.ts
+```
+
+ローカル (`docker compose -f local.yml up`) でも `PLAYWRIGHT_BASE_URL=http://localhost:8080` に変えれば動作する。stg では rate limit (#336) を踏むため、複数回連続実行はやめて、1 回ずつ実行 + 24h おきが安全。
+
+---
+
+## 5. 既知の制約
+
+- **シナリオ 5** (`(No, Yes) → リポスト → (Yes, Yes)`) の独立 spec は省略。シナリオ 4 (`(Yes, No) → 引用 + 投稿 → (Yes, Yes)`) と論理的に対称で、内部状態としてシナリオ 7+8 で `(Yes, Yes)` の作成と取消をすべてカバーしているため。
+- **REPOST tweet 起点 (シナリオ 10)** は サーバ側 pytest (`apps/tweets/tests/test_actions_api.py::TestResolveTargetRepostFallthrough`) で integration test 済み。UI 経由では再現困難 (REPOST tweet article には現状 RepostButton が無い、§5.2 の Phase 4 マター)。
+- 本 spec は **stg deploy 後に手動実行** が前提。CI には組み込まない (rate limit と E2E 安定性の観点)。


### PR DESCRIPTION
## Summary

「引用付きリポストしようとすると入力欄がすぐ消える」を修正。docs §4.2 全シナリオを Playwright E2E で網羅検証する spec + 検証ドキュメントを追加。

## 不具合の根本原因 (2 件)

1. Radix \`DropdownMenuItem\` は \`role=\"menuitem\"\` で render される。TweetCard \`navigateToDetail\` (#340) で \`closest('a, button, [role=\"button\"]')\` 判定では除外できず、menu item の click が article に bubble して \`/tweet/<id>\` へ誤遷移
2. menu close と Dialog open が同フレームで走ると Radix pointer event 連鎖で Dialog が「outside click」検知 → 即時 close

## 修正

- \`TweetCard.tsx\`: \`closest\` セレクタに \`[role='menuitem']\` 系 + \`[role='dialog']\` + \`[data-radix-popper-content-wrapper]\` を追加
- \`RepostButton.tsx\`: \`DropdownMenuItem onSelect\` で \`setTimeout(0)\` に逃がす (二重防御)

## E2E spec

\`client/e2e/repost-quote-state-machine.spec.ts\` (8 tests):
- bug-fix verify (Dialog が消えないこと)
- シナリオ 1/3/4/6/7+8/9 の状態遷移
- USER2 API + USER1 UI のハイブリッド戦略で stg rate limit (#336) を抑制

## docs

\`docs/specs/repost-quote-e2e-scenarios.md\` 新設。

## Test plan

- [x] vitest 380/380 green、tsc / lint 緑
- [ ] stg deploy 後に spec 実行 → docs に結果追記