### PR TITLE
feat(dm): 添付プレビューを Slack 標準のサムネイル表示に (Closes #469)

### DIFF
--- a/client/e2e/dm-attachment-display.spec.ts
+++ b/client/e2e/dm-attachment-display.spec.ts
@@ -92,17 +92,29 @@ test.describe("DM 添付表示 — 本物の UI E2E (Issue #464)", () => {
 		);
 		await fileInput.setInputFiles(FIXTURE_IMAGE);
 
-		// preview chip (📎 + filename) が出るまで待つ
-		const previewChip = page
-			.locator('ul[aria-label="添付ファイル一覧"] li')
-			.filter({ hasText: "sample-image.png" });
+		// preview チップ (image はサムネイル <img> 描画 / Issue #469)
+		const previewList = page.locator('ul[aria-label="添付ファイル一覧"]');
+		const previewChip = previewList.locator("li").filter({
+			hasText: "sample-image.png",
+		});
 		await expect(previewChip).toBeVisible({ timeout: 30000 });
+		// Issue #469: compose preview 内にサムネイル <img> が出る
+		const previewImg = previewList.getByRole("img", {
+			name: "sample-image.png",
+		});
+		await expect(previewImg).toBeVisible();
 
 		// 送信
 		await page.getByRole("button", { name: "送信" }).click();
 
+		// 送信後 preview が消えること (compose の img が無くなる)
+		await expect(previewList).toHaveCount(0, { timeout: 15000 });
+
 		// bubble 内に <img alt="sample-image.png"> が visible
-		const sentImg = page.getByRole("img", { name: "sample-image.png" }).first();
+		const sentImg = page
+			.locator('[data-testid="message-bubble"]')
+			.getByRole("img", { name: "sample-image.png" })
+			.first();
 		await expect(sentImg).toBeVisible({ timeout: 30000 });
 
 		// 画像クリックで lightbox 起動

--- a/client/src/components/dm/MessageComposer.tsx
+++ b/client/src/components/dm/MessageComposer.tsx
@@ -33,6 +33,8 @@ interface AttachedFile {
 	filename: string;
 	mimeType: string;
 	size: number;
+	/** Issue #469: image MIME のときバックエンド (CloudFront) URL。サムネイル <img src> に使う。 */
+	url: string;
 }
 
 function formatBytes(n: number): string {
@@ -92,6 +94,7 @@ export default function MessageComposer({
 				filename: attachment.filename,
 				mimeType: attachment.mime_type,
 				size: attachment.size,
+				url: attachment.url,
 			},
 		]);
 	}, []);
