### PR TITLE
[feature][follows] おすすめユーザーに relaxed fallback + is_following を追加 (#399)

### DIFF
--- a/apps/follows/services.py
+++ b/apps/follows/services.py
@@ -95,15 +95,21 @@ def _candidates_from_followers_count(exclude_ids: set[int], limit: int) -> list[
     return [{"user_id": row["pk"], "reason": "popular"} for row in qs]
 
 
-def _serialize_users(rows: list[dict]) -> list[dict[str, Any]]:
+def _serialize_users(
+    rows: list[dict], following_ids: set[int] | None = None
+) -> list[dict[str, Any]]:
     """user_id を実 User に解決し API レスポンス形式に整形.
 
     #394: 二段防御で is_active=True のみを返す。Step 2 (reaction) で
     取得した user_id は is_active 未チェックなので、最終 serialize 時に
     弾く必要がある。
+
+    #399: ``following_ids`` が渡された場合、各 row に ``is_following`` を付加。
+    relaxed fallback で既フォローユーザを推奨に出すケースの label 表示用。
     """
     user_ids = [r["user_id"] for r in rows]
     users = {u.pk: u for u in User.objects.filter(pk__in=user_ids, is_active=True)}
+    following = following_ids or set()
     out: list[dict[str, Any]] = []
     for r in rows:
         u = users.get(r["user_id"])
@@ -118,6 +124,7 @@ def _serialize_users(rows: list[dict]) -> list[dict[str, Any]]:
                     "avatar_url": u.avatar_url,
                     "bio": u.bio,
                     "followers_count": u.followers_count,
+                    "is_following": u.pk in following,
                 },
                 "reason": r["reason"],
             }
