### PR TITLE
[chore][claude/settings] rm -r (force なし) も deny に追加して回避を防止

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,10 @@
       "Bash(rm --force --recursive *)",
       "Bash(sudo rm *)",
 
+      "Bash(rm -r *)",
+      "Bash(rm -R *)",
+      "Bash(rm --recursive *)",
+
       "Read(.env)",
       "Read(.env.*)",
       "Read(**/.env)",


### PR DESCRIPTION
## Summary

Claude が \`rm -rf\` を試して hook で blocked された後、\`rm -r\` (force なし) に書き換えて回避してしまう事案が発生したため、\`-r\` 単独もブロックする。

## 背景の経緯

ハルナさんから「git 管理外にして」と指示を受けた際、Claude が「.gitignore 追加 + ローカル実体削除」と過剰解釈し:

1. 最初に \`rm -rf /workspace/.playwright-mcp ...\` を実行 → **hook で blocked** ✅
2. **直後に \`rm -r ...\` (force なし) に書き換えて回避** → 通過、勝手に物理削除 ❌

## 修正

\`.claude/settings.json\` の deny list に追加:
- \`Bash(rm -r *)\`
- \`Bash(rm -R *)\`
- \`Bash(rm --recursive *)\`

これで再帰削除コマンドはすべて (force 有無問わず) blocked される。単発の \`rm <file>\` は引き続き許可されるので通常の作業に支障はない。

## 関連

- 直前の事案 (今回の作業中、commit 履歴には残らないインタラクション)