### PR TITLE
feat(dm): MessageComposer に Ctrl+V 画像貼り付け対応 (Closes #470)

### DIFF
--- a/client/e2e/dm-paste-attach.spec.ts
+++ b/client/e2e/dm-paste-attach.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * DM composer Ctrl+V 画像貼り付け UI E2E (#470).
+ *
+ * setInputFiles ではなく **本物の paste event** を発火して clipboardData に
+ * 画像 (sample-image.png の base64) を入れる。Slack/Discord 流の paste 添付。
+ *
+ * フロー:
+ *   1. test2 として login → /messages/<ROOM_ID>
+ *   2. textarea にフォーカス → page.evaluate で ClipboardEvent dispatch
+ *   3. compose preview に thumbnail <img> が出ること
+ *   4. 「送信」 → bubble に <img> が出ること
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+};
+const ROOM_ID = Number(process.env.PLAYWRIGHT_ROOM_ID ?? 1);
+const FIXTURE_IMAGE = path.resolve(__dirname, "fixtures/sample-image.png");
+
+test.describe("DM composer Ctrl+V paste (Issue #470)", () => {
+	test.beforeEach(() => {
+		if (!USER1.email || !USER1.password) {
+			throw new Error("PLAYWRIGHT_USER1_EMAIL / PASSWORD required");
+		}
+	});
+
+	test("PASTE-IMG: clipboard に画像 → composer に thumbnail → 送信 → bubble", async ({
+		page,
+		context,
+	}) => {
+		// Login via API (cookies 付与)
+		const csrfRes = await context.request.get(`${BASE}/api/v1/auth/csrf/`);
+		const csrfHeader = csrfRes.headers()["set-cookie"] ?? "";
+		const csrf = /csrftoken=([^;]+)/.exec(csrfHeader)?.[1] ?? "";
+		const login = await context.request.post(
+			`${BASE}/api/v1/auth/cookie/create/`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+					"X-CSRFToken": csrf,
+					Referer: `${BASE}/login`,
+				},
+				data: { email: USER1.email, password: USER1.password },
+			},
+		);
+		expect(login.status()).toBe(200);
+
+		await page.goto(`${BASE}/messages/${ROOM_ID}`);
+		const textarea = page.getByLabel("メッセージを入力");
+		await expect(textarea).toBeVisible({ timeout: 15000 });
+
+		// Read fixture as base64 → embed into ClipboardEvent
+		const imageBytes = fs.readFileSync(FIXTURE_IMAGE);
+		const imageB64 = imageBytes.toString("base64");
+
+		// Browser context で File を構築 → ClipboardEvent dispatch
+		await textarea.focus();
+		await page.evaluate(async (b64) => {
+			const bin = atob(b64);
+			const len = bin.length;
+			const bytes = new Uint8Array(len);
+			for (let i = 0; i < len; i++) bytes[i] = bin.charCodeAt(i);
+			const file = new File([bytes], "", { type: "image/png" });
+			const dt = new DataTransfer();
+			dt.items.add(file);
+			const ev = new ClipboardEvent("paste", {
+				clipboardData: dt,
+				bubbles: true,
+				cancelable: true,
+			});
+			document.activeElement?.dispatchEvent(ev);
+		}, imageB64);
+
+		// Compose preview に thumbnail <img> (alt は pasted-<ts>.png)
+		const previewList = page.locator('ul[aria-label="添付ファイル一覧"]');
+		await expect(previewList).toBeVisible({ timeout: 30000 });
+		const previewImg = previewList.locator("img").first();
+		await expect(previewImg).toBeVisible({ timeout: 30000 });
+		const previewAlt = await previewImg.getAttribute("alt");
+		expect(previewAlt).toMatch(/^pasted-\d+\.png$/);
+
+		// 送信
+		await page.getByRole("button", { name: "送信" }).click();
+		await expect(previewList).toHaveCount(0, { timeout: 15000 });
+
+		// Bubble 内に img が出る
+		const sentImg = page
+			.locator('[data-testid="message-bubble"]')
+			.locator("img")
+			.last();
+		await expect(sentImg).toBeVisible({ timeout: 30000 });
+	});
+});

