### PR TITLE
[fix][follows] WhoToFollow が backend wrap shape を unwrap していない (#390)

### DIFF
--- a/client/src/components/sidebar/WhoToFollow.tsx
+++ b/client/src/components/sidebar/WhoToFollow.tsx
@@ -18,6 +18,7 @@ import FollowButton from "@/components/follows/FollowButton";
 import {
 	fetchPopularUsers,
 	fetchRecommendedUsers,
+	localizeReason,
 	type SidebarUser,
 } from "@/lib/api/trending";
 
@@ -124,9 +125,9 @@ export default function WhoToFollow({ isAuthenticated }: WhoToFollowProps) {
 								<span className="block truncate text-xs text-muted-foreground">
 									@{user.handle}
 								</span>
-								{isAuthenticated && user.reason && (
+								{isAuthenticated && localizeReason(user.reason) && (
 									<span className="mt-1 inline-block rounded-full bg-lime-500/10 px-2 py-0.5 text-xs text-lime-700 dark:text-lime-400">
-										{user.reason}
+										{localizeReason(user.reason)}
 									</span>
 								)}
 							</div>

--- a/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
+++ b/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
@@ -7,10 +7,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WhoToFollow from "@/components/sidebar/WhoToFollow";
 import { fetchPopularUsers, fetchRecommendedUsers } from "@/lib/api/trending";
 
-vi.mock("@/lib/api/trending", () => ({
-	fetchRecommendedUsers: vi.fn(),
-	fetchPopularUsers: vi.fn(),
-}));
+vi.mock("@/lib/api/trending", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/trending")>(
+			"@/lib/api/trending",
+		);
+	return {
+		...actual,
+		fetchRecommendedUsers: vi.fn(),
+		fetchPopularUsers: vi.fn(),
+	};
+});
 
 // #296: FollowButton は RTK Query を使うため Provider 配線が必要だが、
 // 本 test は WhoToFollow の挙動 (fetch / render / empty / error) を検証する

--- a/client/src/lib/api/__tests__/trending.test.ts
+++ b/client/src/lib/api/__tests__/trending.test.ts
@@ -10,6 +10,7 @@ import {
 	fetchTrendingTags,
 	fetchRecommendedUsers,
 	fetchPopularUsers,
+	localizeReason,
 	type TrendingTag,
 	type SidebarUser,
 } from "@/lib/api/trending";
@@ -168,5 +169,94 @@ describe("fetchPopularUsers", () => {
 		mock.onGet("/users/popular/").networkError();
 
 		await expect(fetchPopularUsers(5, client)).rejects.toThrow();
+	});
+
+	// #390: backend が実際に返す wrap 形 (`{user: {...}, reason: ...}`) を flatten する
+	it("flattens backend wrap shape {user: {...}, reason: ...} (#390)", async () => {
+		const { client, mock } = stub();
+		const wrappedRow = {
+			user: {
+				id: "abc-123",
+				handle: "test3",
+				display_name: "haruna",
+				avatar_url: "https://stg.codeplace.me/avatar.webp",
+				bio: "engineer",
+				followers_count: 1,
+			},
+			reason: "popular",
+		};
+		mock.onGet("/users/popular/").reply(200, { results: [wrappedRow] });
+		const users = await fetchPopularUsers(5, client);
+		expect(users).toHaveLength(1);
+		expect(users[0]!.handle).toBe("test3");
+		expect(users[0]!.display_name).toBe("haruna");
+		expect(users[0]!.followers_count).toBe(1);
+		expect(users[0]!.reason).toBe("popular");
+	});
+
+	it("flattens recommended wrap shape too", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/recommended/").reply(200, {
+			results: [
+				{
+					user: {
+						id: "x",
+						handle: "alice",
+						display_name: "Alice",
+						avatar_url: "",
+						bio: "",
+						followers_count: 0,
+					},
+					reason: "recent_reaction",
+				},
+			],
+		});
+		const users = await fetchRecommendedUsers(5, client);
+		expect(users[0]!.handle).toBe("alice");
+		expect(users[0]!.reason).toBe("recent_reaction");
+	});
+
+	it("treats null reason as undefined (no chip)", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/popular/").reply(200, {
+			results: [
+				{
+					user: {
+						id: "y",
+						handle: "bob",
+						display_name: "Bob",
+						avatar_url: "",
+						bio: "",
+						followers_count: 0,
+					},
+					reason: null,
+				},
+			],
+		});
+		const users = await fetchPopularUsers(5, client);
+		expect(users[0]!.reason).toBeUndefined();
+	});
+});
+
+// ----- localizeReason -----
+
+describe("localizeReason (#390)", () => {
+	it("maps 'recent_reaction' to a Japanese label", () => {
+		expect(localizeReason("recent_reaction")).toBe(
+			"最近リアクションした投稿者",
+		);
+	});
+
+	it("maps 'popular' to a Japanese label", () => {
+		expect(localizeReason("popular")).toBe("フォロワーが多い");
+	});
+
+	it("returns undefined for undefined / null / empty", () => {
+		expect(localizeReason(undefined)).toBeUndefined();
+		expect(localizeReason("")).toBeUndefined();
+	});
+
+	it("falls back to the raw value for unknown reasons (forward-compat)", () => {
+		expect(localizeReason("brand_new_reason")).toBe("brand_new_reason");
 	});
 });

