### PR TITLE
[fix][reactions] ReactionBar grid popup を選択後・outside click・Escape で閉じる (#379)

### DIFF
--- a/client/e2e/reactions-scenarios.spec.ts
+++ b/client/e2e/reactions-scenarios.spec.ts
@@ -545,4 +545,64 @@ test.describe("Reactions UI (ReactionBar)", () => {
 			await deleteTweetAs(USER2, tweetId);
 		}
 	});
+
+	test("RCT-21 UI: kind 選択で popup が即時 close する (#379)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-21 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			await trigger.click();
+			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			await page.locator('button[aria-label^="いいね ("]').first().click();
+			// popup が close する
+			await expect(trigger).toHaveAttribute("aria-expanded", "false");
+			await expect(
+				page.getByRole("group", { name: "リアクションを選択" }),
+			).toHaveCount(0);
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-22 UI: popup 外を click すると popup が close する (#379)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-22 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			await trigger.click();
+			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			// Navbar / 別領域を click
+			await page
+				.locator("nav")
+				.first()
+				.click({ position: { x: 5, y: 5 } });
+			await expect(trigger).toHaveAttribute("aria-expanded", "false");
+		} finally {
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-23 UI: Escape キーで popup が close する (#379)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-23 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			await trigger.click();
+			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			await page.keyboard.press("Escape");
+			await expect(trigger).toHaveAttribute("aria-expanded", "false");
+		} finally {
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
 });

--- a/client/src/components/reactions/ReactionBar.tsx
+++ b/client/src/components/reactions/ReactionBar.tsx
@@ -11,12 +11,24 @@
  *     - If different kind → swap (decrement old, increment new)
  *   - Alt+Enter on the trigger opens the picker (kbd shortcut SPEC §6.2).
  *
+ * Dismiss (#379):
+ *   - Picking any kind closes the popup (X / Slack / Discord 慣習)
+ *   - Outside click closes the popup
+ *   - Escape key closes the popup
+ *
  * Initial counts come from the GET reactions endpoint via props; Tweet objects
  * don't yet carry reaction counts inline (follow-up: include them in
  * TweetListSerializer to avoid an N+1 fetch on the timeline).
  */
 
-import { useCallback, useMemo, useState, type KeyboardEvent } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type KeyboardEvent,
+} from "react";
 import { toast } from "react-toastify";
 
 import {
@@ -38,6 +50,7 @@ export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
 	const [state, setState] = useState<ReactionAggregate>(initial ?? EMPTY);
 	const [open, setOpen] = useState(false);
 	const [busyKind, setBusyKind] = useState<ReactionKind | null>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
 
 	const total = useMemo(
 		() => Object.values(state.counts).reduce((a, b) => a + (b ?? 0), 0),
@@ -56,9 +69,37 @@ export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
 		}
 	};
 
