### PR TITLE
infra(stg): /admin/* と /static/* の routing を追加 (Closes #439)

### DIFF
--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -254,6 +254,7 @@ module "services" {
   media_bucket_name    = module.storage.media_bucket_id
   media_public_domain  = "${var.app_subdomain}.${var.domain_name}"
   static_bucket_name   = module.storage.static_bucket_id
+  app_fqdn             = "${var.app_subdomain}.${var.domain_name}"
 
   # SSR fetch base URL (Next → Django via ALB internal lookup)
   alb_dns_name = module.compute.alb_dns_name

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -284,6 +284,28 @@ resource "aws_lb_listener_rule" "api" {
   }
 }
 
+# /admin/* → app tg (Django admin) (#439)
+# CloudFront default behavior が ALB に流すので、ALB 側で /admin/* を app tg
+# (Django) に振り直す必要がある。/static/* (Django admin static) も併せて
+# app tg に振らないと admin の CSS/JS が 404 になる。
+resource "aws_lb_listener_rule" "admin" {
+  count = var.alb_certificate_arn == "" ? 0 : 1
+
+  listener_arn = aws_lb_listener.https[0].arn
+  priority     = 15 # /api/* (10) より後、/ws/* (20) より先
+
+  condition {
+    path_pattern {
+      values = ["/admin/*", "/admin"]
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this["app"].arn
+  }
+}
+
 # /ws/* → daphne tg (sticky session 有効)
 resource "aws_lb_listener_rule" "ws" {
   count = var.alb_certificate_arn == "" ? 0 : 1

--- a/terraform/modules/edge/main.tf
+++ b/terraform/modules/edge/main.tf
@@ -324,6 +324,26 @@ resource "aws_cloudfront_distribution" "this" {
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer.id
   }
 
+  # -------- /static/* → S3 static (Django collectstatic 出力) (#439) --------
+  # Django admin が `<link href="/static/admin/css/base.css">` 形式で参照する
+  # ためのルート。ECS の `/start` で `collectstatic` が走り `s3://<static_bucket>/static/`
+  # にファイルが置かれている。OAC 経由で CloudFront からのみアクセス可。
+  # base.py の STATICFILES_STORAGE は S3Storage だが
+  # `AWS_S3_STATIC_CUSTOM_DOMAIN` を CloudFront ドメイン (= app_fqdn) に
+  # 設定すれば Django が生成する URL もここを通る (services モジュール側で
+  # 環境変数を入れる)。
+  ordered_cache_behavior {
+    path_pattern           = "/static/*"
+    target_origin_id       = "static"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.cors_s3.id
+  }
+
   # -------- /ws/* → ALB (WebSocket 透過) --------
   # ⚠️ WebSocket keepalive 要件 (architect PR #52 HIGH):
   #   - CloudFront viewer idle timeout = 10 分 (固定)

--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -36,6 +36,11 @@ locals {
     { name = "AWS_STORAGE_BUCKET_NAME", value = var.media_bucket_name },
     { name = "AWS_S3_CUSTOM_DOMAIN", value = var.media_public_domain },
     { name = "AWS_STATIC_BUCKET_NAME", value = var.static_bucket_name },
+    # #439: Django admin の `<link href="/static/admin/css/base.css">` を
+    # CloudFront 経由 (= app_fqdn の /static/* path) で配信させるためのカスタム
+    # ドメイン。base.py の STATICFILES_STORAGE OPTIONS.custom_domain にマッピング
+    # される。CloudFront 側に `/static/* → static origin` の behavior を設定済 (edge/main.tf)。
+    { name = "AWS_S3_STATIC_CUSTOM_DOMAIN", value = var.app_fqdn },
     { name = "POSTGRES_HOST", value = var.rds_endpoint },
     { name = "POSTGRES_PORT", value = "5432" },
     { name = "POSTGRES_DB", value = var.rds_database_name },

--- a/terraform/modules/services/variables.tf
+++ b/terraform/modules/services/variables.tf
@@ -120,6 +120,11 @@ variable "static_bucket_name" {
   type        = string
 }
 
+variable "app_fqdn" {
+  description = "Public app FQDN (e.g., 'stg.codeplace.me'). #439: Used as AWS_S3_STATIC_CUSTOM_DOMAIN so Django admin static URLs route through CloudFront's /static/* behavior."
+  type        = string
+}
+
 variable "alb_dns_name" {
   description = "ALB DNS name (e.g., 'sns-stg-alb-xxx.ap-northeast-1.elb.amazonaws.com'). Used as the SSR fetch base URL injected into Next.js task definition (`API_BASE_URL`). Public domain (`var.domain`) was avoided because DNS delegation to Route53 is incomplete during stg bring-up; ALB DNS resolves to private IPs from inside the VPC."
   type        = string


### PR DESCRIPTION
## Summary

PR #440 で nginx を `/admin` に揃えたが、stg は **CloudFront → ALB → ECS** のパスで nginx を経由しないため admin に届かなかった。本 PR で stg の routing を完成させる。

## 検証結果 (現状)

```
$ curl -I https://stg.codeplace.me/admin/login/
HTTP/2 308          # Next.js が trailing-slash を strip
location: /admin/login

$ curl -I https://stg.codeplace.me/admin/login   # 308 follow 後
HTTP/2 404
x-powered-by: Next.js   ← Django ではなく Next.js が応答
```

## 原因

stg routing:

```
CloudFront ordered_cache_behaviors:
  /api/*       → ALB
  /ws/*        → ALB
  /_next/*     → ALB
  /media/*, /users/*, /dm/*  → S3 media
  default      → ALB (← /admin/ はここ)

ALB listener rules:
  /api/*  → app TG (Django)
  /ws/*   → daphne TG
  default → next TG (Next.js)   ← /admin/ はここで Next.js に飛ぶ
```

→ /admin/ は ALB の default rule で Next.js に飛び 404。

## 変更

### 1. ALB listener rule (`terraform/modules/compute/main.tf`)
- `/admin/* + /admin` (priority=15) → app TG (Django)

### 2. CloudFront ordered_cache_behavior (`terraform/modules/edge/main.tf`)
- `/static/*` → static origin (S3, OAC 経由)
- Django admin の `<link href="/static/admin/css/base.css">` を S3 から配信

### 3. Django 環境変数 (`terraform/modules/services/main.tf` + `variables.tf` + `environments/stg/main.tf`)
- `AWS_S3_STATIC_CUSTOM_DOMAIN = stg.codeplace.me`
- `S3Storage` が CloudFront ドメイン付きの URL を生成

## terraform plan

```
Plan: 6 to add, 1 to change, 5 to destroy.
```

- add: ALB listener rule × 1, CloudFront behavior × 1, ECS task def × 4 (env 変更)
- change: CloudFront distribution
- destroy: 古い task def revisions 5 件 (新版が代替)

`terraform validate` 通過、`terraform fmt` clean。

## Apply 手順 (ハルナさん)

```bash
cd terraform/environments/stg
terraform apply
# task def 再作成のため ECS service が rolling update する
```

## Test plan

- [x] `terraform validate` / `fmt` clean
- [x] `terraform plan` で意図通りの差分のみ
- [ ] (ハルナさん apply 後) `curl -i https://stg.codeplace.me/admin/login/` が Django admin login HTML を返す
- [ ] superuser でログイン → `apps.boards.Board` 作成
- [ ] admin の CSS / JS が `/static/admin/...` 経由で 200

## 注意

PR #440 の nginx 修正はローカル開発環境で有効 (引き続き必要)。本 PR は **stg 限定の修正**。

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)