### PR TITLE
[infra][throttle] stg 限定で DRF rate limit を緩和 (Closes #336)

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -73,3 +73,23 @@ STATIC_URL = "/static/"
 
 # Logging: stg/prod は structlog の JSONRenderer (base.py で env=stg/production
 # のとき自動切替)。CloudWatch Logs に JSON 行で出る前提。
+
+# #336: stg 限定で DRF throttle rate を緩和する。
+# 本番値 (user: 500/day) のままでは E2E spec の連続走行や開発検証で
+# rate-limit (#349 / #354 で実証) に hit するため、stg のみ 10x にする。
+# 認証系 (login: 5/min) や DM presign 等の **abuse 防止が目的の throttle**
+# は据え置き、user / anon / post_tweet_tier_* / reaction だけ緩和する。
+# 本番には影響しない (SENTRY_ENVIRONMENT=production のとき分岐を踏まない)。
+if SENTRY_ENVIRONMENT == "stg":
+    REST_FRAMEWORK = {
+        **REST_FRAMEWORK,
+        "DEFAULT_THROTTLE_RATES": {
+            **REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"],
+            "anon": "2000/day",
+            "user": "5000/day",
+            "post_tweet_tier_1": "1000/day",
+            "post_tweet_tier_2": "5000/day",
+            "post_tweet_tier_3": "10000/day",
+            "reaction": "600/min",
+        },
+    }


### PR DESCRIPTION
## Summary

#349 / #354 の E2E 検証で stg の \`user: 500/day\` を踏み続けてシナリオ 3, 4, 7+8 が flake していた問題を解消。

\`config/settings/production.py\` で \`SENTRY_ENVIRONMENT == "stg"\` のときのみ throttle rate を 10x に緩和:

| scope | 現状 (本番値) | stg 緩和後 |
|---|---|---|
| anon | 200/day | 2000/day |
| user | 500/day | **5000/day** |
| post_tweet_tier_1 | 100/day | 1000/day |
| post_tweet_tier_2 | 500/day | 5000/day |
| post_tweet_tier_3 | 1000/day | 10000/day |
| reaction | 60/min | 600/min |

abuse 防止系 (login: 5/min, dm_attachment_*, tag_propose, avatar_upload) は据え置き。本番 (\`SENTRY_ENVIRONMENT=production\`) は分岐を踏まないので影響なし。

## Test plan

- [x] settings は env 分岐のみで code path は短い
- [ ] CI 緑 (Backend Django pytest が production.py を import できること)
- [ ] stg deploy 後、\`/api/v1/users/me/\` が 429 でなく 200 を返すことを確認
- [ ] #354 spec シナリオ 3, 4, 7+8 を再走行 → PASS

## 関連

- Closes #336
- Unblocks #354 (rate-limit が原因で flaky だったシナリオ)