### PR TITLE
[feature][reactions] tweet レスポンスに reaction_summary を埋め込み + 内訳表示 (#383)

### DIFF
--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -39,6 +39,41 @@ from apps.tweets.models import (
 from apps.tweets.rendering import render_markdown
 
 # -----------------------------------------------------------------------------
+# #383 reaction_summary helper
+# -----------------------------------------------------------------------------
+
+
+def _build_reaction_summary(tweet: Tweet, request: Any | None) -> dict[str, Any]:
+    """Tweet に紐づく Reaction の集計と viewer 別 my_kind を返す.
+
+    形は ``GET /api/v1/tweets/<id>/reactions/`` と同じ:
+        {"counts": {kind: count for 10 kinds (0-fill)}, "my_kind": kind | None}
+
+    各 tweet ごとに 1〜2 query を発行する (counts と my_kind)。timeline 等で
+    N+1 が問題になるなら view 側で ``prefetch_related("reactions")`` するか、
+    本 helper の caller が context に集計済 dict を入れて optimize する。
+    MVP は単純に直接 query する (#383)。
+    """
+    from collections import Counter
+
+    from apps.reactions.models import Reaction, ReactionKind
+
+    rows = Reaction.objects.filter(tweet=tweet).values_list("kind", flat=True)
+    counts = Counter(rows)
+    full_counts = {k.value: counts.get(k.value, 0) for k in ReactionKind}
+
+    my_kind: str | None = None
+    if request is not None and request.user.is_authenticated:
+        my_kind = (
+            Reaction.objects.filter(user=request.user, tweet=tweet)
+            .values_list("kind", flat=True)
+            .first()
+        )
+
+    return {"counts": full_counts, "my_kind": my_kind}
+
+
+# -----------------------------------------------------------------------------
 # P1-10 (char_count) lazy import
 # -----------------------------------------------------------------------------
 # P1-10 は並列実装中なので import が失敗するケースを許容する。
@@ -99,6 +134,9 @@ class TweetBaseMiniSerializer(serializers.ModelSerializer):
     images = TweetImageSerializer(many=True, read_only=True)
     tags = serializers.SerializerMethodField()
     reposted_by_me = serializers.SerializerMethodField()
+    # #383: reaction の kind 別集計 + viewer 別 my_kind。
+    # 形は GET /reactions/ endpoint と同一。
+    reaction_summary = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
@@ -122,6 +160,7 @@ class TweetBaseMiniSerializer(serializers.ModelSerializer):
             "quote_count",
             "reaction_count",
             "reposted_by_me",
+            "reaction_summary",
         ]
         read_only_fields = fields
 
@@ -155,6 +194,9 @@ class TweetBaseMiniSerializer(serializers.ModelSerializer):
             type=TweetType.REPOST,
             repost_of=obj,
         ).exists()
+
+    def get_reaction_summary(self, obj: Tweet) -> dict[str, Any]:
+        return _build_reaction_summary(obj, self.context.get("request"))
 
 
 class TweetMiniSerializer(TweetBaseMiniSerializer):
@@ -210,6 +252,8 @@ class TweetListSerializer(serializers.ModelSerializer):
     # frontend の RepostButton.initialReposted に流して、リロード後も
     # 「リポスト済み」状態が UI に反映されるようにする。
     reposted_by_me = serializers.SerializerMethodField()
+    # #383: reaction の kind 別集計 + viewer 別 my_kind (GET /reactions/ と同形)。
+    reaction_summary = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
@@ -235,6 +279,8 @@ class TweetListSerializer(serializers.ModelSerializer):
             "repost_of",
             # #351
             "reposted_by_me",
+            # #383
+            "reaction_summary",
         ]
         read_only_fields = fields
 
@@ -291,6 +337,9 @@ class TweetListSerializer(serializers.ModelSerializer):
             type=TweetType.REPOST,
             repost_of=obj,
         ).exists()
+
+    def get_reaction_summary(self, obj: Tweet) -> dict[str, Any]:
+        return _build_reaction_summary(obj, self.context.get("request"))
 
 
 class TweetDetailSerializer(TweetListSerializer):

