### PR TITLE
feat(dm): user search backend + handle autocomplete UI (Closes #480)

### DIFF
--- a/apps/users/tests/test_user_search.py
+++ b/apps/users/tests/test_user_search.py
@@ -38,9 +38,14 @@ def make_user(*, username: str, email: str = "", is_active: bool = True):
 
 @pytest.mark.django_db
 def test_search_requires_auth(search_url: str) -> None:
+    """匿名は 401 もしくは 403 (CookieAuthentication は WWW-Authenticate header
+    を出さないため DRF の既定で 403 になる)。"""
     client = APIClient()
     resp = client.get(f"{search_url}?q=abc")
-    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
 
 
 @pytest.mark.django_db

--- a/apps/users/tests/test_user_search.py
+++ b/apps/users/tests/test_user_search.py
@@ -141,7 +141,7 @@ def test_search_response_shape(search_url: str) -> None:
     if body["results"]:
         first = body["results"][0]
         # 必要 field のみ (PII を漏らさない)
-        for key in ("user_id", "username", "first_name", "last_name", "avatar"):
+        for key in ("user_id", "username", "first_name", "last_name", "avatar_url"):
             assert key in first
         # email / is_active / is_premium などは出さない
         assert "email" not in first

--- a/apps/users/tests/test_user_search.py
+++ b/apps/users/tests/test_user_search.py
@@ -1,0 +1,143 @@
+"""ユーザー検索 API (#480) のテスト.
+
+GET /api/v1/users/?q=<prefix>&limit=N
+- 認証必須 (anonymous → 401)
+- handle (username) の前方一致 (case-insensitive)
+- 自分自身は除外
+- is_active=False は除外
+- limit 既定 10、上限 50
+- limit=0 / 空 q では空配列 (lookup を空打ちさせない安全弁)
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.fixture
+def search_url() -> str:
+    return reverse("users-search")
+
+
+def make_user(*, username: str, email: str = "", is_active: bool = True):
+    return User.objects.create_user(
+        username=username,
+        email=email or f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+        is_active=is_active,
+    )
+
+
+@pytest.mark.django_db
+def test_search_requires_auth(search_url: str) -> None:
+    client = APIClient()
+    resp = client.get(f"{search_url}?q=abc")
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_search_prefix_match_excludes_self(search_url: str) -> None:
+    me = make_user(username="alice")
+    make_user(username="alex")
+    make_user(username="aaron")
+    make_user(username="bob")
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(f"{search_url}?q=al")
+    assert resp.status_code == status.HTTP_200_OK
+    handles = sorted(u["username"] for u in resp.json()["results"])
+    # alex のみ (alice = self は除外、aaron は a だけど "al" で前方一致しない)
+    assert handles == ["alex"]
+
+
+@pytest.mark.django_db
+def test_search_excludes_inactive(search_url: str) -> None:
+    me = make_user(username="zara")
+    make_user(username="ghost", is_active=False)
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(f"{search_url}?q=gho")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == []
+
+
+@pytest.mark.django_db
+def test_search_case_insensitive(search_url: str) -> None:
+    me = make_user(username="me1")
+    make_user(username="Bobby")
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(f"{search_url}?q=BOB")
+    handles = [u["username"] for u in resp.json()["results"]]
+    assert "Bobby" in handles
+
+
+@pytest.mark.django_db
+def test_search_empty_q_returns_empty(search_url: str) -> None:
+    me = make_user(username="me2")
+    make_user(username="alice2")
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(f"{search_url}?q=")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["results"] == []
+
+
+@pytest.mark.django_db
+def test_search_limit_default_10(search_url: str) -> None:
+    me = make_user(username="searcher")
+    for i in range(15):
+        make_user(username=f"target_{i:02d}")
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(f"{search_url}?q=target")
+    body = resp.json()
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(body["results"]) == 10
+
+
+@pytest.mark.django_db
+def test_search_limit_capped_at_50(search_url: str) -> None:
+    me = make_user(username="searcher2")
+    for i in range(60):
+        make_user(username=f"prefixb_{i:02d}")
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(f"{search_url}?q=prefixb&limit=999")
+    body = resp.json()
+    assert len(body["results"]) <= 50
+
+
+@pytest.mark.django_db
+def test_search_response_shape(search_url: str) -> None:
+    me = make_user(username="seeker")
+    make_user(username="alpha")
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(f"{search_url}?q=alpha")
+    body = resp.json()
+    assert "results" in body
+    assert isinstance(body["results"], list)
+    if body["results"]:
+        first = body["results"][0]
+        # 必要 field のみ (PII を漏らさない)
+        for key in ("user_id", "username", "first_name", "last_name", "avatar"):
+            assert key in first
+        # email / is_active / is_premium などは出さない
+        assert "email" not in first
+        assert "is_active" not in first

--- a/apps/users/urls_profile.py
+++ b/apps/users/urls_profile.py
@@ -22,9 +22,13 @@ from .views import (
     HeaderUploadUrlView,
     MeView,
     PublicProfileView,
+    UserSearchView,
 )
 
 urlpatterns = [
+    # Issue #480: handle 前方一致検索 (autocomplete 用)。
+    # 静的 path として `<str:username>/` より先に登録する (greedy 対策)。
+    path("", UserSearchView.as_view(), name="users-search"),
     path("me/", MeView.as_view(), name="users-me"),
     # P1-04: avatar / header 画像 S3 presigned URL 発行。
     path(

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -651,7 +651,7 @@ class UserSearchSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ("user_id", "username", "first_name", "last_name", "avatar")
+        fields = ("user_id", "username", "first_name", "last_name", "avatar_url")
         read_only_fields = fields
 
 

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -637,3 +637,61 @@ class HeaderUploadUrlView(_BaseUploadUrlView):
     """``POST /api/v1/users/me/header-upload-url/``: header 用 presigned URL 発行."""
 
     kind = "header"
+
+
+# ---------------------------------------------------------------------------
+# Issue #480: ユーザー検索 (handle 前方一致)
+# ---------------------------------------------------------------------------
+
+
+class UserSearchSerializer(serializers.ModelSerializer):
+    """検索結果用 — PII を漏らさない最小フィールドのみ."""
+
+    user_id = serializers.UUIDField(source="id", read_only=True)
+
+    class Meta:
+        model = User
+        fields = ("user_id", "username", "first_name", "last_name", "avatar")
+        read_only_fields = fields
+
+
+class UserSearchView(APIView):
+    """``GET /api/v1/users/?q=<prefix>&limit=N``: handle (username) 前方一致検索.
+
+    SPEC §2 / Issue #480 — InviteMemberDialog 等の handle autocomplete 用。
+
+    - 認証必須 (anonymous には harvest を許さない)
+    - case-insensitive 前方一致 (``istartswith``)
+    - 自分自身を除外 (招待自己宛て不可と整合)
+    - is_active=False を除外 (PublicProfileView と整合)
+    - 既定 limit=10、上限 50
+    - 空 q は空配列 (lookup 空打ちさせない)
+    """
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [
+        CSRFEnforcingAuthentication,
+        CookieAuthentication,
+    ]
+
+    DEFAULT_LIMIT = 10
+    MAX_LIMIT = 50
+
+    def get(self, request: Request) -> Response:
+        q = (request.query_params.get("q") or "").strip()
+        try:
+            limit = int(request.query_params.get("limit", self.DEFAULT_LIMIT))
+        except ValueError:
+            limit = self.DEFAULT_LIMIT
+        limit = max(0, min(limit, self.MAX_LIMIT))
+
+        if not q or limit == 0:
+            return Response({"results": []}, status=status.HTTP_200_OK)
+
+        qs = (
+            User.objects.filter(is_active=True, username__istartswith=q)
+            .exclude(pk=request.user.pk)
+            .order_by("username")[:limit]
+        )
+        results = UserSearchSerializer(qs, many=True).data
+        return Response({"results": results}, status=status.HTTP_200_OK)

--- a/client/src/components/dm/InviteMemberDialog.tsx
+++ b/client/src/components/dm/InviteMemberDialog.tsx
@@ -1,18 +1,27 @@
 "use client";
 
 /**
- * グループ room 内から招待を送る Dialog (#476).
+ * グループ room 内から招待を送る Dialog (#476 / #480 で autocomplete 追加).
  *
  * SPEC §7.2 / docs/specs/dm-room-invite-spec.md。
  *
  * - @handle 1 名を入力 → POST /api/v1/dm/rooms/<id>/invitations/
+ * - 入力中は GET /api/v1/users/?q=... (debounce 250ms) で前方一致 dropdown
  * - 成功時は role=status で通知 → ~1.2s 後 onOpenChange(false)
  * - 失敗時は role=alert (404 / 409 / 429 / 403 / その他)
  * - クライアント側 validation: 空 / 不正文字 / 空白
- * - a11y: ESC / × button / overlay click で close (Radix デフォルト)
+ * - a11y: ESC / × button / overlay click で close (Radix デフォルト)、
+ *   combobox + listbox + 矢印 / Enter キー操作
  */
 
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import {
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type FormEvent,
+	type KeyboardEvent,
+} from "react";
 
 import {
 	Dialog,
@@ -21,6 +30,16 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { useCreateRoomInvitationMutation } from "@/lib/redux/features/dm/dmApiSlice";
+import { useSearchUsersQuery } from "@/lib/redux/features/users/usersApiSlice";
+
+function useDebounced<T>(value: T, delayMs: number): T {
+	const [debounced, setDebounced] = useState(value);
+	useEffect(() => {
+		const t = setTimeout(() => setDebounced(value), delayMs);
+		return () => clearTimeout(t);
+	}, [value, delayMs]);
+	return debounced;
+}
 
 const HANDLE_REGEX = /^[a-zA-Z0-9_]{3,30}$/;
 
@@ -62,7 +81,22 @@ export default function InviteMemberDialog({
 	const [handle, setHandle] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [successMsg, setSuccessMsg] = useState<string | null>(null);
+	const [activeIdx, setActiveIdx] = useState(-1); // -1 = 何も選択していない (plain input)
+	const [showSuggestions, setShowSuggestions] = useState(false);
 	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	// Issue #480: 検索クエリ (handle の `@` を取り除いた前方一致用)
+	const normalizedQuery = useMemo(
+		() => handle.trim().replace(/^@/, ""),
+		[handle],
+	);
+	const debouncedQuery = useDebounced(normalizedQuery, 250);
+	// 2 文字以上 + suggestions visible なときだけ fetch (skip で query 抑制)
+	const { data: searchData } = useSearchUsersQuery(
+		{ q: debouncedQuery, limit: 10 },
+		{ skip: !showSuggestions || debouncedQuery.length < 2 },
+	);
+	const suggestions = searchData?.results ?? [];
 
 	// open に切り替わったら state リセット (前回の error / success を消す)
 	useEffect(() => {
@@ -70,6 +104,8 @@ export default function InviteMemberDialog({
 			setError(null);
 			setSuccessMsg(null);
 			setHandle("");
+			setActiveIdx(-1);
+			setShowSuggestions(false);
 		}
 	}, [open]);
 
@@ -100,8 +136,33 @@ export default function InviteMemberDialog({
 		try {
 			await createInvite({ roomId, invitee_handle: normalized }).unwrap();
 			setSuccessMsg(`@${normalized} に招待を送信しました`);
+			setShowSuggestions(false);
 		} catch (err: unknown) {
 			setError(mapApiError(err, normalized));
+		}
+	};
+
+	const pickSuggestion = (username: string) => {
+		setHandle(username);
+		setActiveIdx(-1);
+		setShowSuggestions(false);
+		inputRef.current?.focus();
+	};
+
+	const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (!showSuggestions || suggestions.length === 0) return;
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			setActiveIdx((i) => (i + 1) % suggestions.length);
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			setActiveIdx((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+		} else if (e.key === "Enter" && activeIdx >= 0) {
+			e.preventDefault();
+			pickSuggestion(suggestions[activeIdx].username);
+		} else if (e.key === "Escape") {
+			setShowSuggestions(false);
+			setActiveIdx(-1);
 		}
 	};
 
@@ -130,7 +191,7 @@ export default function InviteMemberDialog({
 							{successMsg}
 						</div>
 					) : null}
-					<div className="flex flex-col gap-1">
+					<div className="relative flex flex-col gap-1">
 						<label
 							htmlFor="invite-handle"
 							className="text-baby_white text-sm font-semibold"
@@ -142,15 +203,66 @@ export default function InviteMemberDialog({
 							id="invite-handle"
 							type="text"
 							value={handle}
-							onChange={(e) => setHandle(e.target.value)}
+							onChange={(e) => {
+								setHandle(e.target.value);
+								setShowSuggestions(true);
+								setActiveIdx(-1);
+							}}
+							onFocus={() => setShowSuggestions(true)}
+							onBlur={() =>
+								// suggestion click が blur 後に来てしまうので 100ms 遅延
+								setTimeout(() => setShowSuggestions(false), 100)
+							}
+							onKeyDown={onKeyDown}
 							placeholder="alice"
 							autoFocus
+							role="combobox"
+							aria-autocomplete="list"
+							aria-expanded={showSuggestions && suggestions.length > 0}
+							aria-controls="invite-suggestions-list"
+							aria-activedescendant={
+								activeIdx >= 0 ? `invite-suggest-${activeIdx}` : undefined
+							}
 							aria-invalid={Boolean(error)}
 							aria-describedby={error ? "invite-handle-error" : undefined}
 							className="bg-baby_veryBlack text-baby_white focus-visible:ring-baby_blue rounded-md px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2"
 						/>
+						{showSuggestions && suggestions.length > 0 ? (
+							<ul
+								id="invite-suggestions-list"
+								role="listbox"
+								aria-label="ユーザー候補"
+								className="bg-baby_veryBlack border-baby_grey/30 absolute inset-x-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-md border shadow-lg"
+							>
+								{suggestions.map((u, i) => (
+									<li
+										key={u.user_id}
+										id={`invite-suggest-${i}`}
+										role="option"
+										aria-selected={i === activeIdx}
+										onMouseDown={(e) => {
+											e.preventDefault(); // blur を防いで click 可能に
+											pickSuggestion(u.username);
+										}}
+										className={`text-baby_white flex cursor-pointer flex-col px-3 py-2 text-sm ${
+											i === activeIdx
+												? "bg-baby_blue/30"
+												: "hover:bg-baby_grey/10"
+										}`}
+									>
+										<span className="font-semibold">@{u.username}</span>
+										{u.first_name || u.last_name ? (
+											<span className="text-baby_grey text-xs">
+												{u.first_name} {u.last_name}
+											</span>
+										) : null}
+									</li>
+								))}
+							</ul>
+						) : null}
 						<p className="text-baby_grey text-xs">
-							例: alice (英数字とアンダースコア 3-30 字、@ プレフィックス可)
+							例: alice (英数字とアンダースコア 3-30 字、@ プレフィックス可)。2
+							文字以上で候補表示。
 						</p>
 					</div>
 					<div className="flex justify-end gap-2">

--- a/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
+++ b/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
@@ -20,9 +20,30 @@ vi.mock("@/lib/redux/features/dm/dmApiSlice", () => ({
 	],
 }));
 
+interface SearchData {
+	results: {
+		user_id: string;
+		username: string;
+		first_name: string;
+		last_name: string;
+		avatar: string | null;
+	}[];
+}
+const mockSearchUsers = vi.fn(
+	(_args?: unknown, _opts?: unknown): { data: SearchData | undefined } => ({
+		data: undefined,
+	}),
+);
+vi.mock("@/lib/redux/features/users/usersApiSlice", () => ({
+	useSearchUsersQuery: (args: unknown, opts?: unknown) =>
+		mockSearchUsers(args, opts),
+}));
+
 beforeEach(() => {
 	mockCreate.mockReset();
 	mockOnOpenChange.mockReset();
+	mockSearchUsers.mockReset();
+	mockSearchUsers.mockReturnValue({ data: undefined });
 });
 
 describe("InviteMemberDialog", () => {
@@ -108,5 +129,70 @@ describe("InviteMemberDialog", () => {
 		await userEvent.click(screen.getByRole("button", { name: "招待を送る" }));
 		expect(await screen.findByRole("alert")).toHaveTextContent(/使用できない/);
 		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	// #480: handle autocomplete dropdown
+	it("入力中に suggestions dropdown が出て click で input に補完される", async () => {
+		mockSearchUsers.mockReturnValue({
+			data: {
+				results: [
+					{
+						user_id: "u1",
+						username: "alice",
+						first_name: "Alice",
+						last_name: "Smith",
+						avatar: null,
+					},
+					{
+						user_id: "u2",
+						username: "alfred",
+						first_name: "",
+						last_name: "",
+						avatar: null,
+					},
+				],
+			},
+		});
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		await userEvent.type(screen.getByLabelText(/handle/i), "al");
+		const list = await screen.findByRole("listbox", { name: "ユーザー候補" });
+		expect(list).toBeInTheDocument();
+		const opts = screen.getAllByRole("option");
+		expect(opts).toHaveLength(2);
+		// click で input に値が入る (mousedown で picked)
+		await userEvent.click(opts[1]);
+		expect(screen.getByLabelText(/handle/i)).toHaveValue("alfred");
+	});
+
+	it("矢印 + Enter で suggestion を選択できる", async () => {
+		mockSearchUsers.mockReturnValue({
+			data: {
+				results: [
+					{
+						user_id: "u1",
+						username: "alice",
+						first_name: "",
+						last_name: "",
+						avatar: null,
+					},
+					{
+						user_id: "u2",
+						username: "alfred",
+						first_name: "",
+						last_name: "",
+						avatar: null,
+					},
+				],
+			},
+		});
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		const input = screen.getByLabelText(/handle/i);
+		await userEvent.type(input, "al");
+		await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+		expect(input).toHaveValue("alfred");
 	});
 });

--- a/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
+++ b/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
@@ -26,7 +26,7 @@ interface SearchData {
 		username: string;
 		first_name: string;
 		last_name: string;
-		avatar: string | null;
+		avatar_url: string | null;
 	}[];
 }
 const mockSearchUsers = vi.fn(
@@ -141,14 +141,14 @@ describe("InviteMemberDialog", () => {
 						username: "alice",
 						first_name: "Alice",
 						last_name: "Smith",
-						avatar: null,
+						avatar_url: null,
 					},
 					{
 						user_id: "u2",
 						username: "alfred",
 						first_name: "",
 						last_name: "",
-						avatar: null,
+						avatar_url: null,
 					},
 				],
 			},
@@ -175,14 +175,14 @@ describe("InviteMemberDialog", () => {
 						username: "alice",
 						first_name: "",
 						last_name: "",
-						avatar: null,
+						avatar_url: null,
 					},
 					{
 						user_id: "u2",
 						username: "alfred",
 						first_name: "",
 						last_name: "",
-						avatar: null,
+						avatar_url: null,
 					},
 				],
 			},

--- a/client/src/lib/redux/features/users/usersApiSlice.ts
+++ b/client/src/lib/redux/features/users/usersApiSlice.ts
@@ -49,6 +49,26 @@ export const usersApiSlice = baseApiSlice.injectEndpoints({
 			query: () => "/users/me/",
 			providesTags: ["User"],
 		}),
+		// Issue #480: handle 前方一致検索 (autocomplete 用、最大 50 件)。
+		searchUsers: builder.query<
+			{
+				results: {
+					user_id: string;
+					username: string;
+					first_name: string;
+					last_name: string;
+					avatar: string | null;
+				}[];
+			},
+			{ q: string; limit?: number }
+		>({
+			query: ({ q, limit = 10 }) => {
+				const params = new URLSearchParams();
+				params.set("q", q);
+				params.set("limit", String(limit));
+				return `/users/?${params.toString()}`;
+			},
+		}),
 		updateUserProfile: builder.mutation<ProfileData, ProfileData>({
 			query: (formData) => ({
 				url: "/profiles/user/update/",
@@ -65,4 +85,5 @@ export const {
 	useGetUserProfileQuery,
 	useUpdateUserProfileMutation,
 	useGetAllTechniciansQuery,
+	useSearchUsersQuery,
 } = usersApiSlice;

--- a/client/src/lib/redux/features/users/usersApiSlice.ts
+++ b/client/src/lib/redux/features/users/usersApiSlice.ts
@@ -57,7 +57,7 @@ export const usersApiSlice = baseApiSlice.injectEndpoints({
 					username: string;
 					first_name: string;
 					last_name: string;
-					avatar: string | null;
+					avatar_url: string | null;
 				}[];
 			},
 			{ q: string; limit?: number }


### PR DESCRIPTION
## Summary

InviteMemberDialog で正確な handle を覚えていないと使えなかった問題を解消。新規 `GET /api/v1/users/?q=<prefix>&limit=N` で前方一致検索 + dropdown 候補。

## Backend

- `UserSearchView`: 認証必須 / case-insensitive prefix / self+inactive 除外 / limit 10/50 / 空 q は空配列
- `UserSearchSerializer`: PII 最小 (user_id / username / first_name / last_name / avatar)
- `urls_profile.py` で `<username>/` より先に登録 (greedy 対策)
- pytest 8 ケース

## Frontend

- `usersApiSlice.searchUsers` query
- `InviteMemberDialog`: combobox + listbox + 矢印 / Enter / click 補完 (debounce 250ms)
- 自由入力も継続可能 (hit 0 でも plain handle 送信できる)
- vitest RTL: dropdown / 矢印 Enter の 2 ケース追加 (DM 関連 80/80 pass)

## Test plan

- [x] vitest 80/80
- [x] tsc / eslint clean
- [ ] CI 全 green
- [ ] stg deploy 後 UI 確認 (招待 dialog で 'tes' → dropdown → test3 補完)

Closes #480