+	// #379: outside click / Escape で popup を閉じる。open のときだけ listener を
+	// 登録し、cleanup で解除する。capture で document に渡す必要はなく、
+	// bubble phase の mousedown / keydown で十分。
+	useEffect(() => {
+		if (!open) return;
+		const onPointerDown = (event: MouseEvent) => {
+			const target = event.target as Node | null;
+			if (!target) return;
+			if (containerRef.current?.contains(target)) return;
+			setOpen(false);
+		};
+		const onKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (event.key === "Escape") setOpen(false);
+		};
+		document.addEventListener("mousedown", onPointerDown);
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("mousedown", onPointerDown);
+			document.removeEventListener("keydown", onKeyDown);
+		};
+	}, [open]);
+
 	const handlePick = useCallback(
 		async (kind: ReactionKind) => {
 			if (busyKind) return;
+
+			// #379: 選択した瞬間に popup を閉じる (X / Slack / Discord 慣習)。
+			// API 結果を待たずに閉じるのは、optimistic update と組で UX を即時化
+			// するため。失敗時は state がロールバックされるので popup を閉じても
+			// 結果整合性は保たれる。
+			setOpen(false);
 
 			// Optimistic update
 			const previous = state;
@@ -98,7 +139,7 @@ export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
 	);
 
 	return (
-		<div className="flex flex-col gap-1">
+		<div ref={containerRef} className="flex flex-col gap-1">
 			<button
 				type="button"
 				aria-label="リアクション"
@@ -106,7 +147,7 @@ export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
 				aria-haspopup="true"
 				onClick={() => setOpen((v) => !v)}
 				onKeyDown={onTriggerKeyDown}
-				className="flex items-center gap-1 min-h-[32px] px-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+				className="flex min-h-[32px] items-center gap-1 rounded px-1 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 			>
 				<span aria-hidden="true">{triggerLabel}</span>
 				<span className="sr-only">

--- a/client/src/components/reactions/__tests__/ReactionBar.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionBar.test.tsx
@@ -100,7 +100,7 @@ describe("ReactionBar — toggle", () => {
 		vi.clearAllMocks();
 	});
 
-	it("optimistically increments count and POSTs", async () => {
+	it("optimistically increments count and POSTs (popup closes #379)", async () => {
 		vi.mocked(toggleReaction).mockResolvedValue({
 			kind: "like",
 			created: true,
@@ -109,18 +109,28 @@ describe("ReactionBar — toggle", () => {
 		});
 
 		render(<ReactionBar tweetId={42} />);
-		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
-		const likeBtn = screen.getByRole("button", { name: /いいね/ });
-		await userEvent.click(likeBtn);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
+		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
 
-		// Optimistic count is reflected before the API resolves.
+		// #379: pick 後は popup が閉じる → trigger の aria-expanded=false に。
 		await waitFor(() => {
-			expect(likeBtn.getAttribute("aria-pressed")).toBe("true");
+			expect(trigger.getAttribute("aria-expanded")).toBe("false");
 		});
+		// Trigger label が my_kind 反映 (❤️ 1) になる。
+		expect(trigger.textContent).toContain("❤️");
 		expect(toggleReaction).toHaveBeenCalledWith(42, "like");
+
+		// 再 open して aria-pressed が反映されていることを確認。
+		await userEvent.click(trigger);
+		expect(
+			screen
+				.getByRole("button", { name: /いいね/ })
+				.getAttribute("aria-pressed"),
+		).toBe("true");
 	});
 
-	it("toggles off when clicking the same kind twice", async () => {
+	it("toggles off when clicking the same kind twice (popup closes after each pick)", async () => {
 		vi.mocked(toggleReaction).mockResolvedValue({
 			kind: null,
 			created: false,
@@ -134,24 +144,33 @@ describe("ReactionBar — toggle", () => {
 				initial={{ counts: { like: 1 }, my_kind: "like" }}
 			/>,
 		);
-		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
 		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
 
+		// popup が閉じる
 		await waitFor(() => {
-			expect(
-				screen
-					.getByRole("button", { name: /いいね/ })
-					.getAttribute("aria-pressed"),
-			).toBe("false");
+			expect(trigger.getAttribute("aria-expanded")).toBe("false");
 		});
+		// trigger label は my_kind=null に戻る
+		expect(trigger.textContent).not.toContain("❤️");
+
+		// 再 open → like の aria-pressed=false
+		await userEvent.click(trigger);
+		expect(
+			screen
+				.getByRole("button", { name: /いいね/ })
+				.getAttribute("aria-pressed"),
+		).toBe("false");
 	});
 
-	it("rolls back optimistic state and toasts on error", async () => {
+	it("rolls back optimistic state and toasts on error (popup still closes)", async () => {
 		const { toast } = await import("react-toastify");
 		vi.mocked(toggleReaction).mockRejectedValue(new Error("500"));
 
 		render(<ReactionBar tweetId={1} />);
-		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
 		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
 
 		await waitFor(() => {
@@ -159,10 +178,92 @@ describe("ReactionBar — toggle", () => {
 				expect.stringContaining("更新できませんでした"),
 			);
 		});
+		// popup は close したまま (失敗してもユーザの click 意思は popup を閉じる)
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+		// rollback で my_kind は null
+		expect(trigger.textContent).not.toContain("❤️");
+	});
+});
+
+describe("ReactionBar — popup dismiss (#379)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("closes popup immediately on kind pick", async () => {
+		vi.mocked(toggleReaction).mockResolvedValue({
+			kind: "like",
+			created: true,
+			changed: false,
+			removed: false,
+		});
+
+		render(<ReactionBar tweetId={1} />);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
 		expect(
-			screen
-				.getByRole("button", { name: /いいね/ })
-				.getAttribute("aria-pressed"),
-		).toBe("false");
+			screen.getByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
+		expect(
+			screen.queryByRole("group", { name: "リアクションを選択" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("closes popup on outside click", async () => {
+		render(
+			<div>
+				<ReactionBar tweetId={1} />
+				<button type="button" data-testid="outside">
+					outside
+				</button>
+			</div>,
+		);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
+		expect(
+			screen.getByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+
+		// useEffect 内で listen している mousedown を発火
+		fireEvent.mouseDown(screen.getByTestId("outside"));
+		expect(
+			screen.queryByRole("group", { name: "リアクションを選択" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not close on mousedown inside the popup container", async () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
+		const group = screen.getByRole("group", { name: "リアクションを選択" });
+		fireEvent.mouseDown(group);
+		expect(
+			screen.queryByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+	});
+
+	it("closes popup on Escape key", async () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
+		expect(
+			screen.getByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+
+		fireEvent.keyDown(document, { key: "Escape" });
+		expect(
+			screen.queryByRole("group", { name: "リアクションを選択" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("trigger re-click still toggles the popup (existing behaviour)", async () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		await userEvent.click(trigger);
+		expect(trigger.getAttribute("aria-expanded")).toBe("true");
+		await userEvent.click(trigger);
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
 	});
 });

--- a/docs/specs/reactions-e2e-commands.md
+++ b/docs/specs/reactions-e2e-commands.md
@@ -107,6 +107,15 @@ npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line 
 
 # RCT-19: 削除済み tweet の集計 GET は 404
 npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-19"
+
+# RCT-21: kind 選択で popup が即時 close する (#379)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-21"
+
+# RCT-22: popup 外を click すると popup が close する (#379)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-22"
+
+# RCT-23: Escape キーで popup が close する (#379)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-23"
 ```
 
 ## 5. Phase 2 既存 golden path との関係

--- a/docs/specs/reactions-scenarios.md
+++ b/docs/specs/reactions-scenarios.md
@@ -378,6 +378,71 @@
 - 集計 GET: `counts` の各 kind が `1`、合計 10。
 - 任意の閲覧ユーザの `my_kind` はそのユーザ自身の kind (未付与なら null)。
 
+### RCT-21: kind 選択で popup が即時 close する (#379)
+
+前提:
+
+- actor A、target tweet T。
+- A は trigger を click して grid popup が開いている (`aria-expanded=true`)。
+
+操作:
+
+- grid 内の任意の kind (例: `like`) を click する。
+
+期待結果:
+
+- UI: popup が **即時 close** (grid `role="group"` の DOM が消える)。
+- UI: trigger の `aria-expanded=false`。
+- UI: trigger label が `❤️ {total}` 形式に更新 (optimistic)。
+- API: `POST /tweets/<T.id>/reactions/` `{kind: "like"}` が並行で発火。
+- API 失敗時も popup は close したまま (state はロールバック、trigger label は元に戻る)。
+
+### RCT-22: popup 外を click すると popup が close する (#379)
+
+前提:
+
+- actor A は ReactionBar の grid popup を開いている。
+
+操作:
+
+- popup の外側の領域 (TweetCard の他のボタン、別 tweet、Navbar 等) を click する。
+
+期待結果:
+
+- UI: popup が close (`aria-expanded=false`)。
+- UI: kind state は変化しない (= 単に閉じるだけ)。
+- a11y: `useEffect` 内で `document.mousedown` listener が popup open 中のみ登録される。container 内 mousedown は `containerRef.current.contains(target)` で除外。
+
+### RCT-23: Escape キーで popup が close する (#379)
+
+前提:
+
+- actor A は ReactionBar の grid popup を開いている。
+
+操作:
+
+- `Escape` キーを押す。
+
+期待結果:
+
+- UI: popup が close (`aria-expanded=false`)。
+- a11y: WAI-ARIA Authoring Practices の `aria-haspopup` パターン準拠。
+
+### RCT-24: popup 内 (空き領域) の click では close しない (#379)
+
+前提:
+
+- actor A は ReactionBar の grid popup を開いている。
+
+操作:
+
+- popup の枠内、ただし kind ボタン以外の領域 (border / padding) を mousedown する。
+
+期待結果:
+
+- UI: popup は close せず、開いたまま。
+- ユーザが kind を選ぶ前に意図せず popup が閉じてしまう事故を防ぐ。
+
 ## 4. E2E化メモ
 
 各 E2E は上記の `RCT-XX` をテスト名に含める。

--- a/docs/specs/reactions-spec.md
+++ b/docs/specs/reactions-spec.md
@@ -229,6 +229,22 @@ stateDiagram-v2
 - trigger ボタンは **常に 1 つ**。grid を開閉する。Alt+Enter キーで開閉できる (SPEC §6.2 アクセシビリティ)。
 - `busyKind !== null` の間は grid 内全ボタンが `disabled`、optimistic update 中の二重押下を防止。
 
+#### 4.1.1 popup の開閉 (#379)
+
+| トリガ                               | 振る舞い                                           |
+| ------------------------------------ | -------------------------------------------------- |
+| trigger ボタン click / Enter         | popup を toggle (open ↔ close)                    |
+| trigger ボタン Alt+Enter             | popup を toggle (キーボード代替)                   |
+| grid 内 kind 押下                    | popup を **即時 close** + Optimistic update + POST |
+| popup 外領域 (document) を mousedown | popup を **close**                                 |
+| `Escape` キー                        | popup を **close**                                 |
+
+要点:
+
+- 「kind 押下 → 即時 close」は X / Slack / Discord 等の絵文字 picker 慣習。API 結果を待たずに閉じる (optimistic update と組で UX 即時化、失敗時は state ロールバック)。
+- outside click / Escape は WAI-ARIA Authoring Practices の `aria-haspopup` パターン準拠。
+- 実装は `useEffect` 内で `open === true` のときだけ `document.mousedown` / `document.keydown` listener を登録、cleanup で解除。container 内 mousedown は `containerRef.current.contains(target)` で判定して除外する。
+
 ### 4.2 各 action の遷移と副作用
 
 | 現状態 (`my_kind`)  | action                        | 結果状態 (`my_kind`) | API                                         | counts                   | 備考                                                     |


### PR DESCRIPTION
## 関連 Issue

Closes #379

## 概要

ハルナさん指摘: 「リアクションの選択ポップアップはリアクションを押すと閉じるようにしてください。どこか他の場所をクリックしてもリアクション一覧のポップアップを一度開くと閉じることができないです」。

ReactionBar の grid popup が、一度開くと **trigger 再 click 以外で閉じる手段がなかった**。X / Slack / Discord 慣習および WAI-ARIA Authoring Practices と比べて UX が悪い。

## 修正

`client/src/components/reactions/ReactionBar.tsx`:

1. `handlePick` 冒頭で `setOpen(false)` — kind 選択で popup を即時 close (optimistic update / API 呼び出しの前に閉じて UX 即時化、API 失敗時は state ロールバックで整合)。
2. `useEffect` で `open === true` のときだけ `document.mousedown` と `document.keydown(Escape)` listener を登録、cleanup で解除。container 外 mousedown / Escape で popup を close。
3. container 内 mousedown は `containerRef.current?.contains(target)` で判定して除外。
4. 既存の trigger toggle / Alt+Enter 開閉は変更なし。

## 仕様書 (docs/specs/) 更新

- `reactions-spec.md` §4.1.1 に「popup の開閉」表を新設、各トリガと振る舞いを明文化
- `reactions-scenarios.md` に **RCT-21〜RCT-24** を追加:
  - RCT-21: kind 選択で popup が即時 close
  - RCT-22: 外 click で close
  - RCT-23: Escape で close
  - RCT-24: popup 内 mousedown では close しない (誤閉じ防止)
- `reactions-e2e-commands.md` に RCT-21〜23 の単独実行コマンドを追加

## テスト

- ✅ vitest: ReactionBar.test.tsx 既存 8 件 + 新規 6 件 = **14/14 緑**
  - `popup dismiss` describe (新設): kind 選択 close / outside click / popup 内 mousedown 維持 / Escape close / trigger 再 click 動作の維持
  - `toggle` describe 既存 3 件は popup close 前提に書き換え (trigger label / aria-expanded で状態を確認、再 open して aria-pressed を verify)
- ✅ E2E: `reactions-scenarios.spec.ts` に RCT-21/22/23 を追加
- ✅ tsc / eslint クリーン
- ✅ TweetCard / HomeFeed 関連 97 件含めて計 111 件緑

## Test plan

- [x] vitest 緑 (14 件 + 関連 97 件)
- [x] tsc / eslint クリーン
- [ ] stg deploy 後、Playwright MCP で UI 実機確認:
  - kind 選択後 popup が消える
  - 別領域 click で popup が消える
  - Escape で popup が消える
  - trigger 再 click で従来通り toggle できる

## 影響範囲

- 全 ReactionBar インスタンス (timeline / 個別 tweet / 検索結果カード等)
- backend / API 影響なし