### PR TITLE
[feature][search] グローバル Navbar に検索 box を追加 (X 風) (#377)

### DIFF
--- a/client/e2e/search-scenarios.spec.ts
+++ b/client/e2e/search-scenarios.spec.ts
@@ -349,3 +349,76 @@ test.describe("Search UI (/search)", () => {
 		).toBeVisible();
 	});
 });
+
+// =============================================================================
+// Navbar HeaderSearchBox (#377)
+// =============================================================================
+
+test.describe("Search UI (Navbar HeaderSearchBox)", () => {
+	test("SRC-26: 任意ページの Navbar から submit すると /search?q= に遷移する", async ({
+		page,
+	}) => {
+		await page.goto("/explore");
+		const navbar = page.locator("nav").first();
+		const navbarSearch = navbar.getByRole("search", {
+			name: "ツイート検索",
+		});
+		await expect(navbarSearch).toBeVisible({ timeout: 10_000 });
+		await navbarSearch.getByRole("searchbox").fill("python");
+		await page.keyboard.press("Enter");
+		await expect(page).toHaveURL(/\/search\?q=python/);
+		// /search ページ内 SearchBox にも初期値として伝播
+		await expect(
+			page
+				.locator('main input[name="q"]')
+				.or(page.locator('section input[name="q"]')),
+		).toHaveValue("python");
+	});
+
+	test("SRC-27: Navbar HeaderSearchBox の空文字 submit は navigate しない", async ({
+		page,
+	}) => {
+		await page.goto("/explore");
+		const navbar = page.locator("nav").first();
+		const navbarSearch = navbar.getByRole("search", {
+			name: "ツイート検索",
+		});
+		await expect(navbarSearch).toBeVisible();
+		await navbarSearch.getByRole("searchbox").focus();
+		await page.keyboard.press("Enter");
+		await expect(page).toHaveURL(/\/explore$/);
+	});
+
+	test("SRC-28: Navbar HeaderSearchBox は URL の q を初期値として受け取らない", async ({
+		page,
+	}) => {
+		await gotoSearch(page, "python");
+		const navbar = page.locator("nav").first();
+		const navbarSearchInput = navbar.getByRole("searchbox", {
+			name: "検索クエリ",
+		});
+		await expect(navbarSearchInput).toBeVisible();
+		await expect(navbarSearchInput).toHaveValue("");
+	});
+
+	test("SRC-29: Navbar HeaderSearchBox は未ログインでも表示・動作する", async ({
+		browser,
+	}) => {
+		// 専用 anonymous context
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		try {
+			await page.goto("/explore");
+			const navbar = page.locator("nav").first();
+			const navbarSearch = navbar.getByRole("search", {
+				name: "ツイート検索",
+			});
+			await expect(navbarSearch).toBeVisible({ timeout: 10_000 });
+			await navbarSearch.getByRole("searchbox").fill("python");
+			await page.keyboard.press("Enter");
+			await expect(page).toHaveURL(/\/search\?q=python/);
+		} finally {
+			await context.close();
+		}
+	});
+});

--- a/client/src/components/shared/navbar/HeaderSearchBox.tsx
+++ b/client/src/components/shared/navbar/HeaderSearchBox.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+/**
+ * HeaderSearchBox — global Navbar 内の検索 input (#377).
+ *
+ * 仕様: docs/specs/search-spec.md §4.2
+ *
+ * - Navbar 内に常時表示。submit で /search?q=<encoded> に router.push。
+ * - 演算子ヘルプは /search ページの SearchBox に任せる (Navbar は footprint
+ *   優先で input + button 1 行のみ)。
+ * - URL の q 初期値は受け取らない (= 直接 /search を開いて編集する用途は
+ *   既存 SearchBox の責務)。Navbar の値はページ遷移ごとにリセットされる。
+ */
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+export default function HeaderSearchBox() {
+	const router = useRouter();
+	const [value, setValue] = useState("");
+
+	const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const trimmed = value.trim();
+		if (!trimmed) return;
+		router.push(`/search?q=${encodeURIComponent(trimmed)}`);
+	};
+
+	return (
+		<form
+			role="search"
+			aria-label="ツイート検索"
+			onSubmit={onSubmit}
+			className="flex min-w-0 max-w-md flex-1 items-center gap-2"
+		>
+			<input
+				type="search"
+				name="q"
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
+				placeholder="検索"
+				aria-label="検索クエリ"
+				className="min-w-0 flex-1 rounded-md border border-border bg-card px-3 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			/>
+			<button
+				type="submit"
+				className="hidden shrink-0 rounded-md bg-lime-500 px-3 py-1.5 text-sm font-semibold text-black hover:bg-lime-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex"
+			>
+				検索
+			</button>
+		</form>
+	);
+}

