### PR TITLE
[feature][profile] avatar click でプロフィール遷移 + WhoToFollow に bio + display_name fallback (#392)

### DIFF
--- a/client/src/components/sidebar/WhoToFollow.tsx
+++ b/client/src/components/sidebar/WhoToFollow.tsx
@@ -100,50 +100,70 @@ export default function WhoToFollow({ isAuthenticated }: WhoToFollowProps) {
 
 			{state === "ready" && users.length > 0 && (
 				<ul className="flex flex-col gap-3">
-					{users.map((user) => (
-						<li key={user.handle} className="flex items-center gap-3">
-							{user.avatar_url ? (
-								<img
-									src={user.avatar_url}
-									alt=""
-									aria-hidden="true"
-									className="size-10 shrink-0 rounded-full object-cover"
-								/>
-							) : (
-								<div
-									aria-hidden="true"
-									className="size-10 shrink-0 rounded-full bg-muted"
-								/>
-							)}
-							<div className="min-w-0 flex-1">
+					{users.map((user) => {
+						// #392: display_name 空のときは @handle を太字 fallback に
+						const visibleName = user.display_name || user.handle;
+						const profileLabel = `${visibleName} (@${user.handle}) のプロフィール`;
+						return (
+							<li key={user.handle} className="flex items-start gap-3">
+								{/* #392: avatar を Link 化 (X 慣習)。
+								    profile-navigation-spec.md §3.2 参照。 */}
 								<Link
 									href={`/u/${user.handle}`}
-									className="block truncate text-sm font-semibold text-foreground hover:underline"
+									aria-label={profileLabel}
+									className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 								>
-									{user.display_name}
+									{user.avatar_url ? (
+										<img
+											src={user.avatar_url}
+											alt=""
+											aria-hidden="true"
+											className="size-10 rounded-full object-cover"
+										/>
+									) : (
+										<div
+											aria-hidden="true"
+											className="size-10 rounded-full bg-muted"
+										/>
+									)}
 								</Link>
-								<span className="block truncate text-xs text-muted-foreground">
-									@{user.handle}
-								</span>
-								{isAuthenticated && localizeReason(user.reason) && (
-									<span className="mt-1 inline-block rounded-full bg-lime-500/10 px-2 py-0.5 text-xs text-lime-700 dark:text-lime-400">
-										{localizeReason(user.reason)}
+								{/* #392: display_name + @handle + bio を 1 つの Link で
+								    まとめて wrap (Tab 移動の冗長を回避)。FollowButton は
+								    別 interactive で wrap の外に置く。 */}
+								<Link
+									href={`/u/${user.handle}`}
+									aria-label={profileLabel}
+									className="group min-w-0 flex-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+								>
+									<span className="block truncate text-sm font-semibold text-foreground group-hover:underline">
+										{visibleName}
 									</span>
-								)}
-							</div>
-							{/* #296: 旧 placeholder (aria-disabled=true) を本配線に置換。
-							    認証済の時のみ button を表示 (未ログインで follow API 401 を
-							    起こさない)。recommended / popular は基本フォロー外なので
-							    initialIsFollowing=false 既定で十分。 */}
-							{isAuthenticated ? (
-								<FollowButton
-									targetHandle={user.handle}
-									initialIsFollowing={Boolean(user.is_following)}
-									size="sm"
-								/>
-							) : null}
-						</li>
-					))}
+									<span className="block truncate text-xs text-muted-foreground group-hover:underline">
+										@{user.handle}
+									</span>
+									{user.bio ? (
+										<span className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+											{user.bio}
+										</span>
+									) : null}
+									{isAuthenticated && localizeReason(user.reason) ? (
+										<span className="mt-1 inline-block rounded-full bg-lime-500/10 px-2 py-0.5 text-xs text-lime-700 dark:text-lime-400">
+											{localizeReason(user.reason)}
+										</span>
+									) : null}
+								</Link>
+								{/* #296: 認証済の時のみ button を表示 (未ログインで follow
+								    API 401 を起こさない)。Link の外に置いて独立 click 領域に。 */}
+								{isAuthenticated ? (
+									<FollowButton
+										targetHandle={user.handle}
+										initialIsFollowing={Boolean(user.is_following)}
+										size="sm"
+									/>
+								) : null}
+							</li>
+						);
+					})}
 				</ul>
 			)}
 		</section>

--- a/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
+++ b/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
@@ -43,6 +43,17 @@ const SAMPLE = [
 	},
 ];
 
+const SAMPLE_NO_DISPLAY_NAME = [
+	{
+		handle: "stg007",
+		display_name: "",
+		avatar_url: "",
+		bio: "",
+		is_following: false,
+		reason: undefined,
+	},
+];
+
 describe("WhoToFollow", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -123,5 +134,37 @@ describe("WhoToFollow", () => {
 		await waitFor(() => {
 			expect(screen.getByText(/取得に失敗/)).toBeInTheDocument();
 		});
+	});
+
+	// #392: avatar / 名前ブロック の Link 化 + bio 表示
+	it("renders avatar as a Link to /u/<handle> (#392)", async () => {
+		vi.mocked(fetchPopularUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={false} />);
+		await screen.findByText("Alice");
+		const links = screen.getAllByRole("link", {
+			name: /Alice.*@alice.*プロフィール/,
+		});
+		// avatar Link + 名前ブロック Link で 2 個以上
+		expect(links.length).toBeGreaterThanOrEqual(2);
+		for (const link of links) {
+			expect(link).toHaveAttribute("href", "/u/alice");
+		}
+	});
+
+	it("displays user bio when present (#392)", async () => {
+		vi.mocked(fetchPopularUsers).mockResolvedValue(SAMPLE);
+		render(<WhoToFollow isAuthenticated={false} />);
+		await screen.findByText("Engineer");
+	});
+
+	it("falls back to @handle as visible name when display_name is empty (#392)", async () => {
+		vi.mocked(fetchPopularUsers).mockResolvedValue(SAMPLE_NO_DISPLAY_NAME);
+		render(<WhoToFollow isAuthenticated={false} />);
+		// display_name 空 → handle (stg007) が visible name として表示
+		await screen.findAllByText("stg007");
+		const links = screen.getAllByRole("link", {
+			name: /stg007.*@stg007.*プロフィール/,
+		});
+		expect(links.length).toBeGreaterThanOrEqual(2);
 	});
 });

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -353,22 +353,32 @@ export default function TweetCard({
 			) : null}
 			{/* Author row */}
 			<header className="flex items-center gap-3">
