### PR TITLE
[fix][tweets+timeline] reposted_by_me で RepostButton 永続状態を復元 (Closes #351)

### DIFF
--- a/apps/timeline/views.py
+++ b/apps/timeline/views.py
@@ -18,7 +18,7 @@ from apps.timeline.services import (
     build_explore_tl,
     get_or_build_home_tl,
 )
-from apps.tweets.models import Tweet
+from apps.tweets.models import Tweet, TweetType
 from apps.tweets.serializers import TweetListSerializer
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,28 @@ def _parse_limit(request: Request, default: int = 20, cap: int = 100) -> int:
         return max(1, min(int(request.query_params.get("limit", default)), cap))
     except (TypeError, ValueError):
         return default
+
+
+def _viewer_repost_ids(request: Request, tweets: list[Tweet]) -> set[int]:
+    """#351: viewer が REPOST 済みの target id 集合を 1 query で取得.
+
+    TweetListSerializer.get_reposted_by_me が context["viewer_repost_ids"] を
+    優先して使うので、N+1 を避けるために list 描画前に prefetch する。
+    未認証なら空 set。
+    """
+    if isinstance(request.user, AnonymousUser) or not tweets:
+        return set()
+    target_ids = {t.pk for t in tweets}
+    # repost_of がある (= REPOST tweet) 行は repost_of_id を target にした
+    # 直接対応も含める (UI の REPOST article 上で reposted 表示する将来用)。
+    target_ids.update(t.repost_of_id for t in tweets if t.repost_of_id is not None)
+    return set(
+        Tweet.objects.filter(
+            author=request.user,
+            type=TweetType.REPOST,
+            repost_of_id__in=target_ids,
+        ).values_list("repost_of_id", flat=True)
+    )
 
 
 def _slice_with_cursor(
@@ -77,7 +99,14 @@ class HomeTimelineView(APIView):
             },
         )
 
