### PR TITLE
[docs][phase2] reactions/search 仕様書 + シナリオ + E2E spec を整備

### DIFF
--- a/client/e2e/reactions-scenarios.spec.ts
+++ b/client/e2e/reactions-scenarios.spec.ts
@@ -1,0 +1,548 @@
+/**
+ * Reactions scenarios.
+ *
+ * Spec source: docs/specs/reactions-scenarios.md (RCT-XX)
+ * Run examples:  docs/specs/reactions-e2e-commands.md
+ *
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=<email> PLAYWRIGHT_USER1_PASSWORD=<password> PLAYWRIGHT_USER1_HANDLE=<handle> \
+ *   PLAYWRIGHT_USER2_EMAIL=<email> PLAYWRIGHT_USER2_PASSWORD=<password> PLAYWRIGHT_USER2_HANDLE=<handle> \
+ *   npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --grep "RCT-01"
+ *
+ * Per-test isolation:
+ *  - 各 test は USER2 (target tweet 作成者) を author として API 経由で
+ *    新しい tweet を作成する。共有 stg DB を別 test と汚染しないため。
+ *  - 余計な reaction が残らないよう、各 test の最後で actor の reaction を
+ *    DELETE で取り消す (best-effort).
+ */
+
+import {
+	expect,
+	request,
+	type APIRequestContext,
+	type Page,
+	test,
+} from "@playwright/test";
+
+const API_BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "",
+};
+
+function requireCredentials() {
+	for (const [name, value] of Object.entries({
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER2_EMAIL: USER2.email,
+		PLAYWRIGHT_USER2_PASSWORD: USER2.password,
+	})) {
+		if (!value) throw new Error(`${name} is required`);
+	}
+}
+
+interface AuthedContext {
+	context: APIRequestContext;
+	csrf: string;
+}
+
+async function apiAuthed(
+	email: string,
+	password: string,
+): Promise<AuthedContext> {
+	const context = await request.newContext({ baseURL: API_BASE });
+	await context.get("/api/v1/auth/csrf/");
+	const initial = await context.storageState();
+	const initialCsrf =
+		initial.cookies.find((c) => c.name === "csrftoken")?.value ?? "";
+
+	const login = await context.post("/api/v1/auth/cookie/create/", {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": initialCsrf,
+			Referer: `${API_BASE}/login`,
+		},
+		data: { email, password },
+	});
+	expect(login.status(), `login failed for ${email}`).toBe(200);
+
+	const after = await context.storageState();
+	const csrf =
+		after.cookies.find((c) => c.name === "csrftoken")?.value ?? initialCsrf;
+	return { context, csrf };
+}
+
+async function postTweetAs(user: typeof USER1, body: string): Promise<number> {
+	const api = await apiAuthed(user.email, user.password);
+	try {
+		const res = await api.context.post("/api/v1/tweets/", {
+			headers: {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			},
+			data: { body },
+		});
+		expect(res.status()).toBe(201);
+		return (await res.json()).id as number;
+	} finally {
+		await api.context.dispose();
+	}
+}
+
+async function deleteTweetAs(
+	user: typeof USER1,
+	tweetId: number,
+): Promise<void> {
+	const api = await apiAuthed(user.email, user.password);
+	try {
+		await api.context.delete(`/api/v1/tweets/${tweetId}/`, {
+			headers: { "X-CSRFToken": api.csrf, Referer: `${API_BASE}/` },
+		});
+	} finally {
+		await api.context.dispose();
+	}
+}
+
+async function clearReactionAs(
+	user: typeof USER1,
+	tweetId: number,
+): Promise<void> {
+	const api = await apiAuthed(user.email, user.password);
+	try {
+		// 404 になっても無視 (既存なし)
+		await api.context.delete(`/api/v1/tweets/${tweetId}/reactions/`, {
+			headers: { "X-CSRFToken": api.csrf, Referer: `${API_BASE}/` },
+		});
+	} finally {
+		await api.context.dispose();
+	}
+}
+
+async function loginUI(page: Page, email: string, password: string) {
+	await page.goto("/login");
+	const emailInput = page
+		.locator('input[name="email"], input[type="email"]')
+		.first();
+	await emailInput.fill(email);
+	await page
+		.locator('input[name="password"], input[type="password"]')
+		.first()
+		.fill(password);
+	const signIn = page.getByRole("button", { name: "Sign In", exact: true });
+	if (await signIn.isVisible().catch(() => false)) {
+		await signIn.click();
+	} else {
+		await page.getByRole("button", { name: /ログイン/ }).click();
+	}
+	await page.waitForURL(/\/onboarding|\/$/);
+}
+
+async function openTweet(page: Page, tweetId: number) {
+	await page.goto(`/tweet/${tweetId}`);
+	await expect(page.locator("article").first()).toBeVisible({
+		timeout: 15_000,
+	});
+}
+
+async function reactionTrigger(page: Page) {
+	return page.locator('button[aria-label="リアクション"]').first();
+}
+
+async function pickReactionUI(
+	page: Page,
+	tweetId: number,
+	label: string, // 日本語ラベル e.g. "いいね"
+): Promise<number> {
+	const trigger = await reactionTrigger(page);
+	await expect(trigger).toBeVisible({ timeout: 10_000 });
+	if ((await trigger.getAttribute("aria-expanded")) !== "true") {
+		await trigger.click();
+	}
+	const responsePromise = page.waitForResponse(
+		(r) =>
+			r.url().includes(`/api/v1/tweets/${tweetId}/reactions/`) &&
+			r.request().method() === "POST",
+	);
+	// aria-label="<label> (<count> 件)" にマッチさせる
+	const button = page.locator(`button[aria-label^="${label} ("]`).first();
+	await button.click();
+	const res = await responsePromise;
+	return res.status();
+}
+
+test.beforeAll(() => requireCredentials());
+
+// =============================================================================
+// API-driven scenarios (UI 不要 — toggle 仕様の精密検証)
+// =============================================================================
+
+test.describe("Reactions API (per-spec setup)", () => {
+	test("RCT-01: 未リアクションの tweet にリアクションを付ける (POST 201, created=true)", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-01 ${Date.now()}`);
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const res = await api.context.post(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{
+					headers: {
+						"Content-Type": "application/json",
+						"X-CSRFToken": api.csrf,
+						Referer: `${API_BASE}/`,
+					},
+					data: { kind: "like" },
+				},
+			);
+			expect(res.status()).toBe(201);
+			const body = await res.json();
+			expect(body).toMatchObject({
+				kind: "like",
+				created: true,
+				changed: false,
+				removed: false,
+			});
+		} finally {
+			await api.context.dispose();
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-02: 同じ kind を再押下で取消 (POST 200, removed=true)", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-02 ${Date.now()}`);
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const headers = {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			};
+			const first = await api.context.post(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers, data: { kind: "like" } },
+			);
+			expect(first.status()).toBe(201);
+			const second = await api.context.post(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers, data: { kind: "like" } },
+			);
+			expect(second.status()).toBe(200);
+			expect(await second.json()).toMatchObject({
+				kind: null,
+				removed: true,
+				created: false,
+				changed: false,
+			});
+		} finally {
+			await api.context.dispose();
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-03: 別 kind に変更 (POST 200, changed=true、count 不変)", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-03 ${Date.now()}`);
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const headers = {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			};
+			await api.context.post(`/api/v1/tweets/${tweetId}/reactions/`, {
+				headers,
+				data: { kind: "like" },
+			});
+			const swapped = await api.context.post(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers, data: { kind: "learned" } },
+			);
+			expect(swapped.status()).toBe(200);
+			expect(await swapped.json()).toMatchObject({
+				kind: "learned",
+				changed: true,
+				created: false,
+				removed: false,
+			});
+			const agg = await (
+				await api.context.get(`/api/v1/tweets/${tweetId}/reactions/`)
+			).json();
+			expect(agg.counts.like).toBe(0);
+			expect(agg.counts.learned).toBe(1);
+			expect(agg.my_kind).toBe("learned");
+		} finally {
+			await api.context.dispose();
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-04 / RCT-05: DELETE エンドポイント (204 / 404)", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-04 ${Date.now()}`);
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const headers = {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			};
+			// 既存なし → 404
+			const empty = await api.context.delete(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers },
+			);
+			expect(empty.status()).toBe(404);
+
+			// 作成 → DELETE で 204
+			await api.context.post(`/api/v1/tweets/${tweetId}/reactions/`, {
+				headers,
+				data: { kind: "agree" },
+			});
+			const removed = await api.context.delete(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers },
+			);
+			expect(removed.status()).toBe(204);
+		} finally {
+			await api.context.dispose();
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-06: 集計 GET は未ログインも可、10 kind 全部 0 埋め", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-06 ${Date.now()}`);
+		// 未ログイン context
+		const ctx = await request.newContext({ baseURL: API_BASE });
+		try {
+			const res = await ctx.get(`/api/v1/tweets/${tweetId}/reactions/`);
+			expect(res.status()).toBe(200);
+			const body = await res.json();
+			expect(body.my_kind).toBeNull();
+			for (const k of [
+				"like",
+				"interesting",
+				"learned",
+				"helpful",
+				"agree",
+				"surprised",
+				"congrats",
+				"respect",
+				"funny",
+				"code",
+			]) {
+				expect(body.counts[k]).toBe(0);
+			}
+		} finally {
+			await ctx.dispose();
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-07 / RCT-19: 削除済み tweet は POST/GET ともに 404", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-07 ${Date.now()}`);
+		await deleteTweetAs(USER2, tweetId);
+
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const headers = {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			};
+			const post = await api.context.post(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers, data: { kind: "like" } },
+			);
+			expect(post.status()).toBe(404);
+
+			const get = await api.context.get(`/api/v1/tweets/${tweetId}/reactions/`);
+			expect(get.status()).toBe(404);
+		} finally {
+			await api.context.dispose();
+		}
+	});
+
+	test("RCT-10: 認証なし POST は 401", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-10 ${Date.now()}`);
+		const ctx = await request.newContext({ baseURL: API_BASE });
+		try {
+			const res = await ctx.post(`/api/v1/tweets/${tweetId}/reactions/`, {
+				headers: { "Content-Type": "application/json" },
+				data: { kind: "like" },
+			});
+			expect(res.status()).toBe(401);
+		} finally {
+			await ctx.dispose();
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-11: 不正 kind は 400 (auth 後にバリデーション)", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-11 ${Date.now()}`);
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const headers = {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			};
+			const res = await api.context.post(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers, data: { kind: "love" } },
+			);
+			expect(res.status()).toBe(400);
+		} finally {
+			await api.context.dispose();
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-13: self-reaction は許可される (作者 = 操作者)", async () => {
+		const tweetId = await postTweetAs(USER1, `RCT-13 ${Date.now()}`);
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const headers = {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			};
+			const res = await api.context.post(
+				`/api/v1/tweets/${tweetId}/reactions/`,
+				{ headers, data: { kind: "like" } },
+			);
+			expect(res.status()).toBe(201);
+		} finally {
+			await api.context.dispose();
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER1, tweetId);
+		}
+	});
+
+	test("RCT-16: 種類変更時に Tweet.reaction_count が drift しない", async () => {
+		const tweetId = await postTweetAs(USER2, `RCT-16 ${Date.now()}`);
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			const headers = {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			};
+			await api.context.post(`/api/v1/tweets/${tweetId}/reactions/`, {
+				headers,
+				data: { kind: "like" },
+			});
+			const before = await (
+				await api.context.get(`/api/v1/tweets/${tweetId}/reactions/`)
+			).json();
+			const beforeTotal = Object.values(
+				before.counts as Record<string, number>,
+			).reduce((a, b) => a + b, 0);
+
+			// 連続スワップ
+			for (const kind of ["learned", "agree", "code", "funny"]) {
+				await api.context.post(`/api/v1/tweets/${tweetId}/reactions/`, {
+					headers,
+					data: { kind },
+				});
+			}
+			const after = await (
+				await api.context.get(`/api/v1/tweets/${tweetId}/reactions/`)
+			).json();
+			const afterTotal = Object.values(
+				after.counts as Record<string, number>,
+			).reduce((a, b) => a + b, 0);
+			expect(afterTotal).toBe(beforeTotal);
+			expect(after.my_kind).toBe("funny");
+		} finally {
+			await api.context.dispose();
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+});
+
+// =============================================================================
+// UI scenarios (ReactionBar の押下 → API 呼び出し → render 反映)
+// =============================================================================
+
+test.describe("Reactions UI (ReactionBar)", () => {
+	test("RCT-01 UI: like を押下すると 201 が返り aria-pressed=true になる", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-01-ui ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const status = await pickReactionUI(page, tweetId, "いいね");
+			expect([200, 201]).toContain(status);
+			const likeButton = page.locator('button[aria-label^="いいね ("]').first();
+			await expect(likeButton).toHaveAttribute("aria-pressed", "true");
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-02 UI: 同じ like を再押下すると aria-pressed が外れる", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-02-ui ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			await pickReactionUI(page, tweetId, "いいね");
+			await pickReactionUI(page, tweetId, "いいね");
+			const likeButton = page.locator('button[aria-label^="いいね ("]').first();
+			await expect(likeButton).toHaveAttribute("aria-pressed", "false");
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-03 UI: 別 kind を選ぶと前 kind の aria-pressed が外れて新 kind が pressed", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-03-ui ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			await pickReactionUI(page, tweetId, "いいね");
+			await pickReactionUI(page, tweetId, "勉強になった");
+			await expect(
+				page.locator('button[aria-label^="いいね ("]').first(),
+			).toHaveAttribute("aria-pressed", "false");
+			await expect(
+				page.locator('button[aria-label^="勉強になった ("]').first(),
+			).toHaveAttribute("aria-pressed", "true");
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-17 UI: trigger に Alt+Enter で grid を開閉できる", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-17 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			await trigger.focus();
+			await page.keyboard.press("Alt+Enter");
+			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			await page.keyboard.press("Alt+Enter");
+			await expect(trigger).toHaveAttribute("aria-expanded", "false");
+		} finally {
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+});

--- a/client/e2e/search-scenarios.spec.ts
+++ b/client/e2e/search-scenarios.spec.ts
@@ -1,0 +1,351 @@
+/**
+ * Search scenarios.
+ *
+ * Spec source: docs/specs/search-scenarios.md (SRC-XX)
+ * Run examples:  docs/specs/search-e2e-commands.md
+ *
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=<email> PLAYWRIGHT_USER1_PASSWORD=<password> PLAYWRIGHT_USER1_HANDLE=<handle> \
+ *   PLAYWRIGHT_USER2_EMAIL=<email> PLAYWRIGHT_USER2_PASSWORD=<password> PLAYWRIGHT_USER2_HANDLE=<handle> \
+ *   npx playwright test e2e/search-scenarios.spec.ts --workers=1 --grep "SRC-01"
+ *
+ * 検証戦略:
+ *   - 各 test は USER1 が固有 marker を含む tweet を API で投稿し、その
+ *     marker を q に渡して結果に含まれるかを検証する。stg 共有データ汚染を
+ *     避けるため、結果の総件数は固定せず marker 含有のみアサート。
+ *   - 演算子 (tag/from/since/until/type/has) は parser 単体テスト
+ *     (apps/search/tests/test_parser.py) でカバー済み。本 spec はサーバ層
+ *     〜 UI までの繋ぎを smoke で確認する。
+ */
+
+import {
+	expect,
+	request,
+	type APIRequestContext,
+	type Page,
+	test,
+} from "@playwright/test";
+
+const API_BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireCredentials() {
+	for (const [name, value] of Object.entries({
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	})) {
+		if (!value) throw new Error(`${name} is required`);
+	}
+}
+
+interface AuthedContext {
+	context: APIRequestContext;
+	csrf: string;
+}
+
+async function apiAuthed(
+	email: string,
+	password: string,
+): Promise<AuthedContext> {
+	const context = await request.newContext({ baseURL: API_BASE });
+	await context.get("/api/v1/auth/csrf/");
+	const initial = await context.storageState();
+	const initialCsrf =
+		initial.cookies.find((c) => c.name === "csrftoken")?.value ?? "";
+
+	const login = await context.post("/api/v1/auth/cookie/create/", {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": initialCsrf,
+			Referer: `${API_BASE}/login`,
+		},
+		data: { email, password },
+	});
+	expect(login.status(), `login failed for ${email}`).toBe(200);
+
+	const after = await context.storageState();
+	const csrf =
+		after.cookies.find((c) => c.name === "csrftoken")?.value ?? initialCsrf;
+	return { context, csrf };
+}
+
+async function postTweetAs(user: typeof USER1, body: string): Promise<number> {
+	const api = await apiAuthed(user.email, user.password);
+	try {
+		const res = await api.context.post("/api/v1/tweets/", {
+			headers: {
+				"Content-Type": "application/json",
+				"X-CSRFToken": api.csrf,
+				Referer: `${API_BASE}/`,
+			},
+			data: { body },
+		});
+		expect(res.status()).toBe(201);
+		return (await res.json()).id as number;
+	} finally {
+		await api.context.dispose();
+	}
+}
+
+async function deleteTweetAs(
+	user: typeof USER1,
+	tweetId: number,
+): Promise<void> {
+	const api = await apiAuthed(user.email, user.password);
+	try {
+		await api.context.delete(`/api/v1/tweets/${tweetId}/`, {
+			headers: { "X-CSRFToken": api.csrf, Referer: `${API_BASE}/` },
+		});
+	} finally {
+		await api.context.dispose();
+	}
+}
+
+interface SearchResponse {
+	query: string;
+	count: number;
+	results: { id: number; body: string; tags: string[]; type: string }[];
+}
+
+async function fetchSearchAnon(
+	q: string,
+	limit?: number,
+): Promise<SearchResponse> {
+	const ctx = await request.newContext({ baseURL: API_BASE });
+	try {
+		const params = new URLSearchParams({ q });
+		if (limit !== undefined) params.set("limit", String(limit));
+		const res = await ctx.get(`/api/v1/search/?${params.toString()}`);
+		expect(res.status()).toBe(200);
+		return (await res.json()) as SearchResponse;
+	} finally {
+		await ctx.dispose();
+	}
+}
+
+function uniqueMarker(tag: string): string {
+	const rand = Math.random().toString(36).slice(2, 10);
+	return `e2esearch-${tag}-${Date.now()}-${rand}`;
+}
+
+test.beforeAll(() => requireCredentials());
+
+// =============================================================================
+// API-driven scenarios
+// =============================================================================
+
+test.describe("Search API (per-spec marker)", () => {
+	test("SRC-01: 単純なキーワードで自分の marker tweet がヒットする", async () => {
+		const marker = uniqueMarker("kw");
+		const id = await postTweetAs(USER1, `${marker} python is fun`);
+		try {
+			const data = await fetchSearchAnon(marker);
+			expect(data.count).toBeGreaterThanOrEqual(1);
+			expect(data.results.find((r) => r.id === id)).toBeTruthy();
+		} finally {
+			await deleteTweetAs(USER1, id);
+		}
+	});
+
+	test("SRC-02: 大文字小文字を区別しない (marker を大文字で検索)", async () => {
+		const marker = uniqueMarker("case");
+		const id = await postTweetAs(USER1, `${marker} ruby`);
+		try {
+			const data = await fetchSearchAnon(marker.toUpperCase());
+			expect(data.results.find((r) => r.id === id)).toBeTruthy();
+		} finally {
+			await deleteTweetAs(USER1, id);
+		}
+	});
+
+	test("SRC-03: 空クエリは空結果", async () => {
+		const data1 = await fetchSearchAnon("");
+		expect(data1.count).toBe(0);
+		expect(data1.results).toEqual([]);
+		const data2 = await fetchSearchAnon("   ");
+		expect(data2.count).toBe(0);
+	});
+
+	test("SRC-04: クエリ前後の空白は trim される (query は strip 後を echo)", async () => {
+		const marker = uniqueMarker("trim");
+		const id = await postTweetAs(USER1, `${marker} go`);
+		try {
+			const data = await fetchSearchAnon(`  ${marker}  `);
+			expect(data.query).toBe(marker);
+			expect(data.results.find((r) => r.id === id)).toBeTruthy();
+		} finally {
+			await deleteTweetAs(USER1, id);
+		}
+	});
+
+	test("SRC-07: from:<handle> で投稿者絞り込み", async () => {
+		const marker = uniqueMarker("from");
+		const id = await postTweetAs(USER1, `${marker} from-test`);
+		try {
+			const data = await fetchSearchAnon(`${marker} from:${USER1.handle}`);
+			expect(data.results.find((r) => r.id === id)).toBeTruthy();
+			// 大文字小文字を意識しない (iexact)
+			const upper = await fetchSearchAnon(
+				`${marker} from:${USER1.handle.toUpperCase()}`,
+			);
+			expect(upper.results.find((r) => r.id === id)).toBeTruthy();
+		} finally {
+			await deleteTweetAs(USER1, id);
+		}
+	});
+
+	test("SRC-09: 不正な日付は silent drop (例外にならない、500/400 にならない)", async () => {
+		const data1 = await fetchSearchAnon("since:2026-13-99");
+		expect(data1.count).toBe(0);
+		const data2 = await fetchSearchAnon("since:yesterday");
+		expect(data2.count).toBe(0);
+	});
+
+	test("SRC-10: type: で tweet 種別絞り込み", async () => {
+		const marker = uniqueMarker("type");
+		const id = await postTweetAs(USER1, `${marker} body`);
+		try {
+			const orig = await fetchSearchAnon(`${marker} type:original`);
+			expect(orig.results.find((r) => r.id === id)).toBeTruthy();
+			const replyOnly = await fetchSearchAnon(`${marker} type:reply`);
+			expect(replyOnly.results.find((r) => r.id === id)).toBeFalsy();
+			const invalid = await fetchSearchAnon(`${marker} type:foo`);
+			// type:foo は drop され keyword だけが効く → marker 含有なら hit
+			expect(invalid.results.find((r) => r.id === id)).toBeTruthy();
+		} finally {
+			await deleteTweetAs(USER1, id);
+		}
+	});
+
+	test("SRC-14: 未知演算子は keyword に流れる (literal substring 一致)", async () => {
+		const marker = `e2esearch-foo:bar-${Date.now()}`;
+		const id = await postTweetAs(USER1, `${marker} text`);
+		try {
+			// `foo:bar` の literal が body に含まれるなら、未知演算子 foo:... が
+			// 落ちずに keyword に積まれて icontains で一致する
+			const data = await fetchSearchAnon(marker);
+			expect(data.results.find((r) => r.id === id)).toBeTruthy();
+		} finally {
+			await deleteTweetAs(USER1, id);
+		}
+	});
+
+	test("SRC-15: limit クランプ (500 → 100 以下)", async () => {
+		const data = await fetchSearchAnon("type:original", 500);
+		expect(data.count).toBeLessThanOrEqual(100);
+		expect(data.results.length).toBeLessThanOrEqual(100);
+	});
+
+	test("SRC-16: 不正 limit は default フォールバック (500 を返さない)", async () => {
+		const ctx = await request.newContext({ baseURL: API_BASE });
+		try {
+			const res = await ctx.get(
+				`/api/v1/search/?q=${encodeURIComponent("type:original")}&limit=abc`,
+			);
+			expect(res.status()).toBe(200);
+		} finally {
+			await ctx.dispose();
+		}
+	});
+
+	test("SRC-17: 結果は新着順 (id 降順 tiebreaker)", async () => {
+		const marker = uniqueMarker("order");
+		const idA = await postTweetAs(USER1, `${marker} A`);
+		const idB = await postTweetAs(USER1, `${marker} B`); // newer
+		try {
+			const data = await fetchSearchAnon(marker);
+			const ids = data.results.map((r) => r.id);
+			const aIdx = ids.indexOf(idA);
+			const bIdx = ids.indexOf(idB);
+			expect(aIdx).toBeGreaterThanOrEqual(0);
+			expect(bIdx).toBeGreaterThanOrEqual(0);
+			// 新しい方 (idB) が先に来る
+			expect(bIdx).toBeLessThan(aIdx);
+		} finally {
+			await deleteTweetAs(USER1, idA);
+			await deleteTweetAs(USER1, idB);
+		}
+	});
+
+	test("SRC-18: 削除済み tweet は結果に出ない", async () => {
+		const marker = uniqueMarker("del");
+		const id = await postTweetAs(USER1, `${marker} body`);
+		const before = await fetchSearchAnon(marker);
+		expect(before.results.find((r) => r.id === id)).toBeTruthy();
+		await deleteTweetAs(USER1, id);
+		const after = await fetchSearchAnon(marker);
+		expect(after.results.find((r) => r.id === id)).toBeFalsy();
+	});
+
+	test("SRC-20: 未ログインで検索できる (AllowAny)", async () => {
+		const ctx = await request.newContext({ baseURL: API_BASE });
+		try {
+			const res = await ctx.get("/api/v1/search/?q=type:original");
+			expect(res.status()).toBe(200);
+		} finally {
+			await ctx.dispose();
+		}
+	});
+});
+
+// =============================================================================
+// UI scenarios (/search ページ)
+// =============================================================================
+
+async function gotoSearch(page: Page, q?: string) {
+	const url = q ? `/search?q=${encodeURIComponent(q)}` : "/search";
+	await page.goto(url);
+}
+
+test.describe("Search UI (/search)", () => {
+	test("SRC-21: SearchBox 空文字 submit は navigate しない", async ({
+		page,
+	}) => {
+		await gotoSearch(page);
+		const input = page.locator('input[name="q"]');
+		await input.fill("");
+		await page.getByRole("button", { name: "検索", exact: true }).click();
+		await expect(page).toHaveURL(/\/search$/);
+	});
+
+	test("SRC-22: SearchBox は URL 経由で初期値を受け取る", async ({ page }) => {
+		await gotoSearch(page, "python tag:django");
+		const input = page.locator('input[name="q"]');
+		await expect(input).toHaveValue("python tag:django");
+	});
+
+	test("SRC-01 UI: 結果ありで /search?q=<marker> が 200 で render され、結果カードに本文が出る (#372 回帰防止)", async ({
+		page,
+	}) => {
+		const marker = uniqueMarker("ui");
+		const id = await postTweetAs(USER1, `${marker} ui-render-check`);
+		try {
+			await gotoSearch(page, marker);
+			// SSR 500 (#372) 回帰防止: 結果セクションが見える
+			await expect(page.getByRole("region", { name: "検索結果" })).toBeVisible({
+				timeout: 15_000,
+			});
+			// TweetCardList 経由の article がいる
+			await expect(page.locator("article").first()).toBeVisible({
+				timeout: 10_000,
+			});
+		} finally {
+			await deleteTweetAs(USER1, id);
+		}
+	});
+
+	test("SRC-03 UI: 空クエリでは結果セクションが出ず CTA だけ", async ({
+		page,
+	}) => {
+		await gotoSearch(page);
+		await expect(
+			page.getByText("上のボックスにキーワードを入れて検索してください。"),
+		).toBeVisible();
+	});
+});