@@ -120,27 +123,59 @@ export default function MessageComposer({
 			) : null}
 			{attached.length > 0 ? (
 				<ul aria-label="添付ファイル一覧" className="flex flex-wrap gap-2 px-1">
-					{attached.map((a) => (
-						<li
-							key={a.id}
-							className="bg-baby_veryBlack border-baby_grey/30 text-baby_white flex items-center gap-2 rounded-md border px-2 py-1 text-xs"
-						>
-							<span aria-hidden="true">
-								{a.mimeType.startsWith("image/") ? "🖼️" : "📎"}
-							</span>
-							<span className="max-w-[160px] truncate">{a.filename}</span>
-							<span className="text-baby_grey">{formatBytes(a.size)}</span>
-							<button
-								type="button"
-								onClick={() => removeAttached(a.id)}
-								disabled={submitting}
-								aria-label={`${a.filename} を添付から外す`}
-								className="text-baby_grey hover:text-baby_red focus-visible:ring-baby_blue ml-1 rounded focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+					{attached.map((a) => {
+						const isImage = a.mimeType.startsWith("image/") && a.url;
+						if (isImage) {
+							// Issue #469: image はサムネイル表示 (Slack/Discord/WhatsApp 標準 UX)
+							return (
+								<li
+									key={a.id}
+									className="bg-baby_veryBlack border-baby_grey/30 text-baby_white flex w-20 flex-col gap-1 rounded-md border p-1 text-[10px]"
+								>
+									<div className="relative">
+										{/* eslint-disable-next-line @next/next/no-img-element */}
+										<img
+											src={a.url}
+											alt={a.filename}
+											className="border-baby_grey/20 size-[72px] rounded border object-cover"
+										/>
+										<button
+											type="button"
+											onClick={() => removeAttached(a.id)}
+											disabled={submitting}
+											aria-label={`${a.filename} を添付から外す`}
+											className="bg-baby_veryBlack/80 text-baby_white hover:bg-baby_red focus-visible:ring-baby_blue border-baby_grey/40 absolute -right-1 -top-1 flex size-5 items-center justify-center rounded-full border text-xs leading-none focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+										>
+											×
+										</button>
+									</div>
+									<span className="truncate" title={a.filename}>
+										{a.filename}
+									</span>
+									<span className="text-baby_grey">{formatBytes(a.size)}</span>
+								</li>
+							);
+						}
+						return (
+							<li
+								key={a.id}
+								className="bg-baby_veryBlack border-baby_grey/30 text-baby_white flex items-center gap-2 rounded-md border px-2 py-1 text-xs"
 							>
-								×
-							</button>
-						</li>
-					))}
+								<span aria-hidden="true">📎</span>
+								<span className="max-w-[160px] truncate">{a.filename}</span>
+								<span className="text-baby_grey">{formatBytes(a.size)}</span>
+								<button
+									type="button"
+									onClick={() => removeAttached(a.id)}
+									disabled={submitting}
+									aria-label={`${a.filename} を添付から外す`}
+									className="text-baby_grey hover:text-baby_red focus-visible:ring-baby_blue ml-1 rounded focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+								>
+									×
+								</button>
+							</li>
+						);
+					})}
 				</ul>
 			) : null}
 			<div className="flex items-end gap-2">