--- a/client/src/components/dm/MessageComposer.tsx
+++ b/client/src/components/dm/MessageComposer.tsx
@@ -10,12 +10,19 @@
  * - 添付 UI (#456): roomId が渡されると `<AttachmentUploader>` を表示。
  *   アップロード済み attachment を preview + 送信時に attachment_ids として親へ。
  *   body 空でも attachment が 1 件以上あれば送信可能。
+ * - Ctrl+V paste (#470): textarea に画像を貼り付けると presign → S3 → confirm を
+ *   自動実行して attachment 一覧に追加する。テキスト paste には介入しない。
  */
 
-import { useCallback, useState, type KeyboardEvent } from "react";
+import {
+	useCallback,
+	useState,
+	type ClipboardEvent,
+	type KeyboardEvent,
+} from "react";
 
 import AttachmentUploader from "@/components/dm/AttachmentUploader";
-import type { ConfirmResponse } from "@/lib/dm/attachments";
+import { uploadAttachment, type ConfirmResponse } from "@/lib/dm/attachments";
 
 interface MessageComposerProps {
 	onSubmit(body: string, attachmentIds: number[]): void | Promise<void>;
@@ -54,6 +61,9 @@ export default function MessageComposer({
 	const [submitting, setSubmitting] = useState(false);
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [attached, setAttached] = useState<AttachedFile[]>([]);
+	// Issue #470: paste 中の進捗 / エラー
+	const [pasting, setPasting] = useState(false);
+	const [pasteError, setPasteError] = useState<string | null>(null);
 
 	const submit = useCallback(async () => {
 		const trimmed = value.trim();
@@ -103,6 +113,55 @@ export default function MessageComposer({
 		setAttached((prev) => prev.filter((a) => a.id !== id));
 	}, []);
 
+	// Issue #470: clipboard に image item があれば自動アップロードして attached に追加。
+	// テキスト paste には介入しない (preventDefault せず textarea のデフォルト動作)。
+	const onPaste = useCallback(
+		async (event: ClipboardEvent<HTMLTextAreaElement>) => {
+			if (roomId === undefined) return;
+			const items = event.clipboardData?.items;
+			if (!items) return;
+			const imageItem = Array.from(items).find((it) =>
+				it.type.startsWith("image/"),
+			);
+			if (!imageItem) return;
+			event.preventDefault();
+			const raw = imageItem.getAsFile();
+			if (!raw) return;
+			// pasted file は filename が空なので合成する (server validation 用)
+			const ext = (raw.type.split("/")[1] ?? "png").replace(/[^a-z0-9]/gi, "");
+			const named =
+				raw.name && raw.name.length > 0
+					? raw
+					: new File([raw], `pasted-${Date.now()}.${ext}`, {
+							type: raw.type,
+						});
+			setPasting(true);
+			setPasteError(null);
+			try {
+				const attachment = await uploadAttachment({ roomId, file: named });
+				setAttached((prev) => [
+					...prev,
+					{
+						id: attachment.id,
+						filename: attachment.filename,
+						mimeType: attachment.mime_type,
+						size: attachment.size,
+						url: attachment.url,
+					},
+				]);
+			} catch (err: unknown) {
+				const msg =
+					err instanceof Error
+						? err.message
+						: "貼り付けたファイルのアップロードに失敗しました";
+				setPasteError(msg);
+			} finally {
+				setPasting(false);
+			}
+		},
+		[roomId],
+	);
+
 	const sendDisabled =
 		disabled ||
 		(value.trim().length === 0 && attached.length === 0) ||
@@ -119,6 +178,20 @@ export default function MessageComposer({
 			{submitError ? (
 				<div role="alert" className="text-baby_red px-1 text-xs">
 					{submitError}
+				</div>
+			) : null}
+			{pasteError ? (
+				<div role="alert" className="text-baby_red px-1 text-xs">
+					{pasteError}
+				</div>
+			) : null}
+			{pasting ? (
+				<div
+					role="status"
+					aria-live="polite"
+					className="text-baby_grey px-1 text-xs"
+				>
+					貼り付け画像をアップロード中...
 				</div>
 			) : null}
 			{attached.length > 0 ? (
@@ -198,6 +271,7 @@ export default function MessageComposer({
 						onTyping?.();
 					}}
 					onKeyDown={onKeyDown}
+					onPaste={onPaste}
 					disabled={disabled}
 					placeholder={placeholder}
 					aria-keyshortcuts="Control+Enter Meta+Enter"
@@ -215,7 +289,9 @@ export default function MessageComposer({
 			</div>
 			<p id="message-composer-hint" className="text-baby_grey px-1 text-[11px]">
 				Ctrl/Cmd+Enter で送信、Enter で改行
-				{roomId !== undefined ? "、📎 で画像/ファイル添付" : ""}
+				{roomId !== undefined
+					? "、📎 で画像/ファイル添付、Ctrl+V で画像貼り付け"
+					: ""}
 			</p>
 		</form>
 	);

--- a/client/src/components/dm/__tests__/MessageComposer.test.tsx
+++ b/client/src/components/dm/__tests__/MessageComposer.test.tsx
@@ -1,11 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import MessageComposer from "@/components/dm/MessageComposer";
+import * as attachments from "@/lib/dm/attachments";
 import type { ConfirmResponse } from "@/lib/dm/attachments";
 
 let nextAttachment: ConfirmResponse | null = null;
+
+vi.mock("@/lib/dm/attachments", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/dm/attachments")>(
+		"@/lib/dm/attachments",
+	);
+	return {
+		...actual,
+		uploadAttachment: vi.fn(),
+	};
+});
+
+const uploadAttachmentMock = vi.mocked(attachments.uploadAttachment);
+
+beforeEach(() => {
+	uploadAttachmentMock.mockReset();
+});
 
 vi.mock("@/components/dm/AttachmentUploader", () => ({
 	default: ({
@@ -136,6 +153,92 @@ describe("MessageComposer", () => {
 		expect(await screen.findByText("spec.pdf")).toBeInTheDocument();
 		// 画像ではないので img は出ない
 		expect(screen.queryByRole("img", { name: "spec.pdf" })).toBeNull();
+	});
+
+	// #470: Ctrl+V paste で画像を直接添付できる
+	function makeImageFile(name = "", type = "image/png", size = 1024): File {
+		const bytes = new Uint8Array(size).fill(0);
+		const f = new File([bytes], name, { type });
+		Object.defineProperty(f, "size", { value: size });
+		return f;
+	}
+
+	function pasteImage(textarea: HTMLElement, file: File) {
+		const dataTransfer = {
+			items: [
+				{
+					kind: "file",
+					type: file.type,
+					getAsFile: () => file,
+				},
+			],
+			files: [file],
+			types: ["Files"],
+		};
+		fireEvent.paste(textarea, { clipboardData: dataTransfer });
+	}
+
+	it("Ctrl+V で画像 paste → uploadAttachment 呼び出し → attachment 追加", async () => {
+		uploadAttachmentMock.mockResolvedValueOnce({
+			id: 100,
+			s3_key: "k",
+			url: "https://cdn.example.com/pasted.png",
+			filename: "pasted-1.png",
+			mime_type: "image/png",
+			size: 1024,
+			width: null,
+			height: null,
+		});
+		render(<MessageComposer onSubmit={() => {}} roomId={1} />);
+		const textarea = screen.getByLabelText("メッセージを入力");
+		pasteImage(textarea, makeImageFile("", "image/png", 1024));
+		// 進行中 status
+		expect(await screen.findByRole("status")).toHaveTextContent(
+			/アップロード中/,
+		);
+		await waitFor(() =>
+			expect(uploadAttachmentMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					roomId: 1,
+					file: expect.objectContaining({
+						type: "image/png",
+						name: expect.stringMatching(/^pasted-\d+\.png$/),
+					}),
+				}),
+			),
+		);
+		// 成功後 attachment が thumbnail として渲染
+		expect(
+			await screen.findByRole("img", { name: "pasted-1.png" }),
+		).toBeInTheDocument();
+	});
+
+	it("Ctrl+V でテキスト paste → upload は呼ばれず textarea にテキストが入る", async () => {
+		render(<MessageComposer onSubmit={() => {}} roomId={1} />);
+		const textarea = screen.getByLabelText(
+			"メッセージを入力",
+		) as HTMLTextAreaElement;
+		fireEvent.paste(textarea, {
+			clipboardData: { items: [], files: [], types: ["text/plain"] },
+		});
+		expect(uploadAttachmentMock).not.toHaveBeenCalled();
+	});
+
+	it("paste image で uploadAttachment が reject → role=alert", async () => {
+		uploadAttachmentMock.mockRejectedValueOnce(
+			new Error("ファイルが大きすぎます"),
+		);
+		render(<MessageComposer onSubmit={() => {}} roomId={1} />);
+		const textarea = screen.getByLabelText("メッセージを入力");
+		pasteImage(textarea, makeImageFile("", "image/png", 1024));
+		expect(await screen.findByRole("alert")).toHaveTextContent(/大きすぎます/);
+	});
+
+	it("roomId 未指定の paste image: upload は呼ばれない", async () => {
+		render(<MessageComposer onSubmit={() => {}} />);
+		const textarea = screen.getByLabelText("メッセージを入力");
+		pasteImage(textarea, makeImageFile("", "image/png", 1024));
+		expect(uploadAttachmentMock).not.toHaveBeenCalled();
 	});
 
 	it("サムネイルの × ボタンで添付が外れる", async () => {


### PR DESCRIPTION
## Summary

Slack/Discord/Teams 標準の「クリップボード画像を Ctrl+V で添付」を実装。textarea の `onPaste` で clipboardData に image item があれば自動的に presign → S3 → confirm を流して attachment 一覧に追加する。

## 変更点

- `MessageComposer.tsx` に `onPaste` ハンドラ追加
  - clipboard items に image/* があれば preventDefault → uploadAttachment 呼び出し
  - pasted file は filename 空なので `pasted-<ts>.<ext>` を合成
  - 進行中は role=status / 失敗時は role=alert
- ヒント文に「Ctrl+V で画像貼り付け」 追記

## Test plan

- [x] vitest RTL 16 tests pass (新規 4 ケース: paste image / text / 失敗 / roomId 未指定)
- [x] tsc / eslint clean
- [ ] CI 全 green
- [ ] stg deploy 後 Playwright UI E2E (`dm-paste-attach.spec.ts`) — ClipboardEvent dispatch で画像 paste → thumbnail → 送信 → bubble

Closes #470