@@ -129,21 +136,37 @@ def compute_who_to_follow(user, limit: int = DEFAULT_LIMIT) -> list[dict[str, An
     """SPEC §5.3 の優先順 (興味タグ → リアクション → フォロワー数 fallback) で候補を作成.
 
     興味関心タグ (UserInterestTag) は Phase 4 以降で実装されるまで skip。
+
+    #399: 候補が limit を満たさない場合の **relaxed fallback** を追加。
+      Step 2/3 では既フォロー (following) を除外するが、それでも limit に満たない
+      ときは Step 4 で「自分・blocked のみ除外」して埋める。これにより小規模 DB
+      でも 3 人推奨を表示しやすくなる (frontend は ``is_following`` を見て
+      ボタン表示を切り替える)。
     """
-    exclude = {user.pk} | _existing_follow_ids(user) | _blocked_user_ids(user)
+    self_id = {user.pk}
+    blocked = _blocked_user_ids(user)
+    following = _existing_follow_ids(user)
+    base_exclude = self_id | blocked | following
 
     candidates: list[dict] = []
     # Step 1 (interest tags): skip until UserInterestTag が実装されたら有効化
 
-    # Step 2: reaction history
-    candidates.extend(_candidates_from_reactions(user, exclude, limit))
+    # Step 2: reaction history (excludes self + blocked + following)
+    candidates.extend(_candidates_from_reactions(user, base_exclude, limit))
 
-    # Step 3: fallback
+    # Step 3: popular fallback (excludes self + blocked + following)
     if len(candidates) < limit:
-        already = exclude | {c["user_id"] for c in candidates}
+        already = base_exclude | {c["user_id"] for c in candidates}
         candidates.extend(_candidates_from_followers_count(already, limit - len(candidates)))
 
-    return _serialize_users(candidates[:limit])
+    # Step 4 (#399): relaxed fallback — 既フォローも候補に含める。
+    # 自分 / blocked は引き続き除外。frontend は is_following=true のとき
+    # 「フォロー中」表示に切替。
+    if len(candidates) < limit:
+        already = self_id | blocked | {c["user_id"] for c in candidates}
+        candidates.extend(_candidates_from_followers_count(already, limit - len(candidates)))
+
+    return _serialize_users(candidates[:limit], following_ids=following)
 
 
 def get_who_to_follow(user, limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
@@ -176,6 +199,8 @@ def get_popular_users(limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
                 "avatar_url": row["avatar_url"],
                 "bio": row["bio"],
                 "followers_count": row["followers_count"],
+                # 未認証なので is_following は常に False (#399 — 型安定のため出す)
+                "is_following": False,
             },
             "reason": None,
         }

--- a/apps/follows/tests/test_recommended_relaxed_fallback.py
+++ b/apps/follows/tests/test_recommended_relaxed_fallback.py
@@ -1,0 +1,79 @@
+"""Tests for #399 — recommended users relaxed fallback.
+
+候補が limit に満たない場合、自分・blocked のみ除外して埋める Step 4 fallback
+を検証する。frontend は ``is_following=True`` を見て「フォロー中」表示に切替える
+ため、本テストは ``is_following`` フラグも合わせて検証する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.follows.services import compute_who_to_follow
+from apps.follows.tests._factories import make_follow, make_user
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestRelaxedFallback:
+    def test_includes_followed_users_when_unfollowed_pool_is_empty(self) -> None:
+        """全 candidate を既フォロー済にしても、limit を満たすまで relaxed fallback で埋める."""
+        viewer = make_user()
+        # 3 人ターゲットを作って全員フォロー済にする
+        a = make_user()
+        b = make_user()
+        c = make_user()
+        for t in (a, b, c):
+            make_follow(viewer, t)
+
+        rows = compute_who_to_follow(viewer, limit=3)
+        handles = {r["user"]["handle"] for r in rows}
+        # 既フォローでも relaxed fallback で 3 人入ること
+        assert {a.username, b.username, c.username}.issubset(handles)
+        # 全員 is_following=True で返ること
+        for r in rows:
+            assert r["user"]["is_following"] is True
+
+    def test_strict_then_relaxed_mix(self) -> None:
+        """未フォロー 1 + 既フォロー 2 の DB で limit=3 → 3 人とも埋まる."""
+        viewer = make_user()
+        unfollowed = make_user()
+        followed_1 = make_user()
+        followed_2 = make_user()
+        make_follow(viewer, followed_1)
+        make_follow(viewer, followed_2)
+
+        rows = compute_who_to_follow(viewer, limit=3)
+        by_handle = {r["user"]["handle"]: r["user"]["is_following"] for r in rows}
+        assert unfollowed.username in by_handle
+        assert by_handle[unfollowed.username] is False
+        assert by_handle.get(followed_1.username) is True
+        assert by_handle.get(followed_2.username) is True
+
+    def test_self_is_never_included_even_in_relaxed_fallback(self) -> None:
+        viewer = make_user()
+        make_user()  # other active user
+        rows = compute_who_to_follow(viewer, limit=3)
+        assert viewer.username not in {r["user"]["handle"] for r in rows}
+
+    def test_limit_is_capped_to_available_users(self) -> None:
+        """DB に viewer 以外が居なければ空配列を返す (\"自分を除く全員\" = 0 人)."""
+        viewer = make_user()
+        rows = compute_who_to_follow(viewer, limit=3)
+        assert rows == []
+
+    def test_inactive_users_excluded_even_in_relaxed_fallback(self) -> None:
+        """#394 の方針 (is_active=False → 推奨に出さない) は relaxed fallback でも維持される."""
+        viewer = make_user()
+        active = make_user()
+        inactive = make_user()
+        inactive.is_active = False
+        inactive.save(update_fields=["is_active"])
+        # viewer が両方フォローしていても、inactive は除外されること
+        make_follow(viewer, active)
+        make_follow(viewer, inactive)
+
+        rows = compute_who_to_follow(viewer, limit=3)
+        handles = {r["user"]["handle"] for r in rows}
+        assert active.username in handles
+        assert inactive.username not in handles

--- a/client/src/components/sidebar/WhoToFollow.tsx
+++ b/client/src/components/sidebar/WhoToFollow.tsx
@@ -23,7 +23,9 @@ import {
 } from "@/lib/api/trending";
 
 const SKELETON_ROWS = 3;
-const LIMIT = 5;
+// #399: 基本表示数を 3 に。backend 側で relaxed fallback (既フォロー込み) が
+// 走るため、未フォロー候補が少なくても 3 人埋めようと試みる。
+const LIMIT = 3;
 
 type LoadState = "loading" | "ready" | "error";
 

--- a/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
+++ b/client/src/components/sidebar/__tests__/WhoToFollow.test.tsx
@@ -66,7 +66,7 @@ describe("WhoToFollow", () => {
 		vi.mocked(fetchRecommendedUsers).mockResolvedValue(SAMPLE);
 		render(<WhoToFollow isAuthenticated={true} />);
 		await waitFor(() => {
-			expect(fetchRecommendedUsers).toHaveBeenCalledWith(5);
+			expect(fetchRecommendedUsers).toHaveBeenCalledWith(3);
 		});
 		expect(fetchPopularUsers).not.toHaveBeenCalled();
 	});
@@ -75,7 +75,7 @@ describe("WhoToFollow", () => {
 		vi.mocked(fetchPopularUsers).mockResolvedValue(SAMPLE);
 		render(<WhoToFollow isAuthenticated={false} />);
 		await waitFor(() => {
-			expect(fetchPopularUsers).toHaveBeenCalledWith(5);
+			expect(fetchPopularUsers).toHaveBeenCalledWith(3);
 		});
 		expect(fetchRecommendedUsers).not.toHaveBeenCalled();
 	});

--- a/docs/specs/recommended-users-spec.md
+++ b/docs/specs/recommended-users-spec.md
@@ -52,19 +52,40 @@ candidates = (
 
 各候補に `reason="recent_reaction"` を付与。
 
-#### Step 3: フォロワー数 fallback
+#### Step 3: フォロワー数 fallback (strict)
 
 Step 2 で `limit` 未満なら、フォロワー数上位の User で埋める:
 
 ```python
 qs = (
-    User.objects.exclude(pk__in=exclude_ids)
+    User.objects.filter(is_active=True)
+    .exclude(pk__in=exclude_ids)  # exclude_ids = self + blocked + following
     .order_by("-followers_count")
     [:limit]
 )
 ```
 
 各候補に `reason="popular"` を付与。
+
+#### Step 4: relaxed fallback (#399)
+
+Step 3 後も候補が `limit` に満たない場合 (= 小規模 DB / 既フォロー済が多い viewer)、**既フォロー除外を解いて** さらに埋める:
+
+```python
+already = self_id | blocked | already_picked
+qs = (
+    User.objects.filter(is_active=True)
+    .exclude(pk__in=already)  # following は除外しない
+    .order_by("-followers_count")
+    [:remaining]
+)
+```
+
+これにより、UI 上は「自分以外で active な全員」が候補になりうる。各候補に `reason="popular"` を付与する (Step 3 と同じ)。
+
+frontend は `is_following=true` のユーザに対しては FollowButton を「フォロー中」表示に切替えるため (`_serialize_users` が `following_ids` を見て付加)、ユーザが既フォロー済の人をうっかり再フォローしてしまう事故は起きない。
+
+> 表示数 (limit) 自体は frontend が決める。WhoToFollow component は `LIMIT=3` (#399 で 5 → 3)。基本 3 人、足りなければ "自分・blocked を除いた active 全員" まで広げて埋める。それでも 0 人 (= viewer 以外の active user が居ない) なら空配列を返す。
 
 ### 2.2 除外条件
 


### PR DESCRIPTION
## サマリ

\`/users/recommended/\` で候補が limit に満たないとき、既フォロー除外を緩めて埋める Step 4 fallback を追加。frontend は \`is_following=true\` のユーザを「フォロー中」表示に切替えて誤再フォローを防ぐ。基本表示数も 5 → 3 に。

## 背景

#395 で \`is_active=False\` のユーザを除外して以降、stg では未フォロー候補が 1 人しか出なくなっていた (DB 規模が小さい + viewer が他を既フォロー)。

## 変更内容

### Backend (\`apps/follows/services.py\`)
- \`compute_who_to_follow\` に **Step 4 (relaxed fallback)** を追加
  - 自分・blocked のみ除外 (既フォローを含める)
  - \`is_active=True\` は引き続き必須 (#394 と整合)
- \`_serialize_users\` が \`following_ids\` を受け取り \`is_following\` を各 row に付加
- \`get_popular_users\` (未認証) も \`is_following=False\` を返す (型安定)

### Frontend (\`client/src/components/sidebar/WhoToFollow.tsx\`)
- \`LIMIT 5 → 3\`

### テスト
- pytest: \`apps/follows/tests/test_recommended_relaxed_fallback.py\` 5 ケース
  - 全 candidate を既フォロー済 → relaxed fallback で 3 人埋まる + 全員 is_following=true
  - 未フォロー 1 + 既フォロー 2 → 未フォローは is_following=false、既フォローは true
  - viewer 自身は relaxed でも除外
  - viewer 以外が居なければ空配列
  - is_active=False は relaxed でも除外 (#394 維持)
- vitest: WhoToFollow が \`fetchRecommendedUsers(3)\` / \`fetchPopularUsers(3)\` を呼ぶ

### Spec
- \`docs/specs/recommended-users-spec.md\` §2.1 に Step 4 を追記

## Test Plan
- [x] pytest **8/8 pass**
- [x] vitest **12/12 pass**
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] stg deploy 後にホームでおすすめユーザが 3 人 (DB 上に viewer 以外 active が 3 人以上居れば) 出る

## Closes
- #399

## 関連
- #395 (is_active=False 除外)、#394 (元の問題)