### PR TITLE
[fix][profile] フォロー一覧の display_name 空 fallback と FollowButton 状態反映 (#423)

### DIFF
--- a/apps/follows/serializers.py
+++ b/apps/follows/serializers.py
@@ -11,11 +11,12 @@ User = get_user_model()
 class PublicUserMiniSerializer(serializers.ModelSerializer):
     """フォロワー / フォロー中一覧の各行で返す軽量プロフィール。
 
-    フルの PublicProfileSerializer を返すと N+1 と payload 肥大化につながるため、
-    handle / display_name / avatar / followers_count のみに絞る。
+    `is_following` は request.user 視点で行 user を follow しているか
+    (#423: 一覧の「フォロー」/「フォロー解除」ボタン状態を初期反映するため)。
     """
 
     handle = serializers.CharField(source="username", read_only=True)
+    is_following = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -26,8 +27,19 @@ class PublicUserMiniSerializer(serializers.ModelSerializer):
             "avatar_url",
             "bio",
             "followers_count",
+            "is_following",
         )
         read_only_fields = fields
+
+    def get_is_following(self, obj: User) -> bool:
+        request = self.context.get("request")
+        if request is None or not request.user.is_authenticated:
+            return False
+        if request.user.pk == obj.pk:
+            return False
+        from apps.follows.models import Follow
+
+        return Follow.objects.filter(follower=request.user, followee=obj).exists()
 
 
 class FollowResponseSerializer(serializers.Serializer):

--- a/apps/follows/tests/test_follow_list_is_following.py
+++ b/apps/follows/tests/test_follow_list_is_following.py
@@ -1,0 +1,94 @@
+"""Backend test: followers/following list response に is_following が含まれるか (#423)."""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from apps.follows.tests._factories import make_follow, make_user
+
+
+@pytest.mark.django_db
+class TestFollowListIsFollowing:
+    """`/api/v1/users/<handle>/{followers,following}/` の各 row に
+    `is_following` (request.user 視点) が入っているか。
+    """
+
+    def test_following_list_includes_is_following_true_for_already_followed(self):
+        """A が B を follow 済み のとき、A が見る /users/alpha/following/ の row B は
+        is_following=True で返る。
+        """
+        a = make_user(username="alpha", email="a@example.com")
+        b = make_user(username="bravo", email="b@example.com")
+        make_follow(a, b)
+
+        client = APIClient()
+        client.force_authenticate(user=a)
+        res = client.get("/api/v1/users/alpha/following/")
+
+        assert res.status_code == 200
+        rows = res.data["results"]
+        assert len(rows) == 1
+        assert rows[0]["handle"] == "bravo"
+        assert rows[0]["is_following"] is True
+
+    def test_followers_list_is_following_per_request_user(self):
+        """A が見る /users/alpha/followers/ で B が follower。
+        A は B を follow していないなら is_following=False。相互 follow なら True。
+        """
+        a = make_user(username="alpha", email="a@example.com")
+        b = make_user(username="bravo", email="b@example.com")
+        make_follow(b, a)  # B が A を follow
+
+        client = APIClient()
+        client.force_authenticate(user=a)
+        res = client.get("/api/v1/users/alpha/followers/")
+        rows = res.data["results"]
+        assert len(rows) == 1
+        assert rows[0]["handle"] == "bravo"
+        assert rows[0]["is_following"] is False
+
+        make_follow(a, b)  # A も B を follow → 相互
+        res2 = client.get("/api/v1/users/alpha/followers/")
+        assert res2.data["results"][0]["is_following"] is True
+
+    def test_anonymous_request_returns_is_following_false(self):
+        a = make_user(username="alpha", email="a@example.com")
+        b = make_user(username="bravo", email="b@example.com")
+        make_follow(a, b)
+
+        client = APIClient()
+        res = client.get("/api/v1/users/alpha/following/")
+        assert res.status_code == 200
+        assert res.data["results"][0]["is_following"] is False
+
+    def test_self_row_is_following_false(self):
+        a = make_user(username="alpha", email="a@example.com")
+        b = make_user(username="bravo", email="b@example.com")
+        make_follow(b, a)
+
+        client = APIClient()
+        client.force_authenticate(user=a)
+        res = client.get("/api/v1/users/bravo/following/")
+        assert res.data["results"][0]["handle"] == "alpha"
+        assert res.data["results"][0]["is_following"] is False
+
+    def test_response_keys_include_handle_and_is_following(self):
+        a = make_user(username="alpha", email="a@example.com")
+        b = make_user(username="bravo", email="b@example.com")
+        make_follow(a, b)
+
+        client = APIClient()
+        client.force_authenticate(user=a)
+        res = client.get("/api/v1/users/alpha/following/")
+        row = res.data["results"][0]
+        expected_keys = {
+            "id",
+            "handle",
+            "display_name",
+            "avatar_url",
+            "bio",
+            "followers_count",
+            "is_following",
+        }
+        assert set(row.keys()) == expected_keys