--- a/client/src/components/shared/navbar/Navbar.tsx
+++ b/client/src/components/shared/navbar/Navbar.tsx
@@ -1,26 +1,27 @@
 import { HomeModernIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
 import React from "react";
+import HeaderSearchBox from "./HeaderSearchBox";
 import ThemeSwitcher from "./ThemeSwitcher";
 import MobileNavbar from "./MobileNavbar";
 import AuthAvatar from "@/components/shared/navbar/AuthAvatar";
 
 export default function Navbar() {
 	return (
-		<nav className="flex-between bg-baby_rich border-b-platinum shadow-platinum fixed z-50 w-full gap-5 border-b-2 p-4 sm:p-6 lg:px-12 dark:border-b-0 dark:shadow-none">
-			<Link href="/" className="flex items-center">
-				<HomeModernIcon className="mr-2 size-11 text-lime-500" />
+		<nav className="bg-baby_rich border-b-platinum shadow-platinum fixed z-50 flex w-full items-center gap-3 border-b-2 p-4 dark:border-b-0 dark:shadow-none sm:gap-5 sm:p-6 lg:px-12">
+			<Link href="/" className="flex shrink-0 items-center">
+				<HomeModernIcon className="size-9 text-lime-500 sm:mr-2 sm:size-11" />
 				<p className="h2-bold font-robotoSlab text-veryBlack dark:text-babyPowder hidden sm:block">
 					エンジニア特化型 <span className="text-lime-500">SNS</span>
 				</p>
 			</Link>
 
-			<div className="flex items-center gap-4 sm:gap-6 lg:gap-8">
-				{/* placeholder theme switcher component */}
-				<ThemeSwitcher />
+			{/* #377: グローバル検索 — 全 page から /search?q= に飛べる入口 */}
+			<HeaderSearchBox />
 
+			<div className="flex shrink-0 items-center gap-3 sm:gap-5 lg:gap-6">
+				<ThemeSwitcher />
 				<AuthAvatar />
-				{/* placeholder theme switcher component */}
 				<MobileNavbar />
 			</div>
 		</nav>

--- a/client/src/components/shared/navbar/__tests__/HeaderSearchBox.test.tsx
+++ b/client/src/components/shared/navbar/__tests__/HeaderSearchBox.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Tests for HeaderSearchBox (#377).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import HeaderSearchBox from "@/components/shared/navbar/HeaderSearchBox";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush }),
+	usePathname: () => "/",
+	useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("HeaderSearchBox", () => {
+	beforeEach(() => {
+		mockPush.mockClear();
+	});
+
+	it("renders a search input with an aria-label", () => {
+		render(<HeaderSearchBox />);
+		expect(
+			screen.getByRole("searchbox", { name: "検索クエリ" }),
+		).toBeInTheDocument();
+	});
+
+	it("wraps the input in a form with role=search", () => {
+		render(<HeaderSearchBox />);
+		expect(screen.getByRole("search")).toHaveAttribute(
+			"aria-label",
+			"ツイート検索",
+		);
+	});
+
+	it("submits to /search?q=<encoded> on form submit", async () => {
+		render(<HeaderSearchBox />);
+		await userEvent.type(screen.getByRole("searchbox"), "python");
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).toHaveBeenCalledWith("/search?q=python");
+	});
+
+	it("encodes special characters in the navigated URL", async () => {
+		render(<HeaderSearchBox />);
+		await userEvent.type(
+			screen.getByRole("searchbox"),
+			"hello world tag:django",
+		);
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).toHaveBeenCalledWith(
+			"/search?q=hello%20world%20tag%3Adjango",
+		);
+	});
+
+	it("does not navigate on empty submit", () => {
+		render(<HeaderSearchBox />);
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).not.toHaveBeenCalled();
+	});
+
+	it("does not navigate on whitespace-only submit", async () => {
+		render(<HeaderSearchBox />);
+		await userEvent.type(screen.getByRole("searchbox"), "   ");
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).not.toHaveBeenCalled();
+	});
+
+	it("trims surrounding whitespace before navigating", async () => {
+		render(<HeaderSearchBox />);
+		await userEvent.type(screen.getByRole("searchbox"), "  rust  ");
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).toHaveBeenCalledWith("/search?q=rust");
+	});
+});

--- a/docs/specs/search-e2e-commands.md
+++ b/docs/specs/search-e2e-commands.md
@@ -136,6 +136,18 @@ npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --g
 
 # SRC-22: SearchBox は URL 経由で初期値を受け取る
 npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-22"
