### PR TITLE
[fix][search] /search?q の SSR 500 を解消、TweetCardList で render する (#372)

### DIFF
--- a/client/src/app/(template)/search/page.tsx
+++ b/client/src/app/(template)/search/page.tsx
@@ -1,20 +1,22 @@
 /**
  * /search page (P2-16 / Issue #207).
  *
- * MVP scope:
- *   - Server Component reads ?q from searchParams and calls /api/v1/search/.
- *   - SearchBox (Client) handles form submit → router.push(/search?q=...).
- *   - Results render TweetSummary in lightweight list (TweetCard reuse can
- *     come later once feed cards stabilize across surfaces).
- *   - Operator help is static; autosuggest popup ships as a follow-up.
+ * 仕様: docs/specs/search-spec.md §4.1
+ *
+ * - Server Component が ?q を読み /api/v1/search/ を呼ぶ。
+ * - 結果カードは TweetCardList (Client Component) に委譲。/explore /tag /u と
+ *   同じ rendering pipeline。
+ * - #372 修正: 旧 inline article + dangerouslySetInnerHTML 経路は SSR で
+ *   isomorphic-dompurify (jsdom 依存) が落ちて 500 を返していた。
+ *   TweetCardList で client 側 sanitize に統一して解消。副次的に結果カード
+ *   からも reaction / repost / quote / reply の action button が動く。
  */
 
 import type { Metadata } from "next";
-import Link from "next/link";
 
 import SearchBox from "@/components/search/SearchBox";
+import TweetCardList from "@/components/timeline/TweetCardList";
 import { fetchSearch } from "@/lib/api/search";
-import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
 
 interface SearchPageProps {
 	searchParams: { q?: string };
@@ -54,57 +56,11 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 					<p className="text-sm text-muted-foreground">
 						「{query}」の検索結果: {data.count} 件
 					</p>
-
-					{data.results.length === 0 ? (
-						<p className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
-							一致するツイートはありません。
-						</p>
-					) : (
-						<ul className="space-y-3">
-							{data.results.map((tweet) => (
-								<li key={tweet.id}>
-									<article className="rounded-lg border border-border bg-card p-4">
-										<header className="mb-2 flex items-baseline gap-2 text-sm">
-											<span className="font-semibold text-foreground">
-												{tweet.author_display_name ?? tweet.author_handle}
-											</span>
-											<Link
-												href={`/u/${tweet.author_handle}`}
-												className="text-muted-foreground hover:underline"
-											>
-												@{tweet.author_handle}
-											</Link>
-										</header>
-										<Link
-											href={`/tweet/${tweet.id}`}
-											className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-										>
-											<div
-												className="prose prose-sm dark:prose-invert max-w-none"
-												dangerouslySetInnerHTML={{
-													__html: sanitizeTweetHtml(tweet.html),
-												}}
-											/>
-										</Link>
-										{tweet.tags.length > 0 && (
-											<ul className="mt-2 flex flex-wrap gap-1.5">
-												{tweet.tags.map((tag) => (
-													<li key={tag}>
-														<Link
-															href={`/tag/${tag}`}
-															className="rounded-full bg-lime-500/10 px-2 py-0.5 text-xs text-lime-700 dark:text-lime-400 hover:bg-lime-500/20"
-														>
-															#{tag}
-														</Link>
-													</li>
-												))}
-											</ul>
-										)}
-									</article>
-								</li>
-							))}
-						</ul>
-					)}
+					<TweetCardList
+						tweets={data.results}
+						ariaLabel={`「${query}」の検索結果`}
+						emptyMessage="一致するツイートはありません。"
+					/>
 				</section>
 			)}
 		</main>


### PR DESCRIPTION
## 関連 Issue

Closes #372

## 概要

stg で `/search?q=<keyword>` を検索結果が 1 件以上ある状態で開くと "Application error: a server-side exception has occurred" (500) で落ちていた。原因は `client/src/app/(template)/search/page.tsx` 独自の Server Component 内で `sanitizeTweetHtml` (isomorphic-dompurify, jsdom 依存) を呼んでいたこと。Next.js production server で jsdom 依存が解決できずに SSR が fail していた。

## 修正

検索ページの inline article rendering 経路を撤去し、他ページ (`/explore`, `/tag/[name]`, `/u/[handle]`) と同じ `TweetCardList` (Client Component) に委譲。

```diff
- import Link from "next/link";
- import { sanitizeTweetHtml } from "@/lib/sanitize/sanitizeTweetHtml";
+ import TweetCardList from "@/components/timeline/TweetCardList";

  ...
- <ul>{data.results.map((tweet) => ( <article>...{ dangerouslySetInnerHTML... }</article> ))}</ul>
+ <TweetCardList tweets={data.results} ariaLabel={...} emptyMessage="一致するツイートはありません。" />
```

## 副次効果

- 検索結果カードから reaction / repost / quote / reply の action button が動く (旧コードのコメント "TweetCard reuse can come later" を解消)。
- `/explore` `/tag/[name]` `/u/[handle]` と検索の UX が一貫する。

## 検証

- ✅ vitest: 関連 16 件すべて緑
  - `client/src/lib/api/__tests__/search.test.ts` (3 件)
  - `client/src/lib/sanitize/__tests__/sanitizeTweetHtml.test.ts` (7 件)
  - `client/src/components/search/__tests__/SearchBox.test.tsx` (6 件)
- ✅ `tsc --noEmit`: エラーなし

## Test plan

- [x] 関連 vitest が緑
- [x] tsc --noEmit が緑
- [ ] stg deploy 後に `https://stg.codeplace.me/search?q=test` が 200 で render されること
- [ ] 結果カードに reaction trigger / repost ボタンが表示されること
- [ ] `q=python tag:django` のような演算子を含む複合クエリでも render されること
- [ ] `q=` (空) / 結果 0 件 のときは従来通り 200 で render されること
- [ ] 結果カードから `/tweet/<id>`, `/u/<handle>`, `/tag/<name>` への遷移ができること