-        data = TweetListSerializer(page, many=True, context={"request": request}).data
+        data = TweetListSerializer(
+            page,
+            many=True,
+            context={
+                "request": request,
+                "viewer_repost_ids": _viewer_repost_ids(request, page),
+            },
+        ).data
         return Response(
             {
                 "results": data,
@@ -119,7 +148,14 @@ class FollowingTimelineView(APIView):
         page = rows[:limit]
         next_cursor = encode_cursor(page[-1].pk) if has_more and page else None
 
-        data = TweetListSerializer(page, many=True, context={"request": request}).data
+        data = TweetListSerializer(
+            page,
+            many=True,
+            context={
+                "request": request,
+                "viewer_repost_ids": _viewer_repost_ids(request, page),
+            },
+        ).data
         return Response({"results": data, "next_cursor": next_cursor, "has_more": has_more})
 
 
@@ -139,5 +175,12 @@ class ExploreTimelineView(APIView):
         full = build_explore_tl(viewer=viewer, limit=limit * 5)
         page, next_cursor, has_more = _slice_with_cursor(full, cursor.id if cursor else None, limit)
 
-        data = TweetListSerializer(page, many=True, context={"request": request}).data
+        data = TweetListSerializer(
+            page,
+            many=True,
+            context={
+                "request": request,
+                "viewer_repost_ids": _viewer_repost_ids(request, page),
+            },
+        ).data
         return Response({"results": data, "next_cursor": next_cursor, "has_more": has_more})

--- a/apps/timeline/views.py
+++ b/apps/timeline/views.py
@@ -37,13 +37,13 @@ def _viewer_repost_ids(request: Request, tweets: list[Tweet]) -> set[int]:
     TweetListSerializer.get_reposted_by_me が context["viewer_repost_ids"] を
     優先して使うので、N+1 を避けるために list 描画前に prefetch する。
     未認証なら空 set。
+
+    ``request.user.is_authenticated`` で判定する (AnonymousUser instance check
+    より backend-agnostic)。
     """
-    if isinstance(request.user, AnonymousUser) or not tweets:
+    if not request.user.is_authenticated or not tweets:
         return set()
     target_ids = {t.pk for t in tweets}
-    # repost_of がある (= REPOST tweet) 行は repost_of_id を target にした
-    # 直接対応も含める (UI の REPOST article 上で reposted 表示する将来用)。
-    target_ids.update(t.repost_of_id for t in tweets if t.repost_of_id is not None)
     return set(
         Tweet.objects.filter(
             author=request.user,

--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -34,6 +34,7 @@ from apps.tweets.models import (
     Tweet,
     TweetImage,
     TweetTag,
+    TweetType,
 )
 from apps.tweets.rendering import render_markdown
 
@@ -140,6 +141,10 @@ class TweetListSerializer(serializers.ModelSerializer):
     reply_to = serializers.SerializerMethodField()
     quote_of = serializers.SerializerMethodField()
     repost_of = serializers.SerializerMethodField()
+    # #351: viewer (request.user) 視点で「自分がこの tweet を repost 済みか」。
+    # frontend の RepostButton.initialReposted に流して、リロード後も
+    # 「リポスト済み」状態が UI に反映されるようにする。
+    reposted_by_me = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
@@ -163,6 +168,8 @@ class TweetListSerializer(serializers.ModelSerializer):
             "reply_to",
             "quote_of",
             "repost_of",
+            # #351
+            "reposted_by_me",
         ]
         read_only_fields = fields
 
@@ -199,6 +206,26 @@ class TweetListSerializer(serializers.ModelSerializer):
 
     def get_repost_of(self, obj: Tweet) -> dict[str, Any] | None:
         return self._resolve_parent(obj.repost_of_id)
+
+    def get_reposted_by_me(self, obj: Tweet) -> bool:
+        """#351: viewer 視点での repost 状態.
+
+        N+1 を避けるため context["viewer_repost_ids"] に **既に prefetch 済の
+        id 集合** が入っていれば優先して使う。view 側 (TimelineView 等) が
+        list 描画時に 1 query でまとめ取得できる。fallback は per-row EXISTS
+        クエリ (詳細 view など 1 件取得時のみ許容).
+        """
+        request = self.context.get("request")
+        if request is None or not request.user.is_authenticated:
+            return False
+        prefetched = self.context.get("viewer_repost_ids")
+        if prefetched is not None:
+            return obj.pk in prefetched
+        return Tweet.objects.filter(
+            author=request.user,
+            type=TweetType.REPOST,
+            repost_of=obj,
+        ).exists()
 
 
 class TweetDetailSerializer(TweetListSerializer):

--- a/apps/tweets/tests/test_crud_api.py
+++ b/apps/tweets/tests/test_crud_api.py
@@ -773,9 +773,15 @@ class TestRepostedByMeSerializerField:
         body = self._detail(api_client, tweet.pk)
         assert body["reposted_by_me"] is False
 
-    def test_home_timeline_uses_viewer_repost_ids_prefetch(self, api_client: APIClient) -> None:
+    def test_following_timeline_uses_viewer_repost_ids_prefetch(
+        self, api_client: APIClient
+    ) -> None:
         """#351 review HIGH-1/MEDIUM-2: timeline view の prefetch path で
-        reposted_by_me=True が反映される (1 query で全件解決される) ことを確認.
+        reposted_by_me=True が反映されることを確認.
+
+        home TL は ``_dedup_repost_originals`` で repost と original のうち
+        repost 側を残すため、自分の REPOST が dedup で残って元 tweet が消え、
+        テストが prefetch path を通せない。following TL は dedup しない。
         """
         from apps.follows.tests._factories import make_follow
         from apps.tweets.models import Tweet as _T
@@ -788,10 +794,10 @@ class TestRepostedByMeSerializerField:
         _T.objects.create(author=viewer, body="", type=TweetType.REPOST, repost_of=target)
         api_client.force_authenticate(user=viewer)
 
-        res = api_client.get(reverse("timeline-home"))
+        res = api_client.get(reverse("timeline-following"))
         assert res.status_code == status.HTTP_200_OK, res.content
         results = res.json()["results"]
         flags = {r["id"]: r["reposted_by_me"] for r in results}
-        # 元 tweet (target) が TL に含まれ、reposted_by_me=True
-        assert target.pk in flags
+        # author の original tweet が following TL に含まれ、reposted_by_me=True
+        assert target.pk in flags, f"target {target.pk} not in {list(flags.keys())}"
         assert flags[target.pk] is True

--- a/apps/tweets/tests/test_crud_api.py
+++ b/apps/tweets/tests/test_crud_api.py
@@ -772,3 +772,26 @@ class TestRepostedByMeSerializerField:
         api_client.force_authenticate(user=viewer)
         body = self._detail(api_client, tweet.pk)
         assert body["reposted_by_me"] is False
+
+    def test_home_timeline_uses_viewer_repost_ids_prefetch(self, api_client: APIClient) -> None:
+        """#351 review HIGH-1/MEDIUM-2: timeline view の prefetch path で
+        reposted_by_me=True が反映される (1 query で全件解決される) ことを確認.
+        """
+        from apps.follows.tests._factories import make_follow
+        from apps.tweets.models import Tweet as _T
+        from apps.tweets.models import TweetType
+
+        viewer = make_user()
+        author = make_user()
+        make_follow(viewer, author)
+        target = make_tweet(author=author, body="prefetch target")
+        _T.objects.create(author=viewer, body="", type=TweetType.REPOST, repost_of=target)
+        api_client.force_authenticate(user=viewer)
+
+        res = api_client.get(reverse("timeline-home"))
+        assert res.status_code == status.HTTP_200_OK, res.content
+        results = res.json()["results"]
+        flags = {r["id"]: r["reposted_by_me"] for r in results}
+        # 元 tweet (target) が TL に含まれ、reposted_by_me=True
+        assert target.pk in flags
+        assert flags[target.pk] is True

--- a/apps/tweets/tests/test_crud_api.py
+++ b/apps/tweets/tests/test_crud_api.py
@@ -715,3 +715,60 @@ class TestSerializerExtension323:
         assert body["reply_to"] is not None
         assert body["reply_to"]["id"] == parent.pk
         assert body["reply_to"]["body"] == "parent"
+
+
+# =============================================================================
+# #351: reposted_by_me — viewer 視点の永続 repost 状態を serializer に出す
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestRepostedByMeSerializerField:
+    """#351: TweetListSerializer / TweetDetailSerializer の reposted_by_me 動作."""
+
+    def _detail(self, api_client: APIClient, pk: int) -> dict[str, Any]:
+        res = api_client.get(reverse("tweets-detail", kwargs={"pk": pk}))
+        assert res.status_code == status.HTTP_200_OK, res.content
+        return res.json()
+
+    def test_unauthenticated_viewer_sees_false(self, api_client: APIClient) -> None:
+        author = make_user()
+        tweet = make_tweet(author=author, body="t")
+        body = self._detail(api_client, tweet.pk)
+        assert body["reposted_by_me"] is False
+
+    def test_authenticated_not_reposted_returns_false(self, api_client: APIClient) -> None:
+        author = make_user()
+        tweet = make_tweet(author=author, body="t")
+        viewer = make_user()
+        api_client.force_authenticate(user=viewer)
+        body = self._detail(api_client, tweet.pk)
+        assert body["reposted_by_me"] is False
+
+    def test_authenticated_already_reposted_returns_true(self, api_client: APIClient) -> None:
+        from apps.tweets.models import Tweet as _T
+        from apps.tweets.models import TweetType
+
+        author = make_user()
+        tweet = make_tweet(author=author, body="t")
+        viewer = make_user()
+        # viewer は既にこの tweet を repost 済み
+        _T.objects.create(author=viewer, body="", type=TweetType.REPOST, repost_of=tweet)
+        api_client.force_authenticate(user=viewer)
+        body = self._detail(api_client, tweet.pk)
+        assert body["reposted_by_me"] is True
+
+    def test_other_user_repost_does_not_affect_viewer(self, api_client: APIClient) -> None:
+        """別ユーザーの REPOST は viewer の reposted_by_me に影響しない."""
+        from apps.tweets.models import Tweet as _T
+        from apps.tweets.models import TweetType
+
+        author = make_user()
+        tweet = make_tweet(author=author, body="t")
+        other = make_user()
+        viewer = make_user()
+        _T.objects.create(author=other, body="", type=TweetType.REPOST, repost_of=tweet)
+        api_client.force_authenticate(user=viewer)
+        body = self._detail(api_client, tweet.pk)
+        assert body["reposted_by_me"] is False

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -465,6 +465,9 @@ export default function TweetCard({
 				<div className="flex items-center gap-1">
 					<RepostButton
 						tweetId={tweet.id}
+						// #351: viewer の永続 repost 状態 (server-fetched) を初期値に
+						// 渡す。リロード時に「リポスト済み」 (緑) で正しく復元される。
+						initialReposted={tweet.reposted_by_me ?? false}
 						onPosted={onDescendantPosted}
 						onQuoteRequest={() => setQuoteOpen(true)}
 					/>

--- a/client/src/components/timeline/__tests__/TweetCard.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.test.tsx
@@ -218,6 +218,21 @@ describe("TweetCard — action buttons (placeholder)", () => {
 		).not.toBeInTheDocument();
 	});
 
+	it("#351: tweet.reposted_by_me=true で RepostButton が「リポスト済み」 で初期化される", () => {
+		const reposted = { ...BASE_TWEET, reposted_by_me: true };
+		render(<TweetCard tweet={reposted} />);
+		expect(
+			screen.getByRole("button", { name: "リポスト済み" }),
+		).toBeInTheDocument();
+	});
+
+	it("#351: tweet.reposted_by_me=undefined のとき false 扱い (「リポスト」)", () => {
+		render(<TweetCard tweet={BASE_TWEET} />);
+		expect(
+			screen.getByRole("button", { name: "リポスト" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders ReactionBar trigger in the footer (P2-14 wires the bar)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
 		// ReactionBar exposes the trigger via aria-label="リアクション"

--- a/client/src/lib/api/tweets.ts
+++ b/client/src/lib/api/tweets.ts
@@ -60,6 +60,12 @@ export interface TweetSummary {
 	reply_to?: TweetMini | null;
 	quote_of?: TweetMini | null;
 	repost_of?: TweetMini | null;
+	/**
+	 * #351: viewer (request.user) 視点で「この tweet を自分が repost 済みか」。
+	 * RepostButton.initialReposted に渡してリロード後の状態復元に使う。
+	 * 未認証 / フィールド未付与時は undefined → false 扱い。
+	 */
+	reposted_by_me?: boolean;
 }
 
 export async function createTweet(


### PR DESCRIPTION
## Summary

#349 E2E で発覚した「リロード後に『リポスト済み』が UI に反映されない」を修正。backend に viewer 視点の永続状態を返す \`reposted_by_me\` フィールドを追加し、frontend TweetCard が RepostButton.initialReposted に渡すよう接続。

## 変更点

### Backend
- \`apps/tweets/serializers.py\` TweetListSerializer に \`reposted_by_me\` (SerializerMethodField, bool) 追加。\`context['viewer_repost_ids']\` で prefetched 集合が渡されていれば優先使用、なければ per-row EXISTS クエリで fallback
- \`apps/timeline/views.py\` Home / Following / Explore で list 描画前に 1 query で \`_viewer_repost_ids\` を取得 → context 渡しで N+1 回避

### Frontend
- TweetSummary 型に \`reposted_by_me?: boolean\` 追加
- TweetCard が RepostButton.initialReposted に \`tweet.reposted_by_me ?? false\` を渡す

### Tests
- pytest TestRepostedByMeSerializerField (4)
- vitest TweetCard 2 件追加
- 全 382/382 vitest green、pre-push pytest hook 通過

## Test plan

- [x] vitest 382/382 / pytest pre-push 緑 / tsc 緑
- [ ] CI 緑
- [ ] stg deploy 後に #349 E2E spec シナリオ 1-9 を再走行 → docs に結果追記

## 関連

- Closes #351
- 後続: deploy 後に #349 E2E spec シナリオ 1-9 を再実行