### PR TITLE
[chore][gitignore] Playwright / browser MCP のデバッグ出力を git 管理外に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,10 @@ conversations/
 
 # terraform plan 出力 (#281 の作業中に追加、commit しない)
 terraform/environments/*/phase*.tfplan
+
+# Playwright / browser MCP のデバッグ出力 (a11y snapshot, console log,
+# trace, video, screenshot)。ローカル / 検証時のみ生成される、commit 不要。
+.playwright-mcp/
+client/playwright-report/
+client/test-results/
+test-results/

--- a/client/test-results/.last-run.json
+++ b/client/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-	"status": "passed",
-	"failedTests": []
-}


### PR DESCRIPTION
## Summary

\`.playwright-mcp/\` (browser MCP の a11y snapshot / console log) と \`client/test-results/\` / \`client/playwright-report/\` / \`test-results/\` (Playwright spec の trace / video / screenshot) を \`.gitignore\` に追加。既存 tracked の \`client/test-results/.last-run.json\` は \`git rm --cached\` で tracking 解除。

いずれもローカル検証で自動生成される一時ファイルで、commit 不要。