### PR TITLE
[fix][throttle] #336 緩和を base.py で初期定義時に分岐 (PR #357 の落とし穴修正)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 558
+        "line_number": 546
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-03T15:20:30Z"
+  "generated_at": "2026-05-04T07:51:30Z"
 }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -437,6 +437,27 @@ if SENTRY_ENVIRONMENT in ("stg", "production") and not CORS_ALLOWED_ORIGINS:
     )
 
 
+# #336: stg では throttle rate を緩和する (DRF の SimpleRateThrottle は
+# クラス import 時に api_settings.DEFAULT_THROTTLE_RATES を class attribute に
+# copy するので、production.py で後付け上書きしても効かない既知の特性。
+# REST_FRAMEWORK 初期定義時にここで分岐させる必要がある).
+_IS_STG = SENTRY_ENVIRONMENT == "stg"
+_THROTTLE_RATES_BASE = {
+    "anon": "200/day" if not _IS_STG else "2000/day",
+    "user": "500/day" if not _IS_STG else "5000/day",
+    "post_tweet": "500/day" if not _IS_STG else "5000/day",
+    "post_tweet_tier_1": "100/day" if not _IS_STG else "1000/day",
+    "post_tweet_tier_2": "500/day" if not _IS_STG else "5000/day",
+    "post_tweet_tier_3": "1000/day" if not _IS_STG else "10000/day",
+    "reaction": "60/min" if not _IS_STG else "600/min",
+    # 以下は abuse 防止が目的なので stg でも本番と同値に据え置く:
+    "login": "5/minute",
+    "avatar_upload": "10/minute",
+    "tag_propose": "20/hour",
+    "dm_attachment_presign": "30/hour",
+    "dm_attachment_confirm": "30/hour",
+}
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTAuthentication",
@@ -459,44 +480,11 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
     ),
-    # P1-11 (#97) + SPEC §14.5: 階層 throttle の rate 定義。
+    # P1-11 (#97) + SPEC §14.5 + #336: 階層 throttle の rate 定義。
+    # 値は上の `_THROTTLE_RATES_BASE` で stg 環境分岐済み。
     # 実際に階層を切り替える責務は ``apps.common.throttling.PostTweetThrottle``。
     # このマップは DRF が scope 名から rate を引くだけのテーブルに徹する。
-    "DEFAULT_THROTTLE_RATES": {
-        "anon": "200/day",
-        "user": "500/day",
-        # legacy: P1-08 以前に scope="post_tweet" で指定されていた互換用。
-        # P1-11 時点で ``throttle_scope = "post_tweet"`` を直接指定している view は
-        # 存在せず、実質 dead entry。削除は破壊的変更になり得るため据え置き。
-        # TODO(Phase2): post_tweet_tier_* へ全面移行済みの確認後、削除する。
-        "post_tweet": "500/day",
-        "post_tweet_tier_1": "100/day",  # 通常ユーザー
-        "post_tweet_tier_2": "500/day",  # アクティブユーザー (Phase 2 で自動昇格)
-        "post_tweet_tier_3": "1000/day",  # プレミアム (User.is_premium)
-        # code-reviewer (PR #131 HIGH #2) 指摘: login ブルートフォース対策。
-        # apps.users.views.LoginRateThrottle が scope="login" で参照する。
-        "login": "5/minute",
-        # code-reviewer (PR #139 HIGH #1) 指摘: avatar / header の presigned URL 発行も
-        # 低頻度用の dedicated throttle を持たせ、既定の "user" rate (500/day) から分離する。
-        # apps.users.views.AvatarUploadRateThrottle が scope="avatar_upload" で参照する。
-        "avatar_upload": "10/minute",
-        # code-reviewer (PR #135 HIGH #2) 指摘: タグ新規提案は find_similar_tags で
-        # 全 approved タグを Python 側で走査するため、既定 user レート (500/day) より
-        # 厳しい scope="tag_propose" を用意し DoS 的な連投を抑制する。
-        # apps.tags.views.TagProposeThrottle が参照する。
-        "tag_propose": "20/hour",
-        # P2-04 (sec MEDIUM): リアクション spam 対策。
-        # toggle (post → delete → post) を高速で繰り返すと signals 連打 + DB 書き込みが
-        # 集中するため、user 単位で 60/min に制限する。
-        # apps.reactions.views.ReactionThrottle が参照する。
-        "reaction": "60/min",
-        # P3-06 (security-reviewer HIGH H-3): DM 添付の presign / confirm。
-        # 1 回 25MB 上限なので 500/day では 12GB/user/day の DoS が成立する。
-        # PresignAttachmentView / ConfirmAttachmentView が `dm_attachment_presign` を参照。
-        "dm_attachment_presign": "30/hour",
-        # confirm は head_object を毎回叩くので separate scope で更に絞る。
-        "dm_attachment_confirm": "30/hour",
-    },
+    "DEFAULT_THROTTLE_RATES": _THROTTLE_RATES_BASE,
 }
 
 # P2-07 (sec CRITICAL #1): OGP fetch の User-Agent. 環境変数で override 可能。

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -74,22 +74,7 @@ STATIC_URL = "/static/"
 # Logging: stg/prod は structlog の JSONRenderer (base.py で env=stg/production
 # のとき自動切替)。CloudWatch Logs に JSON 行で出る前提。
 
