### PR TITLE
feat(dm): 既存ルーム内に「招待」ボタンを追加 (Closes #476)

### DIFF
--- a/client/e2e/dm-room-invite.spec.ts
+++ b/client/e2e/dm-room-invite.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * DM ルーム内 招待 UI E2E (#476).
+ *
+ * Spec: docs/specs/dm-room-invite-spec.md §6.2
+ *
+ * フロー:
+ *   1. USER1 (creator) として login → 既存 group room を開く
+ *   2. ヘッダ「+ 招待」button → modal 出る
+ *   3. @USER2_HANDLE 入力 → 「招待を送る」 → success status
+ *   4. USER1 logout、USER2 として login → /messages/invitations で招待 listing 確認
+ *   5. 「承諾」 button → invitee 側で room が見えること
+ *
+ * 必要な env:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me
+ *   PLAYWRIGHT_USER1_EMAIL / PLAYWRIGHT_USER1_PASSWORD / PLAYWRIGHT_USER1_HANDLE  (creator)
+ *   PLAYWRIGHT_USER2_EMAIL / PLAYWRIGHT_USER2_PASSWORD / PLAYWRIGHT_USER2_HANDLE  (invitee)
+ *   PLAYWRIGHT_GROUP_ROOM_ID  (USER1 が creator の既存 group room id)
+ *
+ * クリーンアップ:
+ *   - 開始時に invitee 側 pending invitation をすべて decline する。
+ *   - room から leave / room delete API は現状未実装なので、E2E 後の room state は残る。
+ *     (USER1 = creator のまま、USER2 = membership 追加されたまま、再実行時は 409 を期待)
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "",
+};
+const GROUP_ROOM_ID = Number(process.env.PLAYWRIGHT_GROUP_ROOM_ID ?? 0);
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER2_EMAIL: USER2.email,
+		PLAYWRIGHT_USER2_PASSWORD: USER2.password,
+		PLAYWRIGHT_USER2_HANDLE: USER2.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+	if (!GROUP_ROOM_ID || Number.isNaN(GROUP_ROOM_ID)) {
+		throw new Error("PLAYWRIGHT_GROUP_ROOM_ID must be a positive integer");
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+) {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+/**
+ * USER2 側の pending invitation を全て decline して clean state を作る。
+ */
+async function declineAllPendingInvitations(request: APIRequestContext) {
+	const list = await request.get(
+		`${BASE}/api/v1/dm/invitations/?status=pending`,
+	);
+	if (list.status() !== 200) return;
+	const data = (await list.json()) as { results: { id: number }[] };
+	const cookies = await request.storageState();
+	const csrf = cookies.cookies.find((c) => c.name === "csrftoken")?.value ?? "";
+	for (const inv of data.results) {
+		await request.post(`${BASE}/api/v1/dm/invitations/${inv.id}/decline/`, {
+			headers: { "X-CSRFToken": csrf, Referer: `${BASE}/messages/invitations` },
+		});
+	}
+}
+
+test.describe("DM ルーム内 招待 UI E2E (#476)", () => {
+	test.beforeEach(() => {
+		requireEnv();
+	});
+
+	test("INVITE-FLOW: creator が room 内から招待 → invitee が承諾 → membership 反映", async ({
+		browser,
+	}) => {
+		// USER2 ctx: pre-clean pending invitations
+		const cleanupCtx = await browser.newContext();
+		await loginViaApi(cleanupCtx.request, USER2);
+		await declineAllPendingInvitations(cleanupCtx.request);
+		await cleanupCtx.close();
+
+		// USER1 ctx: open room → click invite button → submit
+		const ctx1 = await browser.newContext();
+		const page1 = await ctx1.newPage();
+		await loginViaApi(ctx1.request, USER1);
+		await page1.goto(`${BASE}/messages/${GROUP_ROOM_ID}`);
+
+		const inviteBtn = page1.getByRole("button", {
+			name: "このグループに招待",
+		});
+		await expect(inviteBtn).toBeVisible({ timeout: 15000 });
+		await inviteBtn.click();
+
+		// modal 出現 + autofocus 入力欄に handle 入力
+		const handleInput = page1.getByLabel(/handle/i);
+		await expect(handleInput).toBeVisible();
+		await handleInput.fill(`@${USER2.handle}`);
+		await page1.getByRole("button", { name: "招待を送る" }).click();
+
+		// 成功 status (1.2s で auto close するので status 表示中に assert)
+		const status = page1
+			.getByRole("status")
+			.filter({ hasText: /送信しました/ });
+		await expect(status).toBeVisible({ timeout: 10000 });
+
+		await ctx1.close();
+
+		// USER2 ctx: /messages/invitations で受け取って accept
+		const ctx2 = await browser.newContext();
+		const page2 = await ctx2.newPage();
+		await loginViaApi(ctx2.request, USER2);
+		await page2.goto(`${BASE}/messages/invitations`);
+
+		// invitation listing に該当 room (= GROUP_ROOM_ID) のエントリ
+		const invitationItem = page2
+			.locator('[data-testid="invitation-item"], li, article')
+			.filter({ hasText: USER1.handle || "test2" })
+			.first();
+		// 緩めに「承諾」 button を探す
+		const acceptBtn = page2.getByRole("button", { name: /承諾|参加/ }).first();
+		await expect(acceptBtn).toBeVisible({ timeout: 15000 });
+		await acceptBtn.click();
+
+		// 承諾後 invitation list は空になる、もしくは「承諾済み」表示。
+		// ここでは accept request が成功裏に return することを確認する目的で
+		// /messages に navigate して該当 room が listing に出ることを assert する。
+		await page2.goto(`${BASE}/messages`);
+		// member 名 (group name) で listing 確認
+		const roomLink = page2
+			.locator(`a[href="/messages/${GROUP_ROOM_ID}"]`)
+			.first();
+		await expect(roomLink).toBeVisible({ timeout: 15000 });
+
+		await ctx2.close();
+	});
+});

--- a/client/src/components/dm/InviteMemberButton.tsx
+++ b/client/src/components/dm/InviteMemberButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * RoomChat header に置く「+ 招待」button + Dialog wrapper (#476).
+ *
+ * 表示条件: `room.kind === "group"` AND `room.creator_id === currentUserId`。
+ * direct / non-creator では `null` を返す (button 自体を出さない)。
+ *
+ * SPEC §7.2 / docs/specs/dm-room-invite-spec.md。
+ */
+
+import { useState } from "react";
+
+import InviteMemberDialog from "@/components/dm/InviteMemberDialog";
+import type { DMRoom } from "@/lib/redux/features/dm/types";
+
+interface InviteMemberButtonProps {
+	room: DMRoom | undefined;
+	currentUserId: number;
+}
+
+export default function InviteMemberButton({
+	room,
+	currentUserId,
+}: InviteMemberButtonProps) {
+	const [open, setOpen] = useState(false);
+
+	if (!room) return null;
+	if (room.kind !== "group") return null;
+	if (room.creator_id !== currentUserId) return null;
+
+	return (
+		<>
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				aria-label="このグループに招待"
+				className="border-baby_grey/40 text-baby_white hover:bg-baby_grey/10 focus-visible:ring-baby_blue rounded-md border px-2 py-1 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2"
+			>
+				＋ 招待
+			</button>
+			<InviteMemberDialog open={open} onOpenChange={setOpen} roomId={room.id} />
+		</>
+	);
+}

--- a/client/src/components/dm/InviteMemberDialog.tsx
+++ b/client/src/components/dm/InviteMemberDialog.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+/**
+ * グループ room 内から招待を送る Dialog (#476).
+ *
+ * SPEC §7.2 / docs/specs/dm-room-invite-spec.md。
+ *
+ * - @handle 1 名を入力 → POST /api/v1/dm/rooms/<id>/invitations/
+ * - 成功時は role=status で通知 → ~1.2s 後 onOpenChange(false)
+ * - 失敗時は role=alert (404 / 409 / 429 / 403 / その他)
+ * - クライアント側 validation: 空 / 不正文字 / 空白
+ * - a11y: ESC / × button / overlay click で close (Radix デフォルト)
+ */
+
+import { useEffect, useRef, useState, type FormEvent } from "react";
+
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { useCreateRoomInvitationMutation } from "@/lib/redux/features/dm/dmApiSlice";
+
+const HANDLE_REGEX = /^[a-zA-Z0-9_]{3,30}$/;
+
+interface InviteMemberDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	roomId: number;
+}
+
+function mapApiError(err: unknown, handle: string): string {
+	if (err && typeof err === "object") {
+		const e = err as { status?: number | string; data?: unknown };
+		const status = typeof e.status === "number" ? e.status : Number(e.status);
+		const data =
+			e.data && typeof e.data === "object"
+				? (e.data as Record<string, unknown>)
+				: {};
+		const detail = typeof data.detail === "string" ? data.detail : undefined;
+		if (status === 404) return `@${handle} というユーザーは見つかりません`;
+		if (status === 409) {
+			if (detail === "already_member") return `@${handle} は既にメンバーです`;
+			if (detail === "pending_invitation")
+				return `@${handle} は既に招待済みです`;
+			return `@${handle} は既にメンバー / 招待済みです`;
+		}
+		if (status === 403) return "招待権限がありません (creator のみ可能)";
+		if (status === 429) return "招待の上限 (50 件/日) に達しました";
+		if (status === 400 && detail) return detail;
+	}
+	return "招待の送信に失敗しました";
+}
+
+export default function InviteMemberDialog({
+	open,
+	onOpenChange,
+	roomId,
+}: InviteMemberDialogProps) {
+	const [createInvite, { isLoading }] = useCreateRoomInvitationMutation();
+	const [handle, setHandle] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const [successMsg, setSuccessMsg] = useState<string | null>(null);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	// open に切り替わったら state リセット (前回の error / success を消す)
+	useEffect(() => {
+		if (open) {
+			setError(null);
+			setSuccessMsg(null);
+			setHandle("");
+		}
+	}, [open]);
+
+	// 成功表示後 1.2s で自動 close
+	useEffect(() => {
+		if (!successMsg) return;
+		const t = setTimeout(() => onOpenChange(false), 1200);
+		return () => clearTimeout(t);
+	}, [successMsg, onOpenChange]);
+
+	const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		setError(null);
+		setSuccessMsg(null);
+		const normalized = handle.trim().replace(/^@/, "");
+		if (normalized.length === 0) {
+			setError("@handle を入力してください");
+			inputRef.current?.focus();
+			return;
+		}
+		if (!HANDLE_REGEX.test(normalized)) {
+			setError(
+				"@handle に使用できない文字が含まれています (英数字とアンダースコア 3-30 字)",
+			);
+			inputRef.current?.focus();
+			return;
+		}
+		try {
+			await createInvite({ roomId, invitee_handle: normalized }).unwrap();
+			setSuccessMsg(`@${normalized} に招待を送信しました`);
+		} catch (err: unknown) {
+			setError(mapApiError(err, normalized));
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>このグループに招待</DialogTitle>
+				</DialogHeader>
+				<form
+					onSubmit={onSubmit}
+					className="flex flex-col gap-4"
+					aria-busy={isLoading}
+				>
+					{error ? (
+						<div role="alert" className="text-baby_red text-sm">
+							{error}
+						</div>
+					) : null}
+					{successMsg ? (
+						<div
+							role="status"
+							aria-live="polite"
+							className="text-baby_green text-sm"
+						>
+							{successMsg}
+						</div>
+					) : null}
+					<div className="flex flex-col gap-1">
+						<label
+							htmlFor="invite-handle"
+							className="text-baby_white text-sm font-semibold"
+						>
+							招待するユーザーの @handle
+						</label>
+						<input
+							ref={inputRef}
+							id="invite-handle"
+							type="text"
+							value={handle}
+							onChange={(e) => setHandle(e.target.value)}
+							placeholder="alice"
+							autoFocus
+							aria-invalid={Boolean(error)}
+							aria-describedby={error ? "invite-handle-error" : undefined}
+							className="bg-baby_veryBlack text-baby_white focus-visible:ring-baby_blue rounded-md px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2"
+						/>
+						<p className="text-baby_grey text-xs">
+							例: alice (英数字とアンダースコア 3-30 字、@ プレフィックス可)
+						</p>
+					</div>
+					<div className="flex justify-end gap-2">
+						<button
+							type="button"
+							onClick={() => onOpenChange(false)}
+							className="border-baby_grey text-baby_grey hover:bg-baby_grey/10 focus-visible:ring-baby_blue rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2"
+						>
+							キャンセル
+						</button>
+						<button
+							type="submit"
+							disabled={isLoading || successMsg !== null}
+							aria-busy={isLoading}
+							className="bg-baby_blue text-baby_white focus-visible:ring-baby_white rounded-md px-4 py-2 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+						>
+							{isLoading ? "送信中..." : "招待を送る"}
+						</button>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -18,6 +18,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import InviteMemberButton from "@/components/dm/InviteMemberButton";
 import MessageComposer from "@/components/dm/MessageComposer";
 import MessageList from "@/components/dm/MessageList";
 import TypingIndicator from "@/components/dm/TypingIndicator";
@@ -167,10 +168,16 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 						{displayName}
 					</h1>
 				</div>
-				<SocketStatusBadge
-					status={socket.status}
-					onReconnect={socket.reconnect}
-				/>
+				<div className="flex items-center gap-2">
+					<InviteMemberButton
+						room={roomQuery.data}
+						currentUserId={currentUserId}
+					/>
+					<SocketStatusBadge
+						status={socket.status}
+						onReconnect={socket.reconnect}
+					/>
+				</div>
 			</header>
 			<MessageList
 				messages={merged}

--- a/client/src/components/dm/__tests__/InviteMemberButton.test.tsx
+++ b/client/src/components/dm/__tests__/InviteMemberButton.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for InviteMemberButton (#476).
+ *
+ * RoomChat header に置く button + InviteMemberDialog の wrapper。
+ * 表示条件: room.kind === "group" AND room.creator_id === currentUserId。
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import InviteMemberButton from "@/components/dm/InviteMemberButton";
+import type { DMRoom } from "@/lib/redux/features/dm/types";
+
+vi.mock("@/components/dm/InviteMemberDialog", () => ({
+	default: ({
+		open,
+		onOpenChange,
+		roomId,
+	}: {
+		open: boolean;
+		onOpenChange: (open: boolean) => void;
+		roomId: number;
+	}) =>
+		open ? (
+			<div data-testid="dialog-mock" data-room-id={roomId}>
+				<button type="button" onClick={() => onOpenChange(false)}>
+					閉じる
+				</button>
+			</div>
+		) : null,
+}));
+
+function makeRoom(overrides: Partial<DMRoom> = {}): DMRoom {
+	return {
+		id: 42,
+		kind: "group",
+		name: "Engineers",
+		creator_id: 1,
+		memberships: [],
+		last_message_at: null,
+		is_archived: false,
+		created_at: "2026-05-09T00:00:00Z",
+		updated_at: "2026-05-09T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("InviteMemberButton", () => {
+	it("group + creator: button が visible", () => {
+		render(
+			<InviteMemberButton
+				room={makeRoom({ kind: "group", creator_id: 1 })}
+				currentUserId={1}
+			/>,
+		);
+		expect(
+			screen.getByRole("button", { name: "このグループに招待" }),
+		).toBeInTheDocument();
+	});
+
+	it("direct room: button 非表示", () => {
+		const { container } = render(
+			<InviteMemberButton
+				room={makeRoom({ kind: "direct", creator_id: 1 })}
+				currentUserId={1}
+			/>,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("group だが creator でない: button 非表示", () => {
+		const { container } = render(
+			<InviteMemberButton
+				room={makeRoom({ kind: "group", creator_id: 1 })}
+				currentUserId={999}
+			/>,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("room=undefined: button 非表示 (loading state)", () => {
+		const { container } = render(
+			<InviteMemberButton room={undefined} currentUserId={1} />,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("button 押下で dialog が開く", async () => {
+		render(
+			<InviteMemberButton
+				room={makeRoom({ kind: "group", creator_id: 1 })}
+				currentUserId={1}
+			/>,
+		);
+		expect(screen.queryByTestId("dialog-mock")).toBeNull();
+		await userEvent.click(
+			screen.getByRole("button", { name: "このグループに招待" }),
+		);
+		expect(screen.getByTestId("dialog-mock")).toHaveAttribute(
+			"data-room-id",
+			"42",
+		);
+	});
+});

--- a/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
+++ b/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
@@ -67,8 +67,12 @@ describe("InviteMemberDialog", () => {
 	});
 
 	it("404 (user not found) → 専用 alert", async () => {
+		// RTK Query は FetchBaseQueryError (非 Error オブジェクト) で reject する
+		// ため、mock 側もそれに合わせる。eslint の prefer-promise-reject-errors を
+		// この箇所だけ抑制する。
 		mockCreate.mockReturnValueOnce({
 			unwrap: () =>
+				// eslint-disable-next-line prefer-promise-reject-errors
 				Promise.reject({ status: 404, data: { detail: "Not found." } }),
 		});
 		render(
@@ -82,6 +86,7 @@ describe("InviteMemberDialog", () => {
 	it("409 既メンバー / 既招待 → 専用 alert", async () => {
 		mockCreate.mockReturnValueOnce({
 			unwrap: () =>
+				// eslint-disable-next-line prefer-promise-reject-errors
 				Promise.reject({
 					status: 409,
 					data: { detail: "already_member" },

--- a/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
+++ b/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests for InviteMemberDialog (#476).
+ *
+ * RoomChat 内から開く「グループに招待」モーダル。
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import InviteMemberDialog from "@/components/dm/InviteMemberDialog";
+
+const mockCreate = vi.fn();
+const mockOnOpenChange = vi.fn();
+
+vi.mock("@/lib/redux/features/dm/dmApiSlice", () => ({
+	useCreateRoomInvitationMutation: () => [
+		mockCreate,
+		{ isLoading: false, isError: false },
+	],
+}));
+
+beforeEach(() => {
+	mockCreate.mockReset();
+	mockOnOpenChange.mockReset();
+});
+
+describe("InviteMemberDialog", () => {
+	it("空入力で送信 → role=alert で必須エラー、API 呼ばない", async () => {
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		await userEvent.click(screen.getByRole("button", { name: "招待を送る" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(/入力/);
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	it("@alice 入力 → 送信 → mutation 呼び出し → 成功 status", async () => {
+		mockCreate.mockReturnValueOnce({
+			unwrap: () =>
+				Promise.resolve({
+					id: 7,
+					room_id: 42,
+					room_name: "G",
+					inviter_id: 1,
+					inviter_handle: "test2",
+					invitee_id: 2,
+					invitee_handle: "alice",
+					accepted: null,
+					responded_at: null,
+					created_at: "2026-05-09T00:00:00Z",
+					updated_at: "2026-05-09T00:00:00Z",
+				}),
+		});
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		await userEvent.type(screen.getByLabelText(/handle/i), "@alice");
+		await userEvent.click(screen.getByRole("button", { name: "招待を送る" }));
+		await waitFor(() =>
+			expect(mockCreate).toHaveBeenCalledWith({
+				roomId: 42,
+				invitee_handle: "alice",
+			}),
+		);
+		expect(await screen.findByRole("status")).toHaveTextContent(/送信しました/);
+	});
+
+	it("404 (user not found) → 専用 alert", async () => {
+		mockCreate.mockReturnValueOnce({
+			unwrap: () =>
+				Promise.reject({ status: 404, data: { detail: "Not found." } }),
+		});
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		await userEvent.type(screen.getByLabelText(/handle/i), "ghost");
+		await userEvent.click(screen.getByRole("button", { name: "招待を送る" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(/ghost/);
+	});
+
+	it("409 既メンバー / 既招待 → 専用 alert", async () => {
+		mockCreate.mockReturnValueOnce({
+			unwrap: () =>
+				Promise.reject({
+					status: 409,
+					data: { detail: "already_member" },
+				}),
+		});
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		await userEvent.type(screen.getByLabelText(/handle/i), "bob");
+		await userEvent.click(screen.getByRole("button", { name: "招待を送る" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(/既に/);
+	});
+
+	it("不正文字 / 空白を含む → クライアント側 alert で API 呼ばない", async () => {
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		await userEvent.type(screen.getByLabelText(/handle/i), "ali ce");
+		await userEvent.click(screen.getByRole("button", { name: "招待を送る" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(/使用できない/);
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+});

--- a/client/src/lib/redux/features/dm/dmApiSlice.ts
+++ b/client/src/lib/redux/features/dm/dmApiSlice.ts
@@ -75,6 +75,23 @@ export const dmApiSlice = baseApiSlice.injectEndpoints({
 						]
 					: [{ type: "DMInvitation" as const, id: "LIST" }],
 		}),
+		// #476: 既存の group room に @handle 1 名を招待する。creator のみ。
+		// backend は POST /api/v1/dm/rooms/<id>/invitations/ (P3-04)。
+		// 成功時は invitation list と該当 room を invalidate して再 fetch させる。
+		createRoomInvitation: builder.mutation<
+			GroupInvitation,
+			{ roomId: number; invitee_handle: string }
+		>({
+			query: ({ roomId, invitee_handle }) => ({
+				url: `/dm/rooms/${roomId}/invitations/`,
+				method: "POST",
+				body: { invitee_handle },
+			}),
+			invalidatesTags: (_result, _error, { roomId }) => [
+				{ type: "DMInvitation" as const, id: "LIST" },
+				{ type: "DMRoom" as const, id: roomId },
+			],
+		}),
 		acceptInvitation: builder.mutation<GroupInvitation, number>({
 			query: (id) => ({
 				url: `/dm/invitations/${id}/accept/`,
@@ -142,6 +159,7 @@ export const {
 	useGetDMRoomQuery,
 	useCreateDMRoomMutation,
 	useListInvitationsQuery,
+	useCreateRoomInvitationMutation,
 	useAcceptInvitationMutation,
 	useDeclineInvitationMutation,
 	useListRoomMessagesQuery,

--- a/docs/specs/dm-room-invite-spec.md
+++ b/docs/specs/dm-room-invite-spec.md
@@ -1,0 +1,175 @@
+# DM ルーム内 招待 UI 仕様
+
+> 関連: [SPEC.md §7.2 グループ招待フロー](../SPEC.md), [docs/issues/phase-3.md](../issues/) (#XXX)
+> Phase 3 follow-up — backend 完成済、UI 不足の解消
+
+## 1. 背景
+
+現状 `/messages` トップに「招待」link (受信箱) と「+ 新規グループ」button があり、グループ作成 _時_ にしか招待を送れない。SPEC §7.2 の「グループ作成者が招待」を満たすには **既存 room の中から後から招待を送れる UI** が必要。Slack/Discord/Teams など標準のチャットアプリではすべて room 内導線を持つ。
+
+backend (`POST /api/v1/dm/rooms/<id>/invitations/`) は P3-04 (#229) で完成しているので、本変更は **UI 追加のみ**。
+
+## 2. やること / やらないこと
+
+### やる
+
+- `RoomChat` ヘッダ右側に「+ 招待」button 追加 (group room かつ自分が creator のとき限定)
+- 押下で `InviteMemberDialog` (Radix Dialog) が開く
+- ダイアログ内で `@handle` 入力 (1 名ずつ) → POST `/api/v1/dm/rooms/<id>/invitations/`
+- 成功 → トースト的フィードバック (`role="status"`) + ダイアログ閉じる
+- 失敗 (404 user not found / 409 既に member / 429 rate limit / 403 not creator) → `role="alert"` でメッセージ表示
+- pending invitation 一覧は本ダイアログ内では出さない (invitee 側の受信箱は `/messages/invitations` 既存)
+
+### やらない (out of scope, follow-up)
+
+- ハンドル autocomplete / インクリメンタル検索 (現状 user search endpoint なし、別 Issue)
+- creator 以外 / direct room の招待 (SPEC §7.2 で creator のみと確定)
+- 招待を送ったあとに invitee 側へ即時 push (Phase 4A 通知で別途配信)
+- まとめて複数人招待 (1 ダイアログで 1 件、連続呼び出しで対応可能)
+- 既に room メンバーの user 一覧を modal 内で見せる (将来の `RoomMembersDialog` で別途)
+
+## 3. UI 詳細
+
+### 3.1 RoomChat ヘッダ
+
+```
+┌─────────────────────────────────────────────┐
+│ ← 一覧  Group名     [+ 招待] ●オンライン     │ ← 新 button
+└─────────────────────────────────────────────┘
+```
+
+- button 表示条件: `room.kind === "group"` **AND** `room.creator_id === currentUserId`
+- direct room、または creator でない参加者には button 自体を非表示 (server 側でも 403 で守られているが、UI で見えないこと自体が安全)
+- aria-label: `"このグループに招待"`
+- 視覚: `border + px-2 py-1 text-xs`、SocketStatusBadge と並べて right-align
+
+### 3.2 InviteMemberDialog
+
+Radix `Dialog` (既存 `@/components/ui/dialog`)。
+
+```
+┌── このグループに招待 ───────────────[×]──┐
+│                                          │
+│  招待するユーザーの @handle を入力        │
+│  ┌──────────────────────────────────┐    │
+│  │ @                                │    │
+│  └──────────────────────────────────┘    │
+│  例: alice                                │
+│                                          │
+│  [キャンセル]               [招待を送る] │
+└──────────────────────────────────────────┘
+```
+
+- `<input>` は `@` プレフィックス受容 (GroupCreateForm と同じ正規化: `@alice`/`alice` → `alice`)
+- 送信中は button `aria-busy="true"` + disable
+- 成功時: `role="status"` で `招待を送信しました` 表示 → 1.2s 後ダイアログ閉じる
+- バリデーション error / API error は `role="alert"` で表示。エラー消化:
+  - 空文字 → `@handle を入力してください`
+  - 不正文字 (`/`, `..`, 空白): `@handle に使用できない文字が含まれています`
+  - 404: `@<handle> というユーザーは見つかりません`
+  - 409 (`already_member` / `pending_invitation`): `@<handle> は既にメンバー / 招待済みです`
+  - 403 (`not_creator`): `招待権限がありません` (creator 以外はそもそも button が見えないので想定外)
+  - 429: `招待の上限 (50 件/日) に達しました`
+- ESC キー / overlay クリック / × button で閉じる (Radix デフォルト)
+- 招待成功時に `RoomChat` への副作用は無し (room メンバー一覧は accept 後に backend が自動更新する)
+
+### 3.3 a11y
+
+- ダイアログ open 時に input にフォーカスを移す (Radix の autofocus)
+- 送信中はキーボード Tab 順序が button → input → button のループに入らないよう disable で除外
+- `<form>` で submit を Enter キーでもトリガー
+- ESC / × button から exit 可能 (WCAG 2.2 AA: 2.1.2 No Keyboard Trap)
+
+## 4. API (backend は実装済)
+
+### `POST /api/v1/dm/rooms/<id>/invitations/`
+
+Request:
+
+```json
+{ "invitee_handle": "alice" }
+```
+
+Response 201:
+
+```json
+{
+	"id": 123,
+	"room_id": 7,
+	"room_name": "プロジェクト相談室",
+	"inviter_id": 5,
+	"inviter_handle": "test2",
+	"invitee_id": 9,
+	"invitee_handle": "alice",
+	"accepted": null,
+	"responded_at": null,
+	"created_at": "2026-05-09T12:34:56+09:00",
+	"updated_at": "2026-05-09T12:34:56+09:00"
+}
+```
+
+Errors:
+
+- 400 — invitee_handle 不正、direct room、自己招待
+- 403 — inviter が creator でない / not authenticated
+- 404 — invitee handle 該当 user なし
+- 409 — 既に member、または pending invitation 既に存在 (idempotent: 既存 invitation が再返却されるケースもあり)
+- 429 — invitation rate limit (50/日)
+
+## 5. 状態遷移 (再掲)
+
+```
+[creator が招待送信] → invitation.accepted=null (pending)
+                         │
+                         ├── invitee が accept → membership 追加、accepted=true
+                         └── invitee が decline → accepted=false (再招待は新規 invitation で可)
+```
+
+## 6. テスト
+
+### 6.1 vitest (RTL)
+
+- `RoomChat` (group + creator): 「招待」 button が visible
+- `RoomChat` (group + non-creator): button 非表示
+- `RoomChat` (direct): button 非表示
+- `InviteMemberDialog`: `@alice` 入力 → 送信 → mocked POST 201 → success status
+- `InviteMemberDialog`: 空文字で submit → role=alert
+- `InviteMemberDialog`: 404 → `見つかりません` alert
+- `InviteMemberDialog`: 409 → `既にメンバー` alert
+- `InviteMemberDialog`: ESC で onOpenChange(false)
+
+### 6.2 Playwright UI E2E (`dm-room-invite.spec.ts`)
+
+stg 上で 2 ユーザー (USER1=test2 = creator、USER2=test3 = invitee) を使う。
+
+1. USER1 として login → 既存 group room (PLAYWRIGHT\*GROUP_ROOM_ID) を開く → 「招待」button 押下 → modal 出る
+2. modal で `@test3` 入力 → 送信 → success status
+3. USER1 logout、USER2 として login → `/messages/invitations` を開く → 該当招待が listing に存在
+4. 「承諾」押下 → invitee side で room が見えるようになることを確認
+5. クリーンアップ: USER2 が room から leave (もしくは USER1 が group を delete) — 現状 leave/delete API があれば呼ぶ、無ければ stg 状態をそのまま
+
+> ⚠️ stg DB の汚染を最小化するため、E2E 開始時に既存の pending invitation を accept/decline で消すクリーンアップ step を入れる。
+
+## 7. UI 不足 / 既出来 切り分け表
+
+| 機能                                                       | backend | frontend | 本 PR         |
+| ---------------------------------------------------------- | ------- | -------- | ------------- |
+| 新規 group 作成時に招待 (`POST /rooms/` `invitee_handles`) | ✅      | ✅       | ―             |
+| 既存 room に後から招待 (`POST /rooms/<id>/invitations/`)   | ✅      | ❌       | ✅            |
+| 自分宛て pending 招待一覧 (`GET /invitations/`)            | ✅      | ✅       | ―             |
+| 招待を承諾 (`POST /invitations/<id>/accept/`)              | ✅      | ✅       | ―             |
+| 招待を拒否 (`POST /invitations/<id>/decline/`)             | ✅      | ✅       | ―             |
+| handle autocomplete (user search)                          | ❌      | ❌       | ❌ (別 Issue) |
+| room メンバー一覧表示 (`/rooms/<id>/` の memberships)      | ✅      | ❌       | ❌ (別 Issue) |
+| 招待を取り消す (`DELETE /invitations/<id>/`)               | ❌      | ❌       | ❌ (別 Issue) |
+
+## 8. 想定スケジュール
+
+1 PR で完結予定。<200 行の UI 追加。
+
+## 9. 関連 Issue / PR
+
+- 本 spec の Issue: 後で追記
+- backend 招待 API: PR #258 (Issue #229) で実装済
+- 1:1 / グループ作成 UI: PR #239 (Issue #233) / PR #248 (Issue #236)
+- 招待リスト UI: PR #248 (Issue #237)


### PR DESCRIPTION
## Summary

ハルナさんの指摘 (`/messages` トップに招待 link しかなく、room 内で招待が送れない) への対応。backend (`POST /api/v1/dm/rooms/<id>/invitations/`) は P3-04 で実装済だったので **UI 追加のみ**。

仕様書: `docs/specs/dm-room-invite-spec.md`

## できている / できていない 切り分け

| 機能 | backend | frontend | 本 PR |
|------|---------|----------|-------|
| 新規 group 作成時招待 | ✅ | ✅ | ― |
| **既存 room 内招待** | ✅ | ❌ | ✅ |
| pending 招待リスト | ✅ | ✅ | ― |
| accept/decline | ✅ | ✅ | ― |
| user search (autocomplete) | ❌ | ❌ | ❌ (別 Issue) |
| room メンバー一覧表示 | ✅ | ❌ | ❌ (別 Issue) |
| 招待取消 (DELETE) | ❌ | ❌ | ❌ (別 Issue) |

## 変更点

- `InviteMemberButton.tsx` (新): `room.kind === 'group'` AND `room.creator_id === currentUserId` のときだけ「+ 招待」button を render、それ以外は `null`
- `InviteMemberDialog.tsx` (新): Radix Dialog + handle 入力 + 送信 + success/error 表示。autofocus / ESC close / aria-busy
- `dmApiSlice.ts`: `createRoomInvitation` mutation 追加 (DMInvitation LIST と DMRoom を invalidate)
- `RoomChat.tsx`: header に `InviteMemberButton` を SocketStatusBadge と並べて配置
- `docs/specs/dm-room-invite-spec.md` (新): 仕様書 (UI / API / a11y / テスト)

## Test plan

- [x] vitest RTL: 10 tests pass (Button visibility 5 + Dialog flow 5)
- [x] DM 関連 12 files / 74 tests 全 pass (regression なし)
- [x] tsc / eslint clean
- [ ] CI 全 green
- [ ] stg deploy 後 Playwright UI E2E (`dm-room-invite.spec.ts`) 実行 (USER1=test2、USER2=test3、既存 group room id を env で渡す)

## Out of scope (別 Issue)

- handle autocomplete (user search endpoint なし)
- room メンバー一覧 (`/rooms/<id>/` の memberships を modal で表示)
- 招待取消 (backend に DELETE 未実装)

Closes #476