--- a/client/src/lib/api/trending.ts
+++ b/client/src/lib/api/trending.ts
@@ -1,9 +1,14 @@
 /**
- * Sidebar API helpers (P2-17 / Issue #189).
+ * Sidebar API helpers (P2-17 / Issue #189, fix #390).
  *
  * Trending tags + Who-to-follow user lists feed the right-rail sidebar.
  * Endpoints accept either a plain array or a paginated `{ results: [...] }`
  * envelope, so consumers stay agnostic.
+ *
+ * #390: backend は per-row も `{user: {...}, reason: ...}` で wrap している
+ * ため二段階 unwrap が必要。本 helper で flatten する。
+ *
+ * 仕様: docs/specs/recommended-users-spec.md
  */
 
 import type { AxiosInstance } from "axios";
@@ -18,16 +23,56 @@ export interface TrendingTag {
 }
 
 export interface SidebarUser {
+	id?: string;
 	handle: string;
 	display_name: string;
 	avatar_url?: string;
 	bio?: string;
+	followers_count?: number;
 	is_following?: boolean;
 	reason?: string;
 }
 
 interface MaybePaginated<T> {
 	results?: T[];
+}
+
+/**
+ * #390: backend の per-row wrapper `{user: {...}, reason: ...}` を flatten する.
+ * 既に flat (テストの mock 等) で来た場合はそのまま返す。
+ */
+function flattenSidebarUser(row: unknown): SidebarUser {
+	if (
+		row !== null &&
+		typeof row === "object" &&
+		"user" in row &&
+		typeof (row as { user: unknown }).user === "object" &&
+		(row as { user: unknown }).user !== null
+	) {
+		const wrapped = row as {
+			user: Record<string, unknown>;
+			reason?: unknown;
+		};
+		return {
+			...(wrapped.user as Partial<SidebarUser>),
+			reason: typeof wrapped.reason === "string" ? wrapped.reason : undefined,
+		} as SidebarUser;
+	}
+	return row as SidebarUser;
+}
+
+/**
+ * #390: reason short-string → 日本語ラベルへの mapping.
+ * 未知値は forward-compat のためそのまま表示。
+ */
+const REASON_LABELS: Record<string, string> = {
+	recent_reaction: "最近リアクションした投稿者",
+	popular: "フォロワーが多い",
+};
+
+export function localizeReason(reason: string | undefined): string | undefined {
+	if (!reason) return undefined;
+	return REASON_LABELS[reason] ?? reason;
 }
 
 function unwrap<T>(data: T[] | MaybePaginated<T>): T[] {
@@ -48,20 +93,20 @@ export async function fetchRecommendedUsers(
 	limit: number,
 	client: AxiosInstance = api,
 ): Promise<SidebarUser[]> {
-	const res = await client.get<SidebarUser[] | MaybePaginated<SidebarUser>>(
+	const res = await client.get<unknown[] | MaybePaginated<unknown>>(
 		"/users/recommended/",
 		{ params: { limit } },
 	);
-	return unwrap(res.data);
+	return unwrap<unknown>(res.data).map(flattenSidebarUser);
 }
 
 export async function fetchPopularUsers(
 	limit: number,
 	client: AxiosInstance = api,
 ): Promise<SidebarUser[]> {
-	const res = await client.get<SidebarUser[] | MaybePaginated<SidebarUser>>(
+	const res = await client.get<unknown[] | MaybePaginated<unknown>>(
 		"/users/popular/",
 		{ params: { limit } },
 	);
-	return unwrap(res.data);
+	return unwrap<unknown>(res.data).map(flattenSidebarUser);
 }

--- a/docs/specs/recommended-users-spec.md
+++ b/docs/specs/recommended-users-spec.md
@@ -1,0 +1,295 @@
+# おすすめユーザー (Who to follow) 仕様書
+
+> Version: 0.1
+> 最終更新: 2026-05-05
+> ステータス: 実装済 (Phase 2 P2-10 / #185 backend、P2-17 / #189 frontend、#370/#390 で bug fix)
+> 関連: [SPEC.md §5](../SPEC.md), [ROADMAP.md Phase 2](../ROADMAP.md), [reactions-spec.md](./reactions-spec.md)
+
+---
+
+## 0. このドキュメントの位置づけ
+
+エンジニア特化型 SNS の **おすすめユーザーサイドバー** (Who to follow) の挙動を、UI / API / DB / キャッシュの全レイヤで一貫させるための仕様書。`docs/SPEC.md §5.3` は要件 (3 段階の優先順) しか触れていないので、本書で API レスポンス形・キャッシュ TTL・Block 連動・viewer 別フィルタ・frontend transform などの細部を確定させる。
+
+**ゴール**: ログインユーザにはパーソナライズされた候補を、未ログインユーザには「人気ユーザー」を、ともに同じ右サイドバー UI で出す。エンジニアコミュニティに新規参加したユーザでも有意な接点を提示する。
+
+---
+
+## 1. 用語
+
+| 用語        | 定義                                                                                                        |
+| ----------- | ----------------------------------------------------------------------------------------------------------- |
+| viewer      | リクエスト元のユーザ (= `request.user`)。匿名は `AnonymousUser`                                             |
+| candidate   | 表示候補となる別ユーザ (= `User` レコード)。viewer 自身 / 既フォロー / Bot / Block 関係は除外               |
+| reason      | 推奨理由 (`recent_reaction` / `popular` / `null`)。frontend で日本語ラベルに mapping                        |
+| WhoToFollow | 右サイドバーの recommendation panel (component)。`client/src/components/sidebar/WhoToFollow.tsx`            |
+| right rail  | デスクトップ (`lg+` 以上) で main column の右側に表示されるサイドバー。RightSidebar component が mount する |
+
+---
+
+## 2. バックエンド仕様
+
+### 2.1 Service: `compute_who_to_follow(user, limit)`
+
+`apps/follows/services.py` が正本。SPEC §5.3 の優先順:
+
+#### Step 1: 興味関心タグ (deferred)
+
+`UserInterestTag` モデルが Phase 4 以降で実装されたら有効化する。それまで no-op (skip)。
+
+#### Step 2: リアクション履歴ベース
+
+直近 30 日 (`RECENT_REACTION_DAYS=30`) で viewer が reaction を付けた tweet の **author** を、reaction 数の多い順で並べる。
+
+```python
+candidates = (
+    Reaction.objects.filter(user=viewer, created_at__gte=cutoff)
+    .values("tweet__author_id")
+    .annotate(c=Count("id"))
+    .order_by("-c")
+)
+```
+
+各候補に `reason="recent_reaction"` を付与。
+
+#### Step 3: フォロワー数 fallback
+
+Step 2 で `limit` 未満なら、フォロワー数上位の User で埋める:
+
+```python
+qs = (
+    User.objects.exclude(pk__in=exclude_ids)
+    .order_by("-followers_count")
+    [:limit]
+)
+```
+
+各候補に `reason="popular"` を付与。
+
+### 2.2 除外条件
+
+すべての Step で以下を除外する (`exclude_ids`):
+
+- viewer 自身 (`user.pk`)
+- viewer が既フォローしているユーザ (`Follow.objects.filter(follower=user).values_list("followee_id")`)
+- viewer と双方向 Block 関係のユーザ (`apps.moderation.Block`、Phase 4B 実装後に有効化)
+- Bot ユーザ (現状 Bot 機能が無いため no-op、Phase 7 で対応)
+
+### 2.3 Service: `get_who_to_follow(user, limit)` キャッシュ
+
+```
+key: who_to_follow:{user_id}
+TTL: 60 min (TTL_SECONDS = 60 * 60)
+```
+
+cache miss → `compute_who_to_follow` を呼ぶ → 結果を Redis に SET → 返す。
+
+設計判断:
+
+- TTL 60 min: 候補の鮮度よりサーバ負荷低減を優先。reaction 履歴は秒単位で変わるが、おすすめは「だいたい合っていれば良い」UX。
+- viewer 別 key: 個人化が前提。共有 key にはしない。
+- invalidation hook は **設けない** (= TTL 切れ待ち)。Phase 8 以降でフォロー / unfollow 後の即時反映が必要になったら手動 invalidate を追加。
+
+### 2.4 Service: `get_popular_users(limit)`
+
+未ログイン用 (anonymous viewer)。viewer 別フィルタを掛けず、フォロワー数上位を素直に返す。`reason=None` 固定。
+
+```python
+qs = User.objects.order_by("-followers_count")[:limit]
+```
+
+キャッシュ無し (= 全 anonymous で同じ結果なので、CDN / Cache-Control header で別途キャッシュする想定。MVP では毎回 DB hit)。
+
+### 2.5 API レスポンス形
+
+`apps/follows/services.py::_serialize_users` の出力:
+
+```json
+{
+	"results": [
+		{
+			"user": {
+				"id": "<uuid string>",
+				"handle": "test3",
+				"display_name": "haruna",
+				"avatar_url": "https://stg.codeplace.me/users/.../avatar.webp",
+				"bio": "...",
+				"followers_count": 1
+			},
+			"reason": "recent_reaction"
+		}
+	]
+}
+```
+
+**重要**: 各行は `{user: {...}, reason: ...}` で **wrap されている**。frontend は per-row `user` wrapper を flatten する責務を持つ (§3.2 参照)。
+
+### 2.6 エンドポイント
+
+| エンドポイント                   | view                   | permission      | 認証 | 動作                                      |
+| -------------------------------- | ---------------------- | --------------- | ---- | ----------------------------------------- |
+| `GET /api/v1/users/recommended/` | `RecommendedUsersView` | IsAuthenticated | 必須 | `get_who_to_follow(viewer, limit)` を返す |
+| `GET /api/v1/users/popular/`     | `PopularUsersView`     | AllowAny        | 不要 | `get_popular_users(limit)` を返す         |
+
+両方とも query string `?limit=N` (1〜50、default 10) を受ける。
+
+**ルーティング注意 (#370)**: `urls_profile.py` の `<str:username>/` greedy match に飲まれて 404 を返していた既知のバグは PR #371 で修正済 (follows.urls を urls_profile より前に登録)。
+
+### 2.7 Rate limit
+
+DRF default の `AnonRateThrottle` / `UserRateThrottle` が適用される。専用 scope は持たない。サイドバー単体 fetch なので 1 page 1 req 程度、rate limit にぶつかる用途ではない。
+
+---
+
+## 3. フロントエンド仕様
+
+### 3.1 Component: `WhoToFollow.tsx`
+
+`client/src/components/sidebar/WhoToFollow.tsx` が正本。
+
+- props: `isAuthenticated: boolean`
+- 動作:
+  - `isAuthenticated=true` → `/users/recommended/?limit=5` を fetch (API 失敗時は error state)
+  - `isAuthenticated=false` → `/users/popular/?limit=5` を fetch (匿名 access OK)
+- 描画状態 (loading / ready / error):
+  - loading: 3 row のスケルトン (animate-pulse、avatar 円 + 2 line)
+  - ready (`users.length > 0`): user 行を `flex flex-col gap-3` で list 化
+  - ready (`users.length === 0`): "おすすめユーザーがいません" の placeholder
+  - error: "おすすめの取得に失敗しました" の placeholder
+- 各 user 行: avatar / display_name / @handle / reason chip / FollowButton
+
+### 3.2 API helper: `trending.ts::fetchRecommendedUsers` / `fetchPopularUsers`
+
+`client/src/lib/api/trending.ts` が正本。
+
+#### 重要 (#390): 2 段階 unwrap
+
+backend response は **二重に wrap** されている:
+
+1. top-level `{results: [...]}` envelope (DRF pagination 風)
+2. per-row `{user: {...}, reason: ...}` wrapper
+
+frontend は両方を flatten して flat な `SidebarUser` 配列を返す。
+
+```ts
+function flattenSidebarUser(row: any): SidebarUser {
+	if (
+		row &&
+		typeof row === "object" &&
+		row.user &&
+		typeof row.user === "object"
+	) {
+		return { ...row.user, reason: row.reason ?? undefined };
+	}
+	return row; // 既に flat (テストの mock 等)
+}
+```
+
+shape:
+
+```ts
+export interface SidebarUser {
+	id?: string;
+	handle: string;
+	display_name: string;
+	avatar_url?: string;
+	bio?: string;
+	followers_count?: number;
+	is_following?: boolean;
+	reason?: string;
+}
+```
+
+### 3.3 Reason 日本語ラベル mapping
+
+backend は `reason` を short string で返す (`recent_reaction` / `popular` / `null`)。frontend で日本語にマップして UI に出す:
+
+| backend value        | UI 表示                       |
+| -------------------- | ----------------------------- |
+| `recent_reaction`    | `最近リアクションした投稿者`  |
+| `popular`            | `フォロワーが多い`            |
+| `null` / `undefined` | chip 非表示                   |
+| 未知の値             | そのまま表示 (forward-compat) |
+
+mapping は frontend `client/src/lib/api/trending.ts` の `REASON_LABELS` 定数で集中管理する。
+
+### 3.4 配置
+
+`client/src/app/(template)/layout.tsx` で `RightSidebar` を mount し、その中で `<WhoToFollow isAuthenticated={...} />` を render する。lg+ (1024px+) のみ表示、tablet 以下では非表示。
+
+`isAuthenticated` の判定は `cookies().get("logged_in")?.value === "true"` (server-side cookie 読み取り、SSR 時に確定)。
+
+---
+
+## 4. a11y
+
+- root: `<section aria-labelledby="sidebar-wtf-heading">`、heading は `<h2 id="sidebar-wtf-heading">おすすめユーザー</h2>`
+- loading 行は `role="listitem" aria-busy="true"`
+- avatar `<img alt="" aria-hidden="true">` (display name が冗長を避けるため装飾扱い)
+- 「FollowButton」: 認証時のみ表示。component 側で `aria-pressed` / `aria-busy` を担当する
+- empty / error state: `<p>` で読み上げ可能なテキスト
+
+---
+
+## 5. パフォーマンス
+
+- viewer 別 cache (60 min) で recommended fetch を高速化
+- popular は cache なしだがリクエスト軽量 (LIMIT 10 の単純 ORDER BY)
+- 各 user 行の avatar は CloudFront 経由でキャッシュ
+- WhoToFollow は client component で `useEffect` mount 時 1 回 fetch (page 切り替えごとに refetch)
+
+---
+
+## 6. 既知の制約・将来課題
+
+- **Step 1 興味関心タグは未実装** (`UserInterestTag` モデルが Phase 4 以降)。MVP は Step 2 / 3 だけで運用。
+- **followers_count drift**: `User.followers_count` は denormalized counter。signals + reconcile Beat で整合する想定だが、reconcile 実装は別 issue (P4 以降)。
+- **Block 連動**: `apps.moderation.Block` は Phase 4B で実装。それまで `_blocked_user_ids()` は no-op。
+- **キャッシュ invalidation**: フォロー / unfollow 直後の即時反映なし (60 min TTL を待つ)。Phase 8 で必要なら手動 invalidate を追加。
+- **個別 reason の精度**: `recent_reaction` は単純 count、文脈 (タグ重なり等) を考慮しない。Phase 7 以降で BERT 類似度等の高度な scoring を導入するか検討。
+
+---
+
+## 7. テスト
+
+### 7.1 backend
+
+- `apps/follows/tests/test_recommended_users.py` (P2-10 で実装):
+  - viewer + reaction → reason=recent_reaction
+  - reaction なしの viewer → reason=popular fallback
+  - 自分・既フォロー・Bot・Block 除外
+  - キャッシュ hit / miss
+  - limit クランプ (1〜50)
+- `apps/follows/tests/test_url_routing.py` (#370 で追加):
+  - `/api/v1/users/popular/` が PublicProfileView に飲まれず PopularUsersView に到達する
+
+### 7.2 frontend
+
+- `client/src/lib/api/__tests__/trending.test.ts`:
+  - `/users/popular/` を fetch して flat な `SidebarUser` を返す (wrap shape を flatten)
+  - paginated `{results: [...]}` 形式と plain array の両方で動く
+  - reason の日本語 mapping (`recent_reaction` → "最近リアクションした投稿者" 等)
+- `client/src/components/sidebar/__tests__/WhoToFollow.test.tsx` (将来追加可):
+  - skeleton → ready の遷移
+  - empty state / error state
+  - reason chip 表示 (auth のみ)
+
+---
+
+## 8. 関連 Issue / PR
+
+- P2-10 (#185): backend `apps/follows` services.py / views.py 実装
+- P2-17 (#189): frontend WhoToFollow + RightSidebar 実装
+- #370 (PR #371): `/api/v1/users/popular/` `/recommended/` のルーティング 404 fix
+- #390 (PR #XXX): WhoToFollow shape unwrap fix + reason 日本語 mapping (本 PR)
+
+## 9. 参考
+
+### 内部参照
+
+- [docs/SPEC.md §5.3](../SPEC.md) おすすめユーザー優先順
+- [apps/follows/services.py](../../apps/follows/services.py)
+- [apps/follows/views.py](../../apps/follows/views.py)
+- [apps/follows/urls.py](../../apps/follows/urls.py)
+- [client/src/components/sidebar/WhoToFollow.tsx](../../client/src/components/sidebar/WhoToFollow.tsx)
+- [client/src/lib/api/trending.ts](../../client/src/lib/api/trending.ts)


### PR DESCRIPTION
## 関連 Issue

Closes #390
Refs #185 (P2-10 backend), #189 (P2-17 frontend)

## ハルナさん指摘

> おすすめユーザーサイドバーってちゃんとバックエンドもフロントエンドも実装されているんですかね？stg環境で見たらピックアップされているユーザーがいないんですけど。これについても先ほどまでと同様、もっと詳しい仕様をdocs/specsとかに書いた上で足りていないところがあれば実装を進めてください。

## 調査結果

stg で確認:
- backend `/api/v1/users/popular/` は **6 名のユーザーを返している** (200 OK)
- frontend WhoToFollow サイドバーは **空に見える / @undefined と表示**

→ 実装はバックエンドもフロントエンドも揃っているが、**response shape の不整合バグ** がある。

## 原因

backend response shape は **二重 wrap**:

```json
{
  "results": [
    { "user": { "handle": "test3", "display_name": "haruna", ... }, "reason": null }
  ]
}
```

frontend `unwrap()` が top-level `results` envelope だけを剥がして per-row `user` wrapper を flatten していなかった → `users[0].handle === undefined`、`@undefined` / `/u/undefined` の壊れた link が render され、「おすすめユーザーがいない」と見えていた。

## 修正

`client/src/lib/api/trending.ts`:

- `flattenSidebarUser(row)` 新設、per-row `{user: {...}, reason: ...}` を flatten
- `fetchRecommendedUsers` / `fetchPopularUsers` で `.map(flattenSidebarUser)`
- `SidebarUser` 型に `id?` / `followers_count?` 追加
- `localizeReason(reason)` 新設 (backend short string → 日本語):
  - `recent_reaction` → `最近リアクションした投稿者`
  - `popular` → `フォロワーが多い`
  - null / 未知値は forward-compat (chip 非表示 / そのまま表示)

`client/src/components/sidebar/WhoToFollow.tsx`:

- reason chip を `localizeReason()` 経由で日本語化

## 仕様書 (新規作成)

`docs/specs/recommended-users-spec.md` (255 行):

- §2 バックエンド: services.py の優先順 (Step 1 興味タグ deferred / Step 2 reaction / Step 3 followers fallback)、除外条件 (viewer 自身 / 既フォロー / Bot / Block)、cache TTL (60 min)、API レスポンス wrap shape、エンドポイント permission、ルーティング注意 (#370 参照)
- §3 フロントエンド: WhoToFollow component 動作、二段階 unwrap、reason mapping、配置、SSR isAuthenticated 判定
- §4 a11y、§5 性能、§6 既知制約 (interest tags / counter drift / Block / cache invalidation / scoring 高度化)
- §7 テスト網羅、§8 関連 Issue / PR、§9 内部参照

## テスト

- ✅ vitest: trending 21 件 (4 件新規) + sidebar 18 件 = **39/39 緑**
  - wrap shape を flatten して flat な SidebarUser を返す
  - recommended でも flatten
  - reason: null → undefined (chip 非表示)
  - localizeReason: recent_reaction / popular / 未知値 / undefined
- ✅ tsc / eslint クリーン (既存 `<img>` warning は本 PR 範囲外)

## Test plan

- [x] vitest / tsc / eslint 緑
- [ ] CI 緑確認
- [ ] stg deploy 後、Playwright MCP で実機確認:
  - WhoToFollow に **6 名のユーザー** が display_name + @handle で正しく表示される
  - `/u/<handle>` link が動作する
  - `/users/recommended/` の reason chip が日本語で表示される