--- a/apps/tweets/tests/test_reaction_summary.py
+++ b/apps/tweets/tests/test_reaction_summary.py
@@ -1,0 +1,148 @@
+"""Tests for `reaction_summary` field in Tweet serializers (#383).
+
+仕様: docs/specs/reactions-spec.md §2.10, §4.1, §4.3
+
+検証観点:
+- counts は 10 kind 全部 0 埋めで返る
+- viewer 別の my_kind が反映される (匿名は null、別 user は別の値)
+- 既存の `reaction_count` と `sum(counts.values())` が一致する
+- TweetListSerializer / TweetDetailSerializer / TweetMiniSerializer 全てで返る
+"""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient, APIRequestFactory
+
+from apps.reactions.models import Reaction
+from apps.tweets.serializers import (
+    TweetDetailSerializer,
+    TweetListSerializer,
+    TweetMiniSerializer,
+)
+from apps.tweets.tests._factories import make_tweet, make_user
+
+
+@pytest.fixture
+def request_factory() -> APIRequestFactory:
+    return APIRequestFactory()
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestReactionSummary:
+    def test_zero_fill_when_no_reactions(self, request_factory: APIRequestFactory) -> None:
+        tweet = make_tweet()
+        request = request_factory.get("/")
+        request.user = make_user()
+        data = TweetListSerializer(tweet, context={"request": request}).data
+        summary = data["reaction_summary"]
+        assert set(summary["counts"].keys()) == {
+            "like",
+            "interesting",
+            "learned",
+            "helpful",
+            "agree",
+            "surprised",
+            "congrats",
+            "respect",
+            "funny",
+            "code",
+        }
+        assert all(v == 0 for v in summary["counts"].values())
+        assert summary["my_kind"] is None
+
+    def test_counts_reflect_reactions_aggregated(self, request_factory: APIRequestFactory) -> None:
+        tweet = make_tweet()
+        u1, u2, u3 = make_user(), make_user(), make_user()
+        Reaction.objects.create(user=u1, tweet=tweet, kind="like")
+        Reaction.objects.create(user=u2, tweet=tweet, kind="like")
+        Reaction.objects.create(user=u3, tweet=tweet, kind="learned")
+
+        request = request_factory.get("/")
+        request.user = make_user()  # 第三者
+        data = TweetListSerializer(tweet, context={"request": request}).data
+        counts = data["reaction_summary"]["counts"]
+        assert counts["like"] == 2
+        assert counts["learned"] == 1
+        assert counts["agree"] == 0
+
+    def test_my_kind_reflects_viewer(self, request_factory: APIRequestFactory) -> None:
+        tweet = make_tweet()
+        u1 = make_user()
+        u2 = make_user()
+        Reaction.objects.create(user=u1, tweet=tweet, kind="like")
+
+        # u1 視点 → my_kind=like
+        req1 = request_factory.get("/")
+        req1.user = u1
+        d1 = TweetListSerializer(tweet, context={"request": req1}).data
+        assert d1["reaction_summary"]["my_kind"] == "like"
+
+        # u2 視点 → my_kind=null (反応していない)
+        req2 = request_factory.get("/")
+        req2.user = u2
+        d2 = TweetListSerializer(tweet, context={"request": req2}).data
+        assert d2["reaction_summary"]["my_kind"] is None
+
+    def test_unauthenticated_my_kind_null(self, request_factory: APIRequestFactory) -> None:
+        tweet = make_tweet()
+        u1 = make_user()
+        Reaction.objects.create(user=u1, tweet=tweet, kind="like")
+
+        from django.contrib.auth.models import AnonymousUser
+
+        request = request_factory.get("/")
+        request.user = AnonymousUser()
+        data = TweetListSerializer(tweet, context={"request": request}).data
+        summary = data["reaction_summary"]
+        assert summary["my_kind"] is None
+        # counts は誰でも見られる
+        assert summary["counts"]["like"] == 1
+
+    def test_detail_serializer_also_returns_summary(
+        self, request_factory: APIRequestFactory
+    ) -> None:
+        tweet = make_tweet()
+        u1 = make_user()
+        Reaction.objects.create(user=u1, tweet=tweet, kind="agree")
+        request = request_factory.get("/")
+        request.user = u1
+        data = TweetDetailSerializer(tweet, context={"request": request}).data
+        assert data["reaction_summary"]["counts"]["agree"] == 1
+        assert data["reaction_summary"]["my_kind"] == "agree"
+
+    def test_mini_serializer_also_returns_summary(self, request_factory: APIRequestFactory) -> None:
+        tweet = make_tweet()
+        u1 = make_user()
+        Reaction.objects.create(user=u1, tweet=tweet, kind="learned")
+        request = request_factory.get("/")
+        request.user = u1
+        data = TweetMiniSerializer(tweet, context={"request": request}).data
+        assert data["reaction_summary"]["counts"]["learned"] == 1
+        assert data["reaction_summary"]["my_kind"] == "learned"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestReactionSummaryViaAPI:
+    def test_timeline_endpoint_includes_reaction_summary(self) -> None:
+        author = make_user()
+        viewer = make_user()
+        tweet = make_tweet(author=author, body="t1")
+        Reaction.objects.create(user=author, tweet=tweet, kind="like")
+
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+        # tweet 詳細経由で確認 (timeline は別 view だが同じ serializer 系)
+        res = client.get(f"/api/v1/tweets/{tweet.id}/")
+        assert res.status_code == 200
+        body = res.data
+        assert "reaction_summary" in body
+        assert body["reaction_summary"]["counts"]["like"] == 1
+        assert body["reaction_summary"]["my_kind"] is None  # viewer は反応していない
+
+        # author 視点では my_kind=like
+        client.force_authenticate(user=author)
+        res = client.get(f"/api/v1/tweets/{tweet.id}/")
+        assert res.data["reaction_summary"]["my_kind"] == "like"

