### PR TITLE
[bug][tweets] + ボタン投稿時の「投稿しました」トースト二重発火を解消 (#398)

### DIFF
--- a/client/src/components/tweets/ComposeTweetDialog.tsx
+++ b/client/src/components/tweets/ComposeTweetDialog.tsx
@@ -8,7 +8,6 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { toast } from "react-toastify";
 
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import TweetComposer from "@/components/tweets/TweetComposer";
@@ -28,8 +27,11 @@ interface ComposeTweetDialogProps {
  * ComposeTweetDialog — 左下 + ボタンから開く root tweet 投稿ダイアログ (#396)。
  *
  * 既存 `TweetComposer` を Radix Dialog でラップしているだけ。投稿成功で
- * 自動 close + toast、router.refresh で TL 再取得。文字数カウント / タグ /
- * バリデーションは TweetComposer 側に閉じている。
+ * 自動 close + router.refresh で TL 再取得。文字数カウント / タグ /
+ * バリデーション / 成功 toast は TweetComposer 側に閉じている。
+ *
+ * #398: トースト二重発火を防ぐため、本コンポーネントでは `toast.success` を
+ * 呼ばない。TweetComposer.tsx 内の `toast.success("投稿しました")` を信頼する。
  *
  * a11y:
  *  - DialogTitle (sr-only) で dialog にアクセシブル名を与える (4.1.2)
@@ -55,7 +57,7 @@ export default function ComposeTweetDialog({
 			onPosted?.(tweet);
 			setLiveMessage("ツイートを投稿しました");
 			onOpenChange(false);
-			toast.success("投稿しました");
+			// #398: toast.success は TweetComposer 側に集約 (二重発火防止)
 			router.refresh();
 		},
 		[onPosted, onOpenChange, router],

--- a/client/src/components/tweets/__tests__/ComposeTweetDialog.test.tsx
+++ b/client/src/components/tweets/__tests__/ComposeTweetDialog.test.tsx
@@ -66,7 +66,7 @@ describe("ComposeTweetDialog", () => {
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 	});
 
-	it("on successful post: closes dialog, refreshes router, shows success toast, forwards onPosted", async () => {
+	it("on successful post: closes dialog, refreshes router, forwards onPosted, does NOT fire its own toast (#398)", async () => {
 		const onOpenChange = vi.fn();
 		const onPosted = vi.fn();
 
@@ -84,7 +84,8 @@ describe("ComposeTweetDialog", () => {
 		expect(onPosted).toHaveBeenCalledTimes(1);
 		expect(onOpenChange).toHaveBeenCalledWith(false);
 		expect(mockRefresh).toHaveBeenCalledTimes(1);
-		expect(toastSuccess).toHaveBeenCalledWith("投稿しました");
+		// #398: TweetComposer 側で toast を出すので、Dialog 側は呼ばない
+		expect(toastSuccess).not.toHaveBeenCalled();
 	});
 
 	it("provides an accessible title (sr-only)", () => {


### PR DESCRIPTION
## サマリ

ホームの + ボタンから投稿すると「投稿しました」トーストが 2 つ出る不具合を修正。

## 原因

#396 で追加した `ComposeTweetDialog` が `handlePosted` で `toast.success("投稿しました")` を発火していたが、内側で wrap している `TweetComposer` も同じ toast を発火するため、1 投稿で 2 個のトーストになっていた。

## 修正内容

- `ComposeTweetDialog.tsx`: `toast.success` 呼び出しを撤去 (TweetComposer 側に集約)
- `import { toast } from "react-toastify"` も使わなくなったので削除
- 既存テストの assertion を `toBeCalledWith` → `not.toHaveBeenCalled` に更新
- sr-only aria-live region の announce はそのまま (TweetComposer は live region を持たない)

## Test Plan
- [x] `vitest` 6/6 pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [ ] stg deploy 後にホームから投稿 → トーストが 1 つだけ出ることを確認

## Closes
- #398