### PR TITLE
[fix][reactions] ReactionSummary: 総計件数撤去 + リアルタイム反映 (#385)

### DIFF
--- a/client/e2e/reactions-scenarios.spec.ts
+++ b/client/e2e/reactions-scenarios.spec.ts
@@ -808,7 +808,7 @@ test.describe("Reactions UI (ReactionBar)", () => {
 		}
 	});
 
-	test("RCT-35 UI: ReactionSummary が count > 0 で表示される (#383)", async ({
+	test("RCT-35 UI: ReactionSummary が count > 0 で表示される (総計件数は出さない #385)", async ({
 		page,
 	}) => {
 		const tweetId = await postTweetAs(USER2, `RCT-35 ${Date.now()}`);
@@ -833,7 +833,40 @@ test.describe("Reactions UI (ReactionBar)", () => {
 			});
 			await expect(summary).toBeVisible({ timeout: 10_000 });
 			await expect(summary).toContainText("❤️");
-			await expect(summary).toContainText("1 件");
+			// #385: 「· N 件」総計表示は撤去
+			const text = (await summary.textContent()) ?? "";
+			expect(text).not.toMatch(/\d+ 件/);
+			expect(text).not.toContain("·");
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
+
+	test("RCT-37 UI: ReactionSummary はリロードせず即時反映する (#385)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-37 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			// 初期: 0 件 → ReactionSummary は非表示
+			await expect(
+				page.getByRole("group", { name: "リアクションの内訳" }),
+			).toHaveCount(0);
+			// trigger を short-click → quick toggle で like
+			await quickToggleUI(page, tweetId);
+			// リロードせずに ReactionSummary が出現する
+			const summary = page.getByRole("group", {
+				name: "リアクションの内訳",
+			});
+			await expect(summary).toBeVisible({ timeout: 5_000 });
+			await expect(summary).toContainText("❤️");
+			// もう一度 click → 取消、ReactionSummary が即座に消える
+			await quickToggleUI(page, tweetId);
+			await expect(
+				page.getByRole("group", { name: "リアクションの内訳" }),
+			).toHaveCount(0);
 		} finally {
 			await clearReactionAs(USER1, tweetId);
 			await deleteTweetAs(USER2, tweetId);

--- a/client/src/components/reactions/ReactionBar.tsx
+++ b/client/src/components/reactions/ReactionBar.tsx
@@ -49,6 +49,12 @@ import {
 interface ReactionBarProps {
 	tweetId: number;
 	initial?: ReactionAggregate;
+	/**
+	 * #385: 内部 state が変化するたびに呼び出される callback。
+	 * TweetCard が ReactionSummary をリアルタイムに更新するために使う。
+	 * optimistic update / API 反映 / rollback いずれの遷移でも発火する。
+	 */
+	onChange?: (next: ReactionAggregate) => void;
 }
 
 const EMPTY: ReactionAggregate = { counts: {}, my_kind: null };
@@ -56,13 +62,25 @@ const LONG_PRESS_MS = 500;
 const QUICK_KIND: ReactionKind = "like";
 const DEFAULT_TRIGGER_EMOJI = "👍";
 
-export default function ReactionBar({ tweetId, initial }: ReactionBarProps) {
+export default function ReactionBar({
+	tweetId,
+	initial,
+	onChange,
+}: ReactionBarProps) {
 	const [state, setState] = useState<ReactionAggregate>(initial ?? EMPTY);
 	const [open, setOpen] = useState(false);
 	const [busyKind, setBusyKind] = useState<ReactionKind | null>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const longPressFiredRef = useRef(false);
+	// #385: state 変化時に onChange を発火させる。useState の updater 内で
+	// 直接呼ぶと React の strict-mode / concurrent rendering で副作用扱いに
+	// なるため、useEffect で state に紐付けて呼ぶ。
+	const onChangeRef = useRef(onChange);
+	onChangeRef.current = onChange;
+	useEffect(() => {
+		onChangeRef.current?.(state);
+	}, [state]);
 
 	const total = useMemo(
 		() => Object.values(state.counts).reduce((a, b) => a + (b ?? 0), 0),

--- a/client/src/components/reactions/ReactionSummary.tsx
+++ b/client/src/components/reactions/ReactionSummary.tsx
@@ -1,20 +1,20 @@
 "use client";
 
 /**
- * ReactionSummary — tweet 本文の下に表示するリアクションのブレイクダウン (#383).
+ * ReactionSummary — tweet 本文の下に表示するリアクションのブレイクダウン (#383, #385).
  *
  * Facebook / Threads / カロッター 等の慣習に倣い、ツイートに付いた reaction を
- * 「kind ごとの内訳 + 総計」で要約表示する:
- *   ❤️ 4  💡 3  👍 2  · 9 件
+ * 「kind ごとの内訳」で要約表示する:
+ *   ❤️ 4  💡 3  👍 2
  *
  * 仕様: docs/specs/reactions-spec.md §4.3
  *
  * - `summary.counts` を **count desc** (tie は kind の宣言順) で sort し
  *   上位 `MAX_VISIBLE_KINDS` (default 3) を表示する。
  * - `total === 0` のときは何も render しない (= 0 件のときに目立たないように)。
- * - 末尾に総計件数 (kind を問わない sum) を表示する。
  * - viewer 別の `my_kind` は本 component では区別しない (集計は全 viewer 共通)。
  *   trigger 側 (ReactionBar) が viewer 別の表示を担当する分業。
+ * - #385: 末尾の `· N 件` 総計表示は撤去 (FB 慣習に合わせて kind 内訳のみ)。
  */
 
 import {
@@ -78,7 +78,6 @@ export default function ReactionSummary({
 					<span>{count}</span>
 				</span>
 			))}
-			<span className="ml-1 text-muted-foreground">· {total} 件</span>
 		</div>
 	);
 }

--- a/client/src/components/reactions/__tests__/ReactionBar.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionBar.test.tsx
@@ -75,6 +75,47 @@ describe("ReactionBar — collapsed state", () => {
 	});
 });
 
+describe("ReactionBar — onChange callback (#385)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("invokes onChange with initial state on mount", () => {
+		const onChange = vi.fn();
+		render(
+			<ReactionBar
+				tweetId={1}
+				initial={{ counts: { like: 3 }, my_kind: null }}
+				onChange={onChange}
+			/>,
+		);
+		expect(onChange).toHaveBeenCalled();
+		expect(onChange).toHaveBeenLastCalledWith({
+			counts: { like: 3 },
+			my_kind: null,
+		});
+	});
+
+	it("invokes onChange on optimistic update (click → like)", async () => {
+		vi.mocked(toggleReaction).mockResolvedValue({
+			kind: "like",
+			created: true,
+			changed: false,
+			removed: false,
+		});
+		const onChange = vi.fn();
+		render(<ReactionBar tweetId={1} onChange={onChange} />);
+		const trigger = screen.getByRole("button", { name: /いいね \(長押し/ });
+		await userEvent.click(trigger);
+		// 最後の onChange call には my_kind=like かつ counts.like=1 が入っている
+		await waitFor(() => {
+			const last = onChange.mock.calls.at(-1)?.[0];
+			expect(last?.my_kind).toBe("like");
+			expect(last?.counts?.like).toBe(1);
+		});
+	});
+});
+
 describe("ReactionBar — quick toggle (click) #381", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/client/src/components/reactions/__tests__/ReactionSummary.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionSummary.test.tsx
@@ -90,7 +90,7 @@ describe("ReactionSummary", () => {
 		expect(group.textContent).not.toContain("📚");
 	});
 
-	it("shows total count at the end", () => {
+	it("does NOT show a total count suffix (#385)", () => {
 		render(
 			<ReactionSummary
 				summary={{
@@ -99,9 +99,12 @@ describe("ReactionSummary", () => {
 				}}
 			/>,
 		);
-		expect(
-			screen.getByRole("group", { name: "リアクションの内訳" }).textContent,
-		).toContain("9 件");
+		// #385: 「· 9 件」のような総計表示は撤去 (FB 慣習に合わせる)
+		const text =
+			screen.getByRole("group", { name: "リアクションの内訳" }).textContent ??
+			"";
+		expect(text).not.toMatch(/\d+ 件/);
+		expect(text).not.toContain("·");
 	});
 
 	it("breaks ties by REACTION_KINDS declaration order", () => {

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -241,6 +241,15 @@ export default function TweetCard({
 	const [repostCountOptimistic, setRepostCountOptimistic] = useState(
 		displayTweet.repost_count ?? 0,
 	);
+	// #385: ReactionSummary をリアルタイム反映するため、ReactionBar の内部
+	// state と同期する shared state を持つ。ReactionBar の onChange callback
+	// で更新する。displayTweet.reaction_summary が prop で変わった場合は再同期。
+	const [reactionAggregate, setReactionAggregate] = useState(
+		displayTweet.reaction_summary,
+	);
+	useEffect(() => {
+		setReactionAggregate(displayTweet.reaction_summary);
+	}, [displayTweet.reaction_summary]);
 
 	// #327: 全 hooks は早期 return より前に呼ぶ (React rules of hooks)。
 	// CRITICAL: sanitize HTML before rendering — strips <script>, event handlers,
@@ -473,10 +482,10 @@ export default function TweetCard({
 			)}
 
 			{/* #383: reaction の kind 別ブレイクダウン (FB / Threads 風)。
-			    総数 0 のときは ReactionSummary 内部で null を返す。 */}
-			{displayTweet.reaction_summary && (
-				<ReactionSummary summary={displayTweet.reaction_summary} />
-			)}
+			    総数 0 のときは ReactionSummary 内部で null を返す。
+			    #385: ReactionBar の onChange で更新される共有 state を渡し、
+			    リロードせずに即時反映する。 */}
+			{reactionAggregate && <ReactionSummary summary={reactionAggregate} />}
 
 			{/* Action buttons. Reactions wired in P2-14, repost/quote/reply in P2-15.
 			    #327: count badge を 0 以上で表示。tweet.is_deleted のとき disable
@@ -562,6 +571,7 @@ export default function TweetCard({
 				<ReactionBar
 					tweetId={displayTweet.id}
 					initial={displayTweet.reaction_summary}
+					onChange={setReactionAggregate}
 				/>
 			</footer>
 

--- a/docs/specs/reactions-e2e-commands.md
+++ b/docs/specs/reactions-e2e-commands.md
@@ -146,6 +146,9 @@ npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line 
 
 # RCT-35: ReactionSummary は count 降順で上位 N 種を表示 (#383)
 npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-35"
+
+# RCT-37: ReactionSummary はリロードせず即時反映する (#385)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-37"
 ```
 
 ## 5. Phase 2 既存 golden path との関係

--- a/docs/specs/reactions-scenarios.md
+++ b/docs/specs/reactions-scenarios.md
@@ -615,7 +615,7 @@
 - footer (action button 列) は通常通り表示される。
 - 「0 件のリアクション」のような empty placeholder は出さない (FB / Threads と同じ)。
 
-### RCT-35: ReactionSummary は count 降順で sort し、上位 N 種だけ表示する (#383)
+### RCT-35: ReactionSummary は count 降順で sort し、上位 N 種だけ表示する (#383, #385)
 
 前提:
 
@@ -628,9 +628,10 @@
 
 期待結果:
 
-- UI: ReactionSummary に **上位 3 種** が表示される: `❤️ 4 📚 3 👍 2 · 10 件`。
+- UI: ReactionSummary に **上位 3 種** が表示される: `❤️ 4 📚 3 👍 2`。
   - 順序は count 降順、tie の場合は `REACTION_KINDS` の宣言順 (`like → interesting → ... → code`)。
-- UI: 4 番目以降 (`helpful=1`) は **表示されない** が、末尾の総計 `10 件` には含まれる。
+- UI: 4 番目以降 (`helpful=1`) は **表示されない**。
+- UI: 末尾の総計件数 (`· 10 件` 等) は **表示しない** (#385 で撤去、FB / カロッター 慣習に合わせる)。
 - a11y: 各 chip は `aria-hidden="true"` の emoji + `sr-only` の kind label (`いいね 4` のように SR が読み上げる)。
 
 ### RCT-36: ReactionSummary は viewer 別の my_kind を区別しない (集計は全 viewer 共通) (#383)
@@ -647,9 +648,28 @@
 
 期待結果:
 
-- UI: ReactionSummary の表示は A と B で **同一** (`❤️ 3 · 3 件`)。
+- UI: ReactionSummary の表示は A と B で **同一** (`❤️ 3`)。
 - UI: trigger は viewer 別 (RCT-33): A は `❤️`, B は `👍`。
 - = ReactionSummary は集計表示のみ、viewer 状態は trigger (ReactionBar) が担当という分業。
+
+### RCT-37: ReactionSummary はリロードせず即時反映する (#385)
+
+前提:
+
+- target tweet T に reaction が付いていない (`reaction_count=0`)。
+- viewer A が T を表示している (ReactionSummary は非表示、trigger は `👍 0`)。
+
+操作:
+
+- A が ReactionBar trigger を short-click して like を付ける。
+
+期待結果:
+
+- API: `POST /api/v1/tweets/<T.id>/reactions/` `{kind:"like"}` が発火 → 201。
+- UI (リロード無し): trigger 表示が `❤️ 1` (lime 強調、`aria-pressed=true`)、ReactionSummary が **即座に表示** されて `❤️ 1` が出る。
+- もう一度 trigger を click すると like が取消される → ReactionSummary が **即座に消える** (count=0 で非表示)。
+- 別 kind に変えた場合 (例: 長押し picker → learned を選択) は ReactionSummary も即時 `📚 1` に変わる。
+- 実装: ReactionBar の `onChange` callback で TweetCard の `reactionAggregate` state を更新し、ReactionSummary に渡す。
 
 ## 4. E2E化メモ
 

--- a/docs/specs/reactions-spec.md
+++ b/docs/specs/reactions-spec.md
@@ -335,20 +335,30 @@ picker 内の grid (`role="group"`) は #379 で確定済の挙動を維持:
 
 #### 表示ルール
 
-| 条件          | 表示                                                                                                                                |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `total === 0` | **何も表示しない** (FB と同じ。0 件の tweet でゴチャつかせない)                                                                     |
-| `total > 0`   | `<role="group" aria-label="リアクションの内訳">` 内に上位 N 種の絵文字 + count を chip 状に並べ、末尾に総計 `· {total} 件` を付ける |
+| 条件          | 表示                                                                                                                   |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `total === 0` | **何も表示しない** (FB と同じ。0 件の tweet でゴチャつかせない)                                                        |
+| `total > 0`   | `<role="group" aria-label="リアクションの内訳">` 内に上位 N 種の絵文字 + count を chip 状に並べる (総計件数は出さない) |
 
 - N の default は **3**。`maxVisibleKinds` props で上書き可。
 - sort 順は **count 降順** (tie は `REACTION_KINDS` の宣言順 `like → interesting → learned → ...`)。
 - 0 件の kind は表示対象から除外 (= 上位 N 種は **必ず count > 0**)。
-- 例: `❤️ 4  📚 3  👍 2 · 9 件`
+- 例: `❤️ 4  📚 3  👍 2`
+- **#385**: 当初 (#383) は末尾に `· {total} 件` を表示していたが、FB / カロッター の慣習に合わせて撤去。kind 内訳のみ。
+
+#### リアルタイム反映 (#385)
+
+ReactionBar からの `onChange(aggregate)` callback を介して `ReactionSummary` をリアルタイム更新する。
+
+- ReactionBar は内部 state が変化するたびに `useEffect([state])` で `onChange?.(state)` を呼ぶ (mount 時の初回 + optimistic update + API 反映 + rollback いずれの遷移でも発火)。
+- TweetCard は `reactionAggregate` shared state を持ち、`<ReactionSummary summary={reactionAggregate} />` と `<ReactionBar onChange={setReactionAggregate} />` で同期する。
+- 結果として、reaction 0 件の tweet に like を付けると **リロード無しで** ReactionSummary に `❤️ 1` が即座に表示される。取消すと即座に消える (count=0 で非表示に戻る)。
+- TweetCard は `displayTweet.reaction_summary` が prop で更新された場合 (= 親コンポーネントが新しい server data を渡してきた場合) も `useEffect` で再同期する。
 
 #### viewer との関係
 
 - ReactionSummary は **集計 (count) のみ** を表示し、viewer 別の `my_kind` は **使わない**。
-- 「自分が like 済みかどうか」は trigger 側 (ReactionBar) が `aria-pressed` と emoji 切り替えで担当する。役割分業を明確化することで、ReactionSummary は server data をそのまま投影する pure rendering になる。
+- 「自分が like 済みかどうか」は trigger 側 (ReactionBar) が `aria-pressed` と emoji 切り替えで担当する。役割分業を明確化することで、ReactionSummary は state をそのまま投影する pure rendering になる。
 
 #### 配置
 


### PR DESCRIPTION
## 関連 Issue

Closes #385

## ハルナさん指摘

> ❤️ 4・4 件 とかなっているじゃないですか。この 4 件というのいらないです。 ❤️ 4 だけでいいです。
> あと、リアクションしてからロードしないと ❤️ 4 が 5 に更新されないです。FB ではそんなことありません。リロードしなくても更新されるようにして。

## 修正

### 1. ReactionSummary の `· N 件` 総計を撤去

`client/src/components/reactions/ReactionSummary.tsx`: 末尾の `<span>· {total} 件</span>` を削除。FB / カロッター の慣習に合わせて kind 内訳のみ表示。

```diff
- <span className="ml-1 text-muted-foreground">· {total} 件</span>
```

### 2. リアクション後に ReactionSummary を即時反映

ReactionBar の内部 state を TweetCard の shared state に lift up:

- `ReactionBar` に `onChange?: (next: ReactionAggregate) => void` props を追加
- 内部 state 変化のたびに `useEffect([state])` で `onChange` を呼ぶ (mount 時 + optimistic update + API 反映 + rollback)
- `TweetCard` が `reactionAggregate` を useState で保持、ReactionBar の onChange で更新、`<ReactionSummary summary={reactionAggregate} />` に渡す
- `displayTweet.reaction_summary` が prop で更新された場合は useEffect で再同期

結果として:
- 0 件 tweet に like を付けた瞬間 `❤️ 1` が画面下部に表示される (リロード不要)
- 取消すと即座に消える (count=0 で非表示)
- 別 kind に変更すると即時 emoji 切り替え

## 仕様書 (docs/specs/) 更新

- `reactions-spec.md` §4.3:
  - 「表示ルール」: 総計表示を撤去、例を `❤️ 4 📚 3 👍 2` に
  - 「リアルタイム反映 (#385)」: ReactionBar onChange → TweetCard shared state → ReactionSummary の経路を明記
- `reactions-scenarios.md`:
  - RCT-35 期待結果から「件数」表示を削除
  - **RCT-37** (リアルタイム反映) を新規追加
- `reactions-e2e-commands.md`: RCT-37 コマンド追加

## テスト

### vitest (前 PR から +2 件)

- `ReactionSummary.test.tsx`: 「shows total count at the end」を「does NOT show a total count suffix (#385)」に書き換え (`/\d+ 件/` と「·」が含まれない assertion)
- `ReactionBar.test.tsx`: onChange callback の発火を検証する 2 件追加
  - mount 時に initial で発火
  - optimistic update で `my_kind`/`counts.like=1` を含む aggregate で発火
- ✅ 計 124/125 緑 + 1 todo
- ✅ tsc / eslint クリーン (eslint warning は既存の Tailwind class order のみ)

### E2E

- RCT-35 を「総計件数なし」前提に書き換え (`/\d+ 件/` 不在を assert)
- **RCT-37** 新規: 0 件 tweet → quick toggle → ReactionSummary 出現 → quick toggle → 消える の流れを **リロード無し** で検証

## Test plan

- [x] vitest 緑
- [x] tsc / eslint クリーン
- [ ] CI 緑確認
- [ ] stg deploy 後、Playwright MCP で実機確認:
  - 既存 reaction tweet で `❤️ N` のみ表示 (`· N 件` がない)
  - 0 件 tweet に like を付けると即時 `❤️ 1` が画面下部に出る (リロード不要)