### PR TITLE
fix(e2e): /auth/csrf/ は GET (dm-attachment-display.spec.ts)

### DIFF
--- a/client/e2e/dm-attachment-display.spec.ts
+++ b/client/e2e/dm-attachment-display.spec.ts
@@ -54,7 +54,8 @@ async function loginViaApi(
 	page: import("@playwright/test").Page,
 	user: { email: string; password: string },
 ) {
-	const resp = await page.context().request.post(`${BASE}/api/v1/auth/csrf/`);
+	// CSRF cookie 種付け (GET エンドポイント)
+	const resp = await page.context().request.get(`${BASE}/api/v1/auth/csrf/`);
 	expect(resp.status()).toBeLessThan(400);
 	const cookies = await page.context().cookies(BASE);
 	const csrf = cookies.find((c) => c.name === "csrftoken")?.value ?? "";


### PR DESCRIPTION
PR #466 の dm-attachment-display.spec.ts で /auth/csrf/ を POST で呼んでいたため stg 実行時に 403 で fail していたのを修正。GET に戻して 2/2 pass を確認。

Refs: #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)