+
+# SRC-26: Navbar HeaderSearchBox から submit すると /search?q= に遷移する
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-26"
+
+# SRC-27: Navbar HeaderSearchBox の空文字 submit は navigate しない
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-27"
+
+# SRC-28: Navbar HeaderSearchBox は URL の q を初期値として受け取らない
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-28"
+
+# SRC-29: Navbar HeaderSearchBox は未ログインでも表示・動作する
+npx playwright test e2e/search-scenarios.spec.ts --workers=1 --reporter=line --grep "SRC-29"
 ```
 
 ## 5. Phase 2 既存 golden path との関係

--- a/docs/specs/search-scenarios.md
+++ b/docs/specs/search-scenarios.md
@@ -429,6 +429,70 @@
 - `Retry-After` header 付与。
 - UI は generic な error 表示 (現状)。
 
+### SRC-26: Navbar の HeaderSearchBox から submit すると `/search?q=` に遷移する (#377)
+
+前提:
+
+- ユーザが任意のページ (`/`, `/explore`, `/tweet/<id>`, `/u/<handle>` 等) を開いている。
+- グローバル `Navbar` が render されている。
+
+操作:
+
+- Navbar 内の検索 input に `python` を入力して Enter (もしくは「検索」ボタンを click)。
+
+期待結果:
+
+- URL が `/search?q=python` に遷移する。
+- `/search` ページの SearchBox に `python` が初期値として表示される。
+- 結果セクションが描画される (キーワードが marker に含まれる場合)。
+- a11y: form は `role="search"` + `aria-label="ツイート検索"`、input は `aria-label="検索クエリ"`。
+
+### SRC-27: Navbar HeaderSearchBox の空文字 submit は navigate しない
+
+前提:
+
+- 任意のページで Navbar が表示されている。
+
+操作:
+
+- 検索 input が空 (もしくは空白のみ) の状態で Enter または「検索」ボタン click。
+
+期待結果:
+
+- URL は変わらない (元のページに留まる)。
+- /search?q= には遷移しない。
+
+### SRC-28: Navbar HeaderSearchBox は URL の `q` を初期値として受け取らない
+
+前提:
+
+- ユーザが `/search?q=python` を開いている (= `/search` 内 SearchBox には `python` が表示済み)。
+
+操作:
+
+- Navbar の HeaderSearchBox を見る。
+
+期待結果:
+
+- Navbar input の value は **空文字**。
+- `/search` ページ内の SearchBox とは別の入力フィールドとして独立している。
+- 別ページに遷移すると Navbar の状態は再初期化される (= 値リセット)。
+
+### SRC-29: Navbar HeaderSearchBox は未ログインでも表示・動作する
+
+前提:
+
+- ユーザは未ログイン状態で `/explore` を開いている。
+
+操作:
+
+- Navbar の検索 input に `python` を入力して submit。
+
+期待結果:
+
+- `/search?q=python` に遷移し、200 で render される (検索 API は AllowAny)。
+- 結果セクションが描画される。
+
 ## 4. E2E 化メモ
 
 各 E2E は上記の `SRC-XX` をテスト名に含める。

--- a/docs/specs/search-spec.md
+++ b/docs/specs/search-spec.md
@@ -171,16 +171,32 @@
 
 - Server Component で `searchParams.q` を読み、サーバサイドで `fetchSearch` を呼ぶ。
 - 認証情報は `cookies()` 経由で SSR fetch に乗る (= ログインユーザのレコメンド調整は今後 / 現状 anon と同じ結果)。
-- レスポンスを `TweetListSerializer` 形式で受けて、`html` を `sanitizeTweetHtml` で消毒したうえで `dangerouslySetInnerHTML`。
-- 結果カードは現状 `TweetCard` を使わず軽量描画 (author + body + tags のみ)。フォロー / リアクション / repost 等のアクションは出ない (= 詳細遷移してから操作する設計)。
+- レスポンスは `TweetCardList` (Client Component) に渡して render する (`/explore` `/tag/<name>` `/u/<handle>` と同じ pipeline)。`#372` 修正後は本ページ専用の inline rendering を持たない。
+- 結果カードは `TweetCard` 経由なので、reaction / repost / quote / reply の action button が動作する。
 
-### 4.2 `SearchBox`
+### 4.2 検索 UI の入口 (2 系統)
+
+検索 UI の SubmitForm は **2 つ** ある。両方とも `router.push('/search?q=' + encodeURIComponent(value))` を呼んで `/search` に navigate する点で共通。
+
+#### 4.2.1 グローバル `HeaderSearchBox` (Navbar、全ページから常時アクセス可)
+
+`client/src/components/shared/navbar/HeaderSearchBox.tsx` が正本 (`#377`)。
+
+- グローバル `Navbar` 内に常時表示。X (Twitter) 同様、ホーム画面を開いた直後でもすぐに検索できる。
+- ログイン / 未ログイン共通で表示される (検索 API は AllowAny)。
+- `<form role="search">` + controlled input + submit button (`sm` 以上で button 表示、`sm` 未満は input + Enter キー submit)。
+- 空 / 空白のみは submit しない (`trimmed === '' なら return`)。
+- URL の `q` 初期値は受け取らない。Navbar の値はページ遷移ごとにリセット。クエリの編集は `/search` ページの SearchBox に任せる。
+- 演算子ヘルプは表示しない (footprint 優先)。
+
+#### 4.2.2 `/search` ページ内 `SearchBox`
 
 `client/src/components/search/SearchBox.tsx` が正本。
 
