### PR TITLE
[bug][layout] Navbar 右上撤去 + 検索修正 + 設定メニュー LeftNavbar 集約 + popular で self 除外 (#406)

### DIFF
--- a/apps/follows/services.py
+++ b/apps/follows/services.py
@@ -189,16 +189,20 @@ def invalidate_who_to_follow(user) -> None:
     cache.delete(CACHE_KEY.format(user_id=user.pk))
 
 
-def get_popular_users(limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
+def get_popular_users(
+    limit: int = DEFAULT_LIMIT, exclude_user_id: int | None = None
+) -> list[dict[str, Any]]:
     """未ログイン用 popular: フォロワー数上位 (reason は付けない).
 
     #394: is_active=True のみ。`PublicProfileView` の隠蔽方針に揃える。
+    #406: ``exclude_user_id`` が指定されたら除外 (認証済 viewer 用の二重防御)。
     """
-    qs = (
-        User.objects.filter(is_active=True)
-        .order_by("-followers_count")
-        .values("id", "username", "display_name", "avatar_url", "bio", "followers_count")[:limit]
-    )
+    qs = User.objects.filter(is_active=True)
+    if exclude_user_id is not None:
+        qs = qs.exclude(pk=exclude_user_id)
+    qs = qs.order_by("-followers_count").values(
+        "id", "username", "display_name", "avatar_url", "bio", "followers_count"
+    )[:limit]
     return [
         {
             "user": {

--- a/apps/follows/tests/test_popular_excludes_self.py
+++ b/apps/follows/tests/test_popular_excludes_self.py
@@ -1,0 +1,64 @@
+"""Tests for #406 — popular endpoint excludes authenticated viewer's self.
+
+Service-level (`get_popular_users`) tests are sufficient for unit coverage.
+View-level wiring (`PopularUsersView` → `request.user.pk`) は既存
+`test_url_routing.py::test_popular_routes_to_popular_view_not_user_lookup`
+で routing が、本テストで service の挙動が、それぞれ独立にカバーされる。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.follows.services import get_popular_users
+from apps.follows.tests._factories import make_user
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestGetPopularUsersExcludeSelf:
+    def test_no_exclude_returns_all_active(self) -> None:
+        a = make_user()
+        b = make_user()
+        rows = get_popular_users(limit=10)
+        handles = {r["user"]["handle"] for r in rows}
+        assert {a.username, b.username}.issubset(handles)
+
+    def test_exclude_user_id_removes_self(self) -> None:
+        a = make_user()
+        b = make_user()
+        rows = get_popular_users(limit=10, exclude_user_id=a.pk)
+        handles = {r["user"]["handle"] for r in rows}
+        assert a.username not in handles
+        assert b.username in handles
+
+    def test_exclude_user_id_none_is_noop(self) -> None:
+        a = make_user()
+        rows = get_popular_users(limit=10, exclude_user_id=None)
+        handles = {r["user"]["handle"] for r in rows}
+        assert a.username in handles
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestPopularUsersViewExcludesSelfWhenAuthenticated:
+    """View 層: ``request.user.pk`` を service に渡しているか."""
+
+    def test_authenticated_request_excludes_self(self, api_client: APIClient) -> None:
+        a = make_user()
+        b = make_user()
+        api_client.force_authenticate(user=a)
+        resp = api_client.get(reverse("users-popular"), {"limit": 10})
+        assert resp.status_code == 200, resp.content
+        handles = {r["user"]["handle"] for r in resp.data["results"]}
+        assert a.username not in handles
+        assert b.username in handles
+
+    def test_anonymous_request_does_not_exclude(self, api_client: APIClient) -> None:
+        a = make_user()
+        resp = api_client.get(reverse("users-popular"), {"limit": 10})
+        assert resp.status_code == 200, resp.content
+        handles = {r["user"]["handle"] for r in resp.data["results"]}
+        assert a.username in handles

--- a/apps/follows/views.py
+++ b/apps/follows/views.py
@@ -172,6 +172,11 @@ class PopularUsersView(APIView):
     """GET /api/v1/users/popular/?limit=10
 
     未ログイン用。フォロワー数上位を返す。explore で使う。
+
+    #406: 認証済 viewer から呼ばれた場合は self を除外。frontend (RightSidebar)
+    が cookie 不整合や redirect 直後の状態で popular endpoint を叩くケースが
+    あり、そのとき自分が WhoToFollow に出てしまうため、二重防御として
+    backend 側でも除外する。
     """
 
     permission_classes = [AllowAny]
@@ -183,5 +188,6 @@ class PopularUsersView(APIView):
             limit = max(1, min(int(request.query_params.get("limit", 10)), 50))
         except (TypeError, ValueError):
             limit = 10
-        rows = get_popular_users(limit=limit)
+        exclude_user_id = request.user.pk if request.user.is_authenticated else None
+        rows = get_popular_users(limit=limit, exclude_user_id=exclude_user_id)
         return Response({"results": rows})

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import SettingsMenu from "@/components/shared/navbar/SettingsMenu";
 import ComposeTweetDialog from "@/components/tweets/ComposeTweetDialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -145,12 +146,10 @@ export default function LeftNavbar() {
 
 			{isAuthenticated ? (
 				<div className="flex flex-col gap-3">
-					<Button
-						onClick={handleLogout}
-						className="lime-gradient small-medium light-border-2 btn-tertiary text-baby_ballon min-h-[41px] w-full rounded-lg border px-4 py-3 shadow-none"
-					>
-						Log Out
-					</Button>
+					{/* #406: Logout 単独ボタンを SettingsMenu (テーマ切替 + ログアウト) に
+					    置き換え。Navbar から ThemeSwitcher を撤去したのに伴いここに
+					    集約する。 */}
+					<SettingsMenu onLogout={handleLogout} />
 
 					{/* #396: 自分プロフィール chip (X 風 — avatar + display_name + @handle)。
 					    handle 未取得時は表示しない (link 先が決まらないため)。

--- a/client/src/components/shared/navbar/Navbar.tsx
+++ b/client/src/components/shared/navbar/Navbar.tsx
@@ -1,9 +1,7 @@
 import { HomeModernIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
 import React from "react";
-import ThemeSwitcher from "./ThemeSwitcher";
 import MobileNavbar from "./MobileNavbar";
-import AuthAvatar from "@/components/shared/navbar/AuthAvatar";
 
 export default function Navbar() {
 	return (
@@ -15,14 +13,13 @@ export default function Navbar() {
 				</p>
 			</Link>
 
-			{/* #396: グローバル検索 box は RightSidebar 上部に移設。Navbar は
-			    シンプルに保つ (logo + theme + auth + mobile) */}
+			{/* #406: AuthAvatar / ThemeSwitcher を撤去。
+			    - AuthAvatar: LeftNavbar 下部の self profile chip と冗長
+			    - ThemeSwitcher: RightSidebar の検索 box と被って入力を阻害していた
+			      → LeftNavbar の「設定」メニュー配下に移設 (SettingsMenu 参照) */}
 
-			<div className="flex shrink-0 items-center gap-3 sm:gap-5 lg:gap-6">
-				<ThemeSwitcher />
-				<AuthAvatar />
-				<MobileNavbar />
-			</div>
+			{/* sm 未満は MobileNavbar (Sheet) に nav リンク群を委ねる */}
+			<MobileNavbar />
 		</nav>
 	);
 }

--- a/client/src/components/shared/navbar/SettingsMenu.tsx
+++ b/client/src/components/shared/navbar/SettingsMenu.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * SettingsMenu (#406).
+ *
+ * LeftNavbar 配下に置く「設定」 dropdown。テーマ切替 (Light/Dark/System) と
+ * ログアウトを集約する。Navbar の右上から ThemeSwitcher / AuthAvatar を撤去
+ * したのに伴い、ユーザがテーマを切り替える唯一の動線になる。
+ */
+
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { LogOut, Monitor, Moon, Settings, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import type { ReactElement } from "react";
+
+interface SettingsMenuProps {
+	onLogout?: () => void;
+	/** lg+ ではボタンに「設定」ラベルを出す。lg 未満は icon のみ。 */
+	collapsed?: boolean;
+}
+
+const THEMES: Array<{
+	value: "light" | "dark" | "system";
+	label: string;
+	icon: ReactElement;
+}> = [
+	{
+		value: "light",
+		label: "ライト",
+		icon: <Sun className="size-4" aria-hidden="true" />,
+	},
+	{
+		value: "dark",
+		label: "ダーク",
+		icon: <Moon className="size-4" aria-hidden="true" />,
+	},
+	{
+		value: "system",
+		label: "システム",
+		icon: <Monitor className="size-4" aria-hidden="true" />,
+	},
+];
+
+export default function SettingsMenu({
+	onLogout,
+	collapsed = false,
+}: SettingsMenuProps): ReactElement {
+	const { theme, setTheme } = useTheme();
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					type="button"
+					aria-label="設定"
+					className="lime-gradient small-medium light-border-2 btn-tertiary text-baby_ballon flex min-h-[41px] w-full items-center justify-center gap-2 rounded-lg border px-4 py-3 shadow-none"
+				>
+					<Settings className="size-5 shrink-0" aria-hidden="true" />
+					{collapsed ? null : <span>設定</span>}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" side="top" className="w-56">
+				<DropdownMenuLabel>テーマ</DropdownMenuLabel>
+				{THEMES.map(({ value, label, icon }) => (
+					<DropdownMenuItem
+						key={value}
+						onClick={() => setTheme(value)}
+						className={`cursor-pointer gap-2 ${theme === value ? "font-semibold" : ""}`}
+					>
+						{icon}
+						<span>{label}</span>
+						{theme === value ? (
+							<span className="ml-auto text-xs text-muted-foreground">
+								選択中
+							</span>
+						) : null}
+					</DropdownMenuItem>
+				))}
+				{onLogout ? (
+					<>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							onClick={onLogout}
+							className="cursor-pointer gap-2 text-destructive focus:text-destructive"
+						>
+							<LogOut className="size-4" aria-hidden="true" />
+							<span>ログアウト</span>
+						</DropdownMenuItem>
+					</>
+				) : null}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/client/src/components/shared/navbar/__tests__/LeftNavbar.test.tsx
+++ b/client/src/components/shared/navbar/__tests__/LeftNavbar.test.tsx
@@ -49,6 +49,20 @@ vi.mock("@/hooks/useUseProfile", () => ({
 	useUserProfile: () => profileState,
 }));
 
+// SettingsMenu は別 unit test (#406) 済み。ここでは LeftNavbar が onLogout を
+// 渡しているかだけ確認したいので stub。
+vi.mock("@/components/shared/navbar/SettingsMenu", () => ({
+	default: ({ onLogout }: { onLogout?: () => void }) => (
+		<button
+			type="button"
+			data-testid="settings-menu-stub"
+			onClick={() => onLogout?.()}
+		>
+			設定
+		</button>
+	),
+}));
+
 // ComposeTweetDialog は別 unit test 済み。ここでは起動ロジックだけ確認したいので stub。
 const composeOpenSpy = vi.fn();
 vi.mock("@/components/tweets/ComposeTweetDialog", () => ({
@@ -134,6 +148,26 @@ describe("LeftNavbar — self profile chip", () => {
 		expect(
 			screen.queryByRole("link", { name: /のプロフィール$/ }),
 		).not.toBeInTheDocument();
+	});
+});
+
+describe("LeftNavbar — SettingsMenu wiring (#406)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		authNavState.isAuthenticated = true;
+		profileState.profile = {
+			username: "alice",
+			display_name: "Alice",
+			avatar_url: "",
+		};
+	});
+
+	it("renders SettingsMenu when authenticated and forwards onLogout", async () => {
+		render(<LeftNavbar />);
+		const stub = screen.getByTestId("settings-menu-stub");
+		expect(stub).toBeInTheDocument();
+		await userEvent.click(stub);
+		expect(authNavState.handleLogout).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/client/src/components/shared/navbar/__tests__/SettingsMenu.test.tsx
+++ b/client/src/components/shared/navbar/__tests__/SettingsMenu.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Tests for SettingsMenu (#406).
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SettingsMenu from "@/components/shared/navbar/SettingsMenu";
+
+const { setThemeSpy, themeRef } = vi.hoisted(() => ({
+	setThemeSpy: vi.fn(),
+	themeRef: { value: "system" as "light" | "dark" | "system" },
+}));
+
+vi.mock("next-themes", () => ({
+	useTheme: () => ({ theme: themeRef.value, setTheme: setThemeSpy }),
+}));
+
+describe("SettingsMenu", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		themeRef.value = "system";
+	});
+
+	it("renders a 設定 trigger button", () => {
+		render(<SettingsMenu />);
+		expect(screen.getByRole("button", { name: "設定" })).toBeInTheDocument();
+	});
+
+	it("opens dropdown on click and shows the three theme options", async () => {
+		render(<SettingsMenu />);
+		await userEvent.click(screen.getByRole("button", { name: "設定" }));
+		expect(
+			screen.getByRole("menuitem", { name: /ライト/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: /ダーク/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: /システム/ }),
+		).toBeInTheDocument();
+	});
+
+	it("calls setTheme('dark') when the ダーク item is clicked", async () => {
+		render(<SettingsMenu />);
+		await userEvent.click(screen.getByRole("button", { name: "設定" }));
+		await userEvent.click(screen.getByRole("menuitem", { name: /ダーク/ }));
+		expect(setThemeSpy).toHaveBeenCalledWith("dark");
+	});
+
+	it("highlights the currently selected theme with '選択中' label", async () => {
+		themeRef.value = "light";
+		render(<SettingsMenu />);
+		await userEvent.click(screen.getByRole("button", { name: "設定" }));
+		const lightItem = screen.getByRole("menuitem", { name: /ライト/ });
+		expect(lightItem).toHaveTextContent(/選択中/);
+		const darkItem = screen.getByRole("menuitem", { name: /ダーク/ });
+		expect(darkItem).not.toHaveTextContent(/選択中/);
+	});
+
+	it("renders a logout item when onLogout is provided and calls it on click", async () => {
+		const onLogout = vi.fn();
+		render(<SettingsMenu onLogout={onLogout} />);
+		await userEvent.click(screen.getByRole("button", { name: "設定" }));
+		await userEvent.click(screen.getByRole("menuitem", { name: /ログアウト/ }));
+		expect(onLogout).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not render a logout item when onLogout is not provided", async () => {
+		render(<SettingsMenu />);
+		await userEvent.click(screen.getByRole("button", { name: "設定" }));
+		expect(
+			screen.queryByRole("menuitem", { name: /ログアウト/ }),
+		).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## サマリ

stg test2 ログイン時の 4 つの問題を一括解消:

| # | 問題 | 修正 |
|---|---|---|
| 1 | 検索ボックスに入力できない | Navbar 右上アイコン (z-50) が検索 (z-10) を覆っていた → 撤去で解消 |
| 2 | 自分が WhoToFollow に出る | popular endpoint が認証済 viewer の self を除外していなかった → 修正 |
| 3 | 右上 AuthAvatar 冗長 | LeftNavbar 下部の chip と重複 → 撤去 |
| 4 | ThemeSwitcher の置き場所 | LeftNavbar 配下の SettingsMenu (新規) に移設、Logout も集約 |

## 変更内容

### Backend
- \`apps/follows/services.py::get_popular_users\` に \`exclude_user_id\` 引数追加
- \`apps/follows/views.py::PopularUsersView\` で \`request.user.is_authenticated\` なら self を渡す (二重防御)

### Frontend
- \`Navbar.tsx\`: AuthAvatar / ThemeSwitcher 撤去、logo + MobileNavbar のみに
- \`SettingsMenu.tsx\` 新規: DropdownMenu で Light / Dark / System 切替 + ログアウトを集約
- \`LeftNavbar.tsx\`: 旧 Log Out 単独ボタンを SettingsMenu に置換

### テスト
- pytest **5/5 pass**: service-level (3) + view-level (2)
- vitest **20/20 pass**: LeftNavbar 7、SettingsMenu 6 (新規)、HeaderSearchBox 7

## Test Plan
- [x] pytest 5/5、apps/follows 全 regression なし
- [x] vitest 20/20
- [x] tsc / eslint クリーン
- [ ] CI green
- [ ] stg deploy 後:
  - test2 ログイン → 検索ボックスに入力できる
  - test2 ログイン → 自分 (test2) が WhoToFollow に出ない
  - 右上に AuthAvatar / ThemeSwitcher が無い
  - LeftNavbar の「設定」 dropdown からテーマ切替できる

## Closes
- #406