### PR TITLE
[docs+test] repost/quote E2E 実行結果記録 + spec 簡略化 (#349 follow-up)

### DIFF
--- a/client/e2e/repost-quote-state-machine.spec.ts
+++ b/client/e2e/repost-quote-state-machine.spec.ts
@@ -1,51 +1,35 @@
 /**
  * #349: docs/specs/repost-quote-state-machine.md §4.2 全シナリオの E2E.
  *
- * 検証する状態遷移 (actor=USER1 から target tweet (USER2 作成) に対する操作):
+ * 検証する状態遷移 (USER1 が自分の tweet に対して操作するスタイル. 現状の
+ * 実装は self-repost / self-quote を block しないため、テストとしては成立する.
+ * X 仕様としては self は disable すべきだが、それは別 issue):
  *
  *   1. (No,  No)  → リポスト          → (Yes, No)
- *   2. (No,  No)  → 引用 + 投稿       → (No,  Yes)
  *   3. (Yes, No)  → リポストを取り消す → (No,  No)
  *   4. (Yes, No)  → 引用 + 投稿       → (Yes, Yes)  ← ハルナさん指摘ポイント
- *   5. (No,  Yes) → リポスト          → (Yes, Yes)
- *   6. (No,  Yes) → 引用 + 投稿       → (No,  Yes)  (件数のみ +1)
- *   7. (Yes, Yes) → リポストを取り消す → (No,  Yes)
- *   8. (Yes, Yes) → 引用 + 投稿       → (Yes, Yes)
+ *   6. (No,  Yes) → 引用 + 投稿       → (No,  Yes)  (件数のみ +1, 状態不変)
+ *   7+8. (Yes, Yes) → 取消 → (No, Yes), 引用 → (Yes, Yes) keep
  *
  * 加えて:
- *   - PostDialog 即時 close 不具合 (#349 fix verify)
- *   - REPOST tweet 起点の repost が repost_of に解決される (#346)
- *   - 削除済み tweet を target にすると 404 (#347 関連)
+ *   - PostDialog 即時 close 不具合 (#349 fix verify, ハルナさん最初の指摘)
+ *   - 削除済み tweet 詳細は 404 / tombstone
  *
- * 直接 API call (axios) で状態遷移を作り、間に UI からの操作を挟むハイブリッド
- * 戦略を採る。これにより stg の rate limit (#336) を抑えつつ、UI の挙動 (menu
- * 描画、Dialog open、icon 色変化) を実機で確認できる。
+ * REPOST tweet 起点 (シナリオ 10) は サーバ pytest で別途検証済み (#346).
  *
  * 実行:
  *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
  *   PLAYWRIGHT_USER1_EMAIL=test3@gmail.com PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
  *   PLAYWRIGHT_USER1_HANDLE=test3 \
- *   PLAYWRIGHT_USER2_EMAIL=test2@gmail.com PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
- *   PLAYWRIGHT_USER2_HANDLE=test2 \
- *   npx playwright test e2e/repost-quote-state-machine.spec.ts
+ *   npx playwright test e2e/repost-quote-state-machine.spec.ts --workers=1
  */
 
-import {
-	type APIRequestContext,
-	expect,
-	type Page,
-	test,
-} from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 const USER1 = {
 	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "alice@example.com",
 	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "supersecret12", // pragma: allowlist secret
 	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "alice",
-};
-const USER2 = {
-	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "bob@example.com",
-	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "supersecret12", // pragma: allowlist secret
-	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "bob",
 };
 
 async function loginUI(page: Page, email: string, password: string) {
@@ -62,27 +46,22 @@ async function loginUI(page: Page, email: string, password: string) {
 }
 
 /**
- * 直接 API で tweet を作る (USER2 として)。stg の rate limit を抑えるため、
- * UI 経由での投稿は最小限に留める。
+ * USER1 (login 済み page) が composer から自分の tweet を投稿し、その id を
+ * 返す。
  */
-async function createTweetAsUser2(
-	request: APIRequestContext,
-	body: string,
-): Promise<number> {
-	// USER2 でログイン → CSRF 取得 → POST → 即 logout
-	await request.post("/api/v1/auth/jwt/create/", {
-		data: { email: USER2.email, password: USER2.password },
-	});
-	const csrfRes = await request.get("/api/v1/auth/csrf/");
-	const csrfToken =
-		(await csrfRes.json().catch(() => null))?.csrf_token ??
-		(await csrfRes.headers())["x-csrftoken"];
-	const res = await request.post("/api/v1/tweets/", {
-		data: { body },
-		headers: csrfToken ? { "X-CSRFToken": csrfToken } : {},
-	});
-	expect(res.status(), `tweet 作成 status (body=${body})`).toBeLessThan(300);
-	const tweet = await res.json();
+async function postOwnTweetUI(page: Page, body: string): Promise<number> {
+	await page.goto("/");
+	const composer = page.getByRole("textbox", { name: "ツイート本文" });
+	await expect(composer).toBeVisible({ timeout: 15_000 });
+	await composer.fill(body);
+	const resp = page.waitForResponse(
+		(r) =>
+			r.url().endsWith("/api/v1/tweets/") && r.request().method() === "POST",
+	);
+	await page.getByRole("button", { name: "投稿", exact: true }).click();
+	const r = await resp;
+	expect(r.status()).toBe(201);
+	const tweet = await r.json();
 	return tweet.id as number;
 }
 
@@ -94,7 +73,6 @@ test.describe("#349 repost/quote 状態遷移 E2E", () => {
 		await loginUI(page, USER1.email, USER1.password);
 		await page.goto("/");
 
-		// 「リポスト」または「リポスト済み」ラベルの trigger button を持つ通常 article
 		const article = page
 			.locator("article")
 			.filter({
@@ -104,69 +82,51 @@ test.describe("#349 repost/quote 状態遷移 E2E", () => {
 		await expect(article).toBeVisible({ timeout: 15_000 });
 		const trigger = article.getByRole("button", { name: /^リポスト(済み)?$/ });
 		await trigger.click();
-
-		// menu「引用」 click → Dialog (textarea) が表示される
 		await page.getByRole("menuitem", { name: "引用" }).click();
 		const textarea = page.getByRole("textbox", { name: "引用リポストの本文" });
-		// 1.5 秒後でも textarea が見えていれば Dialog 即時 close 不具合は解消
 		await expect(textarea).toBeVisible({ timeout: 1_500 });
-		// 念入りに 1 秒後も visible (race condition 排除確認)
+		// 1 秒待っても visible (race condition 排除確認)
 		await page.waitForTimeout(1_000);
 		await expect(textarea).toBeVisible();
 		// URL が /tweet/<id> に飛んでないこと
-		expect(page.url()).toMatch(/\/$|\/(\?|#)/);
-
-		// Dialog 自体は ESC で閉じる
+		expect(page.url()).not.toMatch(/\/tweet\/\d+/);
 		await page.keyboard.press("Escape");
 	});
 
-	test("シナリオ 1: (No, No) → リポスト → (Yes, No) + icon 色変化", async ({
-		page,
-		request,
-	}) => {
-		const targetId = await createTweetAsUser2(
-			request,
-			`#349 sc1 ${Date.now()}`,
-		);
+	test("シナリオ 1: (No, No) → リポスト → (Yes, No)", async ({ page }) => {
 		await loginUI(page, USER1.email, USER1.password);
+		const targetId = await postOwnTweetUI(page, `#349 sc1 ${Date.now()}`);
 		await page.goto(`/tweet/${targetId}`);
 
-		const trigger = page.getByRole("button", { name: "リポスト" });
-		await expect(trigger).toBeVisible({ timeout: 10_000 });
-		await trigger.click();
+		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible({
+			timeout: 10_000,
+		});
+		await page.getByRole("button", { name: "リポスト" }).click();
 		const repostResp = page.waitForResponse(
 			(r) =>
 				r.url().includes(`/tweets/${targetId}/repost/`) &&
 				r.request().method() === "POST",
 		);
 		await page.getByRole("menuitem", { name: "リポスト" }).click();
-		const res = await repostResp;
-		expect([200, 201]).toContain(res.status());
-
-		// state: aria-label が「リポスト済み」に変わる
+		expect([200, 201]).toContain((await repostResp).status());
 		await expect(
 			page.getByRole("button", { name: "リポスト済み" }),
 		).toBeVisible({ timeout: 5_000 });
 	});
 
-	test("シナリオ 3: (Yes, No) → リポストを取り消す → (No, No)", async ({
-		page,
-		request,
-	}) => {
-		const targetId = await createTweetAsUser2(
-			request,
-			`#349 sc3 ${Date.now()}`,
-		);
+	test("シナリオ 3: (Yes, No) → 取消 → (No, No)", async ({ page }) => {
 		await loginUI(page, USER1.email, USER1.password);
-		// まず repost (UI で)
+		const targetId = await postOwnTweetUI(page, `#349 sc3 ${Date.now()}`);
 		await page.goto(`/tweet/${targetId}`);
+
+		// (Yes, No) を作る
 		await page.getByRole("button", { name: "リポスト" }).click();
 		await page.getByRole("menuitem", { name: "リポスト" }).click();
 		await expect(
 			page.getByRole("button", { name: "リポスト済み" }),
 		).toBeVisible({ timeout: 5_000 });
 
-		// reposted=Yes → 取消
+		// 取消
 		await page.getByRole("button", { name: "リポスト済み" }).click();
 		const unrepostResp = page.waitForResponse(
 			(r) =>
@@ -174,125 +134,103 @@ test.describe("#349 repost/quote 状態遷移 E2E", () => {
 				r.request().method() === "DELETE",
 		);
 		await page.getByRole("menuitem", { name: "リポストを取り消す" }).click();
-		const res = await unrepostResp;
-		expect(res.status()).toBe(204);
-
-		// (No, No) に戻る = aria-label が「リポスト」
+		expect((await unrepostResp).status()).toBe(204);
 		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible({
 			timeout: 5_000,
 		});
 	});
 
-	test("シナリオ 4: (Yes, No) → 引用 + 投稿 → (Yes, Yes)  既存 REPOST 残存", async ({
+	test("シナリオ 4: (Yes, No) → 引用 → (Yes, Yes)  既存 REPOST 残存", async ({
 		page,
-		request,
 	}) => {
-		const targetId = await createTweetAsUser2(
-			request,
-			`#349 sc4 ${Date.now()}`,
-		);
 		await loginUI(page, USER1.email, USER1.password);
+		const targetId = await postOwnTweetUI(page, `#349 sc4 ${Date.now()}`);
 		await page.goto(`/tweet/${targetId}`);
-		// repost (Yes, No) state を作る
+
+		// (Yes, No)
 		await page.getByRole("button", { name: "リポスト" }).click();
 		await page.getByRole("menuitem", { name: "リポスト" }).click();
 		await expect(
 			page.getByRole("button", { name: "リポスト済み" }),
 		).toBeVisible({ timeout: 5_000 });
 
-		// reposted=Yes のまま 引用 menu を出す
+		// 引用 (PostDialog が即時 close しないことも兼ねて検証)
 		await page.getByRole("button", { name: "リポスト済み" }).click();
-		// menu に「リポストを取り消す」と「引用」が並ぶ
 		await expect(
 			page.getByRole("menuitem", { name: "リポストを取り消す" }),
 		).toBeVisible();
 		await expect(page.getByRole("menuitem", { name: "引用" })).toBeVisible();
 		await page.getByRole("menuitem", { name: "引用" }).click();
-
-		// PostDialog open (即時 close 不具合の verify)
 		const textarea = page.getByRole("textbox", { name: "引用リポストの本文" });
 		await expect(textarea).toBeVisible({ timeout: 5_000 });
-		const marker = `[#349 sc4 quote ${Date.now()}]`;
-		await textarea.fill(marker);
+		await textarea.fill(`[#349 sc4 ${Date.now()}]`);
 		const quoteResp = page.waitForResponse(
 			(r) =>
 				r.url().includes(`/tweets/${targetId}/quote/`) &&
 				r.request().method() === "POST",
 		);
 		await page.getByRole("button", { name: "引用する", exact: true }).click();
-		const res = await quoteResp;
-		expect(res.status()).toBe(201);
-
-		// state: 既存 REPOST が残っていることを「リポスト済み」 label で確認
+		expect((await quoteResp).status()).toBe(201);
+		// 既存 REPOST が残っていることを「リポスト済み」 label で確認
 		await expect(
 			page.getByRole("button", { name: "リポスト済み" }),
 		).toBeVisible({ timeout: 5_000 });
 	});
 
-	test("シナリオ 6: (No, Yes) → 引用 + 投稿 → (No, Yes)  件数のみ +1, 状態不変", async ({
+	test("シナリオ 6: (No, Yes) → 引用 → (No, Yes) 件数のみ +1, 状態不変", async ({
 		page,
-		request,
 	}) => {
-		const targetId = await createTweetAsUser2(
-			request,
-			`#349 sc6 ${Date.now()}`,
-		);
 		await loginUI(page, USER1.email, USER1.password);
+		const targetId = await postOwnTweetUI(page, `#349 sc6 ${Date.now()}`);
 		await page.goto(`/tweet/${targetId}`);
 
-		// 1 回目の引用で (No, Yes) を作る
+		// 1 回目の引用 → (No, Yes)
 		await page.getByRole("button", { name: "リポスト" }).click();
 		await page.getByRole("menuitem", { name: "引用" }).click();
 		await page
 			.getByRole("textbox", { name: "引用リポストの本文" })
-			.fill(`[#349 sc6 first ${Date.now()}]`);
-		const firstResp = page.waitForResponse(
+			.fill(`[#349 sc6 1st ${Date.now()}]`);
+		const r1 = page.waitForResponse(
 			(r) =>
 				r.url().includes(`/tweets/${targetId}/quote/`) &&
 				r.request().method() === "POST",
 		);
 		await page.getByRole("button", { name: "引用する", exact: true }).click();
-		expect((await firstResp).status()).toBe(201);
-
-		// reposted=No (まだ) であることを「リポスト」label で確認 → state は (No, Yes)
+		expect((await r1).status()).toBe(201);
+		// reposted=No のまま
 		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible({
 			timeout: 5_000,
 		});
 
-		// 2 回目の引用 → state は (No, Yes) のまま、件数だけ +1
+		// 2 回目の引用 → 状態不変
 		await page.getByRole("button", { name: "リポスト" }).click();
 		await page.getByRole("menuitem", { name: "引用" }).click();
 		await page
 			.getByRole("textbox", { name: "引用リポストの本文" })
-			.fill(`[#349 sc6 second ${Date.now()}]`);
-		const secondResp = page.waitForResponse(
+			.fill(`[#349 sc6 2nd ${Date.now()}]`);
+		const r2 = page.waitForResponse(
 			(r) =>
 				r.url().includes(`/tweets/${targetId}/quote/`) &&
 				r.request().method() === "POST",
 		);
 		await page.getByRole("button", { name: "引用する", exact: true }).click();
-		expect((await secondResp).status()).toBe(201);
-		// state: still (No, Yes) — リポスト button は未 reposted
+		expect((await r2).status()).toBe(201);
 		await expect(page.getByRole("button", { name: "リポスト" })).toBeVisible();
 	});
 
-	test("シナリオ 7+8: (Yes, Yes) → 取消 → (No, Yes), 引用 + 投稿 → (Yes, Yes) keep", async ({
+	test("シナリオ 7+8: (Yes, Yes) → 取消 → (No, Yes), 引用 → (Yes, Yes) keep", async ({
 		page,
-		request,
 	}) => {
-		const targetId = await createTweetAsUser2(
-			request,
-			`#349 sc78 ${Date.now()}`,
-		);
 		await loginUI(page, USER1.email, USER1.password);
+		const targetId = await postOwnTweetUI(page, `#349 sc78 ${Date.now()}`);
 		await page.goto(`/tweet/${targetId}`);
-		// repost
+
+		// (Yes, Yes) を作る
 		await page.getByRole("button", { name: "リポスト" }).click();
 		await page.getByRole("menuitem", { name: "リポスト" }).click();
 		await expect(
 			page.getByRole("button", { name: "リポスト済み" }),
 		).toBeVisible();
-		// quote (state -> Yes, Yes)
 		await page.getByRole("button", { name: "リポスト済み" }).click();
 		await page.getByRole("menuitem", { name: "引用" }).click();
 		await page
@@ -305,13 +243,11 @@ test.describe("#349 repost/quote 状態遷移 E2E", () => {
 		);
 		await page.getByRole("button", { name: "引用する", exact: true }).click();
 		expect((await r1).status()).toBe(201);
-
-		// state: (Yes, Yes) → リポスト済み のまま
 		await expect(
 			page.getByRole("button", { name: "リポスト済み" }),
 		).toBeVisible({ timeout: 5_000 });
 
-		// シナリオ 7: 取消 → (No, Yes)
+		// 取消 → (No, Yes)
 		await page.getByRole("button", { name: "リポスト済み" }).click();
 		const r2 = page.waitForResponse(
 			(r) =>
@@ -325,25 +261,17 @@ test.describe("#349 repost/quote 状態遷移 E2E", () => {
 		});
 	});
 
-	test("シナリオ 9: 削除済み tweet に対する操作は 404 (#347 関連)", async ({
+	test("シナリオ 9: 削除済み tweet の詳細は 404 / tombstone", async ({
 		page,
-		request,
 	}) => {
-		const targetId = await createTweetAsUser2(
-			request,
-			`#349 sc9 will-delete ${Date.now()}`,
-		);
-		// USER2 として削除
-		await request.post("/api/v1/auth/jwt/create/", {
-			data: { email: USER2.email, password: USER2.password },
-		});
-		await request.delete(`/api/v1/tweets/${targetId}/`);
-
 		await loginUI(page, USER1.email, USER1.password);
-		// 削除済み tweet 詳細を直接開くと 404 ページ or tombstone を期待
+		const targetId = await postOwnTweetUI(page, `#349 sc9 ${Date.now()}`);
+		// 自分の tweet を API 経由で削除 (page の cookie auth を使う)
+		const delResp = await page.request.delete(`/api/v1/tweets/${targetId}/`);
+		expect([204, 200]).toContain(delResp.status());
+
+		// 削除済み tweet 詳細を開く
 		const resp = await page.goto(`/tweet/${targetId}`);
-		// Next.js では 404 ページが 404 status を返さず content で「削除されました」を出す可能性
-		// どちらでも OK: 「削除された」文言があるか、404 status のいずれか
 		const status = resp?.status() ?? 0;
 		const body = await page.textContent("body").catch(() => "");
 		expect(

--- a/docs/specs/repost-quote-e2e-scenarios.md
+++ b/docs/specs/repost-quote-e2e-scenarios.md
@@ -24,19 +24,19 @@
 
 ## 2. 検証シナリオ一覧
 
-| #                  | 現状態 `(reposted, quoted)` | action                           | 期待結果                                          | 結果                         | 備考                                                                   |
-| ------------------ | --------------------------- | -------------------------------- | ------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------- |
-| **bug-fix verify** | (任意)                      | menu「引用」 click → Dialog open | Dialog が即時 close せず 1 秒以上 visible         | (TBD)                        | #349 fix の verify (もとの不具合)                                      |
-| **1**              | (No, No)                    | リポスト押下                     | (Yes, No), `aria-label='リポスト済み'`, repost +1 | (TBD)                        |                                                                        |
-| **2**              | (No, No)                    | 引用 + 投稿                      | (No, Yes), quote +1                               | (TBD)                        |                                                                        |
-| **3**              | (Yes, No)                   | リポストを取り消す               | (No, No), `aria-label='リポスト'` 復帰, repost -1 | (TBD)                        |                                                                        |
-| **4**              | (Yes, No)                   | 引用 + 投稿                      | (Yes, Yes), 既存 REPOST 残存                      | (TBD)                        | ハルナさん指摘ポイント                                                 |
-| **5**              | (No, Yes)                   | リポスト押下                     | (Yes, Yes), 既存 QUOTE 群残存                     | (TBD)                        | (シナリオ 4 と対称、現 spec では 4 / 6 / 7+8 でカバー)                 |
-| **6**              | (No, Yes)                   | 引用 + 投稿                      | (No, Yes) のまま件数 +1                           | (TBD)                        | 状態不変、count のみ                                                   |
-| **7**              | (Yes, Yes)                  | リポストを取り消す               | (No, Yes), QUOTE 群そのまま                       | (TBD)                        | spec ではシナリオ 7+8 連結                                             |
-| **8**              | (Yes, Yes)                  | 引用 + 投稿                      | (Yes, Yes) keep, count +1                         | (TBD)                        | spec ではシナリオ 7+8 連結                                             |
-| **9**              | 削除済み tweet              | 詳細 navigate / 操作             | 404 もしくは tombstone                            | (TBD)                        | #347 関連                                                              |
-| **10**             | REPOST tweet 起点           | リポスト                         | repost_of (= 元 tweet) を target にする           | サーバ pytest で既に検証済み | #346 で apps/tweets/tests/test_actions_api.py に integration test あり |
+| #                  | 現状態 `(reposted, quoted)` | action                           | 期待結果                                          | 結果 (2026-05-04 stg)       | 備考                                                                   |
+| ------------------ | --------------------------- | -------------------------------- | ------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------- |
+| **bug-fix verify** | (任意)                      | menu「引用」 click → Dialog open | Dialog が即時 close せず 1 秒以上 visible         | ✅ **PASS** (8.9s)          | #349 fix の有効性を実機で確認                                          |
+| **1**              | (No, No)                    | リポスト押下                     | (Yes, No), `aria-label='リポスト済み'`, repost +1 | ❌ blocked by #351          | API は 200/201 だが UI に反映されない (#351)                           |
+| **2**              | (No, No)                    | 引用 + 投稿                      | (No, Yes), quote +1                               | ⏸ did not run              | sc1 fail で serial 中断                                                |
+| **3**              | (Yes, No)                   | リポストを取り消す               | (No, No), `aria-label='リポスト'` 復帰, repost -1 | ⏸ did not run              | sc1 fail で serial 中断                                                |
+| **4**              | (Yes, No)                   | 引用 + 投稿                      | (Yes, Yes), 既存 REPOST 残存                      | ⏸ did not run              | sc1 fail で serial 中断 (ハルナさん指摘ポイント)                       |
+| **5**              | (No, Yes)                   | リポスト押下                     | (Yes, Yes), 既存 QUOTE 群残存                     | ⏸ did not run              | (シナリオ 4 と対称、現 spec では 4 / 6 / 7+8 でカバー)                 |
+| **6**              | (No, Yes)                   | 引用 + 投稿                      | (No, Yes) のまま件数 +1                           | ⏸ did not run              | 状態不変、count のみ                                                   |
+| **7**              | (Yes, Yes)                  | リポストを取り消す               | (No, Yes), QUOTE 群そのまま                       | ⏸ did not run              | spec ではシナリオ 7+8 連結                                             |
+| **8**              | (Yes, Yes)                  | 引用 + 投稿                      | (Yes, Yes) keep, count +1                         | ⏸ did not run              | spec ではシナリオ 7+8 連結                                             |
+| **9**              | 削除済み tweet              | 詳細 navigate / 操作             | 404 もしくは tombstone                            | ⏸ did not run              | #347 関連                                                              |
+| **10**             | REPOST tweet 起点           | リポスト                         | repost_of (= 元 tweet) を target にする           | ✅ サーバ pytest で検証済み | #346 で apps/tweets/tests/test_actions_api.py に integration test あり |
 
 > spec ファイル: `client/e2e/repost-quote-state-machine.spec.ts`
 
@@ -67,7 +67,21 @@
 - `client/src/components/timeline/TweetCard.tsx`: `closest()` セレクタに `[role='menuitem']`, `[role='menuitemradio']`, `[role='menuitemcheckbox']`, `[role='dialog']`, `[data-radix-popper-content-wrapper]` を追加して、Radix が描画する menu / Dialog / Popper portal 内の event を包括除外。
 - `client/src/components/tweets/RepostButton.tsx`: DropdownMenuItem `onSelect` で `setTimeout(() => onQuoteRequest?.(), 0)` に変更。menu close 完了を待ってから Dialog を open する (二重防御)。
 
-**verify**: 本 spec の 「PostDialog 即時 close 不具合の検証」 テストが click 後 1 秒以上 textarea が visible かつ URL が `/` のままであることをアサート。
+**verify**: 本 spec の 「PostDialog 即時 close 不具合の検証」 テストが click 後 1 秒以上 textarea が visible かつ URL が `/tweet/<id>` に飛んでいないことをアサート。**2026-05-04 stg で PASS 確認済み**。
+
+### 3.2 RepostButton の永続状態が UI に反映されない (発見日: 2026-05-04, 別 issue #351)
+
+**症状**: シナリオ 1 (`(No, No) → リポスト → (Yes, No)`) を spec で実行すると、リポスト API は 201 で成功するが、5 秒待っても `aria-label='リポスト済み'` の button が見つからず fail する。同 spec で serial mode のため シナリオ 2-9 が did_not_run。
+
+**根本原因**: `client/src/components/timeline/TweetCard.tsx` で RepostButton に `initialReposted` を渡していない。RepostButton は default `false` で起動するため:
+
+- 自分が既に repost 済みの tweet を再描画すると常に「リポスト」 (= 未) で表示される
+- API call 後に `setReposted(true)` で local state は更新されるが、page reload / re-render するとリセット
+- `/tweet/<id>` (server component) に goto した直後は server-fetched data に `reposted_by_me` が無いため、再 mount 時の `initialReposted` 値も復元できない
+
+**対応**: backend serializer に `reposted_by_me: bool` を追加 + frontend の TweetCard が RepostButton.initialReposted に渡す。**Issue #351 で別途起票して Phase 2 内で対応予定**。
+
+**E2E spec への影響**: シナリオ 1-9 の自動実行は Issue #351 解消後に再走行する。本 PR の docs はそれを既知制約として記録。
 
 ---
 


### PR DESCRIPTION
## Summary

#349 で追加した E2E spec を stg 実機で実行した結果を docs に記録、spec 本体も self-tweet 戦略に簡略化。

## E2E 実行結果 (2026-05-04 stg)

| シナリオ | 結果 |
|---|---|
| **bug-fix verify** | ✅ PASS — PostDialog 即時 close 修正の有効性を実機確認 (8.9s) |
| シナリオ 1 (No,No)→リポスト | ❌ FAIL — API 201 だが UI 反映されず → 別 issue **#351** で起票 |
| シナリオ 2-9 | ⏸ did not run (serial mode で sc1 fail で中断) |
| シナリオ 10 (REPOST 起点) | ✅ サーバ pytest で別途検証済み (#346) |

## 発見した別不具合 (Issue #351)

**TweetCard が RepostButton に \`initialReposted\` を渡していない**。default \`false\` で起動するため、ユーザーが既に repost 済みの tweet を再描画すると常に「リポスト」 (未) 表示される。さらに backend serializer に \`reposted_by_me: bool\` フィールドが無いため、サーバ → クライアントで永続状態を復元できない。

→ **#351 で対応予定**。修正後に E2E spec シナリオ 1-9 を再実行する方針。

## 関連

- 関連: #349, #351