### PR TITLE
[feature][reactions] like を Facebook 風 ThumbsUp icon に: 白抜き → 青塗り (#387)

### DIFF
--- a/client/e2e/reactions-scenarios.spec.ts
+++ b/client/e2e/reactions-scenarios.spec.ts
@@ -872,4 +872,32 @@ test.describe("Reactions UI (ReactionBar)", () => {
 			await deleteTweetAs(USER2, tweetId);
 		}
 	});
+
+	test("RCT-38 UI: like は ThumbsUp SVG (default outlined / active blue-fill) (#387)", async ({
+		page,
+	}) => {
+		const tweetId = await postTweetAs(USER2, `RCT-38 ${Date.now()}`);
+		try {
+			await loginUI(page, USER1.email, USER1.password);
+			await openTweet(page, tweetId);
+			const trigger = await reactionTrigger(page);
+			// 初期 (my_kind=null): trigger 内の ThumbsUp svg は fill="none"
+			const initialFill = await trigger
+				.locator("svg")
+				.first()
+				.getAttribute("fill");
+			expect(initialFill).toBe("none");
+			// quick toggle で like
+			await quickToggleUI(page, tweetId);
+			await expect(trigger).toHaveAttribute("aria-pressed", "true");
+			// active 後: ThumbsUp svg が fill="currentColor" + 青色
+			const activeSvg = trigger.locator("svg").first();
+			await expect(activeSvg).toHaveAttribute("fill", "currentColor");
+			const triggerClass = (await trigger.getAttribute("class")) ?? "";
+			expect(triggerClass).toContain("text-blue-500");
+		} finally {
+			await clearReactionAs(USER1, tweetId);
+			await deleteTweetAs(USER2, tweetId);
+		}
+	});
 });

--- a/client/src/components/reactions/ReactionBar.tsx
+++ b/client/src/components/reactions/ReactionBar.tsx
@@ -38,6 +38,8 @@ import {
 } from "react";
 import { toast } from "react-toastify";
 
