### PR TITLE
[bug][follows] WhoToFollow に「フォロー中」を出さない (#399 Step 4 撤回) + popular で既フォロー除外 (#410)

### DIFF
--- a/apps/follows/services.py
+++ b/apps/follows/services.py
@@ -95,21 +95,19 @@ def _candidates_from_followers_count(exclude_ids: set[int], limit: int) -> list[
     return [{"user_id": row["pk"], "reason": "popular"} for row in qs]
 
 
-def _serialize_users(
-    rows: list[dict], following_ids: set[int] | None = None
-) -> list[dict[str, Any]]:
+def _serialize_users(rows: list[dict]) -> list[dict[str, Any]]:
     """user_id を実 User に解決し API レスポンス形式に整形.
 
     #394: 二段防御で is_active=True のみを返す。Step 2 (reaction) で
     取得した user_id は is_active 未チェックなので、最終 serialize 時に
     弾く必要がある。
 
-    #399: ``following_ids`` が渡された場合、各 row に ``is_following`` を付加。
-    relaxed fallback で既フォローユーザを推奨に出すケースの label 表示用。
+    #410: #399 の relaxed fallback 撤回に伴い `following_ids` 引数を撤去。
+    recommendation には既フォローを含めない方針に揃えたので、`is_following`
+    は常に False で返す (型安定のため field 自体は維持)。
     """
     user_ids = [r["user_id"] for r in rows]
     users = {u.pk: u for u in User.objects.filter(pk__in=user_ids, is_active=True)}
-    following = following_ids or set()
     out: list[dict[str, Any]] = []
     for r in rows:
         u = users.get(r["user_id"])
@@ -124,7 +122,7 @@ def _serialize_users(
                     "avatar_url": u.avatar_url,
                     "bio": u.bio,
                     "followers_count": u.followers_count,
-                    "is_following": u.pk in following,
+                    "is_following": False,
                 },
                 "reason": r["reason"],
             }
@@ -137,11 +135,9 @@ def compute_who_to_follow(user, limit: int = DEFAULT_LIMIT) -> list[dict[str, An
 
     興味関心タグ (UserInterestTag) は Phase 4 以降で実装されるまで skip。
 
-    #399: 候補が limit を満たさない場合の **relaxed fallback** を追加。
-      Step 2/3 では既フォロー (following) を除外するが、それでも limit に満たない
-      ときは Step 4 で「自分・blocked のみ除外」して埋める。これにより小規模 DB
-      でも 3 人推奨を表示しやすくなる (frontend は ``is_following`` を見て
-      ボタン表示を切り替える)。
+    #410: #399 で入れた Step 4 (relaxed fallback) は撤回。**既フォロー
+    (following) は recommendation に出さない** という X / FB 標準の動線に
+    揃える。候補が limit に満たない場合は出る数が少ないままで OK。
     """
     self_id = {user.pk}
     blocked = _blocked_user_ids(user)
@@ -159,14 +155,8 @@ def compute_who_to_follow(user, limit: int = DEFAULT_LIMIT) -> list[dict[str, An
         already = base_exclude | {c["user_id"] for c in candidates}
         candidates.extend(_candidates_from_followers_count(already, limit - len(candidates)))
 
-    # Step 4 (#399): relaxed fallback — 既フォローも候補に含める。
-    # 自分 / blocked は引き続き除外。frontend は is_following=true のとき
-    # 「フォロー中」表示に切替。
-    if len(candidates) < limit:
-        already = self_id | blocked | {c["user_id"] for c in candidates}
-        candidates.extend(_candidates_from_followers_count(already, limit - len(candidates)))
-
-    return _serialize_users(candidates[:limit], following_ids=following)
+    # is_following=False に固定 (既フォローは Step 2/3 で除外済)
+    return _serialize_users(candidates[:limit])
 
 
 def get_who_to_follow(user, limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
@@ -190,16 +180,25 @@ def invalidate_who_to_follow(user) -> None:
 
 
 def get_popular_users(
-    limit: int = DEFAULT_LIMIT, exclude_user_id: int | None = None
+    limit: int = DEFAULT_LIMIT,
+    exclude_user_id: int | None = None,
+    exclude_following_for_user=None,
 ) -> list[dict[str, Any]]:
     """未ログイン用 popular: フォロワー数上位 (reason は付けない).
 
     #394: is_active=True のみ。`PublicProfileView` の隠蔽方針に揃える。
     #406: ``exclude_user_id`` が指定されたら除外 (認証済 viewer 用の二重防御)。
+    #410: ``exclude_following_for_user`` (User) が指定されたら、その人が既に
+    フォローしているユーザも除外する。WhoToFollow は recommended と popular
+    両方の経路で「フォロー中」を出さない方針 (#408 の dismiss と整合)。
     """
     qs = User.objects.filter(is_active=True)
     if exclude_user_id is not None:
         qs = qs.exclude(pk=exclude_user_id)
+    if exclude_following_for_user is not None:
+        following_ids = _existing_follow_ids(exclude_following_for_user)
+        if following_ids:
+            qs = qs.exclude(pk__in=following_ids)
     qs = qs.order_by("-followers_count").values(
         "id", "username", "display_name", "avatar_url", "bio", "followers_count"
     )[:limit]

--- a/apps/follows/tests/test_popular_excludes_self.py
+++ b/apps/follows/tests/test_popular_excludes_self.py
@@ -1,10 +1,4 @@
-"""Tests for #406 — popular endpoint excludes authenticated viewer's self.
-
-Service-level (`get_popular_users`) tests are sufficient for unit coverage.
-View-level wiring (`PopularUsersView` → `request.user.pk`) は既存
-`test_url_routing.py::test_popular_routes_to_popular_view_not_user_lookup`
-で routing が、本テストで service の挙動が、それぞれ独立にカバーされる。
-"""
+"""Tests for #406 / #410 — popular endpoint excludes self + following."""
 
 from __future__ import annotations
 
@@ -13,7 +7,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.follows.services import get_popular_users
-from apps.follows.tests._factories import make_user
+from apps.follows.tests._factories import make_follow, make_user
 
 
 @pytest.mark.django_db
@@ -62,3 +56,38 @@ class TestPopularUsersViewExcludesSelfWhenAuthenticated:
         assert resp.status_code == 200, resp.content
         handles = {r["user"]["handle"] for r in resp.data["results"]}
         assert a.username in handles
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestPopularExcludesFollowing:
+    """#410: 認証済 viewer の既フォローも popular から除外する."""
+
+    def test_get_popular_users_with_exclude_following(self) -> None:
+        viewer = make_user()
+        followed = make_user()
+        unfollowed = make_user()
+        make_follow(viewer, followed)
+
+        rows = get_popular_users(
+            limit=10,
+            exclude_user_id=viewer.pk,
+            exclude_following_for_user=viewer,
+        )
+        handles = {r["user"]["handle"] for r in rows}
+        assert followed.username not in handles
+        assert unfollowed.username in handles
+
+    def test_view_excludes_following_when_authenticated(self, api_client: APIClient) -> None:
+        viewer = make_user()
+        followed = make_user()
+        unfollowed = make_user()
+        make_follow(viewer, followed)
+        api_client.force_authenticate(user=viewer)
+
+        resp = api_client.get(reverse("users-popular"), {"limit": 10})
+        assert resp.status_code == 200, resp.content
+        handles = {r["user"]["handle"] for r in resp.data["results"]}
+        assert viewer.username not in handles
+        assert followed.username not in handles
+        assert unfollowed.username in handles

--- a/apps/follows/tests/test_recommended_relaxed_fallback.py
+++ b/apps/follows/tests/test_recommended_relaxed_fallback.py
@@ -1,8 +1,8 @@
-"""Tests for #399 — recommended users relaxed fallback.
+"""Tests for #410 — relaxed fallback (#399) は撤回された.
 
-候補が limit に満たない場合、自分・blocked のみ除外して埋める Step 4 fallback
-を検証する。frontend は ``is_following=True`` を見て「フォロー中」表示に切替える
-ため、本テストは ``is_following`` フラグも合わせて検証する。
+#399 で導入した Step 4 (既フォロー込みで埋める) は、WhoToFollow に「フォロー中」
+が並ぶ UX を生んでしまい撤回。本テストは「既フォローは推奨に出ない」ことを
+保証する regression test として残す。
 """
 
 from __future__ import annotations
@@ -15,11 +15,10 @@ from apps.follows.tests._factories import make_follow, make_user
 
 @pytest.mark.django_db
 @pytest.mark.integration
-class TestRelaxedFallback:
-    def test_includes_followed_users_when_unfollowed_pool_is_empty(self) -> None:
-        """全 candidate を既フォロー済にしても、limit を満たすまで relaxed fallback で埋める."""
+class TestRecommendedExcludesFollowing:
+    def test_followed_users_are_not_recommended(self) -> None:
+        """全員 follow 済なら recommendation は空 (= relaxed fallback で埋めない)."""
         viewer = make_user()
-        # 3 人ターゲットを作って全員フォロー済にする
         a = make_user()
         b = make_user()
         c = make_user()
@@ -27,15 +26,10 @@ class TestRelaxedFallback:
             make_follow(viewer, t)
 
         rows = compute_who_to_follow(viewer, limit=3)
-        handles = {r["user"]["handle"] for r in rows}
-        # 既フォローでも relaxed fallback で 3 人入ること
-        assert {a.username, b.username, c.username}.issubset(handles)
-        # 全員 is_following=True で返ること
-        for r in rows:
-            assert r["user"]["is_following"] is True
+        assert rows == []
 
-    def test_strict_then_relaxed_mix(self) -> None:
-        """未フォロー 1 + 既フォロー 2 の DB で limit=3 → 3 人とも埋まる."""
+    def test_only_unfollowed_users_appear(self) -> None:
+        """未フォロー 1 + 既フォロー 2 の DB で limit=3 → 1 人だけ返る (既フォローは出ない)."""
         viewer = make_user()
         unfollowed = make_user()
         followed_1 = make_user()
@@ -44,34 +38,28 @@ class TestRelaxedFallback:
         make_follow(viewer, followed_2)
 
         rows = compute_who_to_follow(viewer, limit=3)
-        by_handle = {r["user"]["handle"]: r["user"]["is_following"] for r in rows}
-        assert unfollowed.username in by_handle
-        assert by_handle[unfollowed.username] is False
-        assert by_handle.get(followed_1.username) is True
-        assert by_handle.get(followed_2.username) is True
+        handles = {r["user"]["handle"] for r in rows}
+        assert handles == {unfollowed.username}
+        # is_following は常に False (#410)
+        assert all(r["user"]["is_following"] is False for r in rows)
 
-    def test_self_is_never_included_even_in_relaxed_fallback(self) -> None:
+    def test_self_is_never_included(self) -> None:
         viewer = make_user()
-        make_user()  # other active user
+        make_user()
         rows = compute_who_to_follow(viewer, limit=3)
         assert viewer.username not in {r["user"]["handle"] for r in rows}
 
-    def test_limit_is_capped_to_available_users(self) -> None:
-        """DB に viewer 以外が居なければ空配列を返す (\"自分を除く全員\" = 0 人)."""
+    def test_empty_when_no_other_users(self) -> None:
         viewer = make_user()
         rows = compute_who_to_follow(viewer, limit=3)
         assert rows == []
 
-    def test_inactive_users_excluded_even_in_relaxed_fallback(self) -> None:
-        """#394 の方針 (is_active=False → 推奨に出さない) は relaxed fallback でも維持される."""
+    def test_inactive_users_excluded(self) -> None:
         viewer = make_user()
         active = make_user()
         inactive = make_user()
         inactive.is_active = False
         inactive.save(update_fields=["is_active"])
-        # viewer が両方フォローしていても、inactive は除外されること
-        make_follow(viewer, active)
-        make_follow(viewer, inactive)
 
         rows = compute_who_to_follow(viewer, limit=3)
         handles = {r["user"]["handle"] for r in rows}

--- a/apps/follows/tests/test_who_to_follow_cache_invalidate.py
+++ b/apps/follows/tests/test_who_to_follow_cache_invalidate.py
@@ -63,21 +63,18 @@ class TestFollowSignalsInvalidateWtfCache:
 @pytest.mark.integration
 class TestEndToEndCacheRefreshAfterFollow:
     def test_recommendations_reflect_new_follow_after_signal(self) -> None:
-        """build → cache → follow 1 人 → 次の get_who_to_follow が再 build され relaxed fallback が反映される.
+        """build → cache → follow 1 人 → cache invalidate → 既フォローは消える (#410).
 
         過程:
-          1) viewer から見える未フォロー候補 = a, b
-          2) get_who_to_follow → cache に [a, b] が入る
-          3) viewer が a を follow
-          4) signal で WTF cache が invalidate
-          5) get_who_to_follow を再呼び出し → 再 build。a は既フォローだが relaxed
-             fallback で出る (is_following=True) + b も出る
+          1) viewer から見える未フォロー候補 = a, b 両方出る
+          2) viewer が a を follow → signal で WTF cache が invalidate
+          3) 再呼び出し → a は除外、b のみ残る (relaxed fallback は撤回済 #410)
         """
         viewer = make_user()
         a = make_user()
         b = make_user()
 
-        # 1) 初期 build: a, b 共に未フォローで出る (両方とも is_following=False)
+        # 1) 初期 build: a, b 共に未フォローで出る
         first = get_who_to_follow(viewer, limit=3)
         first_handles = {r["user"]["handle"] for r in first}
         assert {a.username, b.username}.issubset(first_handles)
@@ -85,8 +82,10 @@ class TestEndToEndCacheRefreshAfterFollow:
         # 2) viewer が a を follow → signal 経由で cache 無効化
         make_follow(viewer, a)
 
-        # 3) 再呼び出し: a は is_following=True、b は False で両方とも出る
+        # 3) 再呼び出し: a は既フォローなので除外、b だけ残る
         second = get_who_to_follow(viewer, limit=3)
-        by_handle = {r["user"]["handle"]: r["user"]["is_following"] for r in second}
-        assert by_handle.get(a.username) is True
-        assert by_handle.get(b.username) is False
+        handles = {r["user"]["handle"] for r in second}
+        assert a.username not in handles
+        assert b.username in handles
+        # is_following は常に False (#410: relaxed fallback 撤回後)
+        assert all(r["user"]["is_following"] is False for r in second)

--- a/apps/follows/views.py
+++ b/apps/follows/views.py
@@ -177,6 +177,8 @@ class PopularUsersView(APIView):
     が cookie 不整合や redirect 直後の状態で popular endpoint を叩くケースが
     あり、そのとき自分が WhoToFollow に出てしまうため、二重防御として
     backend 側でも除外する。
+    #410: 認証済 viewer から呼ばれた場合は **既フォロー** も除外する。
+    WhoToFollow に「フォロー中」が並ぶ UX を防ぐ (recommended と整合)。
     """
 
     permission_classes = [AllowAny]
@@ -188,6 +190,12 @@ class PopularUsersView(APIView):
             limit = max(1, min(int(request.query_params.get("limit", 10)), 50))
         except (TypeError, ValueError):
             limit = 10
-        exclude_user_id = request.user.pk if request.user.is_authenticated else None
-        rows = get_popular_users(limit=limit, exclude_user_id=exclude_user_id)
+        if request.user.is_authenticated:
+            rows = get_popular_users(
+                limit=limit,
+                exclude_user_id=request.user.pk,
+                exclude_following_for_user=request.user,
+            )
+        else:
+            rows = get_popular_users(limit=limit)
         return Response({"results": rows})

--- a/docs/specs/recommended-users-spec.md
+++ b/docs/specs/recommended-users-spec.md
@@ -67,25 +67,7 @@ qs = (
 
 各候補に `reason="popular"` を付与。
 
-#### Step 4: relaxed fallback (#399)
-
-Step 3 後も候補が `limit` に満たない場合 (= 小規模 DB / 既フォロー済が多い viewer)、**既フォロー除外を解いて** さらに埋める:
-
-```python
-already = self_id | blocked | already_picked
-qs = (
-    User.objects.filter(is_active=True)
-    .exclude(pk__in=already)  # following は除外しない
-    .order_by("-followers_count")
-    [:remaining]
-)
-```
-
-これにより、UI 上は「自分以外で active な全員」が候補になりうる。各候補に `reason="popular"` を付与する (Step 3 と同じ)。
-
-frontend は `is_following=true` のユーザに対しては FollowButton を「フォロー中」表示に切替えるため (`_serialize_users` が `following_ids` を見て付加)、ユーザが既フォロー済の人をうっかり再フォローしてしまう事故は起きない。
-
-> 表示数 (limit) 自体は frontend が決める。WhoToFollow component は `LIMIT=3` (#399 で 5 → 3)。基本 3 人、足りなければ "自分・blocked を除いた active 全員" まで広げて埋める。それでも 0 人 (= viewer 以外の active user が居ない) なら空配列を返す。
+> 表示数 (limit) 自体は frontend が決める。WhoToFollow component は `LIMIT=3` (#399 で 5 → 3)。**既フォローは決して出さない方針** なので、候補が limit に足りなければ 1〜2 人、または 0 人で表示する。「フォロー中」のユーザを推奨に出す Step 4 (#399 で導入) は #410 で撤回した — UI 上「フォロー中」が並んでも操作の意味がないため、X / FB の動線に揃える。
 
 ### 2.2 除外条件
 


### PR DESCRIPTION
## サマリ

stg test3 でログイン → /u/test3 のサイドバーで stg08354 / haruna(@test2) が両方「フォロー中」状態で並んでいた。#399 で入れた relaxed fallback (Step 4) が原因なので撤回し、X / FB と同じ「既フォローは推奨に出さない」標準動線に揃える。

## 変更内容

### Backend
- \`apps/follows/services.py::compute_who_to_follow\` から Step 4 (relaxed fallback) 撤去
- \`_serialize_users\` の \`following_ids\` 引数を撤去 (常に \`is_following=False\`)
- \`get_popular_users\` に \`exclude_following_for_user\` 引数追加 → 認証済 viewer の既フォローを popular からも除外
- \`PopularUsersView\` で認証済なら self + 既フォロー両方除外

### テスト
- \`test_recommended_relaxed_fallback.py\` を「Step 4 が走らない」regression に書き換え (5 ケース)
- \`test_popular_excludes_self.py\` に既フォロー除外の view/service テスト 2 ケース追加
- \`test_who_to_follow_cache_invalidate.py\` の e2e を「follow → list から消える」に修正

### Spec
- \`docs/specs/recommended-users-spec.md\` の Step 4 セクション削除、撤回経緯を残す

## Test Plan
- [x] pytest **38/38 pass** (apps/follows 全件)
- [x] vitest 13/13 pass (WhoToFollow)
- [x] tsc / eslint クリーン
- [ ] CI green
- [ ] stg deploy 後、test3 でログインして /u/test3 → WhoToFollow に「フォロー中」が出ない
- [ ] (古い cache が残っていれば) follow → unfollow で自動 invalidate or \`python manage.py clear_who_to_follow_cache\`

## Closes
- #410

## 関連
- #399 (relaxed fallback 導入、本 PR で撤回)
- #404 (cache invalidate hook、引き続き有効)
- #406 (popular で self 除外、本 PR でさらに既フォロー除外も追加)