### PR TITLE
[bug][layout] RightSidebar を client component 化、CSR 遷移後の cookie 再評価で WhoToFollow 正常化 (#419)

### DIFF
--- a/client/src/app/(template)/layout.tsx
+++ b/client/src/app/(template)/layout.tsx
@@ -9,9 +9,10 @@ interface LayoutProps {
 }
 
 export default function layout({ children }: LayoutProps) {
-	// #316: ログイン済かを cookie (`logged_in`) で判定して RightSidebar (WhoToFollow
-	// + TrendingTags) に渡す。
-	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	// #316: ログイン済かを cookie (`logged_in`) で判定して初期値として RightSidebar
+	// に渡す。#419: layout は CSR 遷移で再 render されないため、RightSidebar 内
+	// の useEffect でも document.cookie から再評価する (initial value にだけ使う)。
+	const initialIsAuthenticated = cookies().get("logged_in")?.value === "true";
 
 	return (
 		<main className="bg-baby_veryBlack relative">
@@ -27,7 +28,7 @@ export default function layout({ children }: LayoutProps) {
 				</section>
 				{/* #316: 全 (template) 配下 page で WhoToFollow / TrendingTags を表示。
 				    lg+ で表示、それ以下では非表示。 */}
-				<RightSidebar isAuthenticated={isAuthenticated} />
+				<RightSidebar initialIsAuthenticated={initialIsAuthenticated} />
 			</div>
 		</main>
 	);

--- a/client/src/components/sidebar/RightSidebar.tsx
+++ b/client/src/components/sidebar/RightSidebar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * RightSidebar — desktop right rail with HeaderSearchBox + TrendingTags + WhoToFollow.
  *
@@ -5,17 +7,40 @@
  *   - lg+ (≥1024px) のみ表示
  *   - #396: 上部に HeaderSearchBox (Navbar から移設)、sticky で常時可視
  *   - #189: TrendingTags / WhoToFollow
+ *
+ * #419: `isAuthenticated` を SSR 経由 (layout の `cookies()`) ではなく、
+ * client-side で `document.cookie` から読む。Next.js App Router の layout は
+ * CSR 遷移で再 render されないため、login → navigate のあとに古い false 値が
+ * 残ってしまう (WhoToFollow が anonymous 経路を叩く副作用)。本コンポーネントを
+ * `'use client'` 化して mount 時に最新の cookie を読む。
  */
 
 import HeaderSearchBox from "@/components/shared/navbar/HeaderSearchBox";
 import TrendingTags from "@/components/sidebar/TrendingTags";
 import WhoToFollow from "@/components/sidebar/WhoToFollow";
+import { getCookie } from "cookies-next";
+import { useEffect, useState } from "react";
 
 interface RightSidebarProps {
-	isAuthenticated: boolean;
+	/** SSR で `cookies()` から得た初期値。CSR mount 後は document.cookie で再評価する。 */
+	initialIsAuthenticated?: boolean;
 }
 
-export default function RightSidebar({ isAuthenticated }: RightSidebarProps) {
+export default function RightSidebar({
+	initialIsAuthenticated = false,
+}: RightSidebarProps) {
+	const [isAuthenticated, setIsAuthenticated] = useState(
+		initialIsAuthenticated,
+	);
+
+	useEffect(() => {
+		// mount 時に最新の cookie を読む。client-side navigation で layout が
+		// 再 render されない場合でも、本 component (children) は再 mount される
+		// ので、ここで再評価されたら isAuthenticated が更新される。
+		const cookieIsLoggedIn = getCookie("logged_in") === "true";
+		setIsAuthenticated(cookieIsLoggedIn);
+	}, []);
+
 	return (
 		<aside
 			aria-label="サイドバー"

--- a/client/src/components/sidebar/__tests__/RightSidebar.test.tsx
+++ b/client/src/components/sidebar/__tests__/RightSidebar.test.tsx
@@ -1,10 +1,19 @@
 /**
- * Tests for RightSidebar container (P2-17 / Issue #189).
+ * Tests for RightSidebar container (P2-17 / Issue #189, #419 で client-side cookie 対応).
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import RightSidebar from "@/components/sidebar/RightSidebar";
+
+const { getCookieMock } = vi.hoisted(() => ({
+	getCookieMock: vi.fn(),
+}));
+
+vi.mock("cookies-next", () => ({
+	getCookie: getCookieMock,
+}));
 
 vi.mock("@/components/sidebar/TrendingTags", () => ({
 	default: () => <div data-testid="trending">trending stub</div>,
@@ -20,20 +29,27 @@ vi.mock("@/components/shared/navbar/HeaderSearchBox", () => ({
 }));
 
 describe("RightSidebar", () => {
+	beforeEach(() => {
+		getCookieMock.mockReset();
+		// デフォルトは未ログイン (cookie なし)
+		getCookieMock.mockReturnValue(undefined);
+	});
+
 	it("renders HeaderSearchBox at the top, TrendingTags and WhoToFollow", () => {
-		render(<RightSidebar isAuthenticated={true} />);
+		render(<RightSidebar initialIsAuthenticated={true} />);
 		expect(screen.getByTestId("header-search")).toBeInTheDocument();
 		expect(screen.getByTestId("trending")).toBeInTheDocument();
 		expect(screen.getByTestId("wtf")).toBeInTheDocument();
 	});
 
 	it("places search box before TrendingTags / WhoToFollow in the DOM order", () => {
-		const { container } = render(<RightSidebar isAuthenticated={true} />);
+		const { container } = render(
+			<RightSidebar initialIsAuthenticated={true} />,
+		);
 		const searchEl = container.querySelector("[data-testid='header-search']");
 		const trendingEl = container.querySelector("[data-testid='trending']");
 		expect(searchEl).toBeTruthy();
 		expect(trendingEl).toBeTruthy();
-		// compareDocumentPosition: 4 = following
 		expect(
 			searchEl &&
 				trendingEl &&
@@ -42,13 +58,37 @@ describe("RightSidebar", () => {
 		).toBeTruthy();
 	});
 
-	it("forwards isAuthenticated to WhoToFollow", () => {
-		render(<RightSidebar isAuthenticated={false} />);
-		expect(screen.getByTestId("wtf")).toHaveTextContent("anon");
+	it("uses initialIsAuthenticated for first render (SSR fallback)", () => {
+		// cookie はまだ読まれていない (initial render)
+		getCookieMock.mockReturnValue(undefined);
+		render(<RightSidebar initialIsAuthenticated={true} />);
+		// useEffect 後に false で上書きされるが、initial render は true
+		// (この test は SSR-equivalent な動作確認)
+		expect(screen.getByTestId("wtf")).toBeInTheDocument();
+	});
+
+	it("upgrades to auth=true after mount when cookie says logged_in=true (#419)", async () => {
+		// SSR では false (cookie 取れず) だったが client mount 時に取れる
+		getCookieMock.mockReturnValue("true");
+		render(<RightSidebar initialIsAuthenticated={false} />);
+		await waitFor(() => {
+			expect(screen.getByTestId("wtf")).toHaveTextContent("auth");
+		});
+	});
+
+	it("downgrades to auth=false after mount when cookie says not logged_in (#419)", async () => {
+		getCookieMock.mockReturnValue(undefined);
+		// 初期値 true でも、cookie が無いので mount 後 false に降りる
+		render(<RightSidebar initialIsAuthenticated={true} />);
+		await waitFor(() => {
+			expect(screen.getByTestId("wtf")).toHaveTextContent("anon");
+		});
 	});
 
 	it("is hidden below 1024px (lg breakpoint) via Tailwind hidden lg:block", () => {
-		const { container } = render(<RightSidebar isAuthenticated={false} />);
+		const { container } = render(
+			<RightSidebar initialIsAuthenticated={false} />,
+		);
 		const aside = container.querySelector("aside");
 		expect(aside).toBeTruthy();
 		expect(aside?.className).toMatch(/hidden/);
@@ -56,7 +96,9 @@ describe("RightSidebar", () => {
 	});
 
 	it("uses an <aside> landmark with aria-label", () => {
-		const { container } = render(<RightSidebar isAuthenticated={true} />);
+		const { container } = render(
+			<RightSidebar initialIsAuthenticated={true} />,
+		);
 		const aside = container.querySelector("aside");
 		expect(aside?.getAttribute("aria-label")).toBe("サイドバー");
 	});


### PR DESCRIPTION
## サマリ

stg で test2 ログイン中に WhoToFollow に「自分が出る」「フォローボタンが出ない」 regression を修正。

## 根本原因

\`(template)/layout.tsx\` が SSR で \`cookies().get('logged_in')\` を読んでいたが、Next.js App Router の **layout は client-side navigation で再 render されない**ため、login → home へ navigate しても初回 SSR の値 (false) が永続していた。

結果:
- WhoToFollow が anonymous 経路 (\`fetchPopularUsers\`) を叩く
- popular endpoint は viewer が anonymous なら self を除外しない → test2 が含まれる
- \`{isAuthenticated ? <FollowButton /> : null}\` のため FollowButton 自体が非表示

これは #316 で cookie 判定を採用して以降ずっと潜在していたレイヤー問題で、通知実装 (#412/#415/#416) で `/notifications` 等のページ追加 → navigation 経路が増えたため表面化したもの。**通知実装側の WhoToFollow / FollowButton への変更は一切無し**を確認済 (\`git log -p ... -- 'client/src/components/sidebar/' 'client/src/components/follows/'\` で diff ゼロ)。

## 修正

- \`RightSidebar\` を \`'use client'\` 化
- \`initialIsAuthenticated\` を SSR 初期値として受け、\`useEffect\` で \`getCookie('logged_in')\` を読んで再評価
- layout 側は \`initialIsAuthenticated\` 名に rename

これで login 後の navigation でも RightSidebar が再 mount 時に最新 cookie を読み、\`fetchRecommendedUsers\` 経路に切り替わって self 除外 / FollowButton 表示が正常化する。

## テスト
- vitest **7/7** (新規 cookie upgrade/downgrade テスト 2 件追加)
- tsc clean、eslint 既存 warning のみ

## Test Plan
- [x] vitest 7/7
- [x] tsc clean
- [ ] CI green
- [ ] stg deploy 後、test2 でログイン → ホーム / 任意ページで WhoToFollow に自分が出ない、FollowButton (「フォロー」) が表示される

## Closes #419