### PR TITLE
[fix][backend] /api/v1/users/popular/ と /recommended/ のルーティング 404 を解消 (#370)

### DIFF
--- a/apps/follows/tests/test_url_routing.py
+++ b/apps/follows/tests/test_url_routing.py
@@ -1,0 +1,62 @@
+"""URL routing regression tests for /api/v1/users/ shared prefix (#370).
+
+apps.follows.urls の static path (`popular/`, `recommended/`) と
+apps.users.urls_profile の `<str:username>/` (greedy) が同じ prefix に
+mount されているため、登録順が崩れると static path が greedy に飲み込まれて
+404 を返す回帰が起きる。本テストはその回帰を検出する。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+def popular_url() -> str:
+    return reverse("users-popular")
+
+
+def recommended_url() -> str:
+    return reverse("users-recommended")
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUsersPrefixRouting:
+    """`/api/v1/users/popular/` と `/recommended/` が `<str:username>/` に
+    奪われていないことを確認する。
+
+    static path のレスポンスは 200 (空でも OK) を期待する。
+    `PublicProfileView` に飛んでしまうと 404 `No User matches the given query.`
+    になるので、それを検出する。
+    """
+
+    def test_popular_routes_to_popular_view_not_user_lookup(self, api_client: APIClient) -> None:
+        res = api_client.get(popular_url())
+        # PopularUsersView は AllowAny + 200 で空 list を返す。
+        # urls_profile の <str:username>/ にルーティングされると
+        # 404 "No User matches the given query." になる。
+        assert res.status_code == status.HTTP_200_OK
+        assert "results" in res.data or isinstance(res.data, list)
+
+    def test_recommended_unauth_returns_401_not_404(self, api_client: APIClient) -> None:
+        # RecommendedUsersView は IsAuthenticated。未認証なら 401 が期待値。
+        # urls_profile に奪われたら 404 になる。
+        res = api_client.get(recommended_url())
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_popular_response_shape_matches_popular_view(self, api_client: APIClient) -> None:
+        """レスポンス body 形状で PopularUsersView と PublicProfileView を区別する.
+
+        - PopularUsersView → ``{"results": [...]}``
+        - PublicProfileView → user の dict (``{"username": ..., ...}``)
+
+        ルーティングが奪われていれば後者になり、本テストが落ちる。
+        """
+        res = api_client.get(popular_url())
+        assert res.status_code == status.HTTP_200_OK
+        assert isinstance(res.data, dict)
+        assert "results" in res.data
+        assert "username" not in res.data

--- a/config/urls.py
+++ b/config/urls.py
@@ -50,14 +50,18 @@ urlpatterns = [
     path("api/v1/auth/csrf/", csrf_token_view, name="api-csrf"),
     path("api/v1/auth/", include("djoser.urls")),
     path("api/v1/auth/", include("apps.users.urls")),
+    # P2-03: フォロー関連 API は handle ベースで /api/v1/users/<handle>/follow/ などに
+    # マウントする (SPEC §16.2 の RESTful URL 設計)。
+    # #370: follows.urls の static path (popular/, recommended/) は urls_profile の
+    # <str:username>/ (1 セグメント greedy) に飲み込まれて 404 になっていた。
+    # follows.urls を **先** に登録して static match を優先させる。
+    # urls_profile 側の me/ 系も static path だが follows.urls には me/ パターン
+    # が無いので衝突しない。
+    path("api/v1/users/", include("apps.follows.urls")),
     # P1-03 #89: プロフィール API (SPEC §2)。
     # /api/v1/users/me/ (GET/PATCH) と /api/v1/users/<handle>/ (GET) を提供。
     # 認証系 (/api/v1/auth/) と分離するため apps.users.urls_profile として別登録。
     path("api/v1/users/", include("apps.users.urls_profile")),
-    # P2-03: フォロー関連 API は handle ベースで /api/v1/users/<handle>/follow/ などに
-    # マウントする (SPEC §16.2 の RESTful URL 設計)。``urls_profile`` の <str:username>/
-    # (1 セグメント) と本 include の <handle>/follow/ (2 セグメント) は衝突しない。
-    path("api/v1/users/", include("apps.follows.urls")),
     # Phase 0 scaffold (P0-04). Each app ships empty urlpatterns until
     # the owning phase adds real endpoints (see docs/ROADMAP.md).
     path("api/v1/tweets/", include("apps.tweets.urls")),


### PR DESCRIPTION
## 関連 Issue

Closes #370

## 概要

未ログイン状態の `/search` ページで「おすすめユーザーサイドバー」が空表示になっていた件の修正。stg / 本番で `/api/v1/users/popular/` と `/api/v1/users/recommended/` が常に 404 を返していた。

## 原因

`config/urls.py` の include 順序の問題:

```python
path("api/v1/users/", include("apps.users.urls_profile")),  # 先に登録 ← <str:username>/ greedy
path("api/v1/users/", include("apps.follows.urls")),        # 後に登録 ← popular/, recommended/
```

Django は登録順に URL pattern を評価する。`urls_profile.py` の `<str:username>/` (1 セグメント greedy) が `popular/` / `recommended/` を先に拾ってしまい、`PublicProfileView` が `username='popular'` を User 検索 → 404 `No User matches the given query.`。

`apps/follows/urls.py` 冒頭のコメントは「`<handle>/follow/` のような **2 セグメント** だけが衝突回避対象」としており、1 セグメントの `popular/` / `recommended/` の衝突を見落としていた。

## 修正

`config/urls.py` で **`apps.follows.urls` を `apps.users.urls_profile` より前** に登録。`follows.urls` の static path (`popular/`, `recommended/`) が `<str:username>/` greedy より先にマッチするようにした。`urls_profile` の `me/` 系も static path だが、`follows.urls` には `me/` パターンが無いので衝突しない。

## 検証

`django.urls.resolve()` で手動確認 (Postgres 不要):

| URL                              | 解決先              | 状態 |
| -------------------------------- | ------------------- | ---- |
| `/api/v1/users/popular/`         | PopularUsersView    | ✅   |
| `/api/v1/users/recommended/`     | RecommendedUsersView| ✅   |
| `/api/v1/users/me/`              | MeView              | ✅   |
| `/api/v1/users/alice/`           | PublicProfileView   | ✅   |
| `/api/v1/users/alice/follow/`    | FollowView          | ✅   |
| `/api/v1/users/alice/followers/` | FollowersListView   | ✅   |

## 回帰防止テスト

`apps/follows/tests/test_url_routing.py` を新規追加:

- `test_popular_routes_to_popular_view_not_user_lookup` — `/api/v1/users/popular/` が 200 を返す
- `test_recommended_unauth_returns_401_not_404` — 認証必須エンドポイントは未認証で 401 (404 ではない)
- `test_popular_response_shape_matches_popular_view` — body 形状で PublicProfileView と区別

## 影響範囲

- 未ログイン: `/explore`, `/search`, ホーム TL の WhoToFollow サイドバーで「人気ユーザー」が表示されるようになる。
- ログイン: `/users/recommended/` が機能して P2-10 のおすすめユーザー候補が出るようになる。
- 既存 endpoint (`me/`, `<handle>/`, `<handle>/follow/` 等) は影響なし (URL 解決確認済み)。

## Test plan

- [x] `django.urls.resolve()` で全 URL の解決先を確認
- [x] 回帰防止テスト 3 件を追加
- [ ] CI で pytest 緑確認
- [ ] stg deploy 後に `curl https://stg.codeplace.me/api/v1/users/popular/` で 200 確認
- [ ] stg `/search` ページのコンソールエラー消失確認