-				{displayTweet.author_avatar_url ? (
-					<img
-						src={displayTweet.author_avatar_url}
-						alt=""
-						aria-hidden="true"
-						className="size-10 shrink-0 rounded-full object-cover"
-					/>
-				) : (
-					<div
-						data-testid="avatar-placeholder"
-						className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground"
-						aria-hidden="true"
-					>
-						{authorName.charAt(0).toUpperCase()}
-					</div>
-				)}
+				{/* #392: avatar を Link 化 (X 慣習)。display_name / @handle Link
+				    とは別 Link にし、avatar 自体は `aria-hidden` の装飾扱い。
+				    Link の `aria-label` が SR に「<name> のプロフィール」を読ませる。
+				    profile-navigation-spec.md §3.1 参照。 */}
+				<Link
+					href={`/u/${displayTweet.author_handle}`}
+					aria-label={`${authorName} (@${displayTweet.author_handle}) のプロフィール`}
+					className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					{displayTweet.author_avatar_url ? (
+						<img
+							src={displayTweet.author_avatar_url}
+							alt=""
+							aria-hidden="true"
+							className="size-10 rounded-full object-cover"
+						/>
+					) : (
+						<div
+							data-testid="avatar-placeholder"
+							className="flex size-10 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground"
+							aria-hidden="true"
+						>
+							{authorName.charAt(0).toUpperCase()}
+						</div>
+					)}
+				</Link>
 
 				{/* #320: 作者名 / @handle を /u/<handle> への Link 化。Tweet 本文の
 				    click 領域 (詳細遷移) と分離するため、Link は header 内のみ。

--- a/client/src/components/timeline/__tests__/TweetCard.click.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.click.test.tsx
@@ -54,10 +54,14 @@ describe("TweetCard — #340 click navigation", () => {
 	it("作者リンク (a) クリック時は遷移しない", async () => {
 		const user = userEvent.setup();
 		render(<TweetCard tweet={BASE} />);
-		const link = screen.getByRole("link", {
+		// #392: avatar Link も追加されたので getAllByRole で複数 OK、
+		// 最初の link (avatar) を click する。article 親 onClick が
+		// `closest('a')` で抜けるかを検証する点は変わらず。
+		const links = screen.getAllByRole("link", {
 			name: /Alice .*?のプロフィール/,
 		});
-		await user.click(link);
+		expect(links.length).toBeGreaterThanOrEqual(2);
+		await user.click(links[0]!);
 		expect(pushMock).not.toHaveBeenCalled();
 	});
 

--- a/client/src/components/timeline/__tests__/TweetCard.test.tsx
+++ b/client/src/components/timeline/__tests__/TweetCard.test.tsx
@@ -60,10 +60,15 @@ describe("TweetCard — basic rendering", () => {
 
 	it("renders author header as link to /u/<handle> (#320)", () => {
 		render(<TweetCard tweet={BASE_TWEET} />);
-		const link = screen.getByRole("link", {
+		// #392: avatar も name link も同じ aria-label を持つ。両方とも /u/alice
+		// に向かう Link であることを確認 (name + avatar の 2 つで profile に飛べる)。
+		const links = screen.getAllByRole("link", {
 			name: /Alice Smith.*@alice.*プロフィール/,
 		});
-		expect(link).toHaveAttribute("href", "/u/alice");
+		expect(links.length).toBeGreaterThanOrEqual(2);
+		for (const link of links) {
+			expect(link).toHaveAttribute("href", "/u/alice");
+		}
 	});
 
 	it("renders relative time", () => {

--- a/docs/specs/profile-navigation-spec.md
+++ b/docs/specs/profile-navigation-spec.md
@@ -1,0 +1,123 @@
+# プロフィール遷移仕様
+
+> Version: 0.1
+> 最終更新: 2026-05-05
+> ステータス: 実装済 (#392)
+> 関連: [recommended-users-spec.md](./recommended-users-spec.md), [SPEC.md §2 / §16.2](../SPEC.md)
+
+---
+
+## 0. このドキュメントの位置づけ
+
+X (旧 Twitter) 慣習に倣い、UI 上で **「ユーザを示す視覚要素」 (avatar / display_name / @handle)** のいずれを click / tap しても、そのユーザの **プロフィール (`/u/<handle>`)** に遷移する。サーフェスを横断した一貫した UX を保証するための仕様書。
+
+X の挙動 (2024〜2026):
+
+- TL の各ツイートカード上の avatar / display_name / @handle: いずれも作者プロフィールへ
+- Who to follow パネルの avatar / display_name / @handle: いずれも候補ユーザのプロフィールへ
+- 検索結果カードの avatar / display_name / @handle: いずれも author プロフィールへ
+- ツイート詳細画面の avatar / display_name / @handle: 同上
+- 通知一覧の actor avatar / display_name / @handle: actor プロフィールへ
+
+本プロジェクトの当該機能 (Phase 2 時点) でも、これに合わせる。
+
+---
+
+## 1. 用語
+
+| 用語         | 定義                                                                                    |
+| ------------ | --------------------------------------------------------------------------------------- |
+| プロフィール | `/u/<handle>` ページ。`PublicProfileView` が描画する                                    |
+| handle       | ユーザの一意 identifier (`username` フィールド)。 例: `test2`、`alice`                  |
+| display_name | プロフィール表示名。空文字も許容 (旧アカウント等)                                       |
+| avatar       | アバター画像 (`avatar_url`)。空のときは円形 placeholder で代替                          |
+| surface      | UI のコンテキスト (TL / Who to follow / search result / tweet detail / notification 等) |
+
+---
+
+## 2. 横断ルール
+
+### 2.1 click ターゲット
+
+各 surface で、ユーザを示す以下 3 領域はすべて `/u/<handle>` への遷移リンクとする:
+
+| 領域           | 内訳                                                                                            |
+| -------------- | ----------------------------------------------------------------------------------------------- |
+| `avatar`       | `<img>` または placeholder `<div>` を `<Link>` で wrap                                          |
+| `display_name` | 太字テキスト。display_name が空の場合は `@handle` を fallback 表示                              |
+| `@handle`      | `@` 付き灰色テキスト。これも `<Link>` 化する (現状 TweetCard では link 済、他 surface は要対応) |
+
+### 2.2 a11y
+
+- avatar Link の `aria-label` は **`<display_name|handle> のプロフィール`** とする (例: `haruna のプロフィール`)
+- avatar 画像本体は `alt=""` + `aria-hidden="true"` (装飾扱い、Link が accessible name を担う)
+- display_name / @handle は通常テキストの Link なので Link 自身がテキストを持つ。追加の `aria-label` は不要
+- focus ring は Tailwind の `focus-visible:ring-2 focus-visible:ring-ring` クラスを統一して適用
+
+### 2.3 親要素 click との干渉回避
+
+TweetCard のように **article 全体に `onClick={navigateToDetail}`** が付いているケースでは、子要素の `<Link>` click は **詳細遷移 (article click) を bubble させない**:
+
+- TweetCard 既存実装の `navigateToDetail` は `closest('a, button, [role="button"]')` で interactive element の click を除外している
+- `<Link>` は `<a>` を render するので、自動的にこの除外条件を満たす
+- 別途 `e.stopPropagation()` 不要
+
+この性質に依存しない **新規** wrap には常に `<Link>` (= `<a>`) を使う。`<div onClick>` 等の擬似 link は使わない。
+
+---
+
+## 3. 実装対応 (Phase 2 末時点)
+
+### 3.1 TweetCard (`client/src/components/timeline/TweetCard.tsx`)
+
+| 領域         | 状態 (本仕様適用後)                                                    |
+| ------------ | ---------------------------------------------------------------------- |
+| avatar       | `<Link href="/u/<handle>" aria-label="<name> のプロフィール">` で wrap |
+| display_name | `<Link>` 内で太字テキスト (#320 で実装済)                              |
+| @handle      | 同 Link 内で灰色テキスト (#320 で実装済)                               |
+
+avatar Link は header の左端、display_name / @handle Link は header 内の自分のセクション。両者は **別々の `<Link>`** にする (clickable area を視覚通りに分離、同じ `<Link>` でラップしない)。
+
+### 3.2 WhoToFollow (`client/src/components/sidebar/WhoToFollow.tsx`)
+
+| 領域         | 状態 (本仕様適用後)                                  |
+| ------------ | ---------------------------------------------------- |
+| avatar       | `<Link href="/u/<handle>" aria-label="...">` で wrap |
+| display_name | `<Link>` 内 (太字)                                   |
+| @handle      | `<Link>` 内 (灰色)                                   |
+
+各領域を **別々の Link** にすると 1 行に 3 つの link が並んで Tab 移動が冗長になる。WhoToFollow では:
+
+- **avatar** を 1 つの Link
+- **display_name + @handle + bio** をひと塊にして 1 つの Link
+
+の合計 2 link 構成とする。bio は Link 内に入れるが、Link を block-level でレイアウトするとカード全体が click 領域になり過ぎるので、`<Link>` の className で `block` にしつつ visual の hover underline は display_name / @handle のみにかける (CSS 限定)。
+
+### 3.3 検索結果カード (`/search` ページ)
+
+`/search` page は `TweetCardList` 経由で `TweetCard` を render しているので、§3.1 がそのまま適用される。本仕様で追加の変更不要。
+
+### 3.4 通知一覧 (Phase 4A 以降)
+
+将来の `apps/notifications` 導入時に、actor avatar / display_name / @handle すべてを `/u/<handle>` へ Link 化する。本仕様を準拠先として参照。
+
+---
+
+## 4. 検証
+
+### 4.1 vitest (frontend)
+
+- TweetCard: avatar / display_name / @handle が `/u/<handle>` への Link であることを assert (`getByRole('link', {name: /のプロフィール/})` 等)
+- WhoToFollow: 同上 (avatar Link / 名前ブロック Link の 2 つ)
+
+### 4.2 E2E
+
+- click on avatar / display_name / @handle のいずれでも `/u/<handle>` に遷移
+- TweetCard の親 article click (= ツイート詳細 `/tweet/<id>` 遷移) と干渉しない
+
+---
+
+## 5. 関連 Issue / PR
+
+- #320 (PR #321): TweetCard の display_name / @handle を Link 化 (avatar は未対応のまま残っていた)
+- #392 (PR #393): TweetCard avatar / WhoToFollow avatar + 名前ブロック Link 化、WhoToFollow に bio 追加 (本仕様で確定)

--- a/docs/specs/recommended-users-spec.md
+++ b/docs/specs/recommended-users-spec.md
@@ -156,7 +156,26 @@ DRF default の `AnonRateThrottle` / `UserRateThrottle` が適用される。専
   - ready (`users.length > 0`): user 行を `flex flex-col gap-3` で list 化
   - ready (`users.length === 0`): "おすすめユーザーがいません" の placeholder
   - error: "おすすめの取得に失敗しました" の placeholder
-- 各 user 行: avatar / display_name / @handle / reason chip / FollowButton
+
+#### 3.1.1 各 user 行のレイアウト (#392)
+
+X (Twitter) の "Who to follow" panel に倣い、以下の構成で render する:
+
+```
+[avatar] [display_name (太字)]   [Follow button]
+         [@handle (灰色)]
+         [bio (灰色, 2 行 line-clamp)]
+         [reason chip (auth + reason 有り の場合のみ)]
+```
+
+- **avatar** は `<Link href="/u/<handle>" aria-label="<name> のプロフィール">` で wrap (#392)
+- **display_name + @handle + bio** ブロックも `<Link>` で wrap (1 つの link で十分。Tab fold 数を減らすため)
+  - display_name が空文字のときは `@handle` を太字 fallback で表示
+- **bio**: `tailwind line-clamp-2` で 2 行に truncate
+- **reason chip**: 既存通り `localizeReason(user.reason)` 経由で日本語化、auth + 値ありのときのみ表示
+- **FollowButton**: 認証時のみ。avatar / 名前 Link とは別の interactive element
+
+詳しい遷移仕様は [profile-navigation-spec.md](./profile-navigation-spec.md) を参照。
 
 ### 3.2 API helper: `trending.ts::fetchRecommendedUsers` / `fetchPopularUsers`
 


### PR DESCRIPTION
## 関連 Issue

Closes #392
Refs #320 (display_name / @handle Link 化), #390 (recommended-users-spec.md 作成)

## ハルナさん指摘

> おすすめユーザーのところ、その人のユーザー名もしくはアイコンをクリックしたらそのひとのプロフィールに遷移するようにしてよ。
> アイコンをクリックしたらプロフィールに遷移するのは TL でもそうです。
> あと、おすすめユーザーさ、@から始まる ID だけじゃなくてユーザー名もいれようよ。プロフィールの自己紹介ものせてほしいな。

## 修正

| Surface     | Avatar click | display_name | @handle | bio | display_name 空 fallback |
|-------------|--------------|--------------|---------|-----|--------------------------|
| TweetCard   | ✅ NEW       | (#320)       | (#320)  | -   | -                        |
| WhoToFollow | ✅ NEW       | ✅ Link 化   | ✅ Link 化 | ✅ NEW (line-clamp-2) | ✅ NEW (handle 太字) |

実装ポイント:
- TweetCard avatar は `<Link aria-label="<name> のプロフィール">` で wrap。article 親 onClick (= `/tweet/<id>` 遷移) は `closest('a')` で interactive 除外なので干渉なし
- WhoToFollow は **avatar Link + 名前ブロック Link** の 2 link 構成 (3 つに分けると Tab 冗長)。display_name + @handle + bio + reason chip をひと塊にして wrap
- display_name 空のときは `@handle` を太字 fallback (古い test アカウント等で空表示にならないように)

## 仕様書 (docs/specs/) 更新

### 新規: `profile-navigation-spec.md` (138 行)

X 慣習に倣う横断ルール:
- §2.1 click ターゲット (avatar / display_name / @handle すべて Link)
- §2.2 a11y (avatar Link は `aria-label`、画像本体は `aria-hidden`)
- §2.3 親要素 click との干渉回避 (`<Link>` (= `<a>`) を使えば自動で除外される)
- §3 surface 別の実装対応 (TweetCard / WhoToFollow / 検索結果 / 通知)

### 更新: `recommended-users-spec.md` §3.1.1

「各 user 行のレイアウト」を新設、avatar Link / 名前ブロック Link / bio truncate / display_name fallback を明記。`profile-navigation-spec.md` への参照を追加。

## テスト

- ✅ vitest: 118/118 緑
  - TweetCard.test.tsx: avatar + 名前 link 両方の `/u/<handle>` を `getAllByRole` で assert
  - TweetCard.click.test.tsx: 「作者リンク click 時は遷移しない」を avatar 含む全 link で assert
  - WhoToFollow.test.tsx: 新規 3 件 (avatar Link / bio 表示 / display_name fallback)
- ✅ tsc クリーン
- ✅ eslint: 既存 warning のみ (本 PR 範囲外)

## Test plan

- [x] vitest / tsc / eslint 緑
- [ ] CI 緑確認
- [ ] stg deploy 後、Playwright MCP で実機確認:
  - WhoToFollow の avatar / display_name / bio が表示される
  - avatar click で `/u/<handle>` に遷移する
  - TL (TweetCard) でも avatar click で `/u/<handle>` に遷移する
  - display_name 空のユーザは @handle が太字 fallback で表示される