### PR TITLE
[fix][tweets][CRITICAL] TweetCard SSR 500 を解消、DOMPurify を client-only に遅延適用 (#375)

### DIFF
--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -10,7 +10,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import DOMPurify from "isomorphic-dompurify";
 import { MoreHorizontal, Trash2 } from "lucide-react";
 import { toast } from "react-toastify";
@@ -244,13 +244,23 @@ export default function TweetCard({
 	// #327: 全 hooks は早期 return より前に呼ぶ (React rules of hooks)。
 	// CRITICAL: sanitize HTML before rendering — strips <script>, event handlers,
 	// javascript: hrefs, <iframe>, <style>, and other XSS vectors.
-	const safeHtml = useMemo(
-		() =>
-			DOMPurify.sanitize(displayTweet.html ?? escapeHtml(displayTweet.body), {
-				USE_PROFILES: { html: true },
-			}),
-		[displayTweet.body, displayTweet.html],
-	);
+	//
+	// #375: Server (SSR) では DOMPurify を呼ばない。next.config.mjs が server build
+	// で `isomorphic-dompurify` を browser-only `dompurify` にエイリアスしているため
+	// (jsdom が webpack で parse できない理由)、server で `DOMPurify.sanitize()`
+	// を呼ぶと "window is not defined" 系で throw → SSR が 500 になる。
+	// 戦略: server では backend (bleach) 済の html をそのまま使い、client mount
+	// 後の useEffect で DOMPurify による defense-in-depth を再適用する。
+	// hydration mismatch を避けるため初期 render は両側で同じ raw html。
+	const initialHtml = displayTweet.html ?? escapeHtml(displayTweet.body);
+	const [safeHtml, setSafeHtml] = useState(initialHtml);
+	useEffect(() => {
+		// typeof window check は alias 構成下で念のための二重防御。
+		if (typeof window === "undefined") return;
+		setSafeHtml(
+			DOMPurify.sanitize(initialHtml, { USE_PROFILES: { html: true } }),
+		);
+	}, [initialHtml]);
 
 	const relativeTime = useMemo(
 		() => formatRelativeTime(displayTweet.created_at),


### PR DESCRIPTION
## 関連 Issue

Closes #375
Refs #372 (search だけと誤認していた duplicate)

## 概要

stg deploy 後、TweetCard を SSR で 1 件以上 render するページがすべて 500 を返していた:

```
$ curl -s -o /dev/null -w "%{http_code}\n" https://stg.codeplace.me/tweet/17
500
$ curl -s -o /dev/null -w "%{http_code}\n" https://stg.codeplace.me/u/test2
500
$ curl -s -o /dev/null -w "%{http_code}\n" https://stg.codeplace.me/search?q=test
500
```

API は全部 200。TweetCard を render しないページ (`/`, `/login`, `/explore` 0件時) も 200。

## 原因

`client/next.config.mjs` が server build で `isomorphic-dompurify` を browser-only `dompurify` にエイリアスしている (jsdom が webpack で parse できない理由):

```js
if (isServer) {
  config.resolve.alias = {
    ...config.resolve.alias,
    "isomorphic-dompurify": "dompurify",
  };
}
```

意図は「TweetCard は `'use client'` なので DOMPurify は browser でしか動かない」だったが、実際には Next.js SSR は Client Component も server でレンダリングする。`useMemo` が server で実行され、alias 後の browser build (window 必須) が `DOMPurify.sanitize()` で throw → SSR 全体が 500。

## 修正

`useMemo` を `useState` + `useEffect` に置換:

```diff
- const safeHtml = useMemo(
-   () => DOMPurify.sanitize(displayTweet.html ?? escapeHtml(displayTweet.body), {
-     USE_PROFILES: { html: true },
-   }),
-   [displayTweet.body, displayTweet.html],
- );
+ const initialHtml = displayTweet.html ?? escapeHtml(displayTweet.body);
+ const [safeHtml, setSafeHtml] = useState(initialHtml);
+ useEffect(() => {
+   if (typeof window === "undefined") return;
+   setSafeHtml(DOMPurify.sanitize(initialHtml, { USE_PROFILES: { html: true } }));
+ }, [initialHtml]);
```

- **初期 render (server / client 共通)**: backend (bleach) 済の html をそのまま設定。両側で同じ string なので hydration mismatch なし。
- **client mount 後**: `useEffect` 内で DOMPurify による defense-in-depth の再 sanitize を適用。

backend Bleach は Phase 1 で導入済み (`apps/tweets/services.py` の `markdown2 + bleach` pipeline) で、SSR に渡る html は既に safe。DOMPurify はクライアント側 XSS の二段目防御として依然有効。

## 検証

- ✅ vitest: `src/components/timeline/` 全 **97 件緑** (TweetCard.test.tsx 48 + TweetCard.click.test.tsx 7 + HomeFeed.test.tsx 17 他)
- ✅ `tsc --noEmit`: エラーなし

## Test plan

- [x] vitest 緑
- [x] tsc 緑
- [ ] stg deploy 後、`curl https://stg.codeplace.me/tweet/17` が 200
- [ ] 同 `/u/test2`, `/search?q=test` が 200
- [ ] tweet 本文がブラウザで render される (DevTools で確認: client mount 後に DOMPurify 通過版に置き換わる)
- [ ] 既存の XSS 防御テスト (TweetCard.test.tsx の dangerouslySetInnerHTML 系) が通る

## 影響範囲

- 全ての TweetCard render 経路 (`/`, `/explore`, `/tweet/<id>`, `/u/<handle>`, `/tag/<name>`, `/search`)
- 修正は純 frontend、backend 影響なし