### PR TITLE
fix(infra): nginx admin location を /admin に揃える (Closes #439)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ docker compose -f local.yml exec api python manage.py migrate
 # Swagger UI:      http://localhost:8080/api/schema/swagger-ui/
 # ReDoc:           http://localhost:8080/api/schema/redoc/
 # Legacy ReDoc:    http://localhost:8080/redoc/
-# Admin:           http://localhost:8080/supersecret/
+# Admin:           http://localhost:8080/admin/
 # Mailpit:         http://localhost:8025/
 # Flower (Celery): http://localhost:5555/
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ docker compose -f local.yml exec api python manage.py createsuperuser
 |---|---|
 | Next.js (UI) | http://localhost:8080/ (nginx 経由) |
 | Django API | http://localhost:8080/api/v1/ |
-| Django Admin | http://localhost:8080/supersecret/ |
+| Django Admin | http://localhost:8080/admin/ |
 | Swagger / ReDoc | http://localhost:8080/redoc/ |
 | Mailpit (開発メール) | http://localhost:8025/ |
 | Flower (Celery) | http://localhost:5555/ |

--- a/docker/local/nginx/nginx.conf
+++ b/docker/local/nginx/nginx.conf
@@ -63,7 +63,10 @@ server {
     error_log /var/log/nginx/ws_error.log error;
   }
 
-  location /supersecret {
+  # Django admin (#439): nginx 側のロケーションを Django ADMIN_URL ("admin/") に揃える。
+  # 以前は `/supersecret` で書かれていたが Django 側は `/admin/` でルーティングされており
+  # nginx を通った時点で 404 になっていた。
+  location /admin {
     proxy_pass http://api;
     access_log /var/log/nginx/admin_access.log;
   }

--- a/docker/production/nginx/nginx.conf
+++ b/docker/production/nginx/nginx.conf
@@ -76,7 +76,10 @@ http {
       error_log /var/log/nginx/api_error.log error;
     }
 
-    location /supersecret {
+    # Django admin (#439): nginx 側のロケーションを Django ADMIN_URL ("admin/") に揃える。
+    # 以前は `/supersecret` で書かれていたが Django 側は `/admin/` でルーティングされており
+    # nginx を通った時点で 404 になっていた。
+    location /admin {
       proxy_pass http://api;
       access_log /var/log/nginx/admin_access.log;
     }

--- a/docs/specs/boards-scenarios.md
+++ b/docs/specs/boards-scenarios.md
@@ -108,7 +108,7 @@
 
 **When** 一般ユーザーが Web から `POST /api/v1/boards/` を試行する
 **Then** そのエンドポイントは存在しない（404 / 405）
-**And** Django admin の `/supersecret/boards/board/` からは管理者が CRUD できる
+**And** Django admin の `/admin/boards/board/` からは管理者が CRUD できる
 
 ## S-13: レートリミット — スレ作成 5 分に 1 件
 


### PR DESCRIPTION
## Summary

stg で Django admin が 404 になっていた #439 を最小修正で解決。

## 原因

nginx (`docker/{local,production}/nginx/nginx.conf`) は `location /supersecret` で api へ proxy していたが、Django 側は `ADMIN_URL = "admin/"` (terraform / CI / .env.local 全て) で動いていた。結果、`/supersecret/` も `/admin/` も admin に届かず 404。

## 修正方針

Django + terraform + CI を触る案 (`/supersecret/` 統一) と、nginx だけ触る案 (`/admin/` 統一) があったが、後者の方が変更範囲が小さいので採用。

- nginx local + prod: `location /supersecret` → `location /admin`
- ドキュメント表記 (CLAUDE.md / README.md / boards-scenarios.md) を `/admin/` に更新

Django / terraform / CI / .env.local は無変更。

## Test plan

- [x] nginx 設定 syntax 確認
- [ ] stg デプロイ (cd-stg.yml) 後 `https://stg.codeplace.me/admin/login/` が Django admin login 画面 (200) を返す
- [ ] superuser でログイン → `apps.boards.Board` を新規作成できる
- [ ] 既存 phase の admin (tweets / users / follows) も操作できる

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)