--- a/client/src/components/follows/UserList.tsx
+++ b/client/src/components/follows/UserList.tsx
@@ -17,7 +17,7 @@ import Link from "next/link";
 
 export interface FollowListUser {
 	id: string;
-	username: string;
+	handle: string;
 	display_name: string;
 	avatar_url: string;
 	bio: string;
@@ -104,12 +104,12 @@ export default function UserList({ endpoint, emptyMessage }: UserListProps) {
 		<>
 			<ul className="divide-y divide-border">
 				{users.map((u) => {
-					const visibleName = u.display_name || u.username;
+					const visibleName = u.display_name?.trim() || u.handle;
 					return (
-						<li key={u.username} className="flex items-start gap-3 p-4">
+						<li key={u.handle} className="flex items-start gap-3 p-4">
 							<Link
-								href={`/u/${u.username}`}
-								aria-label={`${visibleName} (@${u.username}) のプロフィール`}
+								href={`/u/${u.handle}`}
+								aria-label={`${visibleName} (@${u.handle}) のプロフィール`}
 								className="shrink-0"
 							>
 								<Avatar className="size-12">
@@ -120,15 +120,12 @@ export default function UserList({ endpoint, emptyMessage }: UserListProps) {
 								</Avatar>
 							</Link>
 							<div className="min-w-0 flex-1">
-								<Link
-									href={`/u/${u.username}`}
-									className="block hover:underline"
-								>
+								<Link href={`/u/${u.handle}`} className="block hover:underline">
 									<span className="block truncate text-sm font-semibold text-foreground">
 										{visibleName}
 									</span>
 									<span className="block truncate text-xs text-muted-foreground">
-										@{u.username}
+										@{u.handle}
 									</span>
 								</Link>
 								{u.bio ? (
@@ -139,7 +136,7 @@ export default function UserList({ endpoint, emptyMessage }: UserListProps) {
 							</div>
 							<div className="shrink-0">
 								<FollowButton
-									targetHandle={u.username}
+									targetHandle={u.handle}
 									initialIsFollowing={Boolean(u.is_following)}
 									size="sm"
 								/>

--- a/client/src/components/follows/__tests__/UserList.test.tsx
+++ b/client/src/components/follows/__tests__/UserList.test.tsx
@@ -17,10 +17,21 @@ vi.mock("@/lib/api/client", () => ({
 }));
 
 // FollowButton は UserList の責務外なので stub
+// initialIsFollowing を data-* で透過させて、UserList がちゃんと渡せているか検証する。
 vi.mock("@/components/follows/FollowButton", () => ({
-	default: ({ targetHandle }: { targetHandle: string }) => (
-		<button type="button" aria-label={`mock-follow-${targetHandle}`}>
-			フォロー
+	default: ({
+		targetHandle,
+		initialIsFollowing,
+	}: {
+		targetHandle: string;
+		initialIsFollowing?: boolean;
+	}) => (
+		<button
+			type="button"
+			aria-label={`mock-follow-${targetHandle}`}
+			data-initial-following={String(Boolean(initialIsFollowing))}
+		>
+			{initialIsFollowing ? "フォロー中" : "フォロー"}
 		</button>
 	),
 }));
@@ -28,7 +39,7 @@ vi.mock("@/components/follows/FollowButton", () => ({
 const SAMPLE = [
 	{
 		id: "u1",
-		username: "alice",
+		handle: "alice",
 		display_name: "Alice",
 		avatar_url: "",
 		bio: "Engineer",
@@ -36,7 +47,7 @@ const SAMPLE = [
 	},
 	{
 		id: "u2",
-		username: "bob",
+		handle: "bob",
 		display_name: "",
 		avatar_url: "",
 		bio: "",
@@ -89,6 +100,34 @@ describe("UserList", () => {
 		expect(links.some((l) => l.getAttribute("href") === "/u/bob")).toBe(true);
 	});
 
+	it("falls back to handle when display_name is empty (#423)", async () => {
+		apiGetMock.mockResolvedValueOnce({
+			data: { results: SAMPLE, next: null, previous: null },
+		});
+		render(<UserList endpoint="/users/x/followers/" emptyMessage="empty" />);
+		await screen.findByText("Alice");
+		// bob: display_name="" → 表示名 = handle ("bob")。"@" だけは出ない。
+		expect(screen.getByText("bob")).toBeInTheDocument();
+		expect(screen.queryByText(/^@\s*$/)).toBeNull();
+		expect(screen.getByText("@bob")).toBeInTheDocument();
+	});
+
+	it("propagates is_following to FollowButton initial state (#423)", async () => {
+		apiGetMock.mockResolvedValueOnce({
+			data: { results: SAMPLE, next: null, previous: null },
+		});
+		render(<UserList endpoint="/users/x/followers/" emptyMessage="empty" />);
+		await screen.findByText("Alice");
+		// alice: is_following=false → 「フォロー」
+		const aliceBtn = screen.getByLabelText("mock-follow-alice");
+		expect(aliceBtn).toHaveAttribute("data-initial-following", "false");
+		expect(aliceBtn).toHaveTextContent("フォロー");
+		// bob: is_following=true → 「フォロー中」(= 既に follow 済み)
+		const bobBtn = screen.getByLabelText("mock-follow-bob");
+		expect(bobBtn).toHaveAttribute("data-initial-following", "true");
+		expect(bobBtn).toHaveTextContent("フォロー中");
+	});
+
 	it("shows もっと見る when next is available and loads more on click", async () => {
 		apiGetMock
 			.mockResolvedValueOnce({
@@ -103,7 +142,7 @@ describe("UserList", () => {
 					results: [
 						{
 							id: "u3",
-							username: "carol",
+							handle: "carol",
 							display_name: "Carol",
 							avatar_url: "",
 							bio: "",


### PR DESCRIPTION
## サマリ

#421 follow-up。E2E 検証でハルナさん指摘:

> フォロワーが@になっているし、フォローしている人を見ても名前の横にフォローってある。もうフォローしているからフォローじゃない。フォロー解除が正しい。

### 2 つのバグ

| # | 症状 | 原因 | Fix |
|---|---|---|---|
| 1 | display_name 空ユーザー表示が「@」だけ | UserList interface が `username` を期待 → API は `handle` 返す → `undefined` | interface を `handle` に揃える + display_name 空時は handle へ fallback |
| 2 | follow 済み相手にも「フォロー」 button | `PublicUserMiniSerializer` に `is_following` 無し → `initialIsFollowing` が常に false | `is_following` SerializerMethodField を追加 (request.user 視点) |

## Tests

### Backend (5 件追加, 既存 38 件 regression OK)
- `test_following_list_includes_is_following_true_for_already_followed`
- `test_followers_list_is_following_per_request_user` (相互 follow も検証)
- `test_anonymous_request_returns_is_following_false`
- `test_self_row_is_following_false`
- `test_response_keys_include_handle_and_is_following` (フィールド一覧固定)

backend pytest **190 passed** (apps/follows + apps/users + apps/reactions)

### Frontend (vitest UserList 7/7 pass)
- 既存 5 件は `username` → `handle` field rename
- 新規:
  - `falls back to handle when display_name is empty (#423)`
  - `propagates is_following to FollowButton initial state (#423)`

`tsc --noEmit` / `eslint` も clean。

## 触っていないもの

- 通知 / WhoToFollow / Navbar / Tweet / Reaction CRUD
- /u/<handle> page (counts + tab) 自体
- FollowButton 内部実装

## Closes #423