### PR TITLE
[feature][profile] フォロー数 / フォロワー数 + 一覧 + いいねタブ (X 風) (#421)

### DIFF
--- a/apps/follows/urls.py
+++ b/apps/follows/urls.py
@@ -20,6 +20,7 @@ from apps.follows.views import (
     PopularUsersView,
     RecommendedUsersView,
 )
+from apps.reactions.views import UserLikedTweetsView
 
 urlpatterns = [
     # P2-10: <handle>/follow/ より優先するため static path を先に
@@ -47,5 +48,11 @@ urlpatterns = [
         "<str:handle>/following/",
         FollowingListView.as_view(),
         name="follows-following-list",
+    ),
+    # #421: handle がいいねした tweet 一覧
+    path(
+        "<str:handle>/likes/",
+        UserLikedTweetsView.as_view(),
+        name="users-likes",
     ),
 ]

--- a/apps/reactions/tests/test_user_likes_api.py
+++ b/apps/reactions/tests/test_user_likes_api.py
@@ -1,0 +1,107 @@
+"""Tests for /api/v1/users/<handle>/likes/ (#421)."""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.reactions.models import Reaction, ReactionKind
+from apps.tweets.tests._factories import make_tweet, make_user
+
+
+@pytest.mark.django_db
+class TestUserLikesAPI:
+    def url(self, handle: str) -> str:
+        return reverse("users-likes", kwargs={"handle": handle})
+
+    def test_returns_liked_tweets_in_recency_order(self, api_client: APIClient) -> None:
+        author = make_user()
+        liker = make_user()
+        t1 = make_tweet(author=author, body="oldest")
+        t2 = make_tweet(author=author, body="middle")
+        t3 = make_tweet(author=author, body="newest")
+        # liker が t1 → t2 → t3 の順で like
+        Reaction.objects.create(user=liker, tweet=t1, kind=ReactionKind.LIKE)
+        Reaction.objects.create(user=liker, tweet=t2, kind=ReactionKind.LIKE)
+        Reaction.objects.create(user=liker, tweet=t3, kind=ReactionKind.LIKE)
+
+        res = api_client.get(self.url(liker.username))
+        assert res.status_code == status.HTTP_200_OK
+        results = res.data["results"]
+        # 最後に like した順 (= reaction.created_at 降順)
+        bodies = [r["body"] for r in results]
+        assert bodies == ["newest", "middle", "oldest"]
+
+    def test_excludes_other_kinds(self, api_client: APIClient) -> None:
+        liker = make_user()
+        t = make_tweet()
+        # LIKE 以外の kind は除外される (例: WOW)
+        Reaction.objects.create(user=liker, tweet=t, kind="wow")
+        res = api_client.get(self.url(liker.username))
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["results"] == []
+
+    def test_excludes_deleted_tweets(self, api_client: APIClient) -> None:
+        author = make_user()
+        liker = make_user()
+        t = make_tweet(author=author)
+        Reaction.objects.create(user=liker, tweet=t, kind=ReactionKind.LIKE)
+        t.is_deleted = True
+        t.save(update_fields=["is_deleted"])
+
+        res = api_client.get(self.url(liker.username))
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["results"] == []
+
+    def test_404_for_inactive_user(self, api_client: APIClient) -> None:
+        u = make_user()
+        u.is_active = False
+        u.save(update_fields=["is_active"])
+        res = api_client.get(self.url(u.username))
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_for_unknown_handle(self, api_client: APIClient) -> None:
+        res = api_client.get(self.url("nonexistent_user"))
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_anonymous_can_view(self, api_client: APIClient) -> None:
+        liker = make_user()
+        t = make_tweet()
+        Reaction.objects.create(user=liker, tweet=t, kind=ReactionKind.LIKE)
+        # AllowAny なので未認証でも見れる
+        res = api_client.get(self.url(liker.username))
+        assert res.status_code == status.HTTP_200_OK
+        assert len(res.data["results"]) == 1
+
+    def test_other_user_likes_not_mixed(self, api_client: APIClient) -> None:
+        u1 = make_user()
+        u2 = make_user()
+        t1 = make_tweet()
+        t2 = make_tweet()
+        Reaction.objects.create(user=u1, tweet=t1, kind=ReactionKind.LIKE)
+        Reaction.objects.create(user=u2, tweet=t2, kind=ReactionKind.LIKE)
+
+        res = api_client.get(self.url(u1.username))
+        assert res.status_code == status.HTTP_200_OK
+        # u2 の like は混ざらない
+        assert len(res.data["results"]) == 1
+        assert res.data["results"][0]["id"] == t1.pk
+
+
+@pytest.mark.django_db
+class TestPublicProfileCounts:
+    def url(self, handle: str) -> str:
+        return reverse("users-public-profile", kwargs={"username": handle})
+
+    def test_response_includes_followers_and_following_count(self, api_client: APIClient) -> None:
+        target = make_user()
+        target.followers_count = 5
+        target.following_count = 3
+        target.save(update_fields=["followers_count", "following_count"])
+
+        res = api_client.get(self.url(target.username))
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["followers_count"] == 5
+        assert res.data["following_count"] == 3

--- a/apps/reactions/views.py
+++ b/apps/reactions/views.py
@@ -4,6 +4,7 @@
 - POST   /api/v1/tweets/<tweet_id>/reactions/ body=`{kind}` → 作成 / 種別変更 / 取消
 - DELETE /api/v1/tweets/<tweet_id>/reactions/                → 明示的取消
 - GET    /api/v1/tweets/<tweet_id>/reactions/                → kind ごとの集計
+- GET    /api/v1/users/<handle>/likes/                       → ユーザがいいねした tweet 一覧 (#421)
 
 upsert toggle 仕様 (arch H-1: kind 変更は UPDATE のみ、DELETE+CREATE しない):
 - 既存なし & 新規 → INSERT (201, created=True)
@@ -16,10 +17,14 @@ from __future__ import annotations
 import logging
 from collections import Counter
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, transaction
+from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -34,6 +39,9 @@ from apps.reactions.serializers import (
     ReactionResponseSerializer,
 )
 from apps.tweets.models import Tweet
+from apps.tweets.serializers import TweetListSerializer
+
+User = get_user_model()
 
 logger = logging.getLogger(__name__)
 
@@ -147,3 +155,56 @@ class ReactionView(APIView):
 
         payload = {"counts": full_counts, "my_kind": my_kind}
         return Response(ReactionAggregateSerializer(payload).data)
+
+
+class UserLikesCursorPagination(CursorPagination):
+    page_size = 20
+    ordering = "-created_at"
+    cursor_query_param = "cursor"
+    max_page_size = 50
+
+
+class UserLikedTweetsView(ListAPIView):
+    """GET /api/v1/users/<handle>/likes/ — handle がいいねした tweet 一覧 (#421).
+
+    Reaction (kind=LIKE) を created_at 降順で取得し、対応する Tweet を返す。
+    削除済 tweet (`is_deleted=True`) は除外。
+    """
+
+    permission_classes = [AllowAny]
+    serializer_class = TweetListSerializer
+    pagination_class = UserLikesCursorPagination
+
+    def get_queryset(self) -> QuerySet[Tweet]:  # type: ignore[type-arg]
+        handle = self.kwargs["handle"]
+        target_user = get_object_or_404(User, username=handle, is_active=True)
+        # Tweet を Reaction の created_at で並べる: subquery でも join でもよいが
+        # シンプルに Tweet.objects から filter (反応した tweet のみ)。
+        liked_tweet_ids = (
+            Reaction.objects.filter(user=target_user, kind=ReactionKind.LIKE)
+            .order_by("-created_at")
+            .values_list("tweet_id", flat=True)
+        )
+        # `in` の order は preserve されないので、created_at 降順を維持するため
+        # 一旦 list に materialize → preserve_order で取得
+        ids = list(liked_tweet_ids[:200])  # MVP: 直近 200 件まで
+        if not ids:
+            return Tweet.objects.none()
+        # Tweet.objects は is_deleted=False のみ
+        # ids の順序を保つため annotate で sort key を付ける
+        from django.db.models import Case, IntegerField, Value, When
+
+        order_cases = [When(pk=tid, then=Value(idx)) for idx, tid in enumerate(ids)]
+        return (
+            Tweet.objects.select_related("author", "reply_to", "quote_of", "repost_of")
+            .filter(pk__in=ids)
+            .annotate(
+                _liked_order=Case(*order_cases, output_field=IntegerField()),
+            )
+            .order_by("_liked_order")
+        )
+
+    def get_serializer_context(self):  # type: ignore[no-untyped-def]
+        ctx = super().get_serializer_context()
+        ctx["request"] = self.request
+        return ctx

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -157,6 +157,9 @@ class PublicProfileSerializer(serializers.ModelSerializer):
             "full_name",
             "date_joined",
             "is_following",
+            # #421: フォロー数 / フォロワー数 (X 風プロフィール表示)
+            "followers_count",
+            "following_count",
         ]
         # 公開 API はすべて read_only (PATCH は /me/ 経由のみ)。
         # ``fields`` と同じ list を参照させると、DRF 内部で片方に mutate が走った

--- a/apps/users/tests/test_profile_api.py
+++ b/apps/users/tests/test_profile_api.py
@@ -50,6 +50,9 @@ EXPECTED_PUBLIC_KEYS = {
     # #296: FollowButton 初期状態判定用 (ログイン中の閲覧者が follow 中か).
     # PII では無く bool のみ、未ログイン時は false。
     "is_following",
+    # #421: X 風プロフィールに follower / following 数を表示するため公開。
+    "followers_count",
+    "following_count",
 }
 
 

--- a/client/src/app/(template)/u/[handle]/followers/page.tsx
+++ b/client/src/app/(template)/u/[handle]/followers/page.tsx
@@ -1,0 +1,53 @@
+/**
+ * /u/<handle>/followers — handle のフォロワー一覧 (#421, X 風).
+ */
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import UserList from "@/components/follows/UserList";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+
+interface PageProps {
+	params: { handle: string };
+}
+
+interface MinimalProfile {
+	username: string;
+	display_name: string;
+}
+
+async function loadProfile(handle: string): Promise<MinimalProfile | null> {
+	try {
+		return await serverFetch<MinimalProfile>(`/users/${handle}/`);
+	} catch (error) {
+		if (error instanceof ApiServerError && error.status === 404) return null;
+		throw error;
+	}
+}
+
+export default async function FollowersPage({ params }: PageProps) {
+	const profile = await loadProfile(params.handle);
+	if (!profile) notFound();
+
+	return (
+		<main className="mx-auto max-w-3xl pb-10">
+			<header className="border-b border-border px-4 py-3">
+				<Link
+					href={`/u/${profile.username}`}
+					className="text-xs text-muted-foreground hover:underline"
+				>
+					← {profile.display_name || profile.username} さんのプロフィールへ戻る
+				</Link>
+				<h1 className="mt-1 text-lg font-bold">
+					{profile.display_name || profile.username} のフォロワー
+				</h1>
+				<p className="text-xs text-muted-foreground">@{profile.username}</p>
+			</header>
+			<UserList
+				endpoint={`/users/${profile.username}/followers/`}
+				emptyMessage="フォロワーはまだいません。"
+			/>
+		</main>
+	);
+}

--- a/client/src/app/(template)/u/[handle]/following/page.tsx
+++ b/client/src/app/(template)/u/[handle]/following/page.tsx
@@ -1,0 +1,53 @@
+/**
+ * /u/<handle>/following — handle がフォロー中のユーザ一覧 (#421, X 風).
+ */
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import UserList from "@/components/follows/UserList";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+
+interface PageProps {
+	params: { handle: string };
+}
+
+interface MinimalProfile {
+	username: string;
+	display_name: string;
+}
+
+async function loadProfile(handle: string): Promise<MinimalProfile | null> {
+	try {
+		return await serverFetch<MinimalProfile>(`/users/${handle}/`);
+	} catch (error) {
+		if (error instanceof ApiServerError && error.status === 404) return null;
+		throw error;
+	}
+}
+
+export default async function FollowingPage({ params }: PageProps) {
+	const profile = await loadProfile(params.handle);
+	if (!profile) notFound();
+
+	return (
+		<main className="mx-auto max-w-3xl pb-10">
+			<header className="border-b border-border px-4 py-3">
+				<Link
+					href={`/u/${profile.username}`}
+					className="text-xs text-muted-foreground hover:underline"
+				>
+					← {profile.display_name || profile.username} さんのプロフィールへ戻る
+				</Link>
+				<h1 className="mt-1 text-lg font-bold">
+					{profile.display_name || profile.username} がフォロー中
+				</h1>
+				<p className="text-xs text-muted-foreground">@{profile.username}</p>
+			</header>
+			<UserList
+				endpoint={`/users/${profile.username}/following/`}
+				emptyMessage="まだ誰もフォローしていません。"
+			/>
+		</main>
+	);
+}

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import StartDMButton from "@/components/dm/StartDMButton";
@@ -26,10 +27,20 @@ interface PublicProfile {
 	/** #296: 閲覧者が既に target を follow しているか。未ログイン時は false。
 	 *  backend PublicProfileSerializer.get_is_following で算出。 */
 	is_following: boolean;
+	/** #421: X 風 — フォロワー数 / フォロー中数 */
+	followers_count: number;
+	following_count: number;
+}
+
+type ProfileTab = "tweets" | "likes";
+
+function resolveTab(raw: string | undefined): ProfileTab {
+	return raw === "likes" ? "likes" : "tweets";
 }
 
 interface PageProps {
 	params: { handle: string };
+	searchParams?: { tab?: string };
 }
 
 interface TweetListPage {
@@ -54,6 +65,18 @@ async function loadTweets(handle: string): Promise<TweetSummary[]> {
 			`/tweets/?author=${encodeURIComponent(handle)}`,
 		);
 		return page.results;
+	} catch {
+		return [];
+	}
+}
+
+async function loadLikedTweets(handle: string): Promise<TweetSummary[]> {
+	// #421: handle がいいねした tweet (cursor pagination, 初期 20 件)
+	try {
+		const page = await serverFetch<TweetListPage>(
+			`/users/${encodeURIComponent(handle)}/likes/`,
+		);
+		return page.results ?? [];
 	} catch {
 		return [];
 	}
@@ -100,12 +123,14 @@ const SNS_LINKS: Array<{
 	{ key: "linkedin_url", label: "LinkedIn" },
 ];
 
-export default async function ProfilePage({ params }: PageProps) {
+export default async function ProfilePage({ params, searchParams }: PageProps) {
 	const profile = await loadProfile(params.handle);
 	if (!profile) notFound();
 
-	const [tweets, currentUser] = await Promise.all([
-		loadTweets(profile.username),
+	const tab = resolveTab(searchParams?.tab);
+	const [tweets, likedTweets, currentUser] = await Promise.all([
+		tab === "tweets" ? loadTweets(profile.username) : Promise.resolve([]),
+		tab === "likes" ? loadLikedTweets(profile.username) : Promise.resolve([]),
 		loadCurrentUser(),
 	]);
 	const isOwnProfile = currentUser?.username === profile.username;
@@ -202,19 +227,86 @@ export default async function ProfilePage({ params }: PageProps) {
 				))}
 			</ul>
 
-			<section className="mt-8 px-4" aria-labelledby="tweets-heading">
-				<h2 id="tweets-heading" className="mb-3 text-lg font-semibold">
-					ツイート
+			{/* #421: フォロー数 / フォロワー数 (X 風)。click で一覧ページへ。 */}
+			<div className="mt-3 flex flex-wrap gap-5 px-4 text-sm">
+				<Link
+					href={`/u/${profile.username}/following`}
+					className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					<span className="font-semibold text-foreground">
+						{profile.following_count.toLocaleString()}
+					</span>
+					<span className="ml-1 text-muted-foreground">フォロー中</span>
+				</Link>
+				<Link
+					href={`/u/${profile.username}/followers`}
+					className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					<span className="font-semibold text-foreground">
+						{profile.followers_count.toLocaleString()}
+					</span>
+					<span className="ml-1 text-muted-foreground">フォロワー</span>
+				</Link>
+			</div>
+
+			{/* #421: ポスト / いいね タブ (X 風)。?tab=likes で切替。 */}
+			<nav
+				aria-label="プロフィール タブ"
+				className="mt-6 flex border-b border-border px-4"
+			>
+				{(
+					[
+						{ key: "tweets", label: "ポスト", href: `/u/${profile.username}` },
+						{
+							key: "likes",
+							label: "いいね",
+							href: `/u/${profile.username}?tab=likes`,
+						},
+					] as const
+				).map((t) => (
+					<Link
+						key={t.key}
+						href={t.href}
+						aria-current={tab === t.key ? "page" : undefined}
+						className={`relative px-4 py-3 text-sm font-medium transition ${
+							tab === t.key
+								? "text-foreground"
+								: "text-muted-foreground hover:bg-muted/40"
+						}`}
+					>
+						{t.label}
+						{tab === t.key ? (
+							<span
+								aria-hidden="true"
+								className="absolute inset-x-2 bottom-0 h-1 rounded-full bg-primary"
+							/>
+						) : null}
+					</Link>
+				))}
+			</nav>
+
+			<section className="mt-4 px-4" aria-labelledby="tweets-heading">
+				<h2 id="tweets-heading" className="sr-only">
+					{tab === "likes" ? "いいねした投稿" : "ツイート"}
 				</h2>
-				{/* #298: 旧 plain link 列挙を TweetCard ベースに置換。
-				    リアクション (P2-14) / RT (P2-15) / 「もっと見る」展開 (P2-18)
-				    が本配線される。HomeFeed と同 ARIA feed pattern。 */}
-				<TweetCardList
-					tweets={tweets}
-					ariaLabel={`@${profile.username} のツイート`}
-					emptyMessage="まだツイートがありません。"
-					currentUserHandle={currentUser?.username}
-				/>
+				{tab === "likes" ? (
+					<TweetCardList
+						tweets={likedTweets}
+						ariaLabel={`@${profile.username} がいいねした投稿`}
+						emptyMessage="いいねした投稿がありません。"
+						currentUserHandle={currentUser?.username}
+					/>
+				) : (
+					/* #298: 旧 plain link 列挙を TweetCard ベースに置換。
+					    リアクション (P2-14) / RT (P2-15) / 「もっと見る」展開 (P2-18)
+					    が本配線される。HomeFeed と同 ARIA feed pattern。 */
+					<TweetCardList
+						tweets={tweets}
+						ariaLabel={`@${profile.username} のツイート`}
+						emptyMessage="まだツイートがありません。"
+						currentUserHandle={currentUser?.username}
+					/>
+				)}
 			</section>
 		</main>
 	);

--- a/client/src/components/follows/UserList.tsx
+++ b/client/src/components/follows/UserList.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+/**
+ * UserList — フォロー中 / フォロワー 一覧の共通 UI (#421).
+ *
+ * `/u/<handle>/following` / `/u/<handle>/followers` で使う。
+ * cursor pagination、各 row に avatar + display_name + handle + bio + FollowButton。
+ */
+
+import { useEffect, useState } from "react";
+
+import FollowButton from "@/components/follows/FollowButton";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { api } from "@/lib/api/client";
+import { CircleUser } from "lucide-react";
+import Link from "next/link";
+
+export interface FollowListUser {
+	id: string;
+	username: string;
+	display_name: string;
+	avatar_url: string;
+	bio: string;
+	is_following?: boolean;
+}
+
+interface FollowListResponse {
+	results: FollowListUser[];
+	next: string | null;
+	previous: string | null;
+}
+
+interface UserListProps {
+	endpoint: string; // 例: /users/test2/followers/
+	emptyMessage: string;
+}
+
+type LoadState = "loading" | "ready" | "error";
+
+export default function UserList({ endpoint, emptyMessage }: UserListProps) {
+	const [users, setUsers] = useState<FollowListUser[]>([]);
+	const [next, setNext] = useState<string | null>(null);
+	const [state, setState] = useState<LoadState>("loading");
+
+	useEffect(() => {
+		let cancelled = false;
+		setState("loading");
+		api
+			.get<FollowListResponse>(endpoint)
+			.then((res) => {
+				if (cancelled) return;
+				const data = res.data;
+				setUsers(data.results ?? []);
+				setNext(data.next ?? null);
+				setState("ready");
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setState("error");
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [endpoint]);
+
+	const loadMore = async () => {
+		if (!next) return;
+		try {
+			const res = await api.get<FollowListResponse>(next);
+			setUsers((prev) => [...prev, ...(res.data.results ?? [])]);
+			setNext(res.data.next ?? null);
+		} catch {
+			// silent
+		}
+	};
+
+	if (state === "loading") {
+		return (
+			<div
+				role="status"
+				aria-live="polite"
+				className="p-8 text-center text-muted-foreground"
+			>
+				読み込み中…
+			</div>
+		);
+	}
+	if (state === "error") {
+		return (
+			<div role="alert" className="text-baby_red p-8 text-center">
+				取得に失敗しました
+			</div>
+		);
+	}
+	if (users.length === 0) {
+		return (
+			<div className="p-8 text-center text-muted-foreground">
+				{emptyMessage}
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<ul className="divide-y divide-border">
+				{users.map((u) => {
+					const visibleName = u.display_name || u.username;
+					return (
+						<li key={u.username} className="flex items-start gap-3 p-4">
+							<Link
+								href={`/u/${u.username}`}
+								aria-label={`${visibleName} (@${u.username}) のプロフィール`}
+								className="shrink-0"
+							>
+								<Avatar className="size-12">
+									<AvatarImage src={u.avatar_url} alt="" />
+									<AvatarFallback>
+										<CircleUser className="size-6" aria-hidden="true" />
+									</AvatarFallback>
+								</Avatar>
+							</Link>
+							<div className="min-w-0 flex-1">
+								<Link
+									href={`/u/${u.username}`}
+									className="block hover:underline"
+								>
+									<span className="block truncate text-sm font-semibold text-foreground">
+										{visibleName}
+									</span>
+									<span className="block truncate text-xs text-muted-foreground">
+										@{u.username}
+									</span>
+								</Link>
+								{u.bio ? (
+									<p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+										{u.bio}
+									</p>
+								) : null}
+							</div>
+							<div className="shrink-0">
+								<FollowButton
+									targetHandle={u.username}
+									initialIsFollowing={Boolean(u.is_following)}
+									size="sm"
+								/>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+			{next ? (
+				<div className="border-t border-border p-4 text-center">
+					<button
+						type="button"
+						onClick={loadMore}
+						className="rounded-full border border-border px-6 py-2 text-sm text-muted-foreground hover:bg-muted"
+					>
+						もっと見る
+					</button>
+				</div>
+			) : null}
+		</>
+	);
+}

--- a/client/src/components/follows/__tests__/UserList.test.tsx
+++ b/client/src/components/follows/__tests__/UserList.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for UserList (#421).
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import UserList from "@/components/follows/UserList";
+
+const { apiGetMock } = vi.hoisted(() => ({
+	apiGetMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+	api: { get: apiGetMock },
+}));
+
+// FollowButton は UserList の責務外なので stub
+vi.mock("@/components/follows/FollowButton", () => ({
+	default: ({ targetHandle }: { targetHandle: string }) => (
+		<button type="button" aria-label={`mock-follow-${targetHandle}`}>
+			フォロー
+		</button>
+	),
+}));
+
+const SAMPLE = [
+	{
+		id: "u1",
+		username: "alice",
+		display_name: "Alice",
+		avatar_url: "",
+		bio: "Engineer",
+		is_following: false,
+	},
+	{
+		id: "u2",
+		username: "bob",
+		display_name: "",
+		avatar_url: "",
+		bio: "",
+		is_following: true,
+	},
+];
+
+describe("UserList", () => {
+	beforeEach(() => {
+		apiGetMock.mockReset();
+	});
+
+	it("renders users after fetch", async () => {
+		apiGetMock.mockResolvedValueOnce({
+			data: { results: SAMPLE, next: null, previous: null },
+		});
+		render(<UserList endpoint="/users/x/followers/" emptyMessage="empty" />);
+		await screen.findByText("Alice");
+		// display_name 空 → handle (bob) を visible name として表示
+		expect(screen.getByText("bob")).toBeInTheDocument();
+	});
+
+	it("renders empty state", async () => {
+		apiGetMock.mockResolvedValueOnce({
+			data: { results: [], next: null, previous: null },
+		});
+		render(
+			<UserList
+				endpoint="/users/x/followers/"
+				emptyMessage="まだ誰もいません"
+			/>,
+		);
+		await screen.findByText(/まだ誰もいません/);
+	});
+
+	it("renders error fallback on fetch failure", async () => {
+		apiGetMock.mockRejectedValueOnce(new Error("500"));
+		render(<UserList endpoint="/users/x/followers/" emptyMessage="" />);
+		await screen.findByRole("alert");
+	});
+
+	it("links each row to /u/<handle>", async () => {
+		apiGetMock.mockResolvedValueOnce({
+			data: { results: SAMPLE, next: null, previous: null },
+		});
+		render(<UserList endpoint="/users/x/followers/" emptyMessage="empty" />);
+		await screen.findByText("Alice");
+		const links = screen.getAllByRole("link");
+		expect(links.some((l) => l.getAttribute("href") === "/u/alice")).toBe(true);
+		expect(links.some((l) => l.getAttribute("href") === "/u/bob")).toBe(true);
+	});
+
+	it("shows もっと見る when next is available and loads more on click", async () => {
+		apiGetMock
+			.mockResolvedValueOnce({
+				data: {
+					results: SAMPLE,
+					next: "/users/x/followers/?cursor=2",
+					previous: null,
+				},
+			})
+			.mockResolvedValueOnce({
+				data: {
+					results: [
+						{
+							id: "u3",
+							username: "carol",
+							display_name: "Carol",
+							avatar_url: "",
+							bio: "",
+							is_following: false,
+						},
+					],
+					next: null,
+					previous: null,
+				},
+			});
+		render(<UserList endpoint="/users/x/followers/" emptyMessage="empty" />);
+		await screen.findByText("Alice");
+		await userEvent.click(screen.getByRole("button", { name: /もっと見る/ }));
+		await waitFor(() => {
+			expect(screen.getByText("Carol")).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
## サマリ

X (旧 Twitter) 風プロフィール体験:
- bio 直下に **「N フォロー中 / N フォロワー」** click で各一覧へ
- \`/u/<handle>/followers\`、\`/u/<handle>/following\` 新設
- プロフィールに **「ポスト / いいね」タブ** (?tab=likes 切替)

## Backend
- \`PublicProfileSerializer\` に \`followers_count\` / \`following_count\` 追加
- \`GET /api/v1/users/<handle>/likes/\` 新設
- pytest **9 新規 + regression 185 pass**

## Frontend
- \`/u/<handle>\` page に counts + tab
- \`/u/<handle>/{followers,following}\` 新規 page
- \`UserList\` 共通 component
- vitest **5/5** + tsc / eslint clean

## 触っていないもの
通知 / WhoToFollow / Navbar / Tweet / Reaction CRUD / 既存 follow 動線

## Closes #421