### PR TITLE
fix(infra): static の querystring_auth を False に (#439 follow-up)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -677,6 +677,12 @@ STORAGES = {
                 "bucket_name": getenv("AWS_STATIC_BUCKET_NAME", ""),
                 "custom_domain": getenv("AWS_S3_STATIC_CUSTOM_DOMAIN", "") or None,
                 "location": "static",
+                # #439: custom_domain (CloudFront) 経由で配信する場合は presigned
+                # URL ではなくクリーン URL を生成させる。querystring_auth=True
+                # (default) のままだと <link href="https://<bucket>.s3...?X-Amz-..."> と
+                # S3 直 URL を出してしまい、CloudFront の /static/* path-pattern
+                # behavior をすり抜けて OAC で 403 になる。
+                "querystring_auth": False,
             }
             if _use_s3 and getenv("AWS_STATIC_BUCKET_NAME")
             else {}


### PR DESCRIPTION
## Summary

PR #441 で `AWS_S3_STATIC_CUSTOM_DOMAIN=stg.codeplace.me` を設定したが、django-storages の `S3Storage` は `querystring_auth=True` (default) のままだと **presigned URL** を生成してしまい custom_domain を無視する。

## 検証 (PR #441 apply 後)

```html
<!-- Django admin がレンダリングする <link> -->
<link rel="stylesheet" href="https://sns-stg-static.s3.ap-northeast-1.amazonaws.com/static/admin/css/base.css?X-Amz-Algorithm=...&X-Amz-Signature=...">
```

S3 直 URL (presigned) が出て、CloudFront の `/static/*` behavior をすり抜けて OAC で 403。

一方、CloudFront 経由の `/static/admin/css/base.css` は 200 を返すので **配信パスは正しい**。Django 側の URL 生成だけが間違っていた。

## 修正

`config/settings/base.py` の STATICFILES_STORAGE OPTIONS に `querystring_auth: False` を追加。これで `<link href="https://stg.codeplace.me/static/admin/css/base.css">` というクリーン URL が出るようになる。

## Test plan

- [x] 既存 pytest 緑 (設定追加のみ)
- [ ] stg deploy 後に admin HTML の `<link>` が `https://stg.codeplace.me/static/...` の形になる
- [ ] admin 画面で CSS / JS が正しく適用される (見た目が崩れない)

Refs: #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)