### PR TITLE
fix(dm): ConfirmAttachmentView に url/width/height を含める (Closes #473)

### DIFF
--- a/apps/dm/tests/test_views_attachments.py
+++ b/apps/dm/tests/test_views_attachments.py
@@ -170,6 +170,47 @@ def test_confirm_view_creates_orphan(settings) -> None:
     assert isinstance(body["id"], int)
 
 
+# Issue #473: confirm レスポンスに url/width/height (= MessageAttachmentSerializer 全フィールド)
+# を含める。compose preview のサムネイル表示が a.url を必要とするため。
+
+
+@pytest.mark.django_db
+def test_confirm_view_returns_url_width_height(settings) -> None:
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    settings.DM_ATTACHMENT_BASE_URL = "https://stg.codeplace.me"
+    user = make_user()
+    room = make_room()
+    make_membership(room=room, user=user)
+
+    s3_key = f"dm/{room.pk}/2026/05/cat.png"
+    with patch(
+        "apps.dm.services._presign.head_object",
+        return_value=S3ObjectInfo(content_length=512, content_type="image/png"),
+    ):
+        resp = _client_for(user).post(
+            reverse("dm:attachment-confirm"),
+            {
+                "room_id": room.pk,
+                "s3_key": s3_key,
+                "filename": "cat.png",
+                "mime_type": "image/png",
+                "size": 512,
+                "width": 100,
+                "height": 100,
+            },
+            format="json",
+        )
+
+    assert resp.status_code == 201, resp.content
+    body = resp.json()
+    # MessageAttachmentSerializer 全フィールドが返る
+    assert body["url"] == f"https://stg.codeplace.me/{s3_key}"
+    assert body["width"] == 100
+    assert body["height"] == 100
+    assert body["mime_type"] == "image/png"
+    assert body["size"] == 512
+
+
 # Issue #459: confirm view が width/height を受け付けて DB に保存する
 
 

--- a/apps/dm/views.py
+++ b/apps/dm/views.py
@@ -63,6 +63,7 @@ from apps.dm.serializers import (
     DMRoomSerializer,
     GroupInvitationSerializer,
     MarkRoomReadInputSerializer,
+    MessageAttachmentSerializer,
     MessageSerializer,
     PresignAttachmentInputSerializer,
 )
@@ -486,13 +487,15 @@ class PresignAttachmentView(APIView):
 class ConfirmAttachmentView(APIView):
     """``POST /api/v1/dm/attachments/confirm/``: presign で PUT 完了した object の確定.
 
-    body: ``{"room_id", "s3_key", "filename", "mime_type", "size"}``
-    response (201): ``{"id": <attachment_id>, "s3_key", "filename", "mime_type", "size"}``
+    body: ``{"room_id", "s3_key", "filename", "mime_type", "size", ["width", "height"]}``
+    response (201): ``MessageAttachmentSerializer`` 全フィールド (id, s3_key, url,
+    filename, mime_type, size, width, height)
 
     フロー:
     1. room メンバー検証 (404 で probing 防止)
     2. service ``confirm_attachment`` で S3 head_object 再検証 → orphan 作成
-    3. id を返す (フロントは send_message に attachment_ids として渡す)
+    3. attachment 全フィールドを serializer で返す。frontend (compose preview の
+       サムネイル表示など) が ``url`` を直接利用する。
 
     rate limit ``dm_attachment_confirm`` 30/hour (security-reviewer HIGH H-3)
     """
@@ -524,14 +527,10 @@ class ConfirmAttachmentView(APIView):
         except DjangoPermissionDenied as exc:  # security LOW L-1: 将来の互換のため
             raise PermissionDenied(str(exc)) from exc
 
+        # Issue #473: list/WS と同じ MessageAttachmentSerializer で返し、
+        # compose preview が直接 ``url`` (CloudFront 配信) を使えるようにする
         return Response(
-            {
-                "id": attachment.pk,
-                "s3_key": attachment.s3_key,
-                "filename": attachment.filename,
-                "mime_type": attachment.mime_type,
-                "size": attachment.size,
-            },
+            MessageAttachmentSerializer(attachment).data,
             status=status.HTTP_201_CREATED,
         )
 


### PR DESCRIPTION
## Summary

PR #458 で `MessageAttachmentSerializer` に `url` を追加した際、`ConfirmAttachmentView` は手書き dict を返していたため confirm レスポンスに `url` が含まれていなかった。messages list / WS broadcast は serializer 経由なので bubble 表示は動いていたが、PR #471 で実装した compose preview のサムネイル表示は `a.url` が undefined で常に chip にフォールバックしていた。

## 修正

`ConfirmAttachmentView.post` を `MessageAttachmentSerializer(attachment).data` を返すよう変更。これで `url`, `width`, `height` を含む全 read-only フィールドがレスポンスに乗る。

## Test plan

- [x] 新規 backend test: confirm 応答の `url` field 値 assert (`{base}/{s3_key}`) + width/height 反映
- [x] 既存 `test_confirm_view_creates_orphan` は serializer 経由でも引き続き pass する shape (id/s3_key/filename はそのまま)
- [ ] CI pytest 全 green
- [ ] stg deploy 後 Playwright UI E2E (`dm-attachment-display.spec.ts` ATT-IMG) を再走 → compose preview に thumbnail が出ることを確認 (PR #471 の blocker 解消)
- [x] frontend は変更不要 (`MessageAttachment` interface に `url` 既にあり、PR #471 の MessageComposer は `a.url` を読むだけ)

Refs PR #471 / #466