+import ReactionLikeIcon from "@/components/reactions/ReactionLikeIcon";
+
 import {
 	REACTION_KINDS,
 	REACTION_META,
@@ -60,7 +62,6 @@ interface ReactionBarProps {
 const EMPTY: ReactionAggregate = { counts: {}, my_kind: null };
 const LONG_PRESS_MS = 500;
 const QUICK_KIND: ReactionKind = "like";
-const DEFAULT_TRIGGER_EMOJI = "👍";
 
 export default function ReactionBar({
 	tweetId,
@@ -87,9 +88,6 @@ export default function ReactionBar({
 		[state.counts],
 	);
 	const myActive = state.my_kind;
-	const triggerEmoji = myActive
-		? REACTION_META[myActive].emoji
-		: DEFAULT_TRIGGER_EMOJI;
 	const triggerSrLabel = myActive
 		? `${REACTION_META[myActive].label}を取消 (長押しで他のリアクション)`
 		: "いいね (長押しで他のリアクション)";
@@ -236,12 +234,20 @@ export default function ReactionBar({
 				onPointerLeave={handlePointerUpOrCancel}
 				onKeyDown={onTriggerKeyDown}
 				className={`flex min-h-[32px] touch-manipulation select-none items-center gap-1 rounded px-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-					myActive
-						? "text-lime-700 dark:text-lime-300"
-						: "text-muted-foreground hover:text-foreground"
+					myActive === "like"
+						? "text-blue-500"
+						: myActive
+							? "text-lime-700 dark:text-lime-300"
+							: "text-muted-foreground hover:text-foreground"
 				}`}
 			>
-				<span aria-hidden="true">{triggerEmoji}</span>
+				{/* #387: my_kind=like は青塗り ThumbsUp、my_kind=null は白抜き
+				    ThumbsUp、その他の kind は emoji で表示。 */}
+				{myActive === "like" || myActive === null ? (
+					<ReactionLikeIcon active={myActive === "like"} />
+				) : (
+					<span aria-hidden="true">{REACTION_META[myActive].emoji}</span>
+				)}
 				<span aria-hidden="true">{total}</span>
 				<span className="sr-only">
 					(現在の合計 {total} 件、長押しまたは Alt+Enter で他のリアクション)
@@ -258,6 +264,7 @@ export default function ReactionBar({
 						const meta = REACTION_META[kind];
 						const count = state.counts[kind] ?? 0;
 						const isMine = state.my_kind === kind;
+						const isLike = kind === "like";
 						return (
 							<button
 								key={kind}
@@ -268,11 +275,17 @@ export default function ReactionBar({
 								onClick={() => handlePick(kind)}
 								className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
 									isMine
-										? "bg-lime-500/20 text-lime-700 dark:text-lime-300"
+										? isLike
+											? "bg-blue-500/20 text-blue-500"
+											: "bg-lime-500/20 text-lime-700 dark:text-lime-300"
 										: "hover:bg-muted"
 								} disabled:opacity-50`}
 							>
-								<span aria-hidden="true">{meta.emoji}</span>
+								{isLike ? (
+									<ReactionLikeIcon active={isMine} />
+								) : (
+									<span aria-hidden="true">{meta.emoji}</span>
+								)}
 								<span>{count}</span>
 							</button>
 						);

--- a/client/src/components/reactions/ReactionLikeIcon.tsx
+++ b/client/src/components/reactions/ReactionLikeIcon.tsx
@@ -1,0 +1,33 @@
+/**
+ * ReactionLikeIcon — Facebook 風の Like (ThumbsUp) アイコン (#387).
+ *
+ * 仕様: docs/specs/reactions-spec.md §4.1 / §4.3
+ *
+ * - `active=true`  → 青塗りつぶし ThumbsUp (FB Like 状態)
+ * - `active=false` → 白抜き ThumbsUp (灰色 / 未 Like)
+ *
+ * `like` kind 専用。他の kind (interesting, learned, ...) は `REACTION_META`
+ * の emoji を直接 render する。
+ */
+
+import { ThumbsUp } from "lucide-react";
+
+interface ReactionLikeIconProps {
+	active: boolean;
+	className?: string;
+}
+
+export default function ReactionLikeIcon({
+	active,
+	className,
+}: ReactionLikeIconProps) {
+	const baseSize = "size-4";
+	const colorClass = active ? "text-blue-500" : "text-muted-foreground";
+	return (
+		<ThumbsUp
+			aria-hidden="true"
+			className={`${baseSize} ${colorClass} ${className ?? ""}`.trim()}
+			fill={active ? "currentColor" : "none"}
+		/>
+	);
+}

--- a/client/src/components/reactions/ReactionSummary.tsx
+++ b/client/src/components/reactions/ReactionSummary.tsx
@@ -17,6 +17,7 @@
  * - #385: 末尾の `· N 件` 総計表示は撤去 (FB 慣習に合わせて kind 内訳のみ)。
  */
 
+import ReactionLikeIcon from "@/components/reactions/ReactionLikeIcon";
 import {
 	REACTION_KINDS,
 	REACTION_META,
@@ -73,7 +74,12 @@ export default function ReactionSummary({
 					key={kind}
 					className="inline-flex items-center gap-0.5 rounded-full bg-muted/40 px-2 py-0.5"
 				>
-					<span aria-hidden="true">{REACTION_META[kind].emoji}</span>
+					{/* #387: like は青塗り ThumbsUp で、他は emoji */}
+					{kind === "like" ? (
+						<ReactionLikeIcon active />
+					) : (
+						<span aria-hidden="true">{REACTION_META[kind].emoji}</span>
+					)}
 					<span className="sr-only">{REACTION_META[kind].label}</span>
 					<span>{count}</span>
 				</span>

--- a/client/src/components/reactions/__tests__/ReactionBar.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionBar.test.tsx
@@ -43,13 +43,16 @@ describe("ReactionBar — collapsed state", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("renders 👍 trigger when no my_kind", () => {
-		render(<ReactionBar tweetId={1} />);
+	it("renders ThumbsUp icon (outlined) when no my_kind (#387)", () => {
+		const { container } = render(<ReactionBar tweetId={1} />);
 		const trigger = triggerByDefault();
 		expect(trigger).toBeInTheDocument();
 		expect(trigger.getAttribute("aria-expanded")).toBe("false");
 		expect(trigger.getAttribute("aria-pressed")).toBe("false");
-		expect(trigger.textContent).toContain("👍");
+		// my_kind=null → outlined ThumbsUp svg (lucide-react)
+		const svg = container.querySelector("button svg");
+		expect(svg).toBeTruthy();
+		expect(svg?.getAttribute("fill")).toBe("none");
 	});
 
 	it("renders total count from initial aggregate", () => {
@@ -62,15 +65,31 @@ describe("ReactionBar — collapsed state", () => {
 		expect(triggerByDefault().textContent).toContain("3");
 	});
 
-	it("shows my emoji + aria-pressed=true when my_kind is set", () => {
-		render(
+	it("renders ThumbsUp filled (active) when my_kind=like (#387)", () => {
+		const { container } = render(
 			<ReactionBar
 				tweetId={1}
 				initial={{ counts: { like: 2 }, my_kind: "like" }}
 			/>,
 		);
 		const trigger = triggerByActive();
-		expect(trigger.textContent).toContain("❤️");
+		expect(trigger.getAttribute("aria-pressed")).toBe("true");
+		const svg = container.querySelector("button svg");
+		expect(svg).toBeTruthy();
+		expect(svg?.getAttribute("fill")).toBe("currentColor");
+		// 青色 (text-blue-500) が trigger に当たっている
+		expect(trigger.className).toContain("text-blue-500");
+	});
+
+	it("shows other kind's emoji on trigger when my_kind != like", () => {
+		render(
+			<ReactionBar
+				tweetId={1}
+				initial={{ counts: { learned: 2 }, my_kind: "learned" }}
+			/>,
+		);
+		const trigger = triggerByActive();
+		expect(trigger.textContent).toContain("📚");
 		expect(trigger.getAttribute("aria-pressed")).toBe("true");
 	});
 });

--- a/client/src/components/reactions/__tests__/ReactionSummary.test.tsx
+++ b/client/src/components/reactions/__tests__/ReactionSummary.test.tsx
@@ -47,11 +47,12 @@ describe("ReactionSummary", () => {
 			/>,
 		);
 		const group = screen.getByRole("group", { name: "リアクションの内訳" });
-		// emoji + count が表示される
-		expect(group.textContent).toContain("❤️");
+		// #387: like は ThumbsUp svg、他は emoji。sr-only label で確認。
+		expect(group.textContent).toContain("いいね");
 		expect(group.textContent).toContain("4");
 		expect(group.textContent).toContain("📚");
 		expect(group.textContent).toContain("3");
+		// agree (👍) は emoji
 		expect(group.textContent).toContain("👍");
 		expect(group.textContent).toContain("2");
 	});
@@ -67,9 +68,9 @@ describe("ReactionSummary", () => {
 		);
 		const group = screen.getByRole("group", { name: "リアクションの内訳" });
 		// top 3: like, learned, agree → 表示
-		expect(group.textContent).toContain("❤️");
+		expect(group.textContent).toContain("いいね"); // like sr-only label (#387)
 		expect(group.textContent).toContain("📚");
-		expect(group.textContent).toContain("👍");
+		expect(group.textContent).toContain("👍"); // agree emoji
 		// 4th 以降は表示しない
 		expect(group.textContent).not.toContain("🙏");
 		expect(group.textContent).not.toContain("😂");
@@ -86,7 +87,7 @@ describe("ReactionSummary", () => {
 			/>,
 		);
 		const group = screen.getByRole("group", { name: "リアクションの内訳" });
-		expect(group.textContent).toContain("❤️");
+		expect(group.textContent).toContain("いいね"); // like sr-only label (#387)
 		expect(group.textContent).not.toContain("📚");
 	});
 
@@ -120,7 +121,8 @@ describe("ReactionSummary", () => {
 		);
 		const group = screen.getByRole("group", { name: "リアクションの内訳" });
 		const text = group.textContent ?? "";
-		const likeIdx = text.indexOf("❤️");
+		// #387: like は sr-only label "いいね" で識別 (ThumbsUp svg は textContent に出ない)
+		const likeIdx = text.indexOf("いいね");
 		const interestingIdx = text.indexOf("💡");
 		expect(likeIdx).toBeGreaterThanOrEqual(0);
 		expect(interestingIdx).toBeGreaterThan(likeIdx);

--- a/docs/specs/reactions-e2e-commands.md
+++ b/docs/specs/reactions-e2e-commands.md
@@ -149,6 +149,9 @@ npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line 
 
 # RCT-37: ReactionSummary はリロードせず即時反映する (#385)
 npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-37"
+
+# RCT-38: like は青塗り ThumbsUp icon で表示 (#387)
+npx playwright test e2e/reactions-scenarios.spec.ts --workers=1 --reporter=line --grep "RCT-38"
 ```
 
 ## 5. Phase 2 既存 golden path との関係

--- a/docs/specs/reactions-scenarios.md
+++ b/docs/specs/reactions-scenarios.md
@@ -671,6 +671,25 @@
 - 別 kind に変えた場合 (例: 長押し picker → learned を選択) は ReactionSummary も即時 `📚 1` に変わる。
 - 実装: ReactionBar の `onChange` callback で TweetCard の `reactionAggregate` state を更新し、ReactionSummary に渡す。
 
+### RCT-38: like は Facebook 風の青塗り ThumbsUp icon で表示される (#387)
+
+前提:
+
+- target tweet T、actor A は T に reaction を持っていない (`my_kind=null`)。
+
+操作:
+
+- A が T を表示する。
+- A が trigger を short-click して like を付ける。
+
+期待結果:
+
+- 初期 (`my_kind=null`): trigger 内の icon は **白抜き ThumbsUp SVG** (`fill="none"`、`text-muted-foreground` 灰色)。
+- click 後 (`my_kind="like"`): trigger 内の icon が **青塗り ThumbsUp SVG** (`fill="currentColor"`、`text-blue-500`) に変わる。`aria-pressed=true`。
+- ReactionSummary chip も `like` のとき青塗り ThumbsUp で表示される (集計表示は viewer 別ではなく常に active 描画)。
+- 他の kind (例: `learned`) を picker から選んだ場合は、trigger に `📚` emoji + lime 強調 (旧来通り)。
+- 実装: `client/src/components/reactions/ReactionLikeIcon.tsx` で `lucide-react` の `ThumbsUp` を使い、`active` props で fill/color を切り替える。
+
 ## 4. E2E化メモ
 
 各 E2E は上記の `RCT-XX` をテスト名に含める。

--- a/docs/specs/reactions-spec.md
+++ b/docs/specs/reactions-spec.md
@@ -256,14 +256,19 @@ stateDiagram-v2
 
 ### 4.1 ReactionBar UI 描画
 
-`#381` で **Facebook 風 UX** に変更。trigger は単一の "👍 (Good)" ボタンとして表示し、click は **常に like トグル**、長押しで picker を開く。別 kind に変えたい場合は長押しから選ぶ。
+`#381` で **Facebook 風 UX** に変更。trigger は単一の "Good (Like)" ボタンとして表示し、click は **常に like トグル**、長押しで picker を開く。別 kind に変えたい場合は長押しから選ぶ。
 
-**重要 (#383): trigger 表示は viewer 視点**。`my_kind` は API レスポンス内で **request.user 別** に計算されるので、自分が like 済みの tweet を自分が見れば ❤️、同じ tweet を他人が見れば (その人が未 reaction なら) 👍。匿名閲覧時は常に 👍 (`my_kind=null`)。tweet API 取得時に `reaction_summary` を一緒に返している (§2.10) ので、初期表示も viewer 別の値で正しく出る。
+**重要 (#383): trigger 表示は viewer 視点**。`my_kind` は API レスポンス内で **request.user 別** に計算されるので、自分が like 済みの tweet を自分が見れば「青塗り ThumbsUp」、同じ tweet を他人が見れば (その人が未 reaction なら) 「白抜き ThumbsUp」。匿名閲覧時は常に白抜き (`my_kind=null`)。tweet API 取得時に `reaction_summary` を一緒に返している (§2.10) ので、初期表示も viewer 別の値で正しく出る。
 
-| 状態           | trigger 表示                     | aria-pressed | aria-label                                    |
-| -------------- | -------------------------------- | ------------ | --------------------------------------------- |
-| `my_kind=null` | `👍 {total}` (灰色)              | `false`      | `いいね (長押しで他のリアクション)`           |
-| `my_kind=K`    | `{emoji(K)} {total}` (lime 強調) | `true`       | `{label(K)}を取消 (長押しで他のリアクション)` |
+| 状態             | trigger 表示                                   | aria-pressed | aria-label                                    |
+| ---------------- | ---------------------------------------------- | ------------ | --------------------------------------------- |
+| `my_kind=null`   | **白抜き ThumbsUp** SVG (灰色) + `{total}`     | `false`      | `いいね (長押しで他のリアクション)`           |
+| `my_kind=like`   | **青塗り ThumbsUp** SVG (blue-500) + `{total}` | `true`       | `いいねを取消 (長押しで他のリアクション)`     |
+| `my_kind=K (他)` | `{emoji(K)} {total}` (lime 強調)               | `true`       | `{label(K)}を取消 (長押しで他のリアクション)` |
+
+**`like` の特別扱い (#387)**: Facebook の Like ボタン慣習に合わせ、`like` reaction は `lucide-react` の `ThumbsUp` SVG icon で render する (絵文字ではなく)。`fill="none"` (白抜き) と `fill="currentColor"` + `text-blue-500` (青塗り) を切り替えてアクティブ状態を表現する。他の 9 種は従来通り emoji (💡, 📚, 🙏, 👍, 😲, 🎉, 🫡, 😂, 💻)。
+
+実装は `client/src/components/reactions/ReactionLikeIcon.tsx` (`<ReactionLikeIcon active />`) を使う。同 component は ReactionBar trigger / picker / ReactionSummary chip 全てから呼ばれる。
 
 picker 内の grid (`role="group"`) は #379 で確定済の挙動を維持:
 
@@ -343,7 +348,7 @@ picker 内の grid (`role="group"`) は #379 で確定済の挙動を維持:
 - N の default は **3**。`maxVisibleKinds` props で上書き可。
 - sort 順は **count 降順** (tie は `REACTION_KINDS` の宣言順 `like → interesting → learned → ...`)。
 - 0 件の kind は表示対象から除外 (= 上位 N 種は **必ず count > 0**)。
-- 例: `❤️ 4  📚 3  👍 2`
+- 例: `[青塗りThumbsUp] 4  📚 3  👍 2` (#387 で `like` は SVG ThumbsUp に変更、他は emoji のまま)
 - **#385**: 当初 (#383) は末尾に `· {total} 件` を表示していたが、FB / カロッター の慣習に合わせて撤去。kind 内訳のみ。
 
 #### リアルタイム反映 (#385)


### PR DESCRIPTION
## 関連 Issue

Closes #387

## ハルナさん指摘

> いいねのマークなんですけど、facebookのような柄のものはないの？白抜きのいいねマークをクリックすると青で塗られたいいねマークになるのをまねしたい。あと、今いいねボタンをクリックするとハートマークになってしまうのもいいね（青塗りつぶし）に変えたい。

## 修正

`like` reaction を `lucide-react` の `ThumbsUp` SVG icon で render するように変更。Facebook の Like ボタンと同じく、白抜き ↔ 青塗りつぶし で active 状態を表現。

| 状態           | trigger 表示                                     |
| -------------- | ------------------------------------------------ |
| `my_kind=null` | **白抜き ThumbsUp** SVG (灰色) + count           |
| `my_kind=like` | **青塗り ThumbsUp** SVG (`text-blue-500`) + count |
| `my_kind=K`    | K の emoji + lime 強調 (旧来通り)                |

```tsx
// 新規 ReactionLikeIcon.tsx
<ThumbsUp
  fill={active ? "currentColor" : "none"}
  className={active ? "text-blue-500" : "text-muted-foreground"}
/>
```

ReactionBar trigger / picker・ReactionSummary chip 全てで同 component を使用 (kind="like" のときのみ)。他 9 種は emoji のまま。

## 仕様書 (docs/specs/) 更新

- `reactions-spec.md` §4.1: trigger 表示テーブルに `like` を独立行として追加 (青塗り)、注釈に `lucide-react` の ThumbsUp を使う旨を記載
- `reactions-spec.md` §4.3: ReactionSummary 例を「青塗りThumbsUp」表記に更新
- `reactions-scenarios.md`: **RCT-38** (ThumbsUp SVG / fill 切替) を新規追加
- `reactions-e2e-commands.md`: RCT-38 コマンド追加

## テスト

- vitest: ReactionBar 21 + ReactionSummary 8 + TweetCard / HomeFeed 関連 = **125/126 緑** + 1 todo
  - `renders 👍 trigger` → `renders ThumbsUp icon outlined (#387)` に更新 (svg fill="none" を assert)
  - my_kind=like で svg fill="currentColor" + class に text-blue-500 を assert
  - my_kind=learned (他 kind) は emoji `📚` を assert
  - ReactionSummary の like chip は sr-only 「いいね」 label で識別
- E2E: **RCT-38 UI** を新規追加 (初期 svg fill="none" → click → fill="currentColor" + text-blue-500)
- ✅ tsc / eslint クリーン

## Test plan

- [x] vitest / tsc / eslint 緑
- [ ] CI 緑確認
- [ ] stg deploy 後、Playwright MCP で実機確認:
  - 未 like 状態で 白抜き ThumbsUp が表示
  - click → 青塗り ThumbsUp に切り替わる
  - もう一度 click で 白抜きに戻る
  - 他 kind (例: learned) を picker から選ぶと emoji 📚 + lime に変わる