-# #336: stg 限定で DRF throttle rate を緩和する。
-# 本番値 (user: 500/day) のままでは E2E spec の連続走行や開発検証で
-# rate-limit (#349 / #354 で実証) に hit するため、stg のみ 10x にする。
-# 認証系 (login: 5/min) や DM presign 等の **abuse 防止が目的の throttle**
-# は据え置き、user / anon / post_tweet_tier_* / reaction だけ緩和する。
-# 本番には影響しない (SENTRY_ENVIRONMENT=production のとき分岐を踏まない)。
-if SENTRY_ENVIRONMENT == "stg":
-    REST_FRAMEWORK = {
-        **REST_FRAMEWORK,
-        "DEFAULT_THROTTLE_RATES": {
-            **REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"],
-            "anon": "2000/day",
-            "user": "5000/day",
-            "post_tweet_tier_1": "1000/day",
-            "post_tweet_tier_2": "5000/day",
-            "post_tweet_tier_3": "10000/day",
-            "reaction": "600/min",
-        },
-    }
+# #336: stg 限定の throttle 緩和は base.py の _THROTTLE_RATES_BASE で初期
+# 定義時に分岐させる方針に変更 (DRF SimpleRateThrottle の class-level
+# THROTTLE_RATES が import 時に固定されるため、production.py での後付け
+# override は無効だった)。本ファイルでは throttle 関連 override は行わない。


### PR DESCRIPTION
## Summary

PR #357 で production.py に後付け override を入れたが効かなかった (DRF の SimpleRateThrottle が class-level \`THROTTLE_RATES\` を class import 時に固定する仕様)。base.py で REST_FRAMEWORK 定義時に直接分岐させて修正。

## ハルナさん指摘の症状

ログイン後にホーム画面が出ず、再ログインを求められる現象。原因は:
- /users/me/ が 429 (緩和効かず) で返る
- ホーム page.tsx は API エラー時にランディングページにフォールバック
- ランディングのログインボタンが見える → 「再ログインを求められる」と感じる

## 修正

- \`config/settings/base.py\`:
  - \`SENTRY_ENVIRONMENT == "stg"\` で分岐する \`_THROTTLE_RATES_BASE\` dict を REST_FRAMEWORK 定義の前に置く
  - \`DEFAULT_THROTTLE_RATES\` でこの dict を使う
- \`config/settings/production.py\`: 後付け override を削除 (経緯コメント残置)

これで stg 環境では SimpleRateThrottle が class import 時から緩和値を持つ。本番 (\`SENTRY_ENVIRONMENT=production\`) は分岐を踏まないので影響なし。

## Test plan

- [x] pytest \`test_throttle_engages_after_tier_1_limit\` が通ること (既存 test に影響無)
- [ ] CI 緑
- [ ] cd-stg deploy 後に /api/v1/users/me/ が 200 (auth あり) を返すこと
- [ ] ログイン後にホーム画面が出ること

## 関連

- Fixes regression introduced in #357 (#336 修正)
- Closes ハルナさん報告 (ログイン後に再ログインを求められる)