--- a/client/src/components/dm/__tests__/MessageComposer.test.tsx
+++ b/client/src/components/dm/__tests__/MessageComposer.test.tsx
@@ -3,6 +3,28 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import MessageComposer from "@/components/dm/MessageComposer";
+import type { ConfirmResponse } from "@/lib/dm/attachments";
+
+let nextAttachment: ConfirmResponse | null = null;
+
+vi.mock("@/components/dm/AttachmentUploader", () => ({
+	default: ({
+		onUploaded,
+		disabled,
+	}: {
+		onUploaded: (a: ConfirmResponse) => void;
+		disabled?: boolean;
+	}) => (
+		<button
+			type="button"
+			aria-label="添付ファイルを選択"
+			disabled={disabled}
+			onClick={() => {
+				if (nextAttachment) onUploaded(nextAttachment);
+			}}
+		/>
+	),
+}));
 
 describe("MessageComposer", () => {
 	it("submit で onSubmit が呼ばれ textarea がクリアされる", async () => {
@@ -74,5 +96,69 @@ describe("MessageComposer", () => {
 			screen.getByRole("button", { name: "添付ファイルを選択" }),
 		).toBeInTheDocument();
 		expect(screen.getByText(/画像\/ファイル添付/)).toBeInTheDocument();
+	});
+
+	// #469: image attachment はサムネイル表示 (Slack/Discord 標準 UX)
+	it("image MIME の attachment はサムネイル <img> として描画される", async () => {
+		nextAttachment = {
+			id: 42,
+			s3_key: "rooms/1/cat.png",
+			url: "https://cdn.example.com/cat.png",
+			filename: "cat.png",
+			mime_type: "image/png",
+			size: 1024,
+			width: 100,
+			height: 100,
+		};
+		render(<MessageComposer onSubmit={() => {}} roomId={1} />);
+		await userEvent.click(
+			screen.getByRole("button", { name: "添付ファイルを選択" }),
+		);
+		const img = await screen.findByRole("img", { name: "cat.png" });
+		expect(img).toHaveAttribute("src", "https://cdn.example.com/cat.png");
+	});
+
+	it("non-image MIME の attachment は従来通り chip 表示", async () => {
+		nextAttachment = {
+			id: 43,
+			s3_key: "rooms/1/spec.pdf",
+			url: "https://cdn.example.com/spec.pdf",
+			filename: "spec.pdf",
+			mime_type: "application/pdf",
+			size: 2048,
+			width: null,
+			height: null,
+		};
+		render(<MessageComposer onSubmit={() => {}} roomId={1} />);
+		await userEvent.click(
+			screen.getByRole("button", { name: "添付ファイルを選択" }),
+		);
+		expect(await screen.findByText("spec.pdf")).toBeInTheDocument();
+		// 画像ではないので img は出ない
+		expect(screen.queryByRole("img", { name: "spec.pdf" })).toBeNull();
+	});
+
+	it("サムネイルの × ボタンで添付が外れる", async () => {
+		nextAttachment = {
+			id: 44,
+			s3_key: "rooms/1/dog.jpg",
+			url: "https://cdn.example.com/dog.jpg",
+			filename: "dog.jpg",
+			mime_type: "image/jpeg",
+			size: 512,
+			width: 50,
+			height: 50,
+		};
+		render(<MessageComposer onSubmit={() => {}} roomId={1} />);
+		await userEvent.click(
+			screen.getByRole("button", { name: "添付ファイルを選択" }),
+		);
+		expect(
+			await screen.findByRole("img", { name: "dog.jpg" }),
+		).toBeInTheDocument();
+		await userEvent.click(
+			screen.getByRole("button", { name: "dog.jpg を添付から外す" }),
+		);
+		expect(screen.queryByRole("img", { name: "dog.jpg" })).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

- PR #466 で chip のみだった compose preview を、画像 MIME のとき **72px サムネイル <img>** + ファイル名 + サイズ + × の Slack/Discord/WhatsApp 標準 UX に変更
- non-image (PDF など) は従来通り chip 表示
- AttachedFile に `url` を持たせて backend (`MessageAttachment.url` = CloudFront URL) を直接 `<img src>` に使用 (Object URL 不要、メモリリーク懸念ゼロ)

### Why

ハルナさんが指摘の通り、chip だけだと「Teams 級」と謳えても画像チャットの体感としては **Slack / Discord / WhatsApp / iMessage が標準**。画像はサムネイルが見えないとどの画像かわからない。

### 変更点

| ファイル | 変更 |
|----------|------|
| `client/src/components/dm/MessageComposer.tsx` | `AttachedFile.url` 追加、image MIME 判定で `<img>` サムネイル分岐、× ボタンを overlay 配置 |
| `client/src/components/dm/__tests__/MessageComposer.test.tsx` | `AttachmentUploader` を mock し、image / non-image / × 3 ケース追加 (12/12 GREEN) |
| `client/e2e/dm-attachment-display.spec.ts` | ATT-IMG: compose preview 内の thumbnail `<img>` assert + 送信後 preview 消失 + bubble 取得を `[data-testid="message-bubble"]` スコープに限定 |

## Test plan

- [x] vitest: `MessageComposer.test.tsx` 12/12 PASS (RED → GREEN 確認済み)
- [x] vitest: DM 関連 14 files / 100 tests 全 PASS (regression なし)
- [x] eslint / prettier / tsc clean
- [ ] CI 全 green
- [ ] stg deploy 後 Playwright UI E2E (`PLAYWRIGHT_BASE_URL=https://stg.codeplace.me` で `dm-attachment-display.spec.ts`)
- [ ] 実機 visual 確認 (compose に thumbnail が見える)

## Out of scope (follow-up)

- #470: Ctrl+V クリップボード paste 対応 (別 Issue)