--- a/docs/specs/reactions-e2e-commands.md
+++ b/docs/specs/reactions-e2e-commands.md
@@ -1,0 +1,136 @@
+# リアクション E2E 実行コマンド
+
+> 関連: [reactions-spec.md](./reactions-spec.md), [reactions-scenarios.md](./reactions-scenarios.md)
+> spec ファイル: [`client/e2e/reactions-scenarios.spec.ts`](../../client/e2e/reactions-scenarios.spec.ts) (新規 / Phase 2 追補)
+>
+> 目的: [reactions-scenarios.md](./reactions-scenarios.md) の `RCT-XX` を Playwright で網羅的に走らせるための、環境変数とコマンド集。シナリオ定義 (大きい) とコマンドを分離する。
+
+## 0. 前提
+
+- ローカル: `docker compose -f local.yml up -d` で `api` (:8000), `client` (:3000), `postgres`, `redis`, `mailpit` (:8025) を起動済み。
+- stg: `https://stg.codeplace.me/` が deploy 済み (P2-22 / #194 で稼働)。
+- 認証情報は shell history に残さないため **環境変数で渡す**。`<USER_PASSWORD>` プレースホルダは実値に置き換えて実行する。
+- 並列実行は **`--workers=1`**。Reaction はカウンタ整合性が観点なので、テスト同士の race を避ける。
+
+## 1. テストアカウント
+
+ローカル / stg どちらでも以下 2 アカウントを seed 済みで使う想定。
+
+| handle | email             | 用途                                        |
+| ------ | ----------------- | ------------------------------------------- |
+| test2  | `test2@gmail.com` | USER1 (actor / リアクションを付ける側)      |
+| test3  | `test3@gmail.com` | USER2 (target tweet 作成者、被アクション側) |
+
+block 関係シナリオ (`RCT-08`, `RCT-09`) では別途 `test4` 等を準備する (= 任意 user で OK、stg では block API を直接叩いて状態を作る)。
+
+## 2. 環境変数
+
+```bash
+# 共通
+export PLAYWRIGHT_USER1_EMAIL="test2@gmail.com"
+export PLAYWRIGHT_USER1_PASSWORD="<USER1_PASSWORD>"
+export PLAYWRIGHT_USER1_HANDLE="test2"
+export PLAYWRIGHT_USER2_EMAIL="test3@gmail.com"
+export PLAYWRIGHT_USER2_PASSWORD="<USER2_PASSWORD>"
+export PLAYWRIGHT_USER2_HANDLE="test3"
+
+# stg vs local の切り替え
+# - local:
+export PLAYWRIGHT_BASE_URL="http://localhost:3000"
+# - stg:
+# export PLAYWRIGHT_BASE_URL="https://stg.codeplace.me"
+```
+
+## 3. 全シナリオ実行
+
+```bash
+cd /workspace/client
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line
+```
+
+stg ターゲット例 (rate limit に注意、`reaction` scope は stg で 600/min):
+
+```bash
+cd /workspace/client
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com PLAYWRIGHT_USER1_PASSWORD='<USER1_PASSWORD>' \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+PLAYWRIGHT_USER2_EMAIL=test3@gmail.com PLAYWRIGHT_USER2_PASSWORD='<USER2_PASSWORD>' \
+PLAYWRIGHT_USER2_HANDLE=test3 \
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line
+```
+
+## 4. 単独シナリオ実行
+
+```bash
+# RCT-01: 未リアクションの tweet にリアクションを付ける
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-01"
+
+# RCT-02: 同じ kind を再度押して取り消す
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-02"
+
+# RCT-03: 別 kind に変更する (UPDATE 経路)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-03"
+
+# RCT-04: 明示 DELETE エンドポイントで取り消す
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-04"
+
+# RCT-05: 既存なしで DELETE すると 404
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-05"
+
+# RCT-06: 集計 GET (未ログインも可)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-06"
+
+# RCT-07: 削除済み tweet にリアクションできない
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-07"
+
+# RCT-08: 双方向 Block 関係の相手にはリアクションできない
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-08"
+
+# RCT-10: 認証なし POST は 401
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-10"
+
+# RCT-11: 不正な kind は 400
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-11"
+
+# RCT-13: self-reaction は許可される
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-13"
+
+# RCT-14: API 失敗時に optimistic update がロールバックする
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-14"
+
+# RCT-16: 種類変更時に reaction_count が drift しない
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-16"
+
+# RCT-17: Alt+Enter で grid 開閉できる
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-17"
+
+# RCT-19: 削除済み tweet の集計 GET は 404
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-19"
+```
+
+## 5. Phase 2 既存 golden path との関係
+
+`client/e2e/phase2.spec.ts` (P2-21 / #193) は **golden path 1 本** をカバーするだけ:
+
+> alice follows bob → reacts to bob's tweet → sees in TL → finds via search
+
+これは「リアクションが画面上で押せるか」「TL / 検索が回るか」の **smoke** 用途で、本書のシナリオ網羅は別 spec (`reactions-scenarios.spec.ts`) として分離する。
+
+## 6. 既知の制約・運用ノート
+
+- **Rate limit**: stg は `reaction` scope 600/min、本番は 60/min。連続実行で 429 を踏むと `RCT-12` 以外のシナリオも巻き添えになるので、`--workers=1` を厳守し、必要なら test 間に 1 秒待機。
+- **Block 関係シナリオ (RCT-08, RCT-09)**: stg では block API (`POST /api/v1/users/<handle>/block/`) を spec 内 setup で叩いて状態を作る。teardown で `DELETE` で解除する。test 間で残らないように注意。
+- **Optimistic rollback (RCT-14)**: Playwright の `page.route()` でレスポンスを 500 に書き換えて検証する。本番 / stg では発生しにくいので mock 必須。
+- **同時 race (RCT-15)**: ブラウザ単体では再現困難。サーバ側 pytest (`apps/reactions/tests/test_reaction_api.py`) で `IntegrityError` path をカバー済み。E2E では UI から 1 click ずつ叩く。
+- **CSRF**: `client/src/lib/api/client.ts` の `ensureCsrfToken` がリクエスト前に呼ばれる。stg で 403 になった場合は cookie 残留 / token mismatch を疑う。
+- **アカウントが seed されていない場合**: ローカルなら `docker compose -f local.yml exec api python manage.py shell -c "..."` で `User.objects.create_user(...)` するか、`/admin/` で作成。
+
+## 7. CI 連携
+
+現状 `client/e2e/reactions-scenarios.spec.ts` は **CI に組み込まない**。理由は P2-21 の golden path と同じく:
+
+- フル docker compose stack の起動コストが大きい
+- 認証情報の secret 管理を CI 側で整えるまで保留
+
+`.github/workflows/e2e-stg.yml` (Phase 2 末で追加予定 / 別 issue) で stg deploy 後に手動 trigger する想定。

--- a/docs/specs/reactions-scenarios.md
+++ b/docs/specs/reactions-scenarios.md
@@ -1,0 +1,396 @@
+# リアクションシナリオ仕様
+
+> 関連: [reactions-spec.md](./reactions-spec.md), [reactions-e2e-commands.md](./reactions-e2e-commands.md)
+>
+> 目的: リアクション (Reaction) について、UI / API / DB / 集計 / Block / Tombstone / Rate limit の挙動を、E2E化しやすい形で固定する。
+
+## 1. 用語
+
+| 用語         | 定義                                                                                                               |
+| ------------ | ------------------------------------------------------------------------------------------------------------------ |
+| actor        | 操作しているログインユーザー                                                                                       |
+| target tweet | リアクションの対象となる Tweet                                                                                     |
+| my_kind      | actor が target tweet に対して保有している reaction の kind (`null` または 10 種のいずれか)                        |
+| total        | target tweet に対する全ユーザー reaction の総数 (`Tweet.reaction_count`)。kind を問わない                          |
+| 10 種        | `like` / `interesting` / `learned` / `helpful` / `agree` / `surprised` / `congrats` / `respect` / `funny` / `code` |
+
+## 2. 基本方針
+
+- 1 actor × 1 tweet には reaction が **0 もしくは 1 件** のみ。
+- 同じ kind の再押下は取消、別 kind の押下は種類変更 (UPDATE) とする。
+- 削除済み tweet には reaction できない (404)。
+- 双方向 block 関係の相手の tweet には reaction できない (403)。
+- 未ログインは集計 GET のみ可。POST / DELETE は 401。
+- カウントは optimistic update でフロントが先行し、API 失敗時にロールバック。
+
+## 3. リアクションシナリオ一覧
+
+### RCT-01: 未リアクションの tweet にリアクションを付ける
+
+前提:
+
+- actor A と target tweet T (作者は B)。
+- A は T に対して reaction を持っていない (`my_kind=null`)。
+- T はAのTLに表示されている。
+
+操作:
+
+- A が T のカード上の `リアクション` trigger ボタンを押し、grid を開く。
+- grid 内の `like` (❤️) を選択する。
+
+期待結果:
+
+- API: `POST /api/v1/tweets/<T.id>/reactions/` body=`{kind: "like"}` が **201** を返す。
+- レスポンス body: `{kind: "like", created: true, changed: false, removed: false}`。
+- DB: `Reaction(user=A, tweet=T, kind="like")` が 1 行追加される。
+- DB: `T.reaction_count` が 1 増える。
+- UI: trigger ラベルが `❤️ {total}` 形式に変わる。
+- UI: grid 内 `like` ボタンが `aria-pressed=true`、強調色 (lime) になる。
+- GET の `my_kind` は `"like"` を返す。
+
+### RCT-02: 同じ kind を再度押して取り消す
+
+前提:
+
+- actor A は T に `like` を付けている (`my_kind="like"`)。
+
+操作:
+
+- A が trigger を押して grid を開く。
+- `like` を選択する。
+
+期待結果:
+
+- API: `POST /tweets/<T.id>/reactions/` body=`{kind: "like"}` が **200** を返す。
+- レスポンス body: `{kind: null, created: false, changed: false, removed: true}`。
+- DB: A の Reaction 行は DELETE される。
+- DB: `T.reaction_count` が 1 減る。
+- UI: trigger ラベルが `リアクション {total}` に戻る。
+- UI: grid 内 `like` の `aria-pressed=false`、強調が外れる。
+- GET の `my_kind` は `null`。
+
+### RCT-03: 別 kind に変更する
+
+前提:
+
+- actor A は T に `like` を付けている (`my_kind="like"`)。
+
+操作:
+
+- A が trigger を押して grid を開く。
+- `learned` (📚) を選択する。
+
+期待結果:
+
+- API: `POST /tweets/<T.id>/reactions/` body=`{kind: "learned"}` が **200** を返す。
+- レスポンス body: `{kind: "learned", created: false, changed: true, removed: false}`。
+- DB: A の Reaction 行は **削除されず**、`kind` のみが `learned` に UPDATE される。`id` は不変、`created_at` は不変、`updated_at` のみ更新。
+- DB: `T.reaction_count` は **不変** (count は kind を問わない総数)。
+- UI: trigger ラベルが `📚 {total}` に変わる。
+- UI: grid 内で `like` は `aria-pressed=false`、`learned` が `aria-pressed=true`。
+- 集計 GET の `counts.like` は -1、`counts.learned` は +1。`counts` の合計は不変。
+
+### RCT-04: 明示的に DELETE エンドポイントで取り消す
+
+前提:
+
+- actor A は T に何らかの kind を付けている (`my_kind != null`)。
+
+操作:
+
+- 別タブで kind が変わっている可能性を考慮した UI が `DELETE /api/v1/tweets/<T.id>/reactions/` を直接叩く。
+
+期待結果:
+
+- API: 既存ありなら **204 No Content**。
+- DB: A の Reaction 行は DELETE される。
+- DB: `T.reaction_count` が 1 減る。
+- UI: trigger ラベルが初期形に戻る。
+
+### RCT-05: 既存なしで DELETE すると 404
+
+前提:
+
+- actor A は T に reaction を持っていない (`my_kind=null`)。
+
+操作:
+
+- A が `DELETE /api/v1/tweets/<T.id>/reactions/` を直接叩く。
+
+期待結果:
+
+- API: **404 Not Found**、body `{detail: "リアクションがありません。"}`。
+- DB: 変化なし。
+- UI: 通常運用で発生する経路ではない (UI から DELETE は my_kind != null のときのみ)。
+
+### RCT-06: 集計 GET (未ログインも可)
+
+前提:
+
+- target tweet T にいくつかの reaction が付いている。
+
+操作:
+
+- 任意のクライアント (未ログイン or ログイン) が `GET /api/v1/tweets/<T.id>/reactions/` を叩く。
+
+期待結果:
+
+- API: **200**。
+- レスポンス body の `counts` は **10 kind 全て** を含み、未利用 kind は `0`。
+- 認証時は `my_kind` に actor の kind (または `null`)。
+- 未ログインは `my_kind: null`。
+- Tweet が削除済みなら **404**。
+
+### RCT-07: 削除済み tweet にリアクションできない
+
+前提:
+
+- target tweet T は `is_deleted=true`。
+
+操作:
+
+- A が T に対して `POST /tweets/<T.id>/reactions/` を叩く。
+
+期待結果:
+
+- API: **404 Not Found** (`get_object_or_404` 経由、default Manager で除外)。
+- DB: 変化なし。
+- UI: tombstone カードに ReactionBar を表示しない (= UI からは到達しない)。
+
+### RCT-08: 双方向 Block 関係の相手にはリアクションできない
+
+前提:
+
+- actor A と作者 B が双方向 block 関係 (どちらか一方が block していれば成立)。
+- target tweet T は B 作。
+
+操作:
+
+- A が `POST /tweets/<T.id>/reactions/` を叩く。
+
+期待結果:
+
+- API: **403 Forbidden**、body `{detail: "このツイートにリアクションできません。"}`。
+- DB: 変化なし。
+- UI: B のプロフィール / 投稿は block 関係下では基本的に見えないが、もし旧キャッシュ等で UI 上に T が残っていた場合、reaction 試行で 403 → toast 「リアクションできません」を表示。
+
+### RCT-09: Block 成立前の reaction は残る
+
+前提:
+
+- 過去に A が B の tweet T に reaction を付けていた。
+- その後 A が B を block した (or B が A を block した)。
+
+操作:
+
+- 第三者または A 自身が `T.reaction_count` を確認する。
+
+期待結果:
+
+- DB: A の Reaction 行は **削除されない** (block 操作は reaction を一括取消しない)。
+- DB: `T.reaction_count` は変化なし。
+- UI: T のカードを A が表示できる経路があれば my_kind は維持表示される。
+- 解除のためには A が同じ kind を再押下するか、明示 DELETE を叩く必要あり。
+
+### RCT-10: 認証なしの POST / DELETE は 401
+
+前提:
+
+- target tweet T が存在する。
+- リクエスト元は認証クッキー / Bearer token を持たない。
+
+操作:
+
+- 匿名で `POST /tweets/<T.id>/reactions/` body=`{kind: "like"}` を叩く。
+
+期待結果:
+
+- API: **401 Unauthorized**。
+- DB: 変化なし。
+- UI: ReactionBar の trigger を押した直後に grid を開くだけなら API call 無し。grid から kind を選んだ瞬間に 401 → toast + login CTA が出る (現状 UI は my_kind null 状態でも grid を開ける、login required の事前ガードは TODO)。
+
+### RCT-11: 不正な kind は 400
+
+前提:
+
+- actor A、target tweet T。
+
+操作:
+
+- A が `POST /tweets/<T.id>/reactions/` body=`{kind: "love"}` (10 種に無い) を叩く。
+
+期待結果:
+
+- API: **400 Bad Request**、body にバリデーションエラー (`kind: "選択肢にありません。"` 相当)。
+- DB: 変化なし。
+- UI: ReactionBar は 10 種の固定リストから生成しているため、通常運用で 400 にはならない。
+
+### RCT-12: Rate limit を超えると 429
+
+前提:
+
+- actor A が連続で `POST /tweets/<id>/reactions/` を叩いている。
+- `reaction` scope の rate (本番 60/min, stg 600/min) を超過。
+
+操作:
+
+- 超過後の N+1 リクエストを送る。
+
+期待結果:
+
+- API: **429 Too Many Requests**、`Retry-After` header 付与。
+- DB: 変化なし。
+- UI: toast で「リアクションが多すぎます。少し待ってください。」を表示 (現状 UI は generic toast)。
+
+### RCT-13: 自分のツイートにリアクションを付ける (self-reaction)
+
+前提:
+
+- actor A と target tweet T (作者も A)。
+
+操作:
+
+- A が T 上で `like` を付ける。
+
+期待結果:
+
+- API: 201 で許可される (DB / API レイヤでは self-reaction を禁止しない)。
+- DB: `Reaction(user=A, tweet=T)` が登録される。
+- 通知: `notifications` 実装後 (Phase 4A) でも recipient == actor のため通知は飛ばさない (silent skip)。
+- UI: 通常通り counts 反映。違和感がある場合は将来 UI で抑制 (現状は許容)。
+
+### RCT-14: optimistic update で API 失敗時にロールバック
+
+前提:
+
+- actor A は T に reaction を持たない。
+- API リクエストが何らかのエラー (5xx, ネットワーク断、429 等) で失敗する。
+
+操作:
+
+- A が grid から `like` を選ぶ。
+
+期待結果:
+
+- UI: 押した瞬間 trigger が `❤️ {total+1}`、`like` が `aria-pressed=true` に即時変わる。
+- API: 失敗 (例: 500) を返す。
+- UI: trigger / grid が **押下前の状態に戻る**。
+- toast: 「リアクションを更新できませんでした」が出る。
+- DB: 変化なし。
+
+### RCT-15: 同じ POST が race して二重 INSERT になりかけても idempotent
+
+前提:
+
+- actor A が同時に 2 タブから `POST /tweets/<T.id>/reactions/` body=`{kind: "like"}` を叩く。
+- どちらも `my_kind=null` で出発。
+
+操作:
+
+- 2 リクエストがほぼ同時にサーバ到達する。
+
+期待結果:
+
+- API: 1 つは **201** (`created=true`)、もう 1 つは **200** (`created=false, changed=false, removed=false`)。`IntegrityError` を catch して既存行を返す path で吸収。
+- DB: A の Reaction は **1 行のみ** (UniqueConstraint 違反で fail しない)。
+- DB: `T.reaction_count` は **+1 のみ** (signals は created=true の 1 回だけ +1)。
+
+### RCT-16: 種類変更時に signals は count を触らない
+
+前提:
+
+- A は T に `like` を付けている (`my_kind="like"`)。`T.reaction_count = N`。
+
+操作:
+
+- A が grid で `learned` を選ぶ。
+
+期待結果:
+
+- DB: Reaction 行の kind が `learned` に UPDATE。`id` 不変。
+- DB: `T.reaction_count` は **N のまま** (signals は created=False で no-op)。
+- 集計 GET: `counts.like = -1`, `counts.learned = +1`、合計は不変。
+
+### RCT-17: ReactionBar の Alt+Enter キーボード操作
+
+前提:
+
+- actor A は ReactionBar の trigger ボタンに focus を当てている。
+
+操作:
+
+- `Alt+Enter` を押す。
+
+期待結果:
+
+- UI: grid が開く / 閉じる (toggle)。
+- 通常の `Enter` クリックでも開閉できる (button 標準動作)。
+- a11y: trigger に `aria-haspopup="true"`, `aria-expanded={open}` が付与されている。
+- a11y: grid 内ボタンは `aria-label="<label> ({count} 件)"`、`aria-pressed`。
+
+### RCT-18: 連続して別 kind を押し替える (オプティミスティック整合)
+
+前提:
+
+- actor A は T に reaction を持たない。
+
+操作:
+
+- A が grid を開き、立て続けに `like` → `learned` → `agree` を選ぶ。
+
+期待結果:
+
+- UI: 押す度に `aria-pressed` が新しい kind だけ true になる。
+- API: 順に 201 (like), 200 changed (learned), 200 changed (agree) が返る。
+- DB: Reaction 行は **1 行のみ**、最終的な `kind="agree"`。
+- DB: `T.reaction_count` は最初の +1 のみで以降変動なし。
+- UI: `busyKind !== null` の間 grid は disable されているため、レスポンス前の二重押下は抑止される (現実装では 1 つの API call が完了するまで次が押せない)。
+
+### RCT-19: 削除済み tweet を集計取得すると 404
+
+前提:
+
+- target tweet T は `is_deleted=true`。
+
+操作:
+
+- 任意のクライアントが `GET /tweets/<T.id>/reactions/` を叩く。
+
+期待結果:
+
+- API: **404 Not Found**。
+- UI: tombstone 表示の tweet カードでは ReactionBar 自体を render しない。
+
+### RCT-20: 同じ tweet で異なる 10 種を別ユーザがそれぞれ付ける
+
+前提:
+
+- 10 ユーザ U1〜U10 がそれぞれ異なる kind を T に付ける。
+
+操作:
+
+- 各ユーザが各自 1 種類ずつ POST。
+
+期待結果:
+
+- DB: T に紐づく Reaction は 10 行。
+- DB: `T.reaction_count = 10`。
+- 集計 GET: `counts` の各 kind が `1`、合計 10。
+- 任意の閲覧ユーザの `my_kind` はそのユーザ自身の kind (未付与なら null)。
+
+## 4. E2E化メモ
+
+各 E2E は上記の `RCT-XX` をテスト名に含める。
+
+推奨する検証観点:
+
+- API レスポンス body の `created / changed / removed` フラグが期待値か。
+- HTTP status code (201 / 200 / 204 / 401 / 403 / 404 / 429) が期待値か。
+- DB 上の Reaction 行数 (1 user 1 tweet では 0 or 1)。
+- `Tweet.reaction_count` が drift していないか (signals + reconcile)。
+- UI の `aria-pressed` 切替、trigger label 更新、grid 内強調色。
+- Optimistic update のロールバック (API mock で 500 を返す)。
+- Rate limit 越えの toast。
+- 削除済み tweet, block 関係, 認証なし のエラー経路。
+
+実行コマンドと具体的な Playwright 手順は [reactions-e2e-commands.md](./reactions-e2e-commands.md) を参照。

--- a/docs/specs/reactions-spec.md
+++ b/docs/specs/reactions-spec.md
@@ -1,0 +1,312 @@
+# リアクション機能 仕様書
+
+> Version: 0.1
+> 最終更新: 2026-05-05
+> ステータス: 実装済み (Phase 2 P2-04 / #179, P2-14 / #187 完了済み)
+> 関連: [SPEC.md §6](../SPEC.md), [ER.md §2.9](../ER.md), [reactions-scenarios.md](./reactions-scenarios.md), [reactions-e2e-commands.md](./reactions-e2e-commands.md)
+
+---
+
+## 0. このドキュメントの位置づけ
+
+本プロジェクトの **リアクション (Reaction)** 機能の **UI 上の挙動** と **DB / API の状態遷移** を仕様として固定する。`docs/SPEC.md §6` は機能の存在と 10 種絵文字の表しか触れていないので、トグル方向 / 種別変更 / Block 連動 / カウンタ整合 / Tombstone の挙動など細部を本書で確定させる。
+
+**ゴール**: 「1 user × 1 tweet = 0 もしくは 1 種類の reaction」 を不変条件として、UI / API / DB / 通知のすべてのレイヤで一貫させる。X 本家の Like を 10 種に拡張した独自仕様。
+
+---
+
+## 1. 用語
+
+| 用語               | 定義                                                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| 元 tweet           | reaction の対象となる Tweet 行 (`Tweet`)。`type` は問わない (`original` / `reply` / `quote` 等いずれでも可) |
+| reaction           | `Reaction` モデル 1 行。`(user, tweet, kind)` の三つ組                                                      |
+| kind               | リアクションの種類。10 種固定 (§2.1)                                                                        |
+| my_kind (動詞状態) | あるユーザが対象 tweet について **保有している reaction の kind**。0 種なら `null`、1 種なら kind 値        |
+| reaction_count     | `Tweet.reaction_count`。当該 tweet に紐づく Reaction 行の総数 (kind を問わない)                             |
+
+**ユーザ視点の状態は単一スカラ `my_kind ∈ {null} ∪ KINDS` で表現する**。同一 (user, tweet) ペアに対して複数 kind を持てない (DB レベルで `UniqueConstraint(user, tweet)` で保証)。
+
+---
+
+## 2. 仕様
+
+### 2.1 絵文字セット (10 種固定)
+
+`SPEC.md §6.2` および `apps/reactions/models.py::ReactionKind` を正本とする。
+
+| key           | 絵文字 | label        |
+| ------------- | ------ | ------------ |
+| `like`        | ❤️     | いいね       |
+| `interesting` | 💡     | 面白い       |
+| `learned`     | 📚     | 勉強になった |
+| `helpful`     | 🙏     | 助かった     |
+| `agree`       | 👍     | わかる       |
+| `surprised`   | 😲     | びっくり     |
+| `congrats`    | 🎉     | おめでとう   |
+| `respect`     | 🫡     | リスペクト   |
+| `funny`       | 😂     | 笑った       |
+| `code`        | 💻     | コードよき   |
+
+要点:
+
+- ネガティブ系 (Bad / Dislike / 反対) は **意図的に追加しない** (SPEC §6.2 確定)。
+- フロント表示は `client/src/lib/api/reactions.ts::REACTION_META` を正本とし、emoji + label の対応はバックエンド (`ReactionKind.choices`) と完全一致する。
+- 種類の追加・削除は migration を伴う。frontend の `REACTION_KINDS` 配列とバックエンドの `ReactionKind` を **必ず同時に変更** する (片側変更すると CHOICES 検証で 400 になる)。
+
+### 2.2 1 user × 1 tweet × 0/1 reaction の不変条件
+
+DB:
+
+- `apps/reactions/models.py::Reaction.Meta.constraints` に `UniqueConstraint(fields=["user", "tweet"], name="unique_user_tweet_reaction")`。
+- kind は constraint に **含めない**。種別変更を `UPDATE 1 件` で表現するため (DELETE + CREATE しない / arch H-1)。
+
+API:
+
+- 同じ kind の重複 INSERT は 200 (`changed=False, removed=False`) として idempotent に処理。
+- 別の kind を後押下した場合は **既存行の kind を UPDATE する** だけで `Reaction` の id・`created_at` は変わらない。
+
+UI:
+
+- ReactionBar は同時に 1 つの `aria-pressed=true` ボタンしか持てない (`my_kind` ベース)。
+- 別 kind を押下したら、Optimistic update で「旧 kind の count を -1, 新 kind を +1, my_kind を新 kind に」即座に反映する。
+
+### 2.3 トグル仕様 (upsert)
+
+`POST /api/v1/tweets/<id>/reactions/` body=`{kind: <K>}` の振る舞いは「現状の `my_kind`」で決まる。`apps/reactions/views.py::ReactionView.post` が正本。
+
+| 現状態 (`my_kind`) | リクエスト kind | 副作用                                   | レスポンス例                                                   | HTTP |
+| ------------------ | --------------- | ---------------------------------------- | -------------------------------------------------------------- | ---- |
+| `null` (なし)      | `K`             | INSERT `(user, tweet, K)`, count +1      | `{kind: "K", created: true,  changed: false, removed: false}`  | 201  |
+| `K`                | `K`             | DELETE 自分の Reaction, count -1         | `{kind: null, created: false, changed: false, removed: true}`  | 200  |
+| `K1`               | `K2` (≠ K1)     | UPDATE kind を K2 に. count 変化なし     | `{kind: "K2", created: false, changed: true,  removed: false}` | 200  |
+| `null`             | `K` (race)      | INSERT が IntegrityError → 既存を UPDATE | `{kind: "K", created: false, changed: false, removed: false}`  | 200  |
+
+要点:
+
+- 「同じ kind の再押下 = 取消」は X の Like トグル踏襲。確認ダイアログ無し。
+- 「別 kind 押下 = 種類変更」は内部的に **`UPDATE Reaction SET kind = ?` 1 文** だけで処理し、`reaction_count` は変えない (signals が `created=False` のとき何もしない / `apps/reactions/signals.py::on_reaction_saved`)。
+- 同時 INSERT race は `IntegrityError` を catch して既存行を UPDATE する path で吸収 (idempotent)。
+
+### 2.4 明示的取消 (DELETE)
+
+`DELETE /api/v1/tweets/<id>/reactions/` (body 不要) は actor 自身の Reaction を削除する。
+
+- 既存あり → DELETE → count -1, **204 No Content**。
+- 既存なし → **404 Not Found** (`{detail: "リアクションがありません。"}`)。
+- 認証必須 (未ログインは 401)。
+
+POST のトグル経路と機能的に重複するが、UI が「現在の kind が分からない状態でとにかく取り消したい」とき (例: 別タブで変更した結果が反映されてない場合) に使えるよう残す。
+
+### 2.5 集計取得 (GET)
+
+`GET /api/v1/tweets/<id>/reactions/` は AllowAny (未ログインも可)。
+
+レスポンス形:
+
+```json
+{
+	"counts": {
+		"like": 12,
+		"interesting": 3,
+		"learned": 0,
+		"helpful": 0,
+		"agree": 1,
+		"surprised": 0,
+		"congrats": 0,
+		"respect": 0,
+		"funny": 0,
+		"code": 0
+	},
+	"my_kind": "like"
+}
+```
+
+要点:
+
+- `counts` は **必ず 10 kind 全部** を含む (0 のものも 0 で埋める)。フロントが `counts[kind] ?? 0` の null 判定をしなくても KeyError しないように。
+- `my_kind` は認証時のみ。未ログインは `null`。
+- `Tweet.reaction_count` (denormalized counter) と `sum(counts.values())` は signals + reconcile Beat で整合。reconcile は日次。
+
+### 2.6 Block / 削除 tweet との関連
+
+`apps/reactions/views.py::ReactionView.post` の事前チェック:
+
+| 状況                                      | レスポンス                                               |
+| ----------------------------------------- | -------------------------------------------------------- |
+| 元 tweet が `is_deleted=True`             | 404 (default Manager で除外、`get_object_or_404` 経由)   |
+| actor と tweet author が双方向 block 関係 | 403 `{detail: "このツイートにリアクションできません。"}` |
+| 認証なし                                  | 401                                                      |
+| kind が 10 種以外                         | 400 (DRF ChoiceField validation)                         |
+
+要点:
+
+- Block は **どちらか片方が block** していれば成立 (`is_blocked_relationship` は対称) → A が B を block しても、B が A を block しても、B は A の tweet にリアクション不可。
+- 既存 reaction が後から block 関係になった場合: 既存 reaction 行は **そのまま残る** (= count に乗ったまま)。`SPEC §11 (Block)` と整合させる。一括取消は別 issue。
+
+### 2.7 Rate limit
+
+DRF `ScopedRateThrottle` で `throttle_scope = "reaction"`。`config/settings/base.py::_THROTTLE_RATES_BASE`:
+
+| 環境 | rate                    |
+| ---- | ----------------------- |
+| 本番 | `60/min`                |
+| stg  | `600/min` (`#336` 緩和) |
+
+429 のときは `Retry-After` header を返す (DRF default)。フロントは toast でユーザに知らせる。
+
+### 2.8 通知連動 (Phase 4A 以降)
+
+`signals.py::on_reaction_saved` 内で `apps.common.blocking.safe_notify(kind="LIKE", recipient=tweet.author, actor=instance.user)` を `transaction.on_commit` 経由で呼ぶ。Phase 4A (`apps/notifications/`) 完成までは no-op (`safe_notify` は通知 app が無ければ silent skip)。
+
+要点:
+
+- 通知 kind は `LIKE` 固定 (10 種を区別しない、`SPEC §8 通知` の方針)。
+- 通知文言は通知側で決める (例: 「@{actor} があなたのツイートにリアクションしました (❤️)」)。
+- 自分自身の tweet への self-reaction は **通知しない** (= notify 内で actor == recipient なら skip。Phase 4A で実装)。
+
+### 2.9 カウンタ整合 (drift 防止)
+
+SoT: `Reaction` 行の集計。`Tweet.reaction_count` は denormalized cache。
+
+- `signals.on_reaction_saved` が新規作成時のみ `+1`、kind 変更時は触らない。
+- `signals.on_reaction_deleted` が `-1` (`Greatest(F('reaction_count') - 1, 0)` で 0 でクリップ)。
+- `apps/reactions/tasks.reconcile_reaction_counters` が日次 Beat で `Tweet.reaction_count = COUNT(Reaction WHERE tweet=?)` で再計算 (drift 補正)。
+
+drift が発生する経路:
+
+- `transaction.on_commit` で signal を発行する間に DB rollback / replica lag。
+- `Reaction.objects.bulk_create / bulk_delete` (signals が発火しない) → **MVP では bulk 操作禁止**。
+
+---
+
+## 3. 状態遷移図
+
+ある (actor, target_tweet) ペアの `my_kind` の遷移。kind は 10 種だが図示の都合で 2 種 (`A`, `B`) に縮約。
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    [*] --> NONE : 初期状態
+
+    state "my_kind = null" as NONE
+    state "my_kind = A" as A
+    state "my_kind = B" as B
+
+    NONE --> A : POST {kind: A}\n(INSERT, count +1, 201)
+    NONE --> B : POST {kind: B}\n(INSERT, count +1, 201)
+
+    A --> NONE : POST {kind: A}\n(DELETE, count -1, 200 removed)
+    B --> NONE : POST {kind: B}\n(DELETE, count -1, 200 removed)
+
+    A --> B : POST {kind: B}\n(UPDATE kind, count 不変, 200 changed)
+    B --> A : POST {kind: A}\n(UPDATE kind, count 不変, 200 changed)
+
+    A --> NONE : DELETE\n(204)
+    B --> NONE : DELETE\n(204)
+```
+
+要点:
+
+- ノード数は (10 + 1) = 11、辺数はオーダ 10² だが、構造は完全グラフ (NONE は中心ハブ、各 kind 間も直接遷移)。
+- 「再押下 = 取消」「別押下 = 種類変更」「明示 DELETE = NONE 戻し」の 3 系統のみ。
+
+---
+
+## 4. 条件分岐表 (action × current state × constraint)
+
+### 4.1 ReactionBar UI 描画
+
+| 状態           | trigger ボタン文言 (`triggerLabel`) | grid 内 ボタン色 (kind=K)            | aria-pressed |
+| -------------- | ----------------------------------- | ------------------------------------ | ------------ |
+| `my_kind=null` | `リアクション {total}`              | 全 kind: 灰色 hover                  | 全 false     |
+| `my_kind=K`    | `{emoji(K)} {total}`                | K: lime-500/20 強調 / 他: 灰色 hover | K のみ true  |
+
+要点:
+
+- `total` は `sum(counts)` で 10 kind 合算。X の Like 数表示と同じ「自分の kind と関係なく合計を出す」スタンス。
+- trigger ボタンは **常に 1 つ**。grid を開閉する。Alt+Enter キーで開閉できる (SPEC §6.2 アクセシビリティ)。
+- `busyKind !== null` の間は grid 内全ボタンが `disabled`、optimistic update 中の二重押下を防止。
+
+### 4.2 各 action の遷移と副作用
+
+| 現状態 (`my_kind`)  | action                        | 結果状態 (`my_kind`) | API                                         | counts                   | 備考                                                     |
+| ------------------- | ----------------------------- | -------------------- | ------------------------------------------- | ------------------------ | -------------------------------------------------------- |
+| `null`              | grid で K を click            | `K`                  | `POST /tweets/<id>/reactions/` `{kind: K}`  | `K +1, total +1`         | 201 created                                              |
+| `K`                 | grid で K を click (再押下)   | `null`               | `POST /tweets/<id>/reactions/` `{kind: K}`  | `K -1, total -1`         | 200 removed=true                                         |
+| `K1`                | grid で K2 を click (別 kind) | `K2`                 | `POST /tweets/<id>/reactions/` `{kind: K2}` | `K1 -1, K2 +1, total ±0` | 200 changed=true. UPDATE 1 文                            |
+| `K`                 | DELETE エンドポイント         | `null`               | `DELETE /tweets/<id>/reactions/`            | `K -1, total -1`         | 204 No Content                                           |
+| `null`              | DELETE エンドポイント         | `null`               | `DELETE /tweets/<id>/reactions/`            | 不変                     | 404 (既存なし)                                           |
+| 元 tweet が削除済み | POST or DELETE                | -                    | -                                           | -                        | 404. UI 側でも tombstone カードに ReactionBar を出さない |
+| 双方向 block 関係   | POST                          | -                    | -                                           | -                        | 403 `このツイートにリアクションできません。`             |
+| Rate limit 超過     | POST                          | -                    | -                                           | -                        | 429 + `Retry-After`. UI は toast 表示                    |
+| 認証なし            | POST or DELETE                | -                    | -                                           | -                        | 401. UI は LoginCTA を表示                               |
+| 未ログイン          | GET                           | -                    | `GET /tweets/<id>/reactions/`               | counts のみ              | `my_kind=null`                                           |
+
+---
+
+## 5. 実装対応方針
+
+### 5.1 バックエンド
+
+- `Reaction` モデルは `(user, tweet, kind)` 三つ組 + `created_at, updated_at`。`UniqueConstraint(user, tweet)`。
+- view は **POST upsert / DELETE 明示 / GET 集計** の 3 verb のみ。`PUT/PATCH` は提供しない (POST upsert で兼ねる)。
+- POST は `select_for_update` で同一 (user, tweet) の行をロックしてから既存判定 → INSERT / DELETE / UPDATE 分岐。
+- IntegrityError は同時 race の保険として `existing` を再 fetch + UPDATE で吸収。
+- counts 集計は GET 内で `Counter(values_list("kind"))`、10 kind を 0 で埋めて返す。
+- Block チェックは `apps.common.blocking.is_blocked_relationship`。
+- 削除済み tweet は default Manager で除外、`get_object_or_404` で 404。
+- Rate limit は `ScopedRateThrottle` の `reaction` スコープ。stg は 10x 緩和 (#336)。
+
+### 5.2 フロントエンド
+
+- `ReactionBar` は trigger button + 開閉式 grid。trigger の `aria-expanded` で grid 状態を表現。
+- Click は **Optimistic update**: count と my_kind を即時反映、API レスポンス到着で my_kind だけ server 値で reconcile。
+- API 失敗時は previous state にロールバック + `react-toastify` で通知。
+- grid 内 button は 10 kind 分。`aria-pressed=true` で現在の kind を示す。
+- Alt+Enter で grid 開閉 (キーボード代替)。
+- 削除済み tweet (tombstone) のカードは ReactionBar を **render しない**。
+- 未ログインで POST すると 401 → トースト + ログイン CTA。GET は AllowAny なので counts のみ表示し、grid を開いた瞬間にログイン required の placeholder を出す (現実装は trigger を押せる、実際の API 401 時に toast)。
+
+### 5.3 通知
+
+- Phase 4A の `apps/notifications/` 実装後に `safe_notify(kind="LIKE", ...)` が稼働。
+- 種別 (10 種) は通知に乗せない設計。「@user がリアクションしました」のみ。
+- self-reaction は通知しない。
+- 通知 throttling は通知側の責務 (短時間連続 react は 1 通知に集約、SPEC §8.4)。
+
+### 5.4 カウンタ drift 補正
+
+- 日次 Celery Beat `apps.reactions.tasks.reconcile_reaction_counters` が全 Tweet をバッチで集計し直す。
+- 差分があった行のみ UPDATE。Sentry にメトリクス送出 (drift 件数)。
+- DB 直叩き / bulk_create / DML migration 後のずれ救済が主目的。
+
+---
+
+## 6. 参考
+
+### 内部参照
+
+- [docs/SPEC.md §6](../SPEC.md) (リアクション仕様)
+- [docs/ER.md §2.9](../ER.md) (Reaction モデル)
+- [apps/reactions/models.py](../../apps/reactions/models.py)
+- [apps/reactions/views.py](../../apps/reactions/views.py)
+- [apps/reactions/serializers.py](../../apps/reactions/serializers.py)
+- [apps/reactions/signals.py](../../apps/reactions/signals.py)
+- [apps/reactions/tasks.py](../../apps/reactions/tasks.py)
+- [apps/reactions/tests/test_reaction_api.py](../../apps/reactions/tests/test_reaction_api.py)
+- [client/src/components/reactions/ReactionBar.tsx](../../client/src/components/reactions/ReactionBar.tsx)
+- [client/src/lib/api/reactions.ts](../../client/src/lib/api/reactions.ts)
+
+### 関連 Issue / PR
+
+- P2-04 (#179): apps/reactions モデル + API
+- P2-14 (#187): リアクション UI (10 種 + Alt+Enter)
+- P2-21 (#193): E2E (golden path)
+- #336: stg rate limit 緩和
+
+### 関連ドキュメント
+
+- [reactions-scenarios.md](./reactions-scenarios.md) — 日本語シナリオ集
+- [reactions-e2e-commands.md](./reactions-e2e-commands.md) — E2E 実行コマンド

--- a/docs/specs/search-e2e-commands.md
+++ b/docs/specs/search-e2e-commands.md
@@ -1,0 +1,178 @@
+# 検索 E2E 実行コマンド
+
+> 関連: [search-spec.md](./search-spec.md), [search-scenarios.md](./search-scenarios.md)
+> spec ファイル: [`client/e2e/search-scenarios.spec.ts`](../../client/e2e/search-scenarios.spec.ts) (新規 / Phase 2 追補)
+>
+> 目的: [search-scenarios.md](./search-scenarios.md) の `SRC-XX` を Playwright で網羅的に走らせるための、環境変数とコマンド集。シナリオ定義 (大きい) とコマンドを分離する。
+
+## 0. 前提
+
+- ローカル: `docker compose -f local.yml up -d` で `api`, `client`, `postgres`, `redis`, `mailpit` を起動済み。
+- stg: `https://stg.codeplace.me/` が deploy 済み (P2-22 / #194 で稼働)。
+- 認証情報は shell history に残さないため **環境変数で渡す**。`<USER_PASSWORD>` プレースホルダは実値に置き換えて実行する。
+- 並列実行は **`--workers=1`**。検索結果の順序検証で stable な状態を期待するため、テスト間で fixture が混ざらないよう直列。
+- 検索は AllowAny だが、スパム判定 `anon` 200/day を本番で踏まないように、ログイン状態でテストすることを推奨。
+
+## 1. テストアカウント
+
+ローカル / stg どちらでも以下を使う。シナリオによっては事前 seed が必要 (= `from:alice` を成立させるため `alice` が必要)。
+
+| handle | email               | 用途                                |
+| ------ | ------------------- | ----------------------------------- |
+| alice  | `alice@example.com` | `from:alice` の照合用、tweet 投稿   |
+| bob    | `bob@example.com`   | 別作者で除外検証用                  |
+| test2  | `test2@gmail.com`   | 既存 stg seed (代替で alice の代用) |
+
+ローカル seed 例:
+
+```bash
+docker compose -f local.yml exec api python manage.py shell <<'PY'
+from django.contrib.auth import get_user_model
+U = get_user_model()
+for handle, email in [("alice","alice@example.com"),("bob","bob@example.com")]:
+    u, created = U.objects.get_or_create(username=handle, defaults={"email": email})
+    if created:
+        u.set_password("supersecret12")  # pragma: allowlist secret
+        u.save()
+PY
+```
+
+## 2. 環境変数
+
+```bash
+# 共通
+export PLAYWRIGHT_USER1_EMAIL="alice@example.com"
+export PLAYWRIGHT_USER1_PASSWORD="<USER1_PASSWORD>"
+export PLAYWRIGHT_USER1_HANDLE="alice"
+export PLAYWRIGHT_USER2_EMAIL="bob@example.com"
+export PLAYWRIGHT_USER2_PASSWORD="<USER2_PASSWORD>"
+export PLAYWRIGHT_USER2_HANDLE="bob"
+
+# stg vs local の切り替え
+# - local:
+export PLAYWRIGHT_BASE_URL="http://localhost:3000"
+# - stg:
+# export PLAYWRIGHT_BASE_URL="https://stg.codeplace.me"
+```
+
+## 3. 全シナリオ実行
+
+```bash
+cd /workspace/client
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line
+```
+
+stg ターゲット例:
+
+```bash
+cd /workspace/client
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=alice@example.com PLAYWRIGHT_USER1_PASSWORD='<USER1_PASSWORD>' \
+PLAYWRIGHT_USER1_HANDLE=alice \
+PLAYWRIGHT_USER2_EMAIL=bob@example.com PLAYWRIGHT_USER2_PASSWORD='<USER2_PASSWORD>' \
+PLAYWRIGHT_USER2_HANDLE=bob \
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line
+```
+
+## 4. 単独シナリオ実行
+
+```bash
+# SRC-01: 単純なキーワードで tweet を検索する
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-01"
+
+# SRC-02: 大文字小文字を区別しない
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-02"
+
+# SRC-03: 空クエリは空結果
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-03"
+
+# SRC-05: tag: で tag 絞り込み
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-05"
+
+# SRC-06: tag: 複数指定は AND 結合
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-06"
+
+# SRC-07: from: で投稿者絞り込み
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-07"
+
+# SRC-08: since: / until: で日付範囲絞り込み
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-08"
+
+# SRC-09: 不正な日付は silent drop
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-09"
+
+# SRC-10: type: で tweet 種別絞り込み
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-10"
+
+# SRC-11: has:image の絞り込み
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-11"
+
+# SRC-12: has:code の絞り込み
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-12"
+
+# SRC-13: 複合演算子で AND 絞り込み
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-13"
+
+# SRC-14: 未知演算子は keyword に流れる
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-14"
+
+# SRC-15: limit のクランプ
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-15"
+
+# SRC-16: limit が int 以外でも default にフォールバック
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-16"
+
+# SRC-17: 結果は新着順
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-17"
+
+# SRC-18: 削除済み tweet は結果に出ない
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-18"
+
+# SRC-20: 未ログインで検索できる
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-20"
+
+# SRC-21: SearchBox 空文字 submit は navigate しない
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-21"
+
+# SRC-22: SearchBox は URL 経由で初期値を受け取る
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-22"
+```
+
+## 5. Phase 2 既存 golden path との関係
+
+`client/e2e/phase2.spec.ts` (P2-21 / #193) は **golden path 1 本** のみ:
+
+> alice follows bob → reacts to bob's tweet → sees in TL → finds via search
+
+これは「検索ボックスから submit して結果が出る」 smoke 用途で、本書のシナリオ網羅は別 spec (`search-scenarios.spec.ts`) として分離する。
+
+## 6. API 直叩きで通すシナリオ
+
+UI 操作を経由しなくても通る検証は **直接 axios で叩く** スタイルが安定:
+
+```bash
+# stg / 未ログインで API 直叩き smoke
+curl -s 'https://stg.codeplace.me/api/v1/search/?q=python' | jq '.count, .results[0:3] | .[] | {id, body, author_handle}'
+
+# 演算子検証
+curl -s 'https://stg.codeplace.me/api/v1/search/?q=tag:django%20from:alice' | jq '.count'
+
+# limit クランプ確認
+curl -s 'https://stg.codeplace.me/api/v1/search/?q=python&limit=500' | jq '.count'
+```
+
+サーバ側 pytest:
+
+```bash
+docker compose -f local.yml exec api pytest apps/search/tests/ -v
+docker compose -f local.yml exec api pytest apps/search/tests/test_parser.py -v -k "tag"
+```
+
+## 7. 既知の制約・運用ノート
+
+- **`anon` rate limit**: 未ログインで連投すると本番 200/day を踏む。stg は 2000/day (#336)。
+- **fixture 依存**: 結果順序検証 (SRC-17) や複合クエリ (SRC-13) は事前に正しい本文 / tag / created_at の tweet が seed されている必要あり。spec 内 `beforeAll` で API 直叩き seed する戦略を推奨。
+- **stg 共有データ汚染**: stg は他のテスト・人手作業で結果が変動する。`SRC-NN` の検証は固有の marker 文字列 (`"e2e-search-marker-<rand>"` 等) を含めて作成し、その marker を含むかで検証する (= 全結果数を期待値で固定しない)。
+- **Block 関係の影響**: 現状 検索結果は block 関係を考慮しない (search-spec.md §3.4)。block 済み user の tweet も結果に出るので、検証側はその前提でアサート。
+- **Tombstone (削除済み)**: SRC-18 は spec 内で `DELETE /api/v1/tweets/<id>/` を叩いて soft-delete してから検索する。teardown は不要 (soft-delete は復元機能なし)。
+- **CI 連携**: 現状 `client/e2e/search-scenarios.spec.ts` は **CI に組み込まない**。理由は phase2.spec.ts と同じ。`.github/workflows/e2e-stg.yml` 整備時にまとめて追加する。

--- a/docs/specs/search-scenarios.md
+++ b/docs/specs/search-scenarios.md
@@ -1,0 +1,446 @@
+# 検索シナリオ仕様
+
+> 関連: [search-spec.md](./search-spec.md), [search-e2e-commands.md](./search-e2e-commands.md)
+>
+> 目的: 検索 (`/api/v1/search/` + `/search` ページ) の文法・API・UI 挙動を、E2E 化しやすい形で固定する。
+
+## 1. 用語
+
+| 用語          | 定義                                                                                      |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| query (q)     | URL の `?q=...` に渡す検索文字列                                                          |
+| 演算子        | `<key>:<value>` 形式の token。`tag` / `from` / `since` / `until` / `type` / `has` の 6 種 |
+| keyword       | 演算子に該当しなかった残りの token (空白連結後の文字列)                                   |
+| 結果カード    | `/search` ページに描画される 1 tweet 分のカード                                           |
+| MAX_LIMIT     | `apps/search/services.py::MAX_LIMIT = 100`                                                |
+| DEFAULT_LIMIT | `apps/search/services.py::DEFAULT_LIMIT = 20`                                             |
+
+## 2. 基本方針
+
+- 検索は **未ログインでも実行可能** (AllowAny)。
+- パラメータ不正・未知演算子・不正値は **silent drop** で 200 + 部分結果 (例外を投げない)。
+- 空クエリ (`q=""` / `q="   "` / 演算子も無し) は **空結果**。
+- 結果は **新着順** (`created_at desc`, tie は `id desc`)。
+- 結果数は `min(limit, MAX_LIMIT=100)`、default は 20。
+- 削除済み tweet は default Manager で除外 → 結果に出ない。
+- Block 関係 (現状) は結果に **反映しない**。
+- インフラは Postgres `body__icontains` + pg_bigm GIN index (ADR-0002 PoC 採用)。
+- 対象は tweet 本文のみ (article は Phase 6 以降)。
+
+## 3. 検索シナリオ一覧
+
+### SRC-01: 単純なキーワードで tweet を検索する
+
+前提:
+
+- ユーザ B が `body="python is fun"` の tweet T1、`body="rust is safe"` の tweet T2 を投稿済み。
+
+操作:
+
+- 任意のクライアントが `GET /api/v1/search/?q=python` を叩く。
+- または `/search?q=python` ページを開く。
+
+期待結果:
+
+- API: **200**。
+- レスポンス body: `{query: "python", results: [<T1>, ...], count: >=1}`。
+- T1 (python を含む) は結果に含まれる。
+- T2 (python を含まない) は結果に含まれない。
+- UI: 結果カードに T1 の本文が表示される。
+- UI: ヘッダに `「python」の検索結果: <count> 件` が表示される。
+
+### SRC-02: 大文字小文字を区別しない
+
+前提:
+
+- B の tweet T1 に `python` の文字列を含む。
+
+操作:
+
+- `GET /api/v1/search/?q=PYTHON`。
+
+期待結果:
+
+- API: 200、T1 が結果に含まれる (`body__icontains` のため)。
+
+### SRC-03: 空クエリは空結果
+
+前提:
+
+- 検索可能な tweet が存在する。
+
+操作:
+
+- `GET /api/v1/search/?q=` または `GET /api/v1/search/?q=%20%20` (空白のみ)。
+
+期待結果:
+
+- API: 200。
+- レスポンス body: `{query: "" or "   ", results: [], count: 0}`。
+- UI: 検索ボックスは出るが、結果セクションは表示されず、CTA テキスト「上のボックスにキーワードを入れて検索してください。」が出る。
+
+### SRC-04: クエリ前後の空白は trim される
+
+前提:
+
+- B の tweet T1 が `python` を含む。
+
+操作:
+
+- `GET /api/v1/search/?q=%20%20python%20%20`。
+
+期待結果:
+
+- 内部的に `python` として処理。
+- T1 が結果に含まれる。
+- レスポンス body の `query` は **strip 済みの文字列** (`apps/search/views.py::SearchView.get` 内で `(request.query_params.get("q") or "").strip()` 後の値が echo される)。例: `?q=  python  ` → `query: "python"`。
+
+### SRC-05: `tag:<name>` で tag 絞り込み
+
+前提:
+
+- T1 が `body="hello"` で tag `django` を持つ。
+- T2 が `body="hello"` で tag `python` を持つ。
+
+操作:
+
+- `GET /api/v1/search/?q=hello%20tag:django`。
+
+期待結果:
+
+- API: 200。
+- T1 のみ含まれる。T2 は除外。
+- 演算子 `tag:#Django` も小文字化されて `django` 一致 (= T1 ヒット)。
+
+### SRC-06: `tag:` 複数指定は AND 結合
+
+前提:
+
+- T1 が tag `django` と `python` を両方持つ。
+- T2 は `django` のみ。
+
+操作:
+
+- `GET /api/v1/search/?q=tag:django%20tag:python`。
+
+期待結果:
+
+- T1 のみ含まれる。T2 は除外。
+
+### SRC-07: `from:<handle>` で投稿者絞り込み
+
+前提:
+
+- alice が tweet T1 を投稿。
+- bob が tweet T2 を投稿。
+
+操作:
+
+- `GET /api/v1/search/?q=from:alice`。
+- `GET /api/v1/search/?q=from:@alice` (前置 `@`)。
+
+期待結果:
+
+- 両クエリとも T1 のみ含まれる (handle 大文字小文字無視で iexact 比較)。
+- `from:bad-handle!` (記号入り) は drop され、空クエリ扱い → 空結果 or keyword に流れる。
+
+### SRC-08: `since:` / `until:` で日付範囲絞り込み
+
+前提:
+
+- 2026-01-15 投稿の T1。
+- 2026-04-01 投稿の T2。
+- 2026-12-31 投稿の T3。
+
+操作:
+
+- `GET /api/v1/search/?q=since:2026-02-01`。
+- `GET /api/v1/search/?q=until:2026-04-01`。
+- `GET /api/v1/search/?q=since:2026-02-01%20until:2026-12-30`。
+
+期待結果:
+
+- `since:2026-02-01` → T2, T3 含まれる (T1 除外)。
+- `until:2026-04-01` → T1, T2 含まれる (T3 除外、until は inclusive で 2026-04-01 23:59:59 まで)。
+- `since:2026-02-01 until:2026-12-30` → T2 のみ。
+
+### SRC-09: 不正な日付は silent drop
+
+前提:
+
+- 任意の tweet が存在。
+
+操作:
+
+- `GET /api/v1/search/?q=since:2026-13-99` (存在しない月日)
+- `GET /api/v1/search/?q=since:yesterday`
+
+期待結果:
+
+- API: 200。
+- `since` は drop され、フィルタとして適用されない。
+- keyword も他に無ければ空クエリ扱い → 空結果。
+
+### SRC-10: `type:<kind>` で tweet 種別絞り込み
+
+前提:
+
+- T_orig (`type=original`)、T_reply (`type=reply`)、T_repost (`type=repost`)、T_quote (`type=quote`) が存在し、いずれも `python` を含む。
+
+操作:
+
+- `GET /api/v1/search/?q=python%20type:reply`。
+
+期待結果:
+
+- T_reply のみ含まれる。
+- `type:foo` (許可外) は drop。
+
+### SRC-11: `has:image` で添付画像ありの絞り込み
+
+前提:
+
+- T1 (画像添付あり)、T2 (添付なし) ともに `python` を含む。
+
+操作:
+
+- `GET /api/v1/search/?q=python%20has:image`。
+
+期待結果:
+
+- T1 のみ含まれる。
+
+### SRC-12: `has:code` で Markdown コードブロックを含む tweet の絞り込み
+
+前提:
+
+- T1 の body に ` ``` ` (3 連続バッククォート) が含まれる。
+- T2 の body にコードブロックなし。
+
+操作:
+
+- `GET /api/v1/search/?q=has:code`。
+
+期待結果:
+
+- T1 のみ含まれる。
+- インライン code (バッククォート 1 個) は対象外 (フェンス記法のみ)。
+
+### SRC-13: 複合演算子で AND 絞り込み
+
+前提:
+
+- alice が `body="kubernetes"` で tag `k8s`、2026-01-15 投稿の T1。
+
+操作:
+
+- `GET /api/v1/search/?q=kubernetes%20tag:k8s%20from:alice%20since:2026-01-01`。
+
+期待結果:
+
+- T1 が結果に含まれる。
+- 各演算子は AND 結合。
+
+### SRC-14: 未知演算子は keyword に流れる
+
+前提:
+
+- T1 の body に `foo:bar` という文字列を含む。
+
+操作:
+
+- `GET /api/v1/search/?q=foo:bar` (`foo` は 6 種に無い)。
+
+期待結果:
+
+- `foo:bar` は literal として keywords に積まれる。
+- `body__icontains="foo:bar"` で T1 が含まれる。
+- silent miss を避ける fail-open 設計。
+
+### SRC-15: limit のクランプ
+
+前提:
+
+- 検索ヒットする tweet が 200 件存在。
+
+操作:
+
+- `GET /api/v1/search/?q=python&limit=500` (= MAX_LIMIT=100 を超過)。
+
+期待結果:
+
+- API: 200。
+- `count` は 100 以下。
+- `results` 配列の長さは 100 以下。
+
+### SRC-16: limit が int 以外でも default にフォールバック
+
+前提:
+
+- 検索ヒットする tweet が 30 件存在。
+
+操作:
+
+- `GET /api/v1/search/?q=python&limit=abc`。
+
+期待結果:
+
+- API: 200、500 エラーにならない。
+- DEFAULT_LIMIT=20 が適用され、`count <= 20`。
+
+### SRC-17: 結果は新着順
+
+前提:
+
+- T1 (古い) と T2 (新しい) がいずれも `python` を含む。
+
+操作:
+
+- `GET /api/v1/search/?q=python`。
+
+期待結果:
+
+- `results[0]` は T2 (新しい方)。
+- `results[1]` は T1。
+- 同じ created_at の場合は id 大が先。
+
+### SRC-18: 削除済み tweet は結果に出ない
+
+前提:
+
+- T1 を投稿後に soft-delete (`is_deleted=True`)。
+
+操作:
+
+- `GET /api/v1/search/?q=<T1 の本文>`。
+
+期待結果:
+
+- T1 は結果に含まれない。
+- T1 の作者プロフィール上にも出ない (default Manager で除外)。
+
+### SRC-19: 元 tweet 削除済みの quote は結果に出る (placeholder 表示)
+
+前提:
+
+- B が source tweet S を投稿、A が S を引用 (quote tweet Q) した後、B が S を削除。
+
+操作:
+
+- `GET /api/v1/search/?q=<Q の引用本文に含まれる文字列>`。
+
+期待結果:
+
+- Q が結果に含まれる (alive)。
+- UI 上は埋め込み元 tweet 部分が「このポストは表示できません」 placeholder にレンダされる (TweetCard 経由 / 結果カードで簡易表示の場合は引用元表示なし)。
+
+### SRC-20: 未ログインで検索できる
+
+前提:
+
+- 検索ヒット候補 tweet が存在。
+- リクエスト元は認証 cookie / token を持たない。
+
+操作:
+
+- `GET /api/v1/search/?q=python`。
+
+期待結果:
+
+- API: **200** (AllowAny)。
+- 通常通り結果が返る。
+- 未ログインユーザは結果カードの個別アクション (フォロー / リアクション等) は使えないが、本文閲覧と詳細遷移はできる。
+
+### SRC-21: SearchBox 空文字 submit は navigate しない
+
+前提:
+
+- ユーザが `/search` ページを開いている。
+
+操作:
+
+- 空のまま、または空白のみで submit ボタンを押す。
+
+期待結果:
+
+- URL は `/search` のまま (q parameter が付かない)。
+- 結果セクションは表示されない (= CTA のみ)。
+- 演算子ヘルプの `<details>` は閉じたまま。
+
+### SRC-22: SearchBox は URL 経由で初期値を受け取る
+
+前提:
+
+- 直接 `/search?q=python%20tag:django` にアクセス。
+
+操作:
+
+- ページがロードされる。
+
+期待結果:
+
+- 検索ボックスの input value は `python tag:django` (decode 済み)。
+- 結果セクションに該当 tweet が描画される。
+
+### SRC-23: 演算子のみで keywords 空でも検索が走る
+
+前提:
+
+- alice の tweet T1 (本文に `python` 含む)。
+
+操作:
+
+- `GET /api/v1/search/?q=from:alice`。
+
+期待結果:
+
+- API: 200。
+- T1 が結果に含まれる (alice の tweet 全部が候補)。
+- `keywords=""` でも `parsed.from_handle != None` で `has_filter=True`。
+
+### SRC-24: タグハッシュタグの `#` プレフィックスは無視
+
+前提:
+
+- T1 が tag `python` を持つ。
+
+操作:
+
+- `GET /api/v1/search/?q=tag:%23python`。
+
+期待結果:
+
+- `#python` の `#` を strip し `python` として一致。
+- T1 が含まれる。
+
+### SRC-25: 大量同時 anon リクエストで rate limit を踏む
+
+前提:
+
+- 未ログインで連続 201 件の `/api/v1/search/` リクエストを 24h 以内に送る (本番設定)。
+
+操作:
+
+- 同一 IP から検索を連投。
+
+期待結果:
+
+- 200/day を超えたリクエストは **429**。
+- `Retry-After` header 付与。
+- UI は generic な error 表示 (現状)。
+
+## 4. E2E 化メモ
+
+各 E2E は上記の `SRC-XX` をテスト名に含める。
+
+推奨する検証観点:
+
+- API レスポンスの `count` / `results[N].id` / `results[N].body` の照合。
+- HTTP status (200 / 429)、不正入力でも 200。
+- UI で結果カードの本文 / author / tags が描画される。
+- 削除済み tweet が結果に出ない。
+- 演算子の AND 結合が効く (複合クエリの結果集合が積になる)。
+- limit クランプが効く (`limit=500` でも 100 以下)。
+- 並び順が新着順。
+
+実行コマンドと具体的な Playwright 手順は [search-e2e-commands.md](./search-e2e-commands.md) を参照。

--- a/docs/specs/search-spec.md
+++ b/docs/specs/search-spec.md
@@ -1,0 +1,252 @@
+# 検索機能 仕様書
+
+> Version: 0.1
+> 最終更新: 2026-05-05
+> ステータス: 実装済み (Phase 2 P2-11 / #205, P2-12 / #206, P2-16 / #207 完了済み)
+> 関連: [SPEC.md §10](../SPEC.md), [ADR-0002](../adr/0002-search-infrastructure.md), [search-scenarios.md](./search-scenarios.md), [search-e2e-commands.md](./search-e2e-commands.md)
+
+---
+
+## 0. このドキュメントの位置づけ
+
+本プロジェクトの **検索 (Search)** 機能の **クエリ文法 / API 挙動 / フロント描画 / Block 連動 / Tombstone 扱い** を仕様として固定する。`docs/SPEC.md §10` は対象範囲と演算子の存在しか触れていないので、parser の文法、未知演算子の扱い、空クエリ、limit、未ログインの可視性、削除済み tweet の扱いなど細部を本書で確定させる。
+
+**ゴール**: tweet 本文に対する **キーワード検索 + 6 種演算子** で絞り込みでき、未ログインでも検索可能 (SEO 対象)、削除済み / Block 関係はサーバ側で除外されるという不変条件を、UI / API / DB 全レイヤで一貫させる。
+
+> **MVP 範囲**: tweet 本文のみ対象。`SPEC §10.1` で記事 (article) も対象に含める計画があるが、Phase 6 (記事機能) 完成までは tweet のみ。タブ「すべて」「ツイート」「記事」のうち、現状は「ツイート」のみ動作する。
+
+> **インフラ**: 当面は Postgres `body__icontains` + pg_bigm GIN index で運用 (ADR-0002 の PoC 結果)。`SPEC §10.2` の Meilisearch は検索負荷が pg_bigm 限界 (P95 200ms 超 or 月間 1M クエリ) を超えたら導入検討。
+
+---
+
+## 1. 用語
+
+| 用語       | 定義                                                                                      |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| クエリ     | URL の `?q=...` に乗る検索文字列 (生)。空白区切りで token に分割される                    |
+| token      | クエリを空白で split した 1 単位                                                          |
+| 演算子     | `<key>:<value>` 形式の token。`tag` / `from` / `since` / `until` / `type` / `has` の 6 種 |
+| keyword    | 演算子に該当しなかった残りの token。スペース連結して `body__icontains` に渡される         |
+| 未知演算子 | `<key>:<value>` の文法には合うが key が 6 種に無い token                                  |
+| 不正値     | key は正しいが value が文法に合わない token (例: `since:yesterday`, `from:bad-handle!`)   |
+
+---
+
+## 2. クエリ文法
+
+### 2.1 全体規則
+
+`apps/search/parser.py::parse_search_query` が正本。
+
+- 空白で token に分割。**引用符 (`"phrase search"`) はサポートしない** (TODO / 将来 follow-up)。
+- 各 token を順に判定:
+  1. `^[a-z]+:.+$` の正規表現にマッチするか
+  2. マッチしたら `key` を 6 種演算子と照合
+  3. 6 種ならそれぞれの value 検証 → 通れば struct に格納
+  4. 未知演算子は **literal として keyword に積む** (silent miss を避けるため)
+  5. 不正値は **silent drop** (例外を投げない)
+- 残った非演算子 token を `" ".join(...)` して `keywords` に入れる。
+- 大文字小文字は **value を小文字化** する演算子と、しないものが混在 (§2.2 個別)。
+
+設計の指針: **ユーザ入力で例外を投げない**。fail-open で何かしら結果を返すことを優先 (検索 UX)。
+
+### 2.2 演算子個別仕様
+
+#### `tag:<name>`
+
+- value 例: `tag:django`, `tag:#Django`, `tag:Python`
+- value から先頭 `#` を strip し、**小文字化** して `parsed.tags` に append。
+- **複数指定可能** (`tag:django tag:python` で AND 結合)。
+- 同じ tag の重複指定は dedupe しない (Tag テーブルの一意性で結果は同じ)。
+- value が空 (`tag:`) は drop。
+- バックエンド: `qs.filter(tweet_tags__tag__name=tag)` を tags 個数だけ重ねる。`distinct()` 必要。
+
+#### `from:<handle>`
+
+- value 例: `from:alice`, `from:@alice`
+- value 先頭の `@` を strip。残りが `^[A-Za-z0-9_]{1,32}$` にマッチすれば `parsed.from_handle` にセット。**大文字小文字は保持** (DB 検索は `iexact` で吸収)。
+- マッチしない (ハイフン / 記号 / 33 文字以上) は drop。
+- 後勝ち: 複数指定すると最後の値が勝つ (parser 実装上)。
+- バックエンド: `qs.filter(author__username__iexact=parsed.from_handle)`。
+
+#### `since:<YYYY-MM-DD>` / `until:<YYYY-MM-DD>`
+
+- value 例: `since:2026-01-15`, `until:2026-12-31`
+- `datetime.strptime(value, "%Y-%m-%d").date()` でパース。失敗は drop (silent)。
+- タイムゾーンは **JST** (`timezone.get_current_timezone()`)。
+- `since` は **inclusive**: `created_at >= 当日 00:00 JST`。
+- `until` は **inclusive (人間直感)** = サーバ内部では **exclusive 翌日 00:00**: `created_at < (until + 1 day) 00:00 JST`。`until:2026-04-23` は 2026-04-23 23:59:59 JST まで含む。
+- 範囲が逆転 (`since > until`) でも parser は drop しない。サービス層も例外を投げず空結果を返す。
+- 後勝ち: 複数指定で最後の値が勝つ。
+
+#### `type:<kind>`
+
+- 許可値: `original` / `reply` / `repost` / `quote` (lowercase 比較)。
+- 6 種以外 (`type:foo`) は drop。
+- バックエンド: `qs.filter(type=parsed.type)`。
+- 後勝ち。
+
+#### `has:<kind>`
+
+- 許可値: `image` / `code`。
+- バックエンド:
+  - `has:image` → `qs.filter(images__isnull=False)` + `distinct()`
+  - `has:code` → `qs.filter(body__contains='```')` (Markdown フェンス検知)
+- 複数指定可。重複は parser 側で dedupe。
+- 6 種以外 (`has:video` 等) は drop。
+
+### 2.3 keywords (フリーテキスト)
+
+- 演算子に該当しなかった全 token を空白連結。
+- バックエンド: `qs.filter(body__icontains=parsed.keywords)`。
+- **case-insensitive** (`icontains`)。
+- 複数 token は **連結後の文字列を 1 つの substring** として扱う (= スペース込みで 1 substring 一致)。事前空白 strip 済み。
+- pg_bigm GIN index が `LIKE '%...%'` を加速する。Postgres 以外 (sqlite テスト時) は素のシーケンシャルスキャン。
+
+### 2.4 空クエリ・空結果
+
+- `q=""`, `q="   "`, `q=None` (= URL に q 無し): `services.search_tweets` は **即座に空リスト** を返す。`has_filter=False` の経路。
+- 演算子が 1 つでも有効に立てば、keywords 空でも検索実行 (例: `tag:django` 単独 OK)。
+- 結果 0 件: 200 で `{query, results: [], count: 0}`。
+
+### 2.5 limit
+
+- query string `?limit=N` で指定可能。`max(1, min(N, MAX_LIMIT))` でクランプ。
+- `MAX_LIMIT = 100`、`DEFAULT_LIMIT = 20` (`apps/search/services.py`)。
+- `limit` が int 以外 / 空文字: DEFAULT_LIMIT にフォールバック (例外を投げない)。
+
+### 2.6 並び順
+
+- `qs.order_by("-created_at", "-id")[:capped]`。**新着順** (created_at 降順、tie-breaker は id 降順)。
+- SPEC §10.4 の「関連度順」は未実装 (Meilisearch 移行後 or 別演算子で対応予定)。
+- ページング (cursor / page) は **未実装** (limit のみ)。
+
+---
+
+## 3. API
+
+### 3.1 GET `/api/v1/search/`
+
+- 認証: **AllowAny** (未ログインも可)。
+- query string:
+  - `q` (str, 必須相当) — クエリ。空なら空結果。
+  - `limit` (int, optional) — 1〜100。default 20。
+- レスポンス:
+  ```json
+  {
+    "query": "python tag:django",
+    "results": [<TweetListSerializer>, ...],
+    "count": 5
+  }
+  ```
+- `count` は **このレスポンスに含まれる結果数**。総ヒット数ではない (= ページングが無いので実装上同じ意味)。
+- 結果は `TweetListSerializer` でシリアライズ。`reaction_count`, `repost_count`, `quote_count`, `tags`, `author_handle`, `html` 等を含む。
+- 削除済み tweet は default Manager で除外されるので結果に出ない。
+
+### 3.2 エラー
+
+- query 文字列が壊れていても **200 で空結果** (parser が silent drop するため)。
+- `limit` が int 以外でも 200 (default にフォールバック)。
+- 4xx / 5xx は通常運用で発生しない。サーバエラーのみ 500。
+
+### 3.3 Rate limit
+
+- DRF default の `AnonRateThrottle` (`anon` scope) と `UserRateThrottle` (`user` scope) が適用される。検索専用 scope は無い。
+- 未ログインで連投すると `anon` の 200/day (本番) / 2000/day (stg) を踏む。
+- 429 のときは `Retry-After` 付き。
+
+### 3.4 Block 連動
+
+- 検索結果は **block 関係を考慮しない** (現実装)。block している author の tweet も結果に出る可能性がある。
+- 厳格に除外するには `services.search_tweets` に request 引数を渡し、`apps.common.blocking.exclude_blocked_tweets` 相当の filter を追加する必要 (TODO / 別 issue)。
+- MVP 段階では「Block 関係でも公開検索結果に出る」 = SPEC §11 と整合 (Block は TL と通知の話で、検索結果除外ではない、と解釈)。
+
+---
+
+## 4. フロント
+
+### 4.1 `/search` ページ
+
+`client/src/app/(template)/search/page.tsx` が正本。
+
+- Server Component で `searchParams.q` を読み、サーバサイドで `fetchSearch` を呼ぶ。
+- 認証情報は `cookies()` 経由で SSR fetch に乗る (= ログインユーザのレコメンド調整は今後 / 現状 anon と同じ結果)。
+- レスポンスを `TweetListSerializer` 形式で受けて、`html` を `sanitizeTweetHtml` で消毒したうえで `dangerouslySetInnerHTML`。
+- 結果カードは現状 `TweetCard` を使わず軽量描画 (author + body + tags のみ)。フォロー / リアクション / repost 等のアクションは出ない (= 詳細遷移してから操作する設計)。
+
+### 4.2 `SearchBox`
+
+`client/src/components/search/SearchBox.tsx` が正本。
+
+- `<form role="search">` + controlled input。
+- submit で `router.push('/search?q=' + encodeURIComponent(value))`。
+- 空 / 空白のみは submit しない (`trimmed === '' なら return`)。
+- 演算子ヘルプは `<details>` で折りたたみ表示。autosuggest popup は未実装 (TODO)。
+
+### 4.3 SEO
+
+- `metadata` に `title`, `description` を設定。
+- 検索結果ページは Google 等のクローラに公開 (未ログインで閲覧可能)。
+- パラメータ無し (`/search`) は CTA のみで noindex 推奨だが現状未指定 (TODO)。
+
+---
+
+## 5. 実装対応方針
+
+### 5.1 バックエンド
+
+- `apps/search/parser.py` は **クエリ文字列 → ParsedQuery dataclass** の純関数。例外を投げない。テストしやすい。
+- `apps/search/services.py::search_tweets` は ParsedQuery を QuerySet にマッピング。Tweet model の filter を組み立てるだけ。
+- `apps/search/views.py::SearchView` は API の thin wrapper。AllowAny。limit クランプのみここで担当。
+- 削除済み tweet は `Tweet.objects` (default Manager) が `is_deleted=False` 行のみ返すので、自動的に除外される。
+- pg_bigm / pg_trgm extension は migration `0002_create_postgres_extensions.py` で `CREATE EXTENSION IF NOT EXISTS pg_bigm` を実行。Postgres 以外 (sqlite テスト) は migration が no-op。
+- 関連 Tag は pg_trgm GIN index で `tag.name LIKE` を加速 (`tag:` 演算子向けの将来最適化、現状は等価一致 `tag__name=`)。
+
+### 5.2 フロントエンド
+
+- `client/src/lib/api/search.ts::fetchSearch` は SSR fetch (cookie 込み)。client component から使う場合は `api` axios instance 経由に switch。
+- `SearchBox` は controlled state、debounce 無し。submit 時のみ navigate。
+- 結果ページの list レンダリングは **stable**: 同じ q で再 navigate しても順序がブレない (新着順 + id tiebreaker)。
+- 演算子の autosuggest は将来追加 (TODO)。
+
+### 5.3 Tombstone・Block
+
+- 削除済み tweet は default Manager で除外。`is_deleted=True` の tweet が結果に出ない。
+- 元 tweet が削除された QUOTE / REPLY tweet は結果に出る (= alive 行が残っているので)。`html` 内の埋め込みカードがフロントで placeholder にレンダされる。
+- Block 関係は **検索結果には反映しない** (前述 §3.4)。
+
+### 5.4 Rate limit / DDOS
+
+- `anon` scope は本番 200/day。未ログインクローラが暴走したらここでブロック。
+- 検索専用の scope (例: `search_anon`, `search_user`) を導入するかは別 issue。MVP は default で問題なし。
+
+---
+
+## 6. 参考
+
+### 内部参照
+
+- [docs/SPEC.md §10](../SPEC.md) (検索機能仕様)
+- [docs/adr/0002-search-infrastructure.md](../adr/0002-search-infrastructure.md) (pg_bigm vs Meilisearch PoC)
+- [apps/search/parser.py](../../apps/search/parser.py)
+- [apps/search/services.py](../../apps/search/services.py)
+- [apps/search/views.py](../../apps/search/views.py)
+- [apps/search/urls.py](../../apps/search/urls.py)
+- [apps/search/tests/test_parser.py](../../apps/search/tests/test_parser.py)
+- [apps/search/tests/test_services.py](../../apps/search/tests/test_services.py)
+- [client/src/app/(template)/search/page.tsx](<../../client/src/app/(template)/search/page.tsx>)
+- [client/src/components/search/SearchBox.tsx](../../client/src/components/search/SearchBox.tsx)
+- [client/src/lib/api/search.ts](../../client/src/lib/api/search.ts)
+
+### 関連 Issue / PR
+
+- P2-01 (#204): 検索 PoC (pg_bigm + Lindera vs Meilisearch ベンチマーク)
+- P2-02 (#177): pg_bigm / pg_trgm CREATE EXTENSION migration
+- P2-11 (#205): apps/search 実装
+- P2-12 (#206): 検索 API 演算子
+- P2-16 (#207): 検索画面 UI
+
+### 関連ドキュメント
+
+- [search-scenarios.md](./search-scenarios.md) — 日本語シナリオ集
+- [search-e2e-commands.md](./search-e2e-commands.md) — E2E 実行コマンド


### PR DESCRIPTION
## 関連

- Refs #207 #179 #187 #205 #206 (Phase 2 reactions/search 実装 issues)
- 関連修正: PR #371 (Closes #370 routing 404), PR #373 (Closes #372 SSR 500)

## 概要

Phase 2 (TL・リアクション・検索) のドキュメント整備とテスト網羅。`docs/specs/repost-quote-state-machine.md` / `docs/specs/tweet-delete-scenarios.md` と同じ三段構成 (機能仕様 / シナリオ / 実行コマンド) を、リアクションと検索に拡張する。

## 追加ファイル (8 件)

### ドキュメント (docs/specs/)

| ファイル | 役割 |
|---|---|
| `reactions-spec.md` | リアクション機能仕様 (10 種 / upsert toggle / Block / Tombstone / drift / 通知) |
| `reactions-scenarios.md` | RCT-01〜RCT-20 の日本語シナリオ集 |
| `reactions-e2e-commands.md` | Playwright 実行コマンド集 (シナリオから分離) |
| `search-spec.md` | 検索機能仕様 (parser 文法 6 種演算子 / limit / ranking / 未ログイン) |
| `search-scenarios.md` | SRC-01〜SRC-25 の日本語シナリオ集 |
| `search-e2e-commands.md` | Playwright 実行コマンド集 |

### E2E spec (client/e2e/)

| ファイル | 役割 |
|---|---|
| `reactions-scenarios.spec.ts` | RCT 主要シナリオを API 駆動 + UI smoke で検証 |
| `search-scenarios.spec.ts` | SRC 主要シナリオを API 駆動 + UI smoke で検証 (#372 回帰防止 含む) |

## 検証

実装の現状を正本として記述。stg API レイヤで以下を `curl` で事前検証済み:

- リアクション: RCT-06 (集計 GET 未ログイン)、RCT-10 (POST 401)、RCT-19 (削除済み 404)
- 検索: SRC-01〜04, SRC-08〜18 — 主要演算子 / limit クランプ / 新着順 / silent drop

検査中に次の不具合を発見・別 PR で修正済み:

- #370: `/api/v1/users/popular/` と `/recommended/` のルーティング 404 → PR #371
- #372: `/search?q=...` の SSR 500 → PR #373

`search-scenarios.spec.ts` には `#372` 回帰防止テスト ("SRC-01 UI: 結果ありで /search?q=<marker> が 200 で render される") を含めた。

## Test plan

- [x] tsc --noEmit: エラーなし
- [x] eslint: クリーン
- [ ] stg deploy + credentials 後に `npx playwright test e2e/reactions-scenarios.spec.ts --workers=1` で全 RCT が緑
- [ ] 同 `e2e/search-scenarios.spec.ts` で全 SRC が緑
- [ ] PR #371, #373 のマージ後に SRC-01 UI / RCT-* UI が安定して通る (現状は壊れている)

## ノート

- 認証必須シナリオは `PLAYWRIGHT_USER1_*` / `PLAYWRIGHT_USER2_*` 環境変数が要る (詳細は `e2e-commands.md` 参照)。
- CI には組み込まない (rate limit / cred 管理の都合)。stg deploy 後の手動 trigger 想定。