### PR TITLE
[feature][reactions] Facebook 風 UX: click=いいね / 長押し=picker (#381)

### DIFF
--- a/client/e2e/reactions-scenarios.spec.ts
+++ b/client/e2e/reactions-scenarios.spec.ts
@@ -154,9 +154,20 @@ async function openTweet(page: Page, tweetId: number) {
 }
 
 async function reactionTrigger(page: Page) {
-	return page.locator('button[aria-label="リアクション"]').first();
+	// #381: trigger の aria-label は my_kind により変わる
+	//   - my_kind=null: "いいね (長押しで他のリアクション)"
+	//   - my_kind=K   : "<label>を取消 (長押しで他のリアクション)"
+	// aria-haspopup=true を持つ button が常に唯一の trigger なのでこれで識別する。
+	return page
+		.locator('button[aria-haspopup="true"][aria-label*="長押し"]')
+		.first();
 }
 
+/**
+ * picker から kind を選ぶ helper。長押しで picker を開いてから kind を click する。
+ * Alt+Enter でも picker は開けるが、Playwright の長押し検証も兼ねて
+ * mouse hold を使う。
+ */
 async function pickReactionUI(
 	page: Page,
 	tweetId: number,
@@ -165,16 +176,35 @@ async function pickReactionUI(
 	const trigger = await reactionTrigger(page);
 	await expect(trigger).toBeVisible({ timeout: 10_000 });
 	if ((await trigger.getAttribute("aria-expanded")) !== "true") {
-		await trigger.click();
+		// Alt+Enter でキーボード経由 open (mouse hold より test 安定)
+		await trigger.focus();
+		await page.keyboard.press("Alt+Enter");
+		await expect(trigger).toHaveAttribute("aria-expanded", "true");
 	}
 	const responsePromise = page.waitForResponse(
 		(r) =>
 			r.url().includes(`/api/v1/tweets/${tweetId}/reactions/`) &&
 			r.request().method() === "POST",
 	);
-	// aria-label="<label> (<count> 件)" にマッチさせる
+	// picker 内 button は aria-label="<label> (<count> 件)" 形式
 	const button = page.locator(`button[aria-label^="${label} ("]`).first();
 	await button.click();
+	const res = await responsePromise;
+	return res.status();
+}
+
+/**
+ * #381: trigger を short-click して quick toggle (like) を発火する helper。
+ */
+async function quickToggleUI(page: Page, tweetId: number): Promise<number> {
+	const trigger = await reactionTrigger(page);
+	await expect(trigger).toBeVisible({ timeout: 10_000 });
+	const responsePromise = page.waitForResponse(
+		(r) =>
+			r.url().includes(`/api/v1/tweets/${tweetId}/reactions/`) &&
+			r.request().method() === "POST",
+	);
+	await trigger.click();
 	const res = await responsePromise;
 	return res.status();
 }
@@ -473,7 +503,7 @@ test.describe("Reactions API (per-spec setup)", () => {
 // =============================================================================
 
 test.describe("Reactions UI (ReactionBar)", () => {
-	test("RCT-01 UI: like を押下すると 201 が返り aria-pressed=true になる", async ({
+	test("RCT-01 UI: picker から like を押下すると 201 + trigger aria-pressed=true", async ({
 		page,
 	}) => {
 		const tweetId = await postTweetAs(USER2, `RCT-01-ui ${Date.now()}`);
@@ -482,15 +512,16 @@ test.describe("Reactions UI (ReactionBar)", () => {
 			await openTweet(page, tweetId);
 			const status = await pickReactionUI(page, tweetId, "いいね");
 			expect([200, 201]).toContain(status);
-			const likeButton = page.locator('button[aria-label^="いいね ("]').first();
-			await expect(likeButton).toHaveAttribute("aria-pressed", "true");
+			// pick 後 popup は close、trigger 側で my_kind 反映を確認
+			const trigger = await reactionTrigger(page);
+			await expect(trigger).toHaveAttribute("aria-pressed", "true");
 		} finally {
 			await clearReactionAs(USER1, tweetId);
 			await deleteTweetAs(USER2, tweetId);
 		}
 	});
 
-	test("RCT-02 UI: 同じ like を再押下すると aria-pressed が外れる", async ({
+	test("RCT-02 UI: 同じ like を picker から 2 回押下すると aria-pressed が外れる", async ({
 		page,
 	}) => {
 		const tweetId = await postTweetAs(USER2, `RCT-02-ui ${Date.now()}`);
@@ -499,8 +530,8 @@ test.describe("Reactions UI (ReactionBar)", () => {
 			await openTweet(page, tweetId);
 			await pickReactionUI(page, tweetId, "いいね");
 			await pickReactionUI(page, tweetId, "いいね");
-			const likeButton = page.locator('button[aria-label^="いいね ("]').first();
-			await expect(likeButton).toHaveAttribute("aria-pressed", "false");
+			const trigger = await reactionTrigger(page);
+			await expect(trigger).toHaveAttribute("aria-pressed", "false");
 		} finally {
 			await clearReactionAs(USER1, tweetId);
 			await deleteTweetAs(USER2, tweetId);
@@ -516,6 +547,10 @@ test.describe("Reactions UI (ReactionBar)", () => {
 			await openTweet(page, tweetId);
 			await pickReactionUI(page, tweetId, "いいね");
 			await pickReactionUI(page, tweetId, "勉強になった");
+			// pick 後 popup close、再 open して picker 側 aria-pressed を verify
+			const trigger = await reactionTrigger(page);
+			await trigger.focus();
+			await page.keyboard.press("Alt+Enter");
 			await expect(
 				page.locator('button[aria-label^="いいね ("]').first(),
 			).toHaveAttribute("aria-pressed", "false");
@@ -528,23 +563,16 @@ test.describe("Reactions UI (ReactionBar)", () => {
 		}
 	});
 
-	test("RCT-17 UI: trigger に Alt+Enter で grid を開閉できる", async ({
-		page,
-	}) => {
-		const tweetId = await postTweetAs(USER2, `RCT-17 ${Date.now()}`);
-		try {
-			await loginUI(page, USER1.email, USER1.password);
-			await openTweet(page, tweetId);
-			const trigger = await reactionTrigger(page);
-			await trigger.focus();
-			await page.keyboard.press("Alt+Enter");
-			await expect(trigger).toHaveAttribute("aria-expanded", "true");
-			await page.keyboard.press("Alt+Enter");
-			await expect(trigger).toHaveAttribute("aria-expanded", "false");
-		} finally {
-			await deleteTweetAs(USER2, tweetId);
-		}
-	});
+	// #381 で trigger click は quick toggle になったため、popup を開く操作は
+	// Alt+Enter (キーボード代替) を使う。長押しは Playwright で安定して
+	// 模擬しづらく、また RCT-27 で別途検証する。
+	async function openPickerViaKbd(page: Page) {
+		const trigger = await reactionTrigger(page);
+		await trigger.focus();
+		await page.keyboard.press("Alt+Enter");
+		await expect(trigger).toHaveAttribute("aria-expanded", "true");
+		return trigger;
+	}
 
 	test("RCT-21 UI: kind 選択で popup が即時 close する (#379)", async ({
 		page,
@@ -553,11 +581,8 @@ test.describe("Reactions UI (ReactionBar)", () => {
 		try {
 			await loginUI(page, USER1.email, USER1.password);
 			await openTweet(page, tweetId);
-			const trigger = await reactionTrigger(page);
-			await trigger.click();
-			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			const trigger = await openPickerViaKbd(page);
 			await page.locator('button[aria-label^="いいね ("]').first().click();
-			// popup が close する
 			await expect(trigger).toHaveAttribute("aria-expanded", "false");
 			await expect(
 				page.getByRole("group", { name: "リアクションを選択" }),
@@ -575,9 +600,7 @@ test.describe("Reactions UI (ReactionBar)", () => {
 		try {
 			await loginUI(page, USER1.email, USER1.password);
 			await openTweet(page, tweetId);
-			const trigger = await reactionTrigger(page);
-			await trigger.click();
-			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			const trigger = await openPickerViaKbd(page);
 			// Navbar / 別領域を click
 			await page
 				.locator("nav")
@@ -596,10 +619,124 @@ test.describe("Reactions UI (ReactionBar)", () => {
 		try {
 			await loginUI(page, USER1.email, USER1.password);
 			await openTweet(page, tweetId);
-			const trigger = await reactionTrigger(page);
-			await trigger.click();
-			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			const trigger = await openPickerViaKbd(page);
 			await page.keyboard.press("Escape");
+			await expect(trigger).toHaveAttribute("aria-expanded", "false");
+		} finally {
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	// =====================================================================
+	// FB-style trigger (#381)
+	// =====================================================================
+
+	test("RCT-25 UI: trigger click で quick toggle (like) — picker は開かない (#381)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-25 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const status = await quickToggleUI(page, tweetId);
+			expect([200, 201]).toContain(status);
+			const trigger = await reactionTrigger(page);
+			await expect(trigger).toHaveAttribute("aria-expanded", "false");
+			await expect(trigger).toHaveAttribute("aria-pressed", "true");
+			await expect(
+				page.getByRole("group", { name: "リアクションを選択" }),
+			).toHaveCount(0);
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-26 UI: my_kind=K のときに trigger click で K を取消す (#381)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-26 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			// 事前に learned を picker で付ける
+			await pickReactionUI(page, tweetId, "勉強になった");
+			const trigger = await reactionTrigger(page);
+			await expect(trigger).toHaveAttribute("aria-pressed", "true");
+			// trigger click → my_kind を取消す (POST kind=learned で removed)
+			await quickToggleUI(page, tweetId);
+			await expect(trigger).toHaveAttribute("aria-pressed", "false");
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-27 UI: 500ms 以上の長押しで picker が開く (#381)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-27 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			const box = await trigger.boundingBox();
+			if (!box) throw new Error("trigger has no bounding box");
+			await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+			await page.mouse.down();
+			// 600ms 保持 (LONG_PRESS_MS=500ms より長く)
+			await page.waitForTimeout(600);
+			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			await page.mouse.up();
+			// 続く click は suppress 済み — quick toggle は走らない (API 呼ばれない)
+			await page.waitForTimeout(200);
+			// picker は開いたまま
+			await expect(
+				page.getByRole("group", { name: "リアクションを選択" }),
+			).toBeVisible();
+		} finally {
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-31 UI: Enter キーで quick toggle (#381)", async ({ page }) => {
+		const tweetId = await postTweetAs(USER2, `RCT-31 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			await trigger.focus();
+			const responsePromise = page.waitForResponse(
+				(r) =>
+					r.url().includes(`/api/v1/tweets/${tweetId}/reactions/`) &&
+					r.request().method() === "POST",
+			);
+			await page.keyboard.press("Enter");
+			const status = (await responsePromise).status();
+			expect([200, 201]).toContain(status);
+			await expect(trigger).toHaveAttribute("aria-pressed", "true");
+			// picker は開かない
+			await expect(
+				page.getByRole("group", { name: "リアクションを選択" }),
+			).toHaveCount(0);
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-32 UI: Alt+Enter で picker open / 再度で close (#381)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-32 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			await trigger.focus();
+			await page.keyboard.press("Alt+Enter");
+			await expect(trigger).toHaveAttribute("aria-expanded", "true");
+			await page.keyboard.press("Alt+Enter");
 			await expect(trigger).toHaveAttribute("aria-expanded", "false");
 		} finally {
 			await deleteTweetAs(USER2, tweetId);

--- a/client/src/components/reactions/ReactionBar.tsx
+++ b/client/src/components/reactions/ReactionBar.tsx
@@ -1,24 +1,30 @@
 "use client";
 
 /**
- * ReactionBar — inline reaction picker on each tweet (P2-14 / Issue #187).
+ * ReactionBar — Facebook-style reaction widget (P2-14 #187, FB-style #381).
  *
- * Behaviour:
- *   - Trigger button: shows "<emoji> <count>" (or "リアクション 0" empty state),
- *     toggles a 10-emoji grid below.
- *   - Click any emoji → optimistic count adjust + POST /tweets/<id>/reactions/
- *     - If picked the same kind currently active → toggles off (X-style)
- *     - If different kind → swap (decrement old, increment new)
- *   - Alt+Enter on the trigger opens the picker (kbd shortcut SPEC §6.2).
+ * Trigger button:
+ *   - my_kind=null  → 👍 + count (灰色)
+ *   - my_kind=K     → 絵文字(K) + count (lime 強調)
  *
- * Dismiss (#379):
- *   - Picking any kind closes the popup (X / Slack / Discord 慣習)
- *   - Outside click closes the popup
- *   - Escape key closes the popup
+ * Operations (#381):
+ *   - 単 click / tap (短押し, < LONG_PRESS_MS) → quick toggle:
+ *       my_kind=null → like を付ける
+ *       my_kind=K    → 取消 (`null` に戻す)
+ *     つまり Facebook と同じく、click は **常に like トグル**。別 kind に
+ *     変えたい場合は長押しから picker を開く。
+ *   - 長押し (>= LONG_PRESS_MS) → picker popup を開く
+ *   - picker 内 kind click → 選択して popup close (#379, #187)
+ *   - Enter キー → quick toggle (= click)
+ *   - Alt+Enter キー → picker 開閉 (キーボード代替, SPEC §6.2)
+ *   - Escape / outside click → popup close (#379)
  *
- * Initial counts come from the GET reactions endpoint via props; Tweet objects
- * don't yet carry reaction counts inline (follow-up: include them in
- * TweetListSerializer to avoid an N+1 fetch on the timeline).
+ * 長押し判定:
+ *   - pointerdown で setTimeout(LONG_PRESS_MS) を開始、`longPressFiredRef=false`
+ *   - timer 満了で `longPressFiredRef=true` + `setOpen(true)`
+ *   - pointerup / pointercancel で timer 解除
+ *   - 続く click イベントで `longPressFiredRef===true` なら quick toggle を
+ *     suppress (= picker open のみ)
  */
 
 import {
@@ -28,6 +34,7 @@ import {
 	useRef,
 	useState,
 	type KeyboardEvent,
+	type PointerEvent,
 } from "react";
 import { toast } from "react-toastify";
 
@@ -45,33 +52,131 @@ interface ReactionBarProps {
 }
 
 const EMPTY: ReactionAggregate = { counts: {}, my_kind: null };
+const LONG_PRESS_MS = 500;
+const QUICK_KIND: ReactionKind = "like";
+const DEFAULT_TRIGGER_EMOJI = "👍";
 
 export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
 	const [state, setState] = useState<ReactionAggregate>(initial ?? EMPTY);
 	const [open, setOpen] = useState(false);
 	const [busyKind, setBusyKind] = useState<ReactionKind | null>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const longPressFiredRef = useRef(false);
 
 	const total = useMemo(
 		() => Object.values(state.counts).reduce((a, b) => a + (b ?? 0), 0),
 		[state.counts],
 	);
 	const myActive = state.my_kind;
-	const triggerLabel = myActive
-		? `${REACTION_META[myActive].emoji} ${total}`
-		: `リアクション ${total}`;
+	const triggerEmoji = myActive
+		? REACTION_META[myActive].emoji
+		: DEFAULT_TRIGGER_EMOJI;
+	const triggerSrLabel = myActive
+		? `${REACTION_META[myActive].label}を取消 (長押しで他のリアクション)`
+		: "いいね (長押しで他のリアクション)";
+
+	const handlePick = useCallback(
+		async (kind: ReactionKind) => {
+			if (busyKind) return;
+
+			// #379: 選択した瞬間に popup を閉じる (X / Slack / Discord 慣習)。
+			setOpen(false);
+
+			// Optimistic update
+			const previous = state;
+			setBusyKind(kind);
+			setState((prev) => {
+				const next = { ...prev, counts: { ...prev.counts } };
+				if (prev.my_kind === kind) {
+					next.counts[kind] = Math.max(0, (next.counts[kind] ?? 0) - 1);
+					next.my_kind = null;
+				} else {
+					if (prev.my_kind) {
+						next.counts[prev.my_kind] = Math.max(
+							0,
+							(next.counts[prev.my_kind] ?? 0) - 1,
+						);
+					}
+					next.counts[kind] = (next.counts[kind] ?? 0) + 1;
+					next.my_kind = kind;
+				}
+				return next;
+			});
+
+			try {
+				const result = await toggleReaction(tweetId, kind);
+				setState((prev) => ({ ...prev, my_kind: result.kind }));
+			} catch {
+				setState(previous);
+				toast.error("リアクションを更新できませんでした");
+			} finally {
+				setBusyKind(null);
+			}
+		},
+		[busyKind, state, tweetId],
+	);
+
+	// #381: quick toggle (click / Enter) — FB と同じく click は常に like を
+	// トグルする。my_kind が like 以外でも click は「現在のリアクションを取消」
+	// になる (handlePick が同じ kind 再押下で取消する仕様)。
+	const handleQuickToggle = useCallback(() => {
+		if (busyKind) return;
+		const kind: ReactionKind = state.my_kind ?? QUICK_KIND;
+		// fire-and-forget: handlePick 内で error は toast 化される
+		handlePick(kind).catch(() => {});
+	}, [busyKind, state.my_kind, handlePick]);
+
+	const clearLongPressTimer = useCallback(() => {
+		if (longPressTimerRef.current !== null) {
+			clearTimeout(longPressTimerRef.current);
+			longPressTimerRef.current = null;
+		}
+	}, []);
+
+	// #381: pointerdown で 500ms タイマ開始、満了で picker open。
+	// pointer event は touch / mouse / pen を統一して扱える。
+	const handlePointerDown = useCallback(
+		(e: PointerEvent<HTMLButtonElement>) => {
+			// 右 click / middle click は無視 (button 0 = main)。
+			// jsdom (test) では button が undefined なケースがあるので、
+			// 数値で 0 以外のときのみ早期 return する (real browser では常に
+			// 数値で初期化される)。
+			if (typeof e.button === "number" && e.button !== 0) return;
+			longPressFiredRef.current = false;
+			clearLongPressTimer();
+			longPressTimerRef.current = setTimeout(() => {
+				longPressFiredRef.current = true;
+				setOpen(true);
+				longPressTimerRef.current = null;
+			}, LONG_PRESS_MS);
+		},
+		[clearLongPressTimer],
+	);
+
+	const handlePointerUpOrCancel = useCallback(() => {
+		clearLongPressTimer();
+	}, [clearLongPressTimer]);
+
+	// #381: 長押し満了後の click を suppress。click は pointerup の後に発火する。
+	const handleClick = useCallback(() => {
+		if (longPressFiredRef.current) {
+			longPressFiredRef.current = false;
+			return;
+		}
+		handleQuickToggle();
+	}, [handleQuickToggle]);
 
 	const onTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
-		// SPEC §6.2: Alt+Enter is the keyboard alternative to mouse hover.
 		if (e.altKey && e.key === "Enter") {
+			// SPEC §6.2: Alt+Enter is the keyboard alternative to long-press.
 			e.preventDefault();
 			setOpen((v) => !v);
 		}
+		// Enter / Space はブラウザが自動で button.click() を発火する。
 	};
 
-	// #379: outside click / Escape で popup を閉じる。open のときだけ listener を
-	// 登録し、cleanup で解除する。capture で document に渡す必要はなく、
-	// bubble phase の mousedown / keydown で十分。
+	// #379: outside click / Escape で popup を閉じる。
 	useEffect(() => {
 		if (!open) return;
 		const onPointerDown = (event: MouseEvent) => {
@@ -91,67 +196,37 @@ export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
 		};
 	}, [open]);
 
-	const handlePick = useCallback(
-		async (kind: ReactionKind) => {
-			if (busyKind) return;
-
-			// #379: 選択した瞬間に popup を閉じる (X / Slack / Discord 慣習)。
-			// API 結果を待たずに閉じるのは、optimistic update と組で UX を即時化
-			// するため。失敗時は state がロールバックされるので popup を閉じても
-			// 結果整合性は保たれる。
-			setOpen(false);
-
-			// Optimistic update
-			const previous = state;
-			setBusyKind(kind);
-			setState((prev) => {
-				const next = { ...prev, counts: { ...prev.counts } };
-				if (prev.my_kind === kind) {
-					// Toggle off
-					next.counts[kind] = Math.max(0, (next.counts[kind] ?? 0) - 1);
-					next.my_kind = null;
-				} else {
-					// Swap: decrement old (if any), increment new
-					if (prev.my_kind) {
-						next.counts[prev.my_kind] = Math.max(
-							0,
-							(next.counts[prev.my_kind] ?? 0) - 1,
-						);
-					}
-					next.counts[kind] = (next.counts[kind] ?? 0) + 1;
-					next.my_kind = kind;
-				}
-				return next;
-			});
-
-			try {
-				const result = await toggleReaction(tweetId, kind);
-				// Reconcile with server: trust server's view of my_kind.
-				setState((prev) => ({ ...prev, my_kind: result.kind }));
-			} catch {
-				setState(previous);
-				toast.error("リアクションを更新できませんでした");
-			} finally {
-				setBusyKind(null);
-			}
-		},
-		[busyKind, state, tweetId],
-	);
+	// unmount 時の timer cleanup
+	useEffect(() => {
+		return () => {
+			clearLongPressTimer();
+		};
+	}, [clearLongPressTimer]);
 
 	return (
 		<div ref={containerRef} className="flex flex-col gap-1">
 			<button
 				type="button"
-				aria-label="リアクション"
+				aria-label={triggerSrLabel}
 				aria-expanded={open}
 				aria-haspopup="true"
-				onClick={() => setOpen((v) => !v)}
+				aria-pressed={myActive !== null}
+				onClick={handleClick}
+				onPointerDown={handlePointerDown}
+				onPointerUp={handlePointerUpOrCancel}
+				onPointerCancel={handlePointerUpOrCancel}
+				onPointerLeave={handlePointerUpOrCancel}
 				onKeyDown={onTriggerKeyDown}
-				className="flex min-h-[32px] items-center gap-1 rounded px-1 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				className={`flex min-h-[32px] touch-manipulation select-none items-center gap-1 rounded px-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+					myActive
+						? "text-lime-700 dark:text-lime-300"
+						: "text-muted-foreground hover:text-foreground"
+				}`}
 			>
-				<span aria-hidden="true">{triggerLabel}</span>
+				<span aria-hidden="true">{triggerEmoji}</span>
+				<span aria-hidden="true">{total}</span>
 				<span className="sr-only">
-					(Alt+Enter で開閉、現在の合計 {total} 件)
+					(現在の合計 {total} 件、長押しまたは Alt+Enter で他のリアクション)
 				</span>
 			</button>
 

--- a/client/src/components/reactions/__tests__/ReactionBar.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionBar.test.tsx
@@ -1,8 +1,14 @@
 /**
- * Tests for ReactionBar (P2-14 / Issue #187).
+ * Tests for ReactionBar (P2-14 #187, FB-style #381).
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ReactionBar from "@/components/reactions/ReactionBar";
@@ -19,6 +25,16 @@ vi.mock("react-toastify", () => ({
 	toast: { error: vi.fn(), success: vi.fn() },
 }));
 
+// trigger は aria-label が my_kind に応じて変わる:
+//   - my_kind=null → "いいね (長押しで他のリアクション)"
+//   - my_kind=K    → "<label>を取消 (長押しで他のリアクション)"
+const TRIGGER_LIKE_LABEL = /いいね \(長押し/;
+const TRIGGER_TAKE_BACK = /を取消 \(長押し/;
+const triggerByDefault = () =>
+	screen.getByRole("button", { name: TRIGGER_LIKE_LABEL });
+const triggerByActive = () =>
+	screen.getByRole("button", { name: TRIGGER_TAKE_BACK });
+
 describe("ReactionBar — collapsed state", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -27,11 +43,13 @@ describe("ReactionBar — collapsed state", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("renders an empty trigger when no initial counts", () => {
+	it("renders 👍 trigger when no my_kind", () => {
 		render(<ReactionBar tweetId={1} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		const trigger = triggerByDefault();
 		expect(trigger).toBeInTheDocument();
 		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+		expect(trigger.getAttribute("aria-pressed")).toBe("false");
+		expect(trigger.textContent).toContain("👍");
 	});
 
 	it("renders total count from initial aggregate", () => {
@@ -41,66 +59,28 @@ describe("ReactionBar — collapsed state", () => {
 				initial={{ counts: { like: 2, agree: 1 }, my_kind: null }}
 			/>,
 		);
-		expect(
-			screen.getByRole("button", { name: /リアクション/ }),
-		).toHaveTextContent("3");
+		expect(triggerByDefault().textContent).toContain("3");
 	});
 
-	it("shows my emoji when my_kind is set", () => {
+	it("shows my emoji + aria-pressed=true when my_kind is set", () => {
 		render(
 			<ReactionBar
 				tweetId={1}
 				initial={{ counts: { like: 2 }, my_kind: "like" }}
 			/>,
 		);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		const trigger = triggerByActive();
 		expect(trigger.textContent).toContain("❤️");
+		expect(trigger.getAttribute("aria-pressed")).toBe("true");
 	});
 });
 
-describe("ReactionBar — picker", () => {
+describe("ReactionBar — quick toggle (click) #381", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("opens the picker on trigger click", async () => {
-		render(<ReactionBar tweetId={1} />);
-		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
-		expect(
-			screen.getByRole("group", { name: "リアクションを選択" }),
-		).toBeInTheDocument();
-	});
-
-	it("opens the picker on Alt+Enter (keyboard alt)", () => {
-		render(<ReactionBar tweetId={1} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
-		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
-		expect(
-			screen.getByRole("group", { name: "リアクションを選択" }),
-		).toBeInTheDocument();
-	});
-
-	it("renders all 10 emoji buttons when open", async () => {
-		render(<ReactionBar tweetId={1} />);
-		await userEvent.click(screen.getByRole("button", { name: /リアクション/ }));
-		// Each emoji button has aria-label "<label> (N 件)"
-		expect(screen.getByRole("button", { name: /いいね/ })).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: /面白い/ })).toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: /勉強になった/ }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: /コードよき/ }),
-		).toBeInTheDocument();
-	});
-});
-
-describe("ReactionBar — toggle", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
-
-	it("optimistically increments count and POSTs (popup closes #379)", async () => {
+	it("click on default trigger sends like POST and does not open picker", async () => {
 		vi.mocked(toggleReaction).mockResolvedValue({
 			kind: "like",
 			created: true,
@@ -109,28 +89,21 @@ describe("ReactionBar — toggle", () => {
 		});
 
 		render(<ReactionBar tweetId={42} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		const trigger = triggerByDefault();
 		await userEvent.click(trigger);
-		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
 
-		// #379: pick 後は popup が閉じる → trigger の aria-expanded=false に。
-		await waitFor(() => {
-			expect(trigger.getAttribute("aria-expanded")).toBe("false");
-		});
-		// Trigger label が my_kind 反映 (❤️ 1) になる。
-		expect(trigger.textContent).toContain("❤️");
 		expect(toggleReaction).toHaveBeenCalledWith(42, "like");
-
-		// 再 open して aria-pressed が反映されていることを確認。
-		await userEvent.click(trigger);
+		// picker は開かない
 		expect(
-			screen
-				.getByRole("button", { name: /いいね/ })
-				.getAttribute("aria-pressed"),
-		).toBe("true");
+			screen.queryByRole("group", { name: "リアクションを選択" }),
+		).not.toBeInTheDocument();
+		// optimistic で my_kind=like → trigger label が変わる
+		await waitFor(() => {
+			expect(triggerByActive()).toBeInTheDocument();
+		});
 	});
 
-	it("toggles off when clicking the same kind twice (popup closes after each pick)", async () => {
+	it("click when my_kind=like → toggle off (POST kind=like → removed)", async () => {
 		vi.mocked(toggleReaction).mockResolvedValue({
 			kind: null,
 			created: false,
@@ -140,57 +113,87 @@ describe("ReactionBar — toggle", () => {
 
 		render(
 			<ReactionBar
-				tweetId={1}
+				tweetId={7}
 				initial={{ counts: { like: 1 }, my_kind: "like" }}
 			/>,
 		);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
+		const trigger = triggerByActive();
 		await userEvent.click(trigger);
-		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
 
-		// popup が閉じる
+		expect(toggleReaction).toHaveBeenCalledWith(7, "like");
 		await waitFor(() => {
-			expect(trigger.getAttribute("aria-expanded")).toBe("false");
+			expect(triggerByDefault()).toBeInTheDocument();
 		});
-		// trigger label は my_kind=null に戻る
-		expect(trigger.textContent).not.toContain("❤️");
-
-		// 再 open → like の aria-pressed=false
-		await userEvent.click(trigger);
-		expect(
-			screen
-				.getByRole("button", { name: /いいね/ })
-				.getAttribute("aria-pressed"),
-		).toBe("false");
 	});
 
-	it("rolls back optimistic state and toasts on error (popup still closes)", async () => {
+	it("click when my_kind=love (other) → toggle off the existing kind", async () => {
+		vi.mocked(toggleReaction).mockResolvedValue({
+			kind: null,
+			created: false,
+			changed: false,
+			removed: true,
+		});
+
+		render(
+			<ReactionBar
+				tweetId={7}
+				initial={{ counts: { learned: 1 }, my_kind: "learned" }}
+			/>,
+		);
+		const trigger = triggerByActive();
+		await userEvent.click(trigger);
+
+		// FB と同じく click は「現在の kind を取消」 (= POST に同じ kind を投げて
+		// サーバ側 toggle 仕様で消える)
+		expect(toggleReaction).toHaveBeenCalledWith(7, "learned");
+	});
+
+	it("rolls back optimistic state on error", async () => {
 		const { toast } = await import("react-toastify");
 		vi.mocked(toggleReaction).mockRejectedValue(new Error("500"));
 
 		render(<ReactionBar tweetId={1} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
-		await userEvent.click(trigger);
-		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
+		await userEvent.click(triggerByDefault());
 
 		await waitFor(() => {
 			expect(toast.error).toHaveBeenCalledWith(
 				expect.stringContaining("更新できませんでした"),
 			);
 		});
-		// popup は close したまま (失敗してもユーザの click 意思は popup を閉じる)
-		expect(trigger.getAttribute("aria-expanded")).toBe("false");
-		// rollback で my_kind は null
-		expect(trigger.textContent).not.toContain("❤️");
+		// rollback → trigger は default (👍) に戻る
+		expect(triggerByDefault()).toBeInTheDocument();
 	});
 });
 
-describe("ReactionBar — popup dismiss (#379)", () => {
+describe("ReactionBar — long-press opens picker #381", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
-	it("closes popup immediately on kind pick", async () => {
+	it("pointerdown for >= 500ms opens the picker (no quick toggle)", async () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = triggerByDefault();
+		fireEvent.pointerDown(trigger, { button: 0 });
+		// 500ms 経過させる (await act でタイマ満了後の React state flush を待つ)
+		await act(async () => {
+			vi.advanceTimersByTime(500);
+		});
+		// picker が開いている
+		expect(
+			screen.getByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+		// 続く pointerup → click は suppress される
+		fireEvent.pointerUp(trigger);
+		fireEvent.click(trigger);
+		// quick toggle が走らないので API は呼ばれていない
+		expect(toggleReaction).not.toHaveBeenCalled();
+	});
+
+	it("pointerdown released before 500ms does NOT open picker (quick toggle path)", async () => {
 		vi.mocked(toggleReaction).mockResolvedValue({
 			kind: "like",
 			created: true,
@@ -199,19 +202,119 @@ describe("ReactionBar — popup dismiss (#379)", () => {
 		});
 
 		render(<ReactionBar tweetId={1} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
-		await userEvent.click(trigger);
+		const trigger = triggerByDefault();
+		fireEvent.pointerDown(trigger, { button: 0 });
+		vi.advanceTimersByTime(200); // < 500ms
+		fireEvent.pointerUp(trigger);
+		// picker は開かない
 		expect(
-			screen.getByRole("group", { name: "リアクションを選択" }),
-		).toBeInTheDocument();
+			screen.queryByRole("group", { name: "リアクションを選択" }),
+		).not.toBeInTheDocument();
+		// click が発火 → quick toggle
+		fireEvent.click(trigger);
+		await vi.runAllTimersAsync();
+		expect(toggleReaction).toHaveBeenCalledWith(1, "like");
+	});
 
-		await userEvent.click(screen.getByRole("button", { name: /いいね/ }));
+	it("pointercancel before 500ms cancels the long-press", () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = triggerByDefault();
+		fireEvent.pointerDown(trigger, { button: 0 });
+		vi.advanceTimersByTime(300);
+		fireEvent.pointerCancel(trigger);
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
 		expect(
 			screen.queryByRole("group", { name: "リアクションを選択" }),
 		).not.toBeInTheDocument();
 	});
 
-	it("closes popup on outside click", async () => {
+	// jsdom の PointerEvent は `button` 初期化値を React synthetic event に
+	// 伝搬しない (e.button が undefined になる) ため、fireEvent では
+	// 右 click 抑制を unit test で再現できない。実装側 guard は
+	// `typeof e.button === "number" && e.button !== 0` で production の
+	// real browser のみ効く。実機検証は Playwright `click({ button: "right" })` 等で。
+	it.todo("ignores non-main button pointerdown (right click) — E2E only");
+});
+
+describe("ReactionBar — keyboard #381 / #187", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("Alt+Enter opens the picker (キーボード代替)", () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = triggerByDefault();
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
+		expect(
+			screen.getByRole("group", { name: "リアクションを選択" }),
+		).toBeInTheDocument();
+	});
+
+	it("Alt+Enter toggles the picker open/closed", () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = triggerByDefault();
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
+		expect(trigger.getAttribute("aria-expanded")).toBe("true");
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+	});
+});
+
+describe("ReactionBar — picker", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders all 10 emoji buttons when open via Alt+Enter", () => {
+		render(<ReactionBar tweetId={1} />);
+		const trigger = triggerByDefault();
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
+		// picker 内 button は aria-label="<label> (<N> 件)" 形式。trigger の
+		// "いいね (長押しで...)" と区別するため "件)" 付きで照合する。
+		expect(
+			screen.getByRole("button", { name: /いいね \(\d+ 件\)/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /面白い \(\d+ 件\)/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /勉強になった \(\d+ 件\)/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /コードよき \(\d+ 件\)/ }),
+		).toBeInTheDocument();
+	});
+
+	it("picker pick → POST + popup closes", async () => {
+		vi.mocked(toggleReaction).mockResolvedValue({
+			kind: "learned",
+			created: true,
+			changed: false,
+			removed: false,
+		});
+
+		render(<ReactionBar tweetId={42} />);
+		const trigger = triggerByDefault();
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
+		await userEvent.click(
+			screen.getByRole("button", { name: /勉強になった \(\d+ 件\)/ }),
+		);
+
+		expect(toggleReaction).toHaveBeenCalledWith(42, "learned");
+		expect(
+			screen.queryByRole("group", { name: "リアクションを選択" }),
+		).not.toBeInTheDocument();
+	});
+});
+
+describe("ReactionBar — popup dismiss (#379)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("closes popup on outside click", () => {
 		render(
 			<div>
 				<ReactionBar tweetId={1} />
@@ -220,23 +323,22 @@ describe("ReactionBar — popup dismiss (#379)", () => {
 				</button>
 			</div>,
 		);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
-		await userEvent.click(trigger);
+		const trigger = triggerByDefault();
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
 		expect(
 			screen.getByRole("group", { name: "リアクションを選択" }),
 		).toBeInTheDocument();
 
-		// useEffect 内で listen している mousedown を発火
 		fireEvent.mouseDown(screen.getByTestId("outside"));
 		expect(
 			screen.queryByRole("group", { name: "リアクションを選択" }),
 		).not.toBeInTheDocument();
 	});
 
-	it("does not close on mousedown inside the popup container", async () => {
+	it("does not close on mousedown inside the popup container", () => {
 		render(<ReactionBar tweetId={1} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
-		await userEvent.click(trigger);
+		const trigger = triggerByDefault();
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
 		const group = screen.getByRole("group", { name: "リアクションを選択" });
 		fireEvent.mouseDown(group);
 		expect(
@@ -244,26 +346,16 @@ describe("ReactionBar — popup dismiss (#379)", () => {
 		).toBeInTheDocument();
 	});
 
-	it("closes popup on Escape key", async () => {
+	it("closes popup on Escape key", () => {
 		render(<ReactionBar tweetId={1} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
-		await userEvent.click(trigger);
+		const trigger = triggerByDefault();
+		fireEvent.keyDown(trigger, { key: "Enter", altKey: true });
 		expect(
 			screen.getByRole("group", { name: "リアクションを選択" }),
 		).toBeInTheDocument();
-
 		fireEvent.keyDown(document, { key: "Escape" });
 		expect(
 			screen.queryByRole("group", { name: "リアクションを選択" }),
 		).not.toBeInTheDocument();
-	});
-
-	it("trigger re-click still toggles the popup (existing behaviour)", async () => {
-		render(<ReactionBar tweetId={1} />);
-		const trigger = screen.getByRole("button", { name: /リアクション/ });
-		await userEvent.click(trigger);
-		expect(trigger.getAttribute("aria-expanded")).toBe("true");
-		await userEvent.click(trigger);
-		expect(trigger.getAttribute("aria-expanded")).toBe("false");
 	});
 });

--- a/docs/specs/reactions-e2e-commands.md
+++ b/docs/specs/reactions-e2e-commands.md
@@ -116,6 +116,27 @@ npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line 
 
 # RCT-23: Escape キーで popup が close する (#379)
 npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-23"
+
+# RCT-25: trigger を click すると quick toggle で like される (#381)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-25"
+
+# RCT-26: my_kind=K のときに trigger を click すると K を取消す (#381)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-26"
+
+# RCT-27: trigger を 500ms 以上長押しすると picker が開く (#381)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-27"
+
+# RCT-28: 短押しは quick toggle のみ (#381)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-28"
+
+# RCT-30: 長押し後 picker から kind 選択 (#381 + #379)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-30"
+
+# RCT-31: Enter キーで quick toggle (#381)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-31"
+
+# RCT-32: Alt+Enter キーで picker 開閉 (#381 / #187)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-32"
 ```
 
 ## 5. Phase 2 既存 golden path との関係

--- a/docs/specs/reactions-scenarios.md
+++ b/docs/specs/reactions-scenarios.md
@@ -443,6 +443,137 @@
 - UI: popup は close せず、開いたまま。
 - ユーザが kind を選ぶ前に意図せず popup が閉じてしまう事故を防ぐ。
 
+### RCT-25: trigger を click すると quick toggle で like される (#381 / FB 風)
+
+前提:
+
+- actor A、target tweet T (作者は B)。
+- A は T に reaction を持っていない (`my_kind=null`)。
+- trigger ボタンの aria-label は `いいね (長押しで他のリアクション)` で、表示は `👍 {total}`。
+
+操作:
+
+- A が trigger を short-click する (短押し、< 500ms)。
+
+期待結果:
+
+- API: `POST /api/v1/tweets/<T.id>/reactions/` `{kind: "like"}` が **201** を返す。
+- DB: `Reaction(user=A, tweet=T, kind="like")` 行が追加される。
+- UI: picker popup は **開かない**。
+- UI: trigger 表示が `❤️ {total+1}`、`aria-pressed=true`、`aria-label="いいねを取消 (長押しで他のリアクション)"`。
+
+### RCT-26: my_kind=K のときに trigger を click すると K を取消す (#381)
+
+前提:
+
+- actor A は T に reaction `learned` を持っている (`my_kind="learned"`)。
+- trigger 表示は `📚 {total}`。
+
+操作:
+
+- A が trigger を short-click する。
+
+期待結果:
+
+- API: `POST /api/v1/tweets/<T.id>/reactions/` `{kind: "learned"}` (= 同じ kind 再押下で取消)。
+- DB: A の Reaction 行は DELETE。
+- UI: trigger 表示が `👍 {total-1}`、`aria-pressed=false`、`aria-label="いいね (長押しで他のリアクション)"`。
+- UI: picker popup は開かない。
+- 別 kind (例: like) に switch したい場合は **長押しで picker を開いて選ぶ** 必要がある (= FB 同等の UX)。
+
+### RCT-27: trigger を 500ms 以上長押しすると picker が開く (#381)
+
+前提:
+
+- actor A、target tweet T。
+
+操作:
+
+- A が trigger を `pointerdown` し、500ms 以上保持してから `pointerup`。
+
+期待結果:
+
+- UI: 500ms 経過後に picker popup (`role="group" aria-label="リアクションを選択"`) が表示される。
+- UI: trigger の `aria-expanded=true`。
+- API: 長押し中は API 呼び出し無し。続く `click` event は **quick toggle を suppress** する (= picker 開いただけで like トグルが走らない)。
+
+### RCT-28: 長押し未満 (短押し) は quick toggle のみ (#381)
+
+前提:
+
+- actor A、target tweet T、`my_kind=null`。
+
+操作:
+
+- A が trigger を `pointerdown` し、200ms 程度で `pointerup` → `click`。
+
+期待結果:
+
+- UI: picker は開かない (`aria-expanded=false`)。
+- API: `POST kind=like` が発火 → 201。
+- 「うっかり長押し」を回避し、通常 click で確実に like できる UX。
+
+### RCT-29: 長押し中の `pointercancel` で長押しが取消される (#381)
+
+前提:
+
+- actor A が trigger を `pointerdown` 開始 (300ms 経過)。
+
+操作:
+
+- ブラウザが scroll などで `pointercancel` イベントを発火する (touch スクロール時等)。
+
+期待結果:
+
+- timer がクリアされ、500ms 待っても picker が開かない。
+- `click` も発火しない (= quick toggle も走らない)。
+
+### RCT-30: 長押し後の picker から kind を選ぶと反映 + popup close (#381 + #379)
+
+前提:
+
+- actor A が trigger を長押しして picker が開いている (RCT-27 の延長)。
+
+操作:
+
+- picker 内の任意 kind (例: `learned`) を click する。
+
+期待結果:
+
+- API: `POST kind=learned` → my_kind が `learned` に変わる。
+- UI: popup が close (#379 既存)。trigger 表示が `📚 {total+1}`。
+
+### RCT-31: Enter キーは quick toggle (= click と同じ、#381)
+
+前提:
+
+- actor A が trigger ボタンに focus を当てている、`my_kind=null`。
+
+操作:
+
+- `Enter` キーを押す。
+
+期待結果:
+
+- ブラウザ標準の button click が発火 → quick toggle で `POST kind=like`。
+- picker は開かない。
+
+### RCT-32: Alt+Enter キーは picker open (#381 / #187 の置き換え)
+
+前提:
+
+- actor A が trigger ボタンに focus を当てている。
+
+操作:
+
+- `Alt+Enter` を押す。
+
+期待結果:
+
+- picker が open (`aria-expanded=true`)。
+- 続けて `Alt+Enter` で close (toggle)。
+- a11y: 長押しが使えないキーボードユーザ向けの代替 (SPEC §6.2)。
+
 ## 4. E2E化メモ
 
 各 E2E は上記の `RCT-XX` をテスト名に含める。

--- a/docs/specs/reactions-spec.md
+++ b/docs/specs/reactions-spec.md
@@ -218,23 +218,50 @@ stateDiagram-v2
 
 ### 4.1 ReactionBar UI 描画
 
-| 状態           | trigger ボタン文言 (`triggerLabel`) | grid 内 ボタン色 (kind=K)            | aria-pressed |
-| -------------- | ----------------------------------- | ------------------------------------ | ------------ |
-| `my_kind=null` | `リアクション {total}`              | 全 kind: 灰色 hover                  | 全 false     |
-| `my_kind=K`    | `{emoji(K)} {total}`                | K: lime-500/20 強調 / 他: 灰色 hover | K のみ true  |
+`#381` で **Facebook 風 UX** に変更。trigger は単一の "👍 (Good)" ボタンとして表示し、click は **常に like トグル**、長押しで picker を開く。別 kind に変えたい場合は長押しから選ぶ。
+
+| 状態           | trigger 表示                     | aria-pressed | aria-label                                    |
+| -------------- | -------------------------------- | ------------ | --------------------------------------------- |
+| `my_kind=null` | `👍 {total}` (灰色)              | `false`      | `いいね (長押しで他のリアクション)`           |
+| `my_kind=K`    | `{emoji(K)} {total}` (lime 強調) | `true`       | `{label(K)}を取消 (長押しで他のリアクション)` |
+
+picker 内の grid (`role="group"`) は #379 で確定済の挙動を維持:
+
+- 全 10 kind ボタン (灰色 hover、選択中は lime-500/20 強調)
+- `aria-pressed=true` は my_kind に一致する kind のみ
+- `busyKind !== null` の間は disabled
 
 要点:
 
-- `total` は `sum(counts)` で 10 kind 合算。X の Like 数表示と同じ「自分の kind と関係なく合計を出す」スタンス。
-- trigger ボタンは **常に 1 つ**。grid を開閉する。Alt+Enter キーで開閉できる (SPEC §6.2 アクセシビリティ)。
-- `busyKind !== null` の間は grid 内全ボタンが `disabled`、optimistic update 中の二重押下を防止。
+- `total` は `sum(counts)` で 10 kind 合算 (X の Like 数表示踏襲)。
+- trigger ボタンは **1 つ**。click / Enter で quick toggle、長押し / Alt+Enter で picker。
+- a11y: trigger は `aria-haspopup="true"`, `aria-expanded={open}`, `aria-pressed={my_kind!==null}`。
 
-#### 4.1.1 popup の開閉 (#379)
+#### 4.1.1 操作と判定 (#381)
+
+| 操作                                    | 動作                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------ |
+| click / tap (短押し, < `LONG_PRESS_MS`) | quick toggle: `my_kind=null` → POST `like`、それ以外 → POST `my_kind` (= 取消) |
+| 長押し (>= `LONG_PRESS_MS=500ms`)       | picker を開く (`setOpen(true)`)                                                |
+| picker 内 kind click                    | 既存挙動: kind を反映して popup close (#379, #187)                             |
+| Enter キー                              | quick toggle (= click と同じ。button が自動で click 発火)                      |
+| `Alt+Enter` キー                        | picker 開閉 (キーボード代替、長押しの a11y alternative)                        |
+| Escape                                  | popup close (#379)                                                             |
+| outside click                           | popup close (#379)                                                             |
+
+長押し判定の実装:
+
+- `pointerdown` (button=0 のときのみ) で `setTimeout(LONG_PRESS_MS=500)` を開始、`longPressFiredRef.current=false`
+- timer 満了で `longPressFiredRef.current=true` + `setOpen(true)`
+- `pointerup` / `pointercancel` / `pointerleave` で timer 解除
+- 続く `click` イベントで `longPressFiredRef.current === true` なら quick toggle を **suppress** し、ref を false にリセット
+- jsdom (test 環境) では `e.button` が undefined になるため、guard は `typeof e.button === "number" && e.button !== 0` (production の real browser のみ右 click を抑制)
+
+#### 4.1.2 popup の開閉 (#379, 既存)
 
 | トリガ                               | 振る舞い                                           |
 | ------------------------------------ | -------------------------------------------------- |
-| trigger ボタン click / Enter         | popup を toggle (open ↔ close)                    |
-| trigger ボタン Alt+Enter             | popup を toggle (キーボード代替)                   |
+| 長押し / Alt+Enter                   | popup を open                                      |
 | grid 内 kind 押下                    | popup を **即時 close** + Optimistic update + POST |
 | popup 外領域 (document) を mousedown | popup を **close**                                 |
 | `Escape` キー                        | popup を **close**                                 |


### PR DESCRIPTION
## 関連 Issue

Closes #381

## 概要

ハルナさん指摘:

> リアクションは facebook と同じ仕様にしてもらっていいですか？つまり、グッドボタンに変えてもらって、クリックするといいねになる。そして長押しするといろんなリアクションが選べるポップアップが表示される。

ReactionBar の trigger を Facebook 風に変更:

- 単タップ / click → **いいねトグル** (1 アクションで完了)
- 長押し (>= 500ms) → 10 種 picker を開く
- 別 kind に変えたい場合は長押しで picker を開いてから選ぶ (FB 同等)

## 主な変更

### `ReactionBar.tsx`

| 項目 | 旧 (#379) | 新 (#381 / FB 風) |
|---|---|---|
| trigger 表示 (default) | `リアクション {total}` | `👍 {total}` |
| trigger 表示 (active) | `{emoji(K)} {total}` | 同左 (lime 強調) |
| trigger click | picker 開閉 | quick toggle (like) |
| 長押し | (無し) | picker open |
| Alt+Enter | picker 開閉 | 同左 (キーボード代替) |
| Escape / outside click | popup close | 同左 (#379 維持) |
| picker 内 kind click | 反映 + popup close | 同左 (#379 維持) |

quick toggle ロジック:

- `my_kind=null` → POST `kind=like` (新規いいね)
- `my_kind=K` → POST `kind=K` (同じ kind 再押下でサーバ側 toggle 仕様により削除)

長押し判定:

- `pointerdown` で 500ms timer 開始、満了で `setOpen(true)` + `longPressFiredRef=true`
- `pointerup` / `pointercancel` / `pointerleave` で timer 解除
- 続く `click` イベントで `longPressFiredRef===true` なら quick toggle を suppress
- jsdom の PointerEvent 制約 (button 値が伝搬しない) に対応: guard は `typeof e.button === "number" && e.button !== 0`

a11y:

- aria-label を状態依存に変更 (`いいね (長押しで他のリアクション)` / `<label>を取消 (...)`)
- `aria-pressed` で my_kind の有無、`aria-expanded` で picker 状態
- 長押しが使えないキーボードユーザは **Alt+Enter** で picker 開閉

### 仕様書 (docs/specs/)

- **`reactions-spec.md`** §4.1 を全面書き換え。§4.1.1 操作と判定 / §4.1.2 popup の開閉 (#379 既存) に分離。
- **`reactions-scenarios.md`** に **RCT-25〜RCT-32** を追加:
  - RCT-25: click → quick toggle (like)
  - RCT-26: my_kind=K のとき click で取消
  - RCT-27: 500ms 長押しで picker open
  - RCT-28: 短押しは quick toggle のみ
  - RCT-29: pointercancel で長押し取消
  - RCT-30: 長押し → picker → kind 選択
  - RCT-31: Enter で quick toggle
  - RCT-32: Alt+Enter で picker
- **`reactions-e2e-commands.md`** に RCT-25〜32 の単独実行コマンドを追加

## テスト

### vitest

- ReactionBar.test.tsx を全面書き換え (collapsed / quick toggle / long-press / keyboard / picker / popup dismiss 6 categories)
- **17/18 緑** + 1 `it.todo` (jsdom の PointerEvent.button 伝搬制約で右 click 抑制は E2E 担当)
- 関連 TweetCard / HomeFeed 97 件と合わせて **計 114/115 緑**
- ✅ tsc / eslint クリーン

### E2E

- `reactions-scenarios.spec.ts`:
  - 既存 RCT-01/02/03/17/21/22/23 UI を新仕様 (Alt+Enter で picker open) に更新
  - **RCT-25/26/27/31/32 UI** を新規追加
  - RCT-27 は `page.mouse.down() + waitForTimeout(600) + page.mouse.up()` で長押し模擬

## Test plan

- [x] vitest 緑
- [x] tsc / eslint クリーン
- [ ] stg deploy 後、Playwright MCP で実機確認:
  - trigger が `👍` (default) で表示される
  - click でいいねが付く・取消できる
  - 長押しで picker が開く
  - 長押し後 picker から `learned` 等を選ぶと反映 + popup close
  - Alt+Enter で picker 開閉

## 影響範囲

- 全 ReactionBar インスタンス (timeline, tweet 詳細, 検索結果)
- backend / API は無変更 (= POST/DELETE/GET エンドポイントは既存仕様維持)