### PR TITLE
fix(dm): MessageComposer に AttachmentUploader を統合 (Closes #456)

### DIFF
--- a/client/src/components/dm/MessageComposer.tsx
+++ b/client/src/components/dm/MessageComposer.tsx
@@ -1,23 +1,44 @@
 "use client";
 
 /**
- * メッセージ入力欄 (P3-09 / Issue #234).
+ * メッセージ入力欄 (P3-09 / Issue #234, #456 で添付 UI を統合).
  *
  * - 通常 Enter で改行
  * - Ctrl+Enter / Cmd+Enter で送信 (a11y: キーボードのみで送信可能)
  * - 入力中は親に typing 通知を渡す
  * - submit エラーは `submitError` state で alert 表示 (silent failure 抑制、ts-reviewer HIGH)
- *
- * 添付 UI (P3-10) は別 PR で integrate 予定。
+ * - 添付 UI (#456): roomId が渡されると `<AttachmentUploader>` を表示。
+ *   アップロード済み attachment を preview + 送信時に attachment_ids として親へ。
+ *   body 空でも attachment が 1 件以上あれば送信可能。
  */
 
 import { useCallback, useState, type KeyboardEvent } from "react";
 
+import AttachmentUploader from "@/components/dm/AttachmentUploader";
+import type { ConfirmResponse } from "@/lib/dm/attachments";
+
 interface MessageComposerProps {
-	onSubmit(body: string): void | Promise<void>;
+	onSubmit(body: string, attachmentIds: number[]): void | Promise<void>;
 	onTyping?(): void;
 	disabled?: boolean;
 	placeholder?: string;
+	/**
+	 * 渡されると添付 UI が有効化される。未指定 (例: WS 接続前) なら添付ボタンは非表示。
+	 */
+	roomId?: number;
+}
+
+interface AttachedFile {
+	id: number;
+	filename: string;
+	mimeType: string;
+	size: number;
+}
+
+function formatBytes(n: number): string {
+	if (n < 1024) return `${n} B`;
+	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+	return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 export default function MessageComposer({
@@ -25,26 +46,33 @@ export default function MessageComposer({
 	onTyping,
 	disabled,
 	placeholder = "メッセージを入力",
+	roomId,
 }: MessageComposerProps) {
 	const [value, setValue] = useState("");
 	const [submitting, setSubmitting] = useState(false);
 	const [submitError, setSubmitError] = useState<string | null>(null);
+	const [attached, setAttached] = useState<AttachedFile[]>([]);
 
 	const submit = useCallback(async () => {
 		const trimmed = value.trim();
-		if (!trimmed || submitting) return;
+		// 本文 or 添付 のいずれかが必要
+		if ((!trimmed && attached.length === 0) || submitting) return;
 		setSubmitting(true);
 		setSubmitError(null);
 		try {
-			await onSubmit(trimmed);
+			await onSubmit(
+				trimmed,
+				attached.map((a) => a.id),
+			);
 			setValue("");
+			setAttached([]);
 		} catch (error: unknown) {
 			const msg = error instanceof Error ? error.message : "送信に失敗しました";
 			setSubmitError(msg);
 		} finally {
 			setSubmitting(false);
 		}
-	}, [value, onSubmit, submitting]);
+	}, [value, attached, onSubmit, submitting]);
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -56,20 +84,73 @@ export default function MessageComposer({
 		[submit],
 	);
 
+	const onUploaded = useCallback((attachment: ConfirmResponse) => {
+		setAttached((prev) => [
+			...prev,
+			{
+				id: attachment.id,
+				filename: attachment.filename,
+				mimeType: attachment.mime_type,
+				size: attachment.size,
+			},
+		]);
+	}, []);
+
+	const removeAttached = useCallback((id: number) => {
+		setAttached((prev) => prev.filter((a) => a.id !== id));
+	}, []);
+
+	const sendDisabled =
+		disabled ||
+		(value.trim().length === 0 && attached.length === 0) ||
+		submitting;
+
 	return (
 		<form
 			onSubmit={(e) => {
 				e.preventDefault();
 				submit().catch(() => undefined);
 			}}
-			className="border-baby_grey/10 bg-baby_veryBlack/40 flex flex-col gap-1 border-t p-3"
+			className="border-baby_grey/10 bg-baby_veryBlack/40 flex flex-col gap-2 border-t p-3"
 		>
 			{submitError ? (
 				<div role="alert" className="text-baby_red px-1 text-xs">
 					{submitError}
 				</div>
 			) : null}
+			{attached.length > 0 ? (
+				<ul aria-label="添付ファイル一覧" className="flex flex-wrap gap-2 px-1">
+					{attached.map((a) => (
+						<li
+							key={a.id}
+							className="bg-baby_veryBlack border-baby_grey/30 text-baby_white flex items-center gap-2 rounded-md border px-2 py-1 text-xs"
+						>
+							<span aria-hidden="true">
+								{a.mimeType.startsWith("image/") ? "🖼️" : "📎"}
+							</span>
+							<span className="max-w-[160px] truncate">{a.filename}</span>
+							<span className="text-baby_grey">{formatBytes(a.size)}</span>
+							<button
+								type="button"
+								onClick={() => removeAttached(a.id)}
+								disabled={submitting}
+								aria-label={`${a.filename} を添付から外す`}
+								className="text-baby_grey hover:text-baby_red focus-visible:ring-baby_blue ml-1 rounded focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+							>
+								×
+							</button>
+						</li>
+					))}
+				</ul>
+			) : null}
 			<div className="flex items-end gap-2">
+				{roomId !== undefined ? (
+					<AttachmentUploader
+						roomId={roomId}
+						onUploaded={onUploaded}
+						disabled={disabled || submitting}
+					/>
+				) : null}
 				<label className="sr-only" htmlFor="message-composer-textarea">
 					メッセージを入力
 				</label>
@@ -90,7 +171,7 @@ export default function MessageComposer({
 				/>
 				<button
 					type="submit"
-					disabled={disabled || value.trim().length === 0 || submitting}
+					disabled={sendDisabled}
 					aria-busy={submitting}
 					className="bg-baby_blue text-baby_white focus-visible:ring-baby_white shrink-0 rounded-md px-4 py-2 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
 				>
@@ -99,6 +180,7 @@ export default function MessageComposer({
 			</div>
 			<p id="message-composer-hint" className="text-baby_grey px-1 text-[11px]">
 				Ctrl/Cmd+Enter で送信、Enter で改行
+				{roomId !== undefined ? "、📎 で画像/ファイル添付" : ""}
 			</p>
 		</form>
 	);

--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -138,9 +138,10 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 	}, [messagesQuery.data, liveMessages, deletedIds]);
 
 	const onSubmit = useCallback(
-		async (body: string) => {
+		async (body: string, attachmentIds: number[]) => {
 			setSendError(null);
-			const sent = socket.sendMessage({ body });
+			// #456: AttachmentUploader 経由で confirm 済みの attachment id を WS に乗せる
+			const sent = socket.sendMessage({ body, attachment_ids: attachmentIds });
 			if (!sent) {
 				setSendError("接続が切れています。再接続してから送信してください。");
 			}
@@ -190,6 +191,7 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 				onSubmit={onSubmit}
 				onTyping={socket.sendTyping}
 				disabled={socket.status !== "open"}
+				roomId={roomId}
 			/>
 		</section>
 	);

--- a/client/src/components/dm/__tests__/MessageComposer.test.tsx
+++ b/client/src/components/dm/__tests__/MessageComposer.test.tsx
@@ -11,7 +11,7 @@ describe("MessageComposer", () => {
 		const textarea = screen.getByLabelText("メッセージを入力");
 		await userEvent.type(textarea, "hello");
 		await userEvent.click(screen.getByRole("button", { name: "送信" }));
-		expect(onSubmit).toHaveBeenCalledWith("hello");
+		expect(onSubmit).toHaveBeenCalledWith("hello", []);
 	});
 
 	it("Ctrl+Enter で送信される", async () => {
@@ -19,7 +19,7 @@ describe("MessageComposer", () => {
 		render(<MessageComposer onSubmit={onSubmit} />);
 		const textarea = screen.getByLabelText("メッセージを入力");
 		await userEvent.type(textarea, "hi{Control>}{Enter}{/Control}");
-		expect(onSubmit).toHaveBeenCalledWith("hi");
+		expect(onSubmit).toHaveBeenCalledWith("hi", []);
 	});
 
 	it("Cmd+Enter (metaKey) でも送信される", async () => {
@@ -27,7 +27,7 @@ describe("MessageComposer", () => {
 		render(<MessageComposer onSubmit={onSubmit} />);
 		const textarea = screen.getByLabelText("メッセージを入力");
 		await userEvent.type(textarea, "hi{Meta>}{Enter}{/Meta}");
-		expect(onSubmit).toHaveBeenCalledWith("hi");
+		expect(onSubmit).toHaveBeenCalledWith("hi", []);
 	});
 
 	it("onSubmit 失敗時は alert を表示", async () => {
@@ -58,5 +58,21 @@ describe("MessageComposer", () => {
 		render(<MessageComposer onSubmit={() => {}} onTyping={onTyping} />);
 		await userEvent.type(screen.getByLabelText("メッセージを入力"), "a");
 		expect(onTyping).toHaveBeenCalled();
+	});
+
+	// #456: 添付 UI 統合
+	it("roomId 未指定なら 📎 ボタンは非表示", () => {
+		render(<MessageComposer onSubmit={() => {}} />);
+		expect(
+			screen.queryByRole("button", { name: "添付ファイルを選択" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("roomId 指定で 📎 ボタンと『画像/ファイル添付』ヒントが出る", () => {
+		render(<MessageComposer onSubmit={() => {}} roomId={1} />);
+		expect(
+			screen.getByRole("button", { name: "添付ファイルを選択" }),
+		).toBeInTheDocument();
+		expect(screen.getByText(/画像\/ファイル添付/)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

DM 画面で **画像をアップロードする UI ボタンが出ていなかった** のを修正。
コンポーネント (\`AttachmentUploader\`) と API クライアント (\`lib/dm/attachments\`) は実装済だったが、Issue #235 で「integrate は別 PR」と保留されたまま MessageComposer に組み込まれていなかった。

## stg E2E (PR #455 で API レベルは確認済)

```
1. presign       → 200 + presigned POST URL
2. S3 multipart → 204 (459927 bytes)
3. confirm      → 201 (attachment id=1)
4. WS send_message + attachment_ids → message id=56 + attachments
5. 受信側 GET messages → attachment 表示
6. CloudFront /dm/<key> で download → 元画像と完全一致
```

→ 本 PR でフロントエンド UI 経由でも同じフローが動くようになる。

## 変更内容

### MessageComposer
- props に \`roomId?: number\` を追加 (未指定なら 📎 非表示で旧動作維持)
- onSubmit signature を \`(body, attachmentIds[])\` に変更
- \`<AttachmentUploader>\` を textarea 横に統合、アップロード成功で内部 state に追加
- 添付プレビューリスト (filename / size / × ボタン)
- 送信ボタンの disable 条件を「body 空 **AND** 添付 0」に緩和

### RoomChat
- \`roomId={roomId}\` を MessageComposer に渡す
- onSubmit から attachment_ids を WS \`send_message\` frame に乗せる

### tests
- 既存 7 件の onSubmit assertion を新シグネチャ \`(body, [])\` に追従
- 📎 ボタンの表示/非表示を roomId で出し分けする 2 件を追加 (計 9 件全緑)

## Test plan

- [x] \`npm test src/components/dm/\` → 44/44 全緑
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (warning のみ)
- [ ] (stg deploy 後) ハルナさんが \`/messages/<id>\` で 📎 → 画像選択 → progress → preview → 送信 → 相手に届く までクリック動作確認

Closes #456
Refs: #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)