### PR TITLE
[chore][devcontainer] OpenAI Codex CLI を同梱 (#362)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,7 @@ ARG TZ
 ENV TZ="$TZ"
 
 ARG CLAUDE_CODE_VERSION=latest
+ARG CODEX_VERSION=latest
 
 # Install basic development tools, Python, and iptables/ipset
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -122,11 +123,13 @@ ENV DEVCONTAINER=true
 RUN mkdir -p \
   /workspace \
   /home/node/.claude \
+  /home/node/.codex \
   /home/node/.aws \
   /home/node/.config && \
   chown -R node:node \
   /workspace \
   /home/node/.claude \
+  /home/node/.codex \
   /home/node/.aws \
   /home/node/.config
 
@@ -222,6 +225,12 @@ RUN sed -i "/^export LANG='en_US.UTF-8'$/d; /^export LANGUAGE='en_US:en'$/d; /^e
 
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+# Install Codex CLI (OpenAI). 認証情報 (~/.codex/auth.json) は named volume
+# (claude-code-codex) に永続化されるので、リビルドしても `codex login` 済みの
+# 状態は保持される。CODEX_VERSION を devcontainer.json で固定すれば
+# contributor 間でバージョン揃えも可能 (現状 latest)。
+RUN npm install -g @openai/codex@${CODEX_VERSION}
 
 # Preinstall Playwright's Chromium browser into /home/node/.cache/ms-playwright
 # so the playwright MCP server (registered below with --browser chromium) can

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "args": {
       "TZ": "${localEnv:TZ:America/Los_Angeles}",
       "CLAUDE_CODE_VERSION": "latest",
+      "CODEX_VERSION": "latest",
       "GIT_DELTA_VERSION": "0.18.2",
       "ACT_VERSION": "0.2.80",
       "GH_VERSION": "2.63.2",
@@ -58,6 +59,13 @@
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    // Codex CLI (`@openai/codex`) の auth/config 用 named volume。
+    // `claude-code-aws` / `claude-code-config-xdg` と同じく `${devcontainerId}` を
+    // 含めない固定名にしているため、devcontainer.json を編集してリビルドしても
+    // `codex login` で入れた API key / OAuth token は残る。
+    // 別 PC でこのレポジトリを開いた場合は、その PC で 1 度だけ
+    // `codex login` を打ち直す必要がある (volume はホストごとに独立)。
+    "source=claude-code-codex,target=/home/node/.codex,type=volume",
     // AWS credentials の永続化用 named volume。`${devcontainerId}` を意図的に
     // 含めず固定名にしているため、devcontainer.json を編集してリビルドしても
     // `aws configure` で入れた IAM access key / secret は保持される。


### PR DESCRIPTION
Closes #362

## Summary

- `@openai/codex` を devcontainer に global install して Claude Code と並行利用できるようにする
- `CODEX_VERSION` build arg (default `latest`) で将来 pin できる構造に
- `/home/node/.codex` を named volume `claude-code-codex` (固定名) で永続化 → リビルドしても `codex login` クレデンシャルが残る
- `/home/node/.codex` を image build 時に `node:node` で pre-create (空 named volume が `root:root` で seed される問題を回避、既存 `.aws` / `.config` と同じ理由)

## ファイアウォール

`init-firewall.sh` は既に 80/443 全開なので追加対応不要。OpenAI API (`api.openai.com`) も到達可能。

## Test plan

- [ ] `Dev Containers: Rebuild Container` 後に `codex --version` が動く (要手動: ハルナさんに依頼)
- [ ] `codex login` 後にもう一度 rebuild → ログイン状態が残る
- [ ] CI (lint / type / test / build) 緑

## Risk / 影響範囲

- devcontainer のみの変更。ランタイム・本番影響ゼロ
- 既存の Claude Code セットアップは変更なし
- 既存 contributor は次回 rebuild で codex が増えるだけ