-- `<form role="search">` + controlled input。
+- `<form role="search">` + controlled input + submit button。
 - submit で `router.push('/search?q=' + encodeURIComponent(value))`。
-- 空 / 空白のみは submit しない (`trimmed === '' なら return`)。
+- 空 / 空白のみは submit しない。
+- `initialValue` で URL の `q` を受け取り、現在の検索クエリを編集 / 拡張できるようにする。
 - 演算子ヘルプは `<details>` で折りたたみ表示。autosuggest popup は未実装 (TODO)。
 
 ### 4.3 SEO


### PR DESCRIPTION
## 関連 Issue

Closes #377

## 概要

X (旧 Twitter) のように、画面上部の **Navbar** から常にツイート検索ができるように。`/` を開いた瞬間にすぐ検索できる UX を実現する。

## 変更点

### コード

| ファイル | 変更 |
|---|---|
| `client/src/components/shared/navbar/HeaderSearchBox.tsx` | **新規**。Client Component。`<form role="search">` + controlled input + submit button。submit で `/search?q=<encoded>` に router.push、空白のみは navigate せず |
| `client/src/components/shared/navbar/Navbar.tsx` | Logo + HeaderSearchBox + Theme/Auth/Mobile の 3 列構成に変更。検索 input は `flex-1` で残幅を吸収、submit ボタンは `sm` 以上で表示 |
| `client/src/components/shared/navbar/__tests__/HeaderSearchBox.test.tsx` | **新規**。7 件の vitest テスト |
| `client/e2e/search-scenarios.spec.ts` | SRC-26〜29 を新規追加 (Navbar submit / 空文字 / URL q 非伝搬 / 未ログイン) |

### ドキュメント (docs/specs/)

| ファイル | 変更 |
|---|---|
| `search-spec.md` §4 | 「検索 UI の入口 2 系統」を新設 (4.2.1 Navbar HeaderSearchBox、4.2.2 /search 内 SearchBox)。役割分担を明記 |
| `search-scenarios.md` | SRC-26〜SRC-29 (Navbar 関連) を追加 |
| `search-e2e-commands.md` | SRC-26〜29 の単独実行コマンドを追加 |

## 設計判断

- **Navbar 検索は URL の `q` を初期値として読まない**: ページ遷移ごとにリセット。クエリの編集は `/search` 内 SearchBox に任せる (= input が 2 系統あっても役割が衝突しない)。
- **演算子ヘルプは Navbar に出さない**: footprint 優先。詳細クエリ編集には `/search` ページの `<details>` ヘルプを使う想定。
- **未ログイン / ログイン共通で表示**: 検索 API は AllowAny。

## レスポンシブ

| breakpoint | 表示 |
|---|---|
| `sm` 以上 | input + 検索 button を inline。Logo / Avatar / Theme と共存 |
| `sm` 未満 | input のみ (button 非表示)。Enter キーで submit |

## 検証

- ✅ vitest: `src/components/shared/navbar/` で 7 件、`src/components/search/` で 6 件、`src/lib/api/search.test` で 3 件、計 16 件緑
- ✅ tsc --noEmit: エラーなし
- ✅ eslint: warning 含めて 0
- [ ] stg deploy 後、ホーム / explore / tweet / プロフィールいずれの page でも Navbar に input が出ること
- [ ] Navbar input 入力 + Enter で `/search?q=` に遷移すること
- [ ] /search ページ内の SearchBox は影響を受けないこと

## Test plan

- [x] 関連 vitest 緑
- [x] tsc / eslint クリーン
- [ ] stg deploy → Playwright MCP / curl で Navbar 配置と挙動を確認
- [ ] 既存 phase2.spec.ts (golden path 検索フロー) が引き続き通る (search input は `getByLabel("検索")` 等で取得しているケースを要確認)

## 影響範囲

- 全 (template) layout 配下のページ (`/`, `/explore`, `/tweet/<id>`, `/u/<handle>`, `/search`, `/tag/<name>`, `/messages` 等) で Navbar に検索 input が表示される
- API / Backend には変更なし
- 既存の `/search` ページの SearchBox は影響を受けない (独立実装)