### PR TITLE
feat(dm): RoomChat ヘッダにメンバー一覧 button + dialog 追加 (Closes #479)

### DIFF
--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import InviteMemberButton from "@/components/dm/InviteMemberButton";
 import MessageComposer from "@/components/dm/MessageComposer";
+import RoomMembersButton from "@/components/dm/RoomMembersButton";
 import MessageList from "@/components/dm/MessageList";
 import TypingIndicator from "@/components/dm/TypingIndicator";
 import { useDMSocket } from "@/hooks/useDMSocket";
@@ -169,6 +170,7 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 					</h1>
 				</div>
 				<div className="flex items-center gap-2">
+					<RoomMembersButton room={roomQuery.data} />
 					<InviteMemberButton
 						room={roomQuery.data}
 						currentUserId={currentUserId}

--- a/client/src/components/dm/RoomMembersButton.tsx
+++ b/client/src/components/dm/RoomMembersButton.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * RoomChat header に置く「メンバー」 button + RoomMembersDialog wrapper (#479).
+ *
+ * 表示条件: `room.kind === "group"` (direct は peer header で十分なので非表示)。
+ */
+
+import { useState } from "react";
+
+import RoomMembersDialog from "@/components/dm/RoomMembersDialog";
+import type { DMRoom } from "@/lib/redux/features/dm/types";
+
+interface RoomMembersButtonProps {
+	room: DMRoom | undefined;
+}
+
+export default function RoomMembersButton({ room }: RoomMembersButtonProps) {
+	const [open, setOpen] = useState(false);
+
+	if (!room) return null;
+	if (room.kind !== "group") return null;
+
+	const count = room.memberships?.length ?? 0;
+	return (
+		<>
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				aria-label={`メンバー一覧を表示 (${count} 名)`}
+				className="border-baby_grey/40 text-baby_white hover:bg-baby_grey/10 focus-visible:ring-baby_blue rounded-md border px-2 py-1 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2"
+			>
+				メンバー {count > 0 ? count : ""}
+			</button>
+			<RoomMembersDialog open={open} onOpenChange={setOpen} room={room} />
+		</>
+	);
+}

--- a/client/src/components/dm/RoomMembersDialog.tsx
+++ b/client/src/components/dm/RoomMembersDialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * Group room の現メンバー一覧 dialog (#479).
+ *
+ * SPEC §7.1 / docs/specs/dm-room-invite-spec.md。
+ *
+ * - room.memberships を listing
+ * - creator には「(作成者)」バッジ
+ * - 各行 handle + 参加日
+ * - direct room ではこの button 自体を出さない (RoomMembersButton 側で制御)
+ */
+
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import type { DMRoom, DMRoomMembership } from "@/lib/redux/features/dm/types";
+
+interface RoomMembersDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	room: DMRoom;
+}
+
+function formatJoinDate(iso: string): string {
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return iso;
+	const y = d.getFullYear();
+	const m = `${d.getMonth() + 1}`.padStart(2, "0");
+	const day = `${d.getDate()}`.padStart(2, "0");
+	return `${y}-${m}-${day}`;
+}
+
+export default function RoomMembersDialog({
+	open,
+	onOpenChange,
+	room,
+}: RoomMembersDialogProps) {
+	const memberships: DMRoomMembership[] = room.memberships ?? [];
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>メンバー ({memberships.length} 名)</DialogTitle>
+				</DialogHeader>
+				{memberships.length === 0 ? (
+					<p className="text-baby_grey text-sm">メンバーはいません。</p>
+				) : (
+					<ul
+						role="list"
+						aria-label="メンバー一覧"
+						className="flex flex-col gap-2"
+					>
+						{memberships.map((m) => {
+							const isCreator =
+								room.creator_id !== null && m.user_id === room.creator_id;
+							return (
+								<li
+									key={m.id}
+									role="listitem"
+									className="bg-baby_veryBlack border-baby_grey/30 text-baby_white flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
+								>
+									<div className="flex min-w-0 items-center gap-2">
+										<span className="text-baby_white font-semibold">
+											@{m.handle}
+										</span>
+										{isCreator ? (
+											<span
+												aria-label="作成者"
+												className="bg-baby_blue/20 text-baby_blue rounded-full px-2 py-0.5 text-[10px] font-semibold"
+											>
+												作成者
+											</span>
+										) : null}
+									</div>
+									<time
+										dateTime={m.created_at}
+										className="text-baby_grey shrink-0 text-xs"
+									>
+										{formatJoinDate(m.created_at)}
+									</time>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/client/src/components/dm/__tests__/RoomMembersButton.test.tsx
+++ b/client/src/components/dm/__tests__/RoomMembersButton.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for RoomMembersButton (#479).
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import RoomMembersButton from "@/components/dm/RoomMembersButton";
+import type { DMRoom, DMRoomMembership } from "@/lib/redux/features/dm/types";
+
+function makeMembership(
+	overrides: Partial<DMRoomMembership> = {},
+): DMRoomMembership {
+	return {
+		id: 1,
+		user_id: 1,
+		handle: "alice",
+		last_read_at: null,
+		created_at: "2026-05-01T12:00:00Z",
+		...overrides,
+	};
+}
+
+function makeRoom(overrides: Partial<DMRoom> = {}): DMRoom {
+	return {
+		id: 42,
+		kind: "group",
+		name: "Engineers",
+		creator_id: 1,
+		memberships: [
+			makeMembership({ id: 1, user_id: 1, handle: "alice" }),
+			makeMembership({ id: 2, user_id: 2, handle: "bob" }),
+		],
+		last_message_at: null,
+		is_archived: false,
+		created_at: "2026-05-01T12:00:00Z",
+		updated_at: "2026-05-01T12:00:00Z",
+		...overrides,
+	};
+}
+
+describe("RoomMembersButton", () => {
+	it("group room: button が visible (件数表示)", () => {
+		render(<RoomMembersButton room={makeRoom()} />);
+		expect(
+			screen.getByRole("button", { name: /メンバー一覧を表示 \(2 名\)/ }),
+		).toBeInTheDocument();
+	});
+
+	it("direct room: 非表示", () => {
+		const { container } = render(
+			<RoomMembersButton room={makeRoom({ kind: "direct" })} />,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("room=undefined: 非表示", () => {
+		const { container } = render(<RoomMembersButton room={undefined} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("button 押下で dialog が開き memberships を listing", async () => {
+		render(<RoomMembersButton room={makeRoom()} />);
+		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
+		// memberships listing
+		expect(screen.getByText("@alice")).toBeInTheDocument();
+		expect(screen.getByText("@bob")).toBeInTheDocument();
+		// creator badge は alice (creator_id=1) に
+		expect(screen.getByLabelText("作成者")).toBeInTheDocument();
+	});
+
+	it("creator が memberships に居ない場合は作成者バッジ無し", async () => {
+		render(
+			<RoomMembersButton
+				room={makeRoom({
+					creator_id: 999,
+					memberships: [makeMembership({ id: 1, user_id: 1, handle: "alice" })],
+				})}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
+		expect(screen.queryByLabelText("作成者")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

backend (`GET /rooms/<id>/`) は memberships を既に返しているが、frontend 側に閲覧導線が無かった。SPEC §7.1「グループ最大 20 名」運用の補完。

## 変更点

- `RoomMembersDialog`: room.memberships listing (@handle + 参加日 + 作成者バッジ)
- `RoomMembersButton`: kind=group のみ表示 (direct は peer header で十分)
- `RoomChat` header に RoomMembersButton + InviteMemberButton + SocketStatusBadge を並べる
- vitest RTL: 5 cases

## Test plan

- [x] vitest 5/5
- [x] tsc / eslint clean
- [ ] CI 全 green
- [ ] stg deploy 後 visual 確認

Closes #479