--- a/client/e2e/reactions-scenarios.spec.ts
+++ b/client/e2e/reactions-scenarios.spec.ts
@@ -742,4 +742,101 @@ test.describe("Reactions UI (ReactionBar)", () => {
 			await deleteTweetAs(USER2, tweetId);
 		}
 	});
+
+	// =====================================================================
+	// reaction_summary + ReactionSummary breakdown (#383)
+	// =====================================================================
+
+	test("RCT-33 UI: trigger emoji が viewer 視点で異なる (#383)", async ({
+		browser,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-33 ${Date.now()}`);
+		// USER1 が API 経由で like を付ける
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			await api.context.post(`/api/v1/tweets/${tweetId}/reactions/`, {
+				headers: {
+					"Content-Type": "application/json",
+					"X-CSRFToken": api.csrf,
+					Referer: `${API_BASE}/`,
+				},
+				data: { kind: "like" },
+			});
+		} finally {
+			await api.context.dispose();
+		}
+		try {
+			// USER1 視点: trigger は ❤️ + aria-pressed=true
+			const ctxA = await browser.newContext();
+			const pageA = await ctxA.newPage();
+			await loginUI(pageA, USER1.email, USER1.password);
+			await openTweet(pageA, tweetId);
+			const triggerA = pageA
+				.locator('button[aria-haspopup="true"][aria-label*="長押し"]')
+				.first();
+			await expect(triggerA).toHaveAttribute("aria-pressed", "true");
+			await ctxA.close();
+
+			// 匿名視点: trigger は 👍 + aria-pressed=false
+			const ctxAnon = await browser.newContext();
+			const pageAnon = await ctxAnon.newPage();
+			await pageAnon.goto(`/tweet/${tweetId}`);
+			const triggerAnon = pageAnon
+				.locator('button[aria-haspopup="true"][aria-label*="長押し"]')
+				.first();
+			await expect(triggerAnon).toHaveAttribute("aria-pressed", "false");
+			await expect(triggerAnon).toHaveAttribute("aria-label", /^いいね \(/);
+			await ctxAnon.close();
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-34 UI: ReactionSummary は total=0 で非表示 (#383)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-34 ${Date.now()}`);
+		try {
+			await page.goto(`/tweet/${tweetId}`);
+			// 0 件のリアクション → ReactionSummary は出ない
+			await expect(
+				page.getByRole("group", { name: "リアクションの内訳" }),
+			).toHaveCount(0);
+		} finally {
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-35 UI: ReactionSummary が count > 0 で表示される (#383)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-35 ${Date.now()}`);
+		// USER1 が API で like を付ける
+		const api = await apiAuthed(USER1.email, USER1.password);
+		try {
+			await api.context.post(`/api/v1/tweets/${tweetId}/reactions/`, {
+				headers: {
+					"Content-Type": "application/json",
+					"X-CSRFToken": api.csrf,
+					Referer: `${API_BASE}/`,
+				},
+				data: { kind: "like" },
+			});
+		} finally {
+			await api.context.dispose();
+		}
+		try {
+			await page.goto(`/tweet/${tweetId}`);
+			const summary = page.getByRole("group", {
+				name: "リアクションの内訳",
+			});
+			await expect(summary).toBeVisible({ timeout: 10_000 });
+			await expect(summary).toContainText("❤️");
+			await expect(summary).toContainText("1 件");
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
 });

--- a/client/src/components/reactions/ReactionSummary.tsx
+++ b/client/src/components/reactions/ReactionSummary.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * ReactionSummary — tweet 本文の下に表示するリアクションのブレイクダウン (#383).
+ *
+ * Facebook / Threads / カロッター 等の慣習に倣い、ツイートに付いた reaction を
+ * 「kind ごとの内訳 + 総計」で要約表示する:
+ *   ❤️ 4  💡 3  👍 2  · 9 件
+ *
+ * 仕様: docs/specs/reactions-spec.md §4.3
+ *
+ * - `summary.counts` を **count desc** (tie は kind の宣言順) で sort し
+ *   上位 `MAX_VISIBLE_KINDS` (default 3) を表示する。
+ * - `total === 0` のときは何も render しない (= 0 件のときに目立たないように)。
+ * - 末尾に総計件数 (kind を問わない sum) を表示する。
+ * - viewer 別の `my_kind` は本 component では区別しない (集計は全 viewer 共通)。
+ *   trigger 側 (ReactionBar) が viewer 別の表示を担当する分業。
+ */
+
+import {
+	REACTION_KINDS,
+	REACTION_META,
+	type ReactionAggregate,
+	type ReactionKind,
+} from "@/lib/api/reactions";
+
+interface ReactionSummaryProps {
+	summary: ReactionAggregate;
+	/** 表示する kind 数の上限 (default 3) */
+	maxVisibleKinds?: number;
+}
+
+const DEFAULT_MAX_VISIBLE = 3;
+
+/**
+ * count desc で sort し、tie は REACTION_KINDS の宣言順で。
+ * 0 件の kind は除外する。
+ */
+function sortKinds(
+	counts: Partial<Record<ReactionKind, number>>,
+): Array<{ kind: ReactionKind; count: number }> {
+	const declarationIndex = new Map<ReactionKind, number>();
+	REACTION_KINDS.forEach((k, i) => declarationIndex.set(k, i));
+	return REACTION_KINDS.map((kind) => ({ kind, count: counts[kind] ?? 0 }))
+		.filter((row) => row.count > 0)
+		.sort((a, b) => {
+			if (b.count !== a.count) return b.count - a.count;
+			return (
+				(declarationIndex.get(a.kind) ?? 0) -
+				(declarationIndex.get(b.kind) ?? 0)
+			);
+		});
+}
+
+export default function ReactionSummary({
+	summary,
+	maxVisibleKinds = DEFAULT_MAX_VISIBLE,
+}: ReactionSummaryProps) {
+	const sorted = sortKinds(summary.counts);
+	const total = sorted.reduce((a, b) => a + b.count, 0);
+	if (total === 0) return null;
+
+	const visible = sorted.slice(0, maxVisibleKinds);
+
+	return (
+		<div
+			role="group"
+			aria-label="リアクションの内訳"
+			className="flex flex-wrap items-center gap-1 text-xs text-muted-foreground"
+		>
+			{visible.map(({ kind, count }) => (
+				<span
+					key={kind}
+					className="inline-flex items-center gap-0.5 rounded-full bg-muted/40 px-2 py-0.5"
+				>
+					<span aria-hidden="true">{REACTION_META[kind].emoji}</span>
+					<span className="sr-only">{REACTION_META[kind].label}</span>
+					<span>{count}</span>
+				</span>
+			))}
+			<span className="ml-1 text-muted-foreground">· {total} 件</span>
+		</div>
+	);
+}

--- a/client/src/components/reactions/__tests__/ReactionSummary.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionSummary.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for ReactionSummary (#383).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ReactionSummary from "@/components/reactions/ReactionSummary";
+
+describe("ReactionSummary", () => {
+	it("renders nothing when total is 0", () => {
+		const { container } = render(
+			<ReactionSummary summary={{ counts: {}, my_kind: null }} />,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing when all counts are explicitly 0", () => {
+		const { container } = render(
+			<ReactionSummary
+				summary={{
+					counts: {
+						like: 0,
+						interesting: 0,
+						learned: 0,
+						helpful: 0,
+						agree: 0,
+						surprised: 0,
+						congrats: 0,
+						respect: 0,
+						funny: 0,
+						code: 0,
+					},
+					my_kind: null,
+				}}
+			/>,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders top kinds sorted by count desc", () => {
+		render(
+			<ReactionSummary
+				summary={{
+					counts: { like: 4, learned: 3, agree: 2, helpful: 1 },
+					my_kind: null,
+				}}
+			/>,
+		);
+		const group = screen.getByRole("group", { name: "リアクションの内訳" });
+		// emoji + count が表示される
+		expect(group.textContent).toContain("❤️");
+		expect(group.textContent).toContain("4");
+		expect(group.textContent).toContain("📚");
+		expect(group.textContent).toContain("3");
+		expect(group.textContent).toContain("👍");
+		expect(group.textContent).toContain("2");
+	});
+
+	it("hides kinds beyond maxVisibleKinds (default 3)", () => {
+		render(
+			<ReactionSummary
+				summary={{
+					counts: { like: 10, learned: 5, agree: 3, helpful: 2, funny: 1 },
+					my_kind: null,
+				}}
+			/>,
+		);
+		const group = screen.getByRole("group", { name: "リアクションの内訳" });
+		// top 3: like, learned, agree → 表示
+		expect(group.textContent).toContain("❤️");
+		expect(group.textContent).toContain("📚");
+		expect(group.textContent).toContain("👍");
+		// 4th 以降は表示しない
+		expect(group.textContent).not.toContain("🙏");
+		expect(group.textContent).not.toContain("😂");
+	});
+
+	it("respects custom maxVisibleKinds", () => {
+		render(
+			<ReactionSummary
+				summary={{
+					counts: { like: 5, learned: 3 },
+					my_kind: null,
+				}}
+				maxVisibleKinds={1}
+			/>,
+		);
+		const group = screen.getByRole("group", { name: "リアクションの内訳" });
+		expect(group.textContent).toContain("❤️");
+		expect(group.textContent).not.toContain("📚");
+	});
+
+	it("shows total count at the end", () => {
+		render(
+			<ReactionSummary
+				summary={{
+					counts: { like: 4, learned: 3, agree: 2 },
+					my_kind: null,
+				}}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "リアクションの内訳" }).textContent,
+		).toContain("9 件");
+	});
+
+	it("breaks ties by REACTION_KINDS declaration order", () => {
+		// like と interesting が同数 → REACTION_KINDS の宣言順 (like → interesting)
+		// に従って like が先に来る。
+		render(
+			<ReactionSummary
+				summary={{
+					counts: { like: 2, interesting: 2 },
+					my_kind: null,
+				}}
+			/>,
+		);
+		const group = screen.getByRole("group", { name: "リアクションの内訳" });
+		const text = group.textContent ?? "";
+		const likeIdx = text.indexOf("❤️");
+		const interestingIdx = text.indexOf("💡");
+		expect(likeIdx).toBeGreaterThanOrEqual(0);
+		expect(interestingIdx).toBeGreaterThan(likeIdx);
+	});
+
+	it("does not depend on viewer my_kind (集計は全 viewer 共通)", () => {
+		const summaryA = { counts: { like: 3 }, my_kind: "like" as const };
+		const summaryB = { counts: { like: 3 }, my_kind: null };
+		const { container: cA } = render(<ReactionSummary summary={summaryA} />);
+		const { container: cB } = render(<ReactionSummary summary={summaryB} />);
+		// my_kind が違っても DOM 出力は同じ (集計表示のみ)
+		expect(cA.textContent).toBe(cB.textContent);
+	});
+});

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -15,6 +15,7 @@ import DOMPurify from "isomorphic-dompurify";
 import { MoreHorizontal, Trash2 } from "lucide-react";
 import { toast } from "react-toastify";
 import ReactionBar from "@/components/reactions/ReactionBar";
+import ReactionSummary from "@/components/reactions/ReactionSummary";
 import ExpandableBody from "@/components/timeline/ExpandableBody";
 import PostDialog from "@/components/tweets/PostDialog";
 import RepostButton from "@/components/tweets/RepostButton";
@@ -471,6 +472,12 @@ export default function TweetCard({
 				<QuoteEmbed tweet={displayTweet.quote_of} />
 			)}
 
+			{/* #383: reaction の kind 別ブレイクダウン (FB / Threads 風)。
+			    総数 0 のときは ReactionSummary 内部で null を返す。 */}
+			{displayTweet.reaction_summary && (
+				<ReactionSummary summary={displayTweet.reaction_summary} />
+			)}
+
 			{/* Action buttons. Reactions wired in P2-14, repost/quote/reply in P2-15.
 			    #327: count badge を 0 以上で表示。tweet.is_deleted のとき disable
 			    (実際には is_deleted は早期 return で tombstone なので、ここでは
@@ -552,7 +559,10 @@ export default function TweetCard({
 					})()}
 				</div>
 
-				<ReactionBar tweetId={displayTweet.id} />
+				<ReactionBar
+					tweetId={displayTweet.id}
+					initial={displayTweet.reaction_summary}
+				/>
 			</footer>
 
 			<PostDialog

--- a/client/src/lib/api/tweets.ts
+++ b/client/src/lib/api/tweets.ts
@@ -4,6 +4,7 @@
 
 import type { AxiosInstance } from "axios";
 import { api, ensureCsrfToken } from "@/lib/api/client";
+import type { ReactionAggregate } from "@/lib/api/reactions";
 
 export interface TweetImagePayload {
 	image_url: string;
@@ -44,6 +45,8 @@ export interface TweetMini {
 	repost_count?: number;
 	quote_count?: number;
 	reaction_count?: number;
+	/** #383: reaction kind 別集計 + viewer 別 my_kind. */
+	reaction_summary?: ReactionAggregate;
 	quote_of?: TweetMini | null;
 	reposted_by_me?: boolean;
 }
@@ -70,6 +73,8 @@ export interface TweetSummary {
 	repost_count?: number;
 	quote_count?: number;
 	reaction_count?: number;
+	/** #383: reaction kind 別集計 + viewer 別 my_kind. */
+	reaction_summary?: ReactionAggregate;
 	reply_to?: TweetMini | null;
 	quote_of?: TweetMini | null;
 	repost_of?: TweetMini | null;

--- a/docs/specs/reactions-e2e-commands.md
+++ b/docs/specs/reactions-e2e-commands.md
@@ -137,6 +137,15 @@ npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line 
 
 # RCT-32: Alt+Enter キーで picker 開閉 (#381 / #187)
 npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-32"
+
+# RCT-33: trigger emoji は viewer 視点 (#383)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-33"
+
+# RCT-34: ReactionSummary は total=0 で非表示 (#383)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-34"
+
+# RCT-35: ReactionSummary は count 降順で上位 N 種を表示 (#383)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-35"
 ```
 
 ## 5. Phase 2 既存 golden path との関係

--- a/docs/specs/reactions-scenarios.md
+++ b/docs/specs/reactions-scenarios.md
@@ -574,6 +574,83 @@
 - 続けて `Alt+Enter` で close (toggle)。
 - a11y: 長押しが使えないキーボードユーザ向けの代替 (SPEC §6.2)。
 
+### RCT-33: trigger emoji は viewer 視点で決まる (#383)
+
+前提:
+
+- target tweet T (作者: B)。
+- 過去に actor A が T に like を付けている (`A.my_kind="like"`)。
+- viewer C は T に reaction していない (`C.my_kind=null`)。
+
+操作:
+
+- A が T を表示する (例: `/tweet/<T.id>`)。
+- 同時刻に C が同じ T を表示する。
+- 同時刻に匿名ユーザが同じ T を表示する。
+
+期待結果:
+
+- API レスポンス: 同じ tweet でも `reaction_summary.my_kind` は **viewer 別** に変わる。
+  - A 視点: `my_kind="like"` (200)
+  - C 視点: `my_kind=null`
+  - 匿名: `my_kind=null`
+- UI: A の trigger は `❤️ {total}` (lime 強調、aria-pressed=true)。
+- UI: C の trigger は `👍 {total}` (default、aria-pressed=false)。
+- UI: 匿名の trigger も `👍 {total}` (login 後に reaction 可能、未認証で trigger 押下すると 401 → toast)。
+- `reaction_summary.counts` は **全 viewer 共通** で同じ値 (集計は viewer に依存しない)。
+
+### RCT-34: ReactionSummary は total === 0 のときに何も表示しない (#383)
+
+前提:
+
+- target tweet T に reaction が一切付いていない (`reaction_count=0`)。
+
+操作:
+
+- 任意の viewer が T を表示する。
+
+期待結果:
+
+- UI: tweet カード内に `role="group" aria-label="リアクションの内訳"` 要素は **存在しない**。
+- footer (action button 列) は通常通り表示される。
+- 「0 件のリアクション」のような empty placeholder は出さない (FB / Threads と同じ)。
+
+### RCT-35: ReactionSummary は count 降順で sort し、上位 N 種だけ表示する (#383)
+
+前提:
+
+- target tweet T に以下の reaction が付いている: like=4, learned=3, agree=2, helpful=1。
+- `maxVisibleKinds` の default = 3。
+
+操作:
+
+- viewer が T を表示する。
+
+期待結果:
+
+- UI: ReactionSummary に **上位 3 種** が表示される: `❤️ 4 📚 3 👍 2 · 10 件`。
+  - 順序は count 降順、tie の場合は `REACTION_KINDS` の宣言順 (`like → interesting → ... → code`)。
+- UI: 4 番目以降 (`helpful=1`) は **表示されない** が、末尾の総計 `10 件` には含まれる。
+- a11y: 各 chip は `aria-hidden="true"` の emoji + `sr-only` の kind label (`いいね 4` のように SR が読み上げる)。
+
+### RCT-36: ReactionSummary は viewer 別の my_kind を区別しない (集計は全 viewer 共通) (#383)
+
+前提:
+
+- target tweet T に reaction `like=3` が付いている。
+- viewer A は T に like 済み (`my_kind="like"`)。
+- viewer B は T に reaction していない (`my_kind=null`)。
+
+操作:
+
+- A と B がそれぞれ T を表示する。
+
+期待結果:
+
+- UI: ReactionSummary の表示は A と B で **同一** (`❤️ 3 · 3 件`)。
+- UI: trigger は viewer 別 (RCT-33): A は `❤️`, B は `👍`。
+- = ReactionSummary は集計表示のみ、viewer 状態は trigger (ReactionBar) が担当という分業。
+
 ## 4. E2E化メモ
 
 各 E2E は上記の `RCT-XX` をテスト名に含める。

--- a/docs/specs/reactions-spec.md
+++ b/docs/specs/reactions-spec.md
@@ -178,6 +178,44 @@ drift が発生する経路:
 - `transaction.on_commit` で signal を発行する間に DB rollback / replica lag。
 - `Reaction.objects.bulk_create / bulk_delete` (signals が発火しない) → **MVP では bulk 操作禁止**。
 
+### 2.10 Tweet serializer に埋め込む `reaction_summary` (#383)
+
+各 Tweet を返す API レスポンス (`/api/v1/timeline/*`, `/api/v1/tweets/<id>/`, `/api/v1/search/` 等) は、Tweet ごとに **`reaction_summary` フィールド** を含む。
+
+形:
+
+```json
+{
+  "id": 17,
+  ...,
+  "reaction_count": 9,
+  "reaction_summary": {
+    "counts": {
+      "like": 4,
+      "interesting": 3,
+      "learned": 0,
+      "helpful": 0,
+      "agree": 2,
+      "surprised": 0,
+      "congrats": 0,
+      "respect": 0,
+      "funny": 0,
+      "code": 0
+    },
+    "my_kind": "like"
+  }
+}
+```
+
+要点:
+
+- `counts` は **必ず 10 kind 全部** を含む (0 埋め)。`/api/v1/tweets/<id>/reactions/` GET と同形。
+- `my_kind` は **viewer (request.user) 別**。匿名なら `null`、未 reaction も `null`、reaction 済みなら kind 値。
+- `sum(counts.values())` と `reaction_count` は signals + reconcile Beat で整合する (§2.9)。
+- 個別の `/reactions/` GET は **不要になる** (= フロントは tweet 取得 1 回で集計 + viewer 状態を取れる)。
+- 実装は `apps/tweets/serializers.py::_build_reaction_summary(tweet, request)`。`TweetBaseMiniSerializer` / `TweetMiniSerializer` / `TweetListSerializer` / `TweetDetailSerializer` 全てから返る。
+- 性能: MVP は `SerializerMethodField` で 1〜2 query/tweet。timeline 20 件で 〜40 query。問題化したら view 側で `prefetch_related("reactions")` または raw SQL に最適化する (TODO)。
+
 ---
 
 ## 3. 状態遷移図
@@ -219,6 +257,8 @@ stateDiagram-v2
 ### 4.1 ReactionBar UI 描画
 
 `#381` で **Facebook 風 UX** に変更。trigger は単一の "👍 (Good)" ボタンとして表示し、click は **常に like トグル**、長押しで picker を開く。別 kind に変えたい場合は長押しから選ぶ。
+
+**重要 (#383): trigger 表示は viewer 視点**。`my_kind` は API レスポンス内で **request.user 別** に計算されるので、自分が like 済みの tweet を自分が見れば ❤️、同じ tweet を他人が見れば (その人が未 reaction なら) 👍。匿名閲覧時は常に 👍 (`my_kind=null`)。tweet API 取得時に `reaction_summary` を一緒に返している (§2.10) ので、初期表示も viewer 別の値で正しく出る。
 
 | 状態           | trigger 表示                     | aria-pressed | aria-label                                    |
 | -------------- | -------------------------------- | ------------ | --------------------------------------------- |
@@ -286,6 +326,39 @@ picker 内の grid (`role="group"`) は #379 で確定済の挙動を維持:
 | Rate limit 超過     | POST                          | -                    | -                                           | -                        | 429 + `Retry-After`. UI は toast 表示                    |
 | 認証なし            | POST or DELETE                | -                    | -                                           | -                        | 401. UI は LoginCTA を表示                               |
 | 未ログイン          | GET                           | -                    | `GET /tweets/<id>/reactions/`               | counts のみ              | `my_kind=null`                                           |
+
+### 4.3 ReactionSummary (kind 別ブレイクダウン表示, #383)
+
+ツイート本文と footer (action button 列) の **間** に、Facebook / Threads / カロッター 慣習の reaction breakdown を表示する。
+
+`client/src/components/reactions/ReactionSummary.tsx` が正本。受け取る props は `summary: ReactionAggregate` (`{counts, my_kind}`)。
+
+#### 表示ルール
+
+| 条件          | 表示                                                                                                                                |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `total === 0` | **何も表示しない** (FB と同じ。0 件の tweet でゴチャつかせない)                                                                     |
+| `total > 0`   | `<role="group" aria-label="リアクションの内訳">` 内に上位 N 種の絵文字 + count を chip 状に並べ、末尾に総計 `· {total} 件` を付ける |
+
+- N の default は **3**。`maxVisibleKinds` props で上書き可。
+- sort 順は **count 降順** (tie は `REACTION_KINDS` の宣言順 `like → interesting → learned → ...`)。
+- 0 件の kind は表示対象から除外 (= 上位 N 種は **必ず count > 0**)。
+- 例: `❤️ 4  📚 3  👍 2 · 9 件`
+
+#### viewer との関係
+
+- ReactionSummary は **集計 (count) のみ** を表示し、viewer 別の `my_kind` は **使わない**。
+- 「自分が like 済みかどうか」は trigger 側 (ReactionBar) が `aria-pressed` と emoji 切り替えで担当する。役割分業を明確化することで、ReactionSummary は server data をそのまま投影する pure rendering になる。
+
+#### 配置
+
+`client/src/components/timeline/TweetCard.tsx` で本文 (ExpandableBody) → 引用元 embed → **ReactionSummary** → footer (action button 列) の順で並べる。Facebook の post カードと同じ位置関係。
+
+#### a11y
+
+- `role="group"` + `aria-label="リアクションの内訳"` で SR にグループ化を伝える。
+- 各 chip は emoji を `aria-hidden="true"` で隠し、`<span class="sr-only">` で kind label を読ませる (`いいね 4` のように発音)。
+- 純粋な情報表示で interactive ではない (= focusable な要素無し)。kind 別の操作は ReactionBar の picker で行う。
 
 ---
 


### PR DESCRIPTION
## 関連 Issue

Closes #383

## ハルナさん指摘

> いいねマークが変わるのは自分視点だけね。他の人が同じツイートを見ても
> その人がいいねしていなければグッドボタンが表示されるようにしてね。
> あと、facebook とか最近出てきたカロッターみたいに、ツイートの下に、
> リアクション数が多い順で例えばハートマークが4つついていて、発見マーク
> が3つついていて、というふうにわかるようにしてほしい。

## 主な変更

### 1. Backend: 各 tweet に `reaction_summary` を埋め込み

`apps/tweets/serializers.py`:
- `_build_reaction_summary(tweet, request)` helper を追加
- `TweetBaseMiniSerializer` / `TweetListSerializer` に `reaction_summary` SerializerMethodField
- 形は GET /reactions/ と同一: `{counts: {10 kinds 0-fill}, my_kind: kind|null}`
- Timeline / detail / search / nested embed すべてのレスポンスに自動で付与

これで `/api/v1/timeline/*` を 1 回叩けば各 tweet の **集計 + viewer 別 my_kind** が取れる (= 個別 `/reactions/` GET が不要に)。

### 2. Frontend: viewer 別 trigger emoji の **正しい初期表示**

これまで TweetCard が `<ReactionBar tweetId={...} />` を初期値なしで mount していたため、自分が like 済みの tweet を再ロードしても 👍 のままだった。

```diff
- <ReactionBar tweetId={displayTweet.id} />
+ <ReactionBar tweetId={displayTweet.id} initial={displayTweet.reaction_summary} />
```

- A が like 済み → A 視点では ❤️ trigger (aria-pressed=true)
- 同じ tweet を B (未 reaction) / 匿名 が見れば 👍 trigger (aria-pressed=false)

### 3. Frontend: ReactionSummary component (Facebook / Threads / カロッター 慣習)

新規 `client/src/components/reactions/ReactionSummary.tsx`:

- 表示位置: tweet 本文と footer の間 (FB の post カードと同じ位置関係)
- count 降順 sort、tie は `REACTION_KINDS` 宣言順
- default で上位 3 種、`maxVisibleKinds` props で上書き可
- `total === 0` のときは何も render しない
- a11y: `role="group" aria-label="リアクションの内訳"`、emoji は `aria-hidden`、sr-only で kind label

例: `❤️ 4  📚 3  👍 2 · 9 件`

## 仕様書 (docs/specs/) 更新

- `reactions-spec.md` §2.10 (新設): `reaction_summary` API field の shape + 性能ノート
- `reactions-spec.md` §4.1: trigger 表示が viewer 視点で決まることを明記
- `reactions-spec.md` §4.3 (新設): ReactionSummary の表示ルール / 配置 / a11y
- `reactions-scenarios.md` に RCT-33〜36:
  - RCT-33 viewer 別の trigger (A=❤️, B/匿名=👍)
  - RCT-34 total=0 で ReactionSummary 非表示
  - RCT-35 count 降順で上位 N 種表示
  - RCT-36 集計は viewer 共通 (my_kind には依存しない)
- `reactions-e2e-commands.md` に RCT-33〜35 のコマンド追加

## テスト

### backend (pytest)

`apps/tweets/tests/test_reaction_summary.py` (新規):
- 0 件で 10 kind 全 0 埋め
- counts が aggregate される
- my_kind が viewer 別 (u1 / u2 / 匿名)
- TweetDetail / TweetMini でも返る
- `/api/v1/tweets/<id>/` API で `reaction_summary` が含まれる

### frontend (vitest)

`ReactionSummary.test.tsx` (新規) - 8 件:
- total=0 で non-render
- 全 count=0 で non-render
- 上位 N 種を count 降順で表示
- maxVisibleKinds で上限変更
- 末尾に総計 件数表示
- tie-break が `REACTION_KINDS` 宣言順
- viewer 別 my_kind に依存しない

✅ tsc / eslint クリーン
✅ vitest: ReactionSummary 8 + 既存 ReactionBar 17 + TweetCard / HomeFeed 関連 = **122/123 緑** + 1 todo

### E2E

`reactions-scenarios.spec.ts` に RCT-33/34/35 を追加 (viewer 別 trigger / 0 件非表示 / 1 件以上で内訳表示)。

## Test plan

- [x] vitest 緑
- [x] tsc / eslint クリーン
- [ ] CI 緑確認
- [ ] stg deploy 後、Playwright MCP で実機確認
  - 自分が like 済の tweet が ❤️ で表示される
  - 他人視点では 👍 のまま
  - reaction が付いた tweet で `❤️ N · N 件` 形式の summary が表示される

## 影響範囲

- 全 tweet API レスポンス (timeline / detail / search / embed) に `reaction_summary` が追加 (フィールド追加のみ、既存フィールドは互換)
- 全 ReactionBar インスタンスが viewer 正しい初期表示になる
- 全 TweetCard に ReactionSummary が表示される (count > 0 のときのみ)