### PR TITLE
[fix][follows] popular / recommended から is_active=False ユーザーを除外 (#394)

### DIFF
--- a/apps/follows/services.py
+++ b/apps/follows/services.py
@@ -80,9 +80,15 @@ def _candidates_from_reactions(user, exclude_ids: set[int], limit: int) -> list[
 
 
 def _candidates_from_followers_count(exclude_ids: set[int], limit: int) -> list[dict]:
-    """Step 3: フォロワー数上位の fallback."""
+    """Step 3: フォロワー数上位の fallback.
+
+    #394: is_active=False (= 未アクティベ / 凍結等) のユーザーは
+    `PublicProfileView` で 404 になるため、推奨に出すと「存在しない人」へ
+    の壊れた link になる。ここで除外する。
+    """
     qs = (
-        User.objects.exclude(pk__in=exclude_ids)
+        User.objects.filter(is_active=True)
+        .exclude(pk__in=exclude_ids)
         .order_by("-followers_count")
         .values("pk", "followers_count")[:limit]
     )
@@ -90,9 +96,14 @@ def _candidates_from_followers_count(exclude_ids: set[int], limit: int) -> list[
 
 
 def _serialize_users(rows: list[dict]) -> list[dict[str, Any]]:
-    """user_id を実 User に解決し API レスポンス形式に整形."""
+    """user_id を実 User に解決し API レスポンス形式に整形.
+
+    #394: 二段防御で is_active=True のみを返す。Step 2 (reaction) で
+    取得した user_id は is_active 未チェックなので、最終 serialize 時に
+    弾く必要がある。
+    """
     user_ids = [r["user_id"] for r in rows]
-    users = {u.pk: u for u in User.objects.filter(pk__in=user_ids)}
+    users = {u.pk: u for u in User.objects.filter(pk__in=user_ids, is_active=True)}
     out: list[dict[str, Any]] = []
     for r in rows:
         u = users.get(r["user_id"])
@@ -147,10 +158,15 @@ def get_who_to_follow(user, limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
 
 
 def get_popular_users(limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
-    """未ログイン用 popular: フォロワー数上位 (reason は付けない)."""
-    qs = User.objects.order_by("-followers_count").values(
-        "id", "username", "display_name", "avatar_url", "bio", "followers_count"
-    )[:limit]
+    """未ログイン用 popular: フォロワー数上位 (reason は付けない).
+
+    #394: is_active=True のみ。`PublicProfileView` の隠蔽方針に揃える。
+    """
+    qs = (
+        User.objects.filter(is_active=True)
+        .order_by("-followers_count")
+        .values("id", "username", "display_name", "avatar_url", "bio", "followers_count")[:limit]
+    )
     return [
         {
             "user": {

--- a/apps/follows/tests/test_recommended_active_filter.py
+++ b/apps/follows/tests/test_recommended_active_filter.py
@@ -1,0 +1,65 @@
+"""Tests for is_active=True filter in popular / recommended (#394).
+
+`PublicProfileView` は `is_active=False` ユーザーを 404 で隠す方針。
+推奨にもその filter を揃えないと「クリックすると 404」になる壊れた link が
+出てしまうので、本テストでフィルタを保証する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.follows.services import (
+    compute_who_to_follow,
+    get_popular_users,
+)
+from apps.follows.tests._factories import make_user
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestPopularUsersActiveFilter:
+    def test_popular_excludes_inactive(self) -> None:
+        active_user = make_user()
+        inactive_user = make_user()
+        inactive_user.is_active = False
+        inactive_user.save(update_fields=["is_active"])
+
+        rows = get_popular_users(limit=10)
+        handles = [r["user"]["handle"] for r in rows]
+        assert active_user.username in handles
+        assert inactive_user.username not in handles
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestComputeWhoToFollowActiveFilter:
+    def test_recommended_excludes_inactive_in_followers_fallback(self) -> None:
+        viewer = make_user()
+        # active_user は filter 通過の sanity 確認用 (handles 配列に存在することを確認)
+        active_user = make_user()
+        inactive_user = make_user()
+        inactive_user.is_active = False
+        inactive_user.save(update_fields=["is_active"])
+
+        rows = compute_who_to_follow(viewer, limit=10)
+        handles = [r["user"]["handle"] for r in rows]
+        assert active_user.username in handles
+        assert inactive_user.username not in handles
+
+    def test_recommended_excludes_inactive_in_reaction_step(self) -> None:
+        """Step 2 (reaction) で inactive author の tweet にリアクションしても
+        推奨に出ない (= _serialize_users の二段防御で弾く)。"""
+        from apps.reactions.models import Reaction
+        from apps.tweets.models import Tweet
+
+        viewer = make_user()
+        inactive_author = make_user()
+        inactive_author.is_active = False
+        inactive_author.save(update_fields=["is_active"])
+        tweet = Tweet.objects.create(author=inactive_author, body="hello")
+        Reaction.objects.create(user=viewer, tweet=tweet, kind="like")
+
+        rows = compute_who_to_follow(viewer, limit=10)
+        handles = [r["user"]["handle"] for r in rows]
+        assert inactive_author.username not in handles

--- a/docs/specs/recommended-users-spec.md
+++ b/docs/specs/recommended-users-spec.md
@@ -68,12 +68,13 @@ qs = (
 
 ### 2.2 除外条件
 
-すべての Step で以下を除外する (`exclude_ids`):
+すべての Step で以下を除外する (`exclude_ids` または queryset filter で):
 
 - viewer 自身 (`user.pk`)
 - viewer が既フォローしているユーザ (`Follow.objects.filter(follower=user).values_list("followee_id")`)
 - viewer と双方向 Block 関係のユーザ (`apps.moderation.Block`、Phase 4B 実装後に有効化)
 - Bot ユーザ (現状 Bot 機能が無いため no-op、Phase 7 で対応)
+- **`is_active=False` のユーザ (#394)**: `apps/users/views.py::PublicProfileView` が `is_active=True` だけを公開する方針なので、推奨にも同じ filter を掛けないと「click すると 404」 (壊れた link) になる。`_candidates_from_followers_count` で `User.objects.filter(is_active=True)` を掛け、`_serialize_users` でも二段防御として `pk__in + is_active=True` で再 filter する。`get_popular_users` も同様。
 
 ### 2.3 Service: `get_who_to_follow(user, limit)` キャッシュ
 


### PR DESCRIPTION
## 関連 Issue

Closes #394
Refs #185 (P2-10 backend), #189 (P2-17 frontend), #390 (PR #391), #392 (PR #393)

## ハルナさん指摘

> stg環境で https://stg.codeplace.me/u/stg607545 がないと言われますが、単純に @stg607545 というユーザーが存在していないだけですか？おすすめユーザーにそのユーザーがいるから疑問で。

## 調査結果

stg で確認:

| エンドポイント | 結果 |
|---|---|
| `/api/v1/users/popular/` | `stg607545` を返す (DB に user 存在) |
| `/api/v1/users/stg607545/` | **404** `{"detail": "No User matches the given query."}` |
| `/u/stg607545` (frontend) | 404 ページ |

→ user は DB に存在するが `is_active=False` (登録のみで activate 未完了)。WhoToFollow から click すると 404 ページに飛ぶ壊れた link 状態だった。

## 原因

**実装の整合性バグ** (#394):

`apps/users/views.py::PublicProfileView`:
```python
def get_queryset(self):
    return User.objects.filter(is_active=True)
```
→ `is_active=False` user を 404 で隠蔽する方針。

一方 `apps/follows/services.py` は `is_active` フィルタを **掛けていなかった**:
- `_candidates_from_followers_count` ❌
- `get_popular_users` ❌
- `_serialize_users` ❌

3 箇所で `User.objects.filter(is_active=True)` を追加して隠蔽方針を揃える。`_serialize_users` でも二段防御として再 filter (Step 2 reaction で `user_id` が inactive の場合も弾く)。

## 仕様書 (docs/specs/recommended-users-spec.md §2.2) 更新

「除外条件」に `is_active=False` を追加:

> **`is_active=False` のユーザ (#394)**: `apps/users/views.py::PublicProfileView` が `is_active=True` だけを公開する方針なので、推奨にも同じ filter を掛けないと「click すると 404」 (壊れた link) になる。

## テスト

新規 `apps/follows/tests/test_recommended_active_filter.py`:
- `popular_excludes_inactive`: `get_popular_users` から inactive user 除外
- `recommended_excludes_inactive_in_followers_fallback`: Step 3 fallback で除外 (active 通過 + inactive 除外を両方 assert)
- `recommended_excludes_inactive_in_reaction_step`: Step 2 reaction → `_serialize_users` 二段防御で除外

## Test plan

- [x] ruff / pre-commit 緑
- [ ] CI (Backend Django) 緑確認
- [ ] stg deploy 後、`/api/v1/users/popular/` から `stg607545` が **消える** ことを確認
- [ ] WhoToFollow に表示される全ユーザーが click 可能 (404 にならない)

## 影響範囲

- backend `apps/follows/services.py` の 3 関数のみ変更
- frontend / SPEC に変更なし
- 既存の Redis cache (`who_to_follow:{user_id}`) は古い inactive user を含む可能性があるが、TTL 60min で自然に無効化される