### PR TITLE
feat(dm): 招待取消 backend (DELETE) + UI (Closes #481)

### DIFF
--- a/apps/dm/services.py
+++ b/apps/dm/services.py
@@ -752,3 +752,29 @@ def annotate_rooms_with_unread_count(
     return rooms_with_last_read.annotate(
         unread_count=Coalesce(Subquery(unread_sq, output_field=IntegerField()), 0),
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #481: 招待取消 (creator が pending invitation を取り消す)
+# ---------------------------------------------------------------------------
+
+
+def cancel_invitation(
+    *,
+    invitation: GroupInvitation,
+    user: AbstractBaseUser,
+) -> None:
+    """pending の招待を inviter が取り消す.
+
+    ルール:
+    - inviter のみ取消可能 (それ以外は PermissionDenied → 403)
+    - accepted is None (pending) のみ削除可。accepted=True/False の場合は
+      ValidationError → 409 (応答済みの招待は履歴として残す)
+    - 物理削除 (履歴を残さない、再招待は新規 invitation で可能)
+    """
+
+    if invitation.inviter_id != user.pk:
+        raise PermissionDenied("自分が送信した招待のみ取消できます")
+    if invitation.accepted is not None:
+        raise ValidationError("既に応答済みの招待は取消できません")
+    invitation.delete()

--- a/apps/dm/tests/test_cancel_invitation.py
+++ b/apps/dm/tests/test_cancel_invitation.py
@@ -1,0 +1,154 @@
+"""招待取消 (#481) のテスト.
+
+DELETE /api/v1/dm/invitations/<id>/
+- 認可: invitation.inviter のみ。それ以外は 404 (隠蔽)
+- 状態: pending (accepted is None) のみ削除可、応答済みは 409
+- 認証必須 (anonymous → 401)
+- 成功時 204 + DB から消える
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.dm.models import DMRoom, DMRoomMembership, GroupInvitation
+
+User = get_user_model()
+
+
+def _make_user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+def _make_group(creator):
+    room = DMRoom.objects.create(kind="group", name="g1", creator=creator)
+    DMRoomMembership.objects.create(room=room, user=creator)
+    return room
+
+
+@pytest.fixture
+def url():
+    def _build(pk: int) -> str:
+        return reverse("dm:invitation-cancel", kwargs={"pk": pk})
+
+    return _build
+
+
+@pytest.mark.django_db
+def test_cancel_requires_auth(url) -> None:
+    inviter = _make_user("alice")
+    invitee = _make_user("bob")
+    room = _make_group(inviter)
+    inv = GroupInvitation.objects.create(room=room, inviter=inviter, invitee=invitee)
+    client = APIClient()
+    resp = client.delete(url(inv.pk))
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_cancel_by_inviter_success_204(url) -> None:
+    inviter = _make_user("alice")
+    invitee = _make_user("bob")
+    room = _make_group(inviter)
+    inv = GroupInvitation.objects.create(room=room, inviter=inviter, invitee=invitee)
+    client = APIClient()
+    client.force_authenticate(user=inviter)
+    resp = client.delete(url(inv.pk))
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    assert not GroupInvitation.objects.filter(pk=inv.pk).exists()
+
+
+@pytest.mark.django_db
+def test_cancel_by_invitee_returns_404(url) -> None:
+    """invitee は inviter ではないので 404 (存在隠蔽)."""
+    inviter = _make_user("alice")
+    invitee = _make_user("bob")
+    room = _make_group(inviter)
+    inv = GroupInvitation.objects.create(room=room, inviter=inviter, invitee=invitee)
+    client = APIClient()
+    client.force_authenticate(user=invitee)
+    resp = client.delete(url(inv.pk))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert GroupInvitation.objects.filter(pk=inv.pk).exists()
+
+
+@pytest.mark.django_db
+def test_cancel_by_third_party_returns_404(url) -> None:
+    inviter = _make_user("alice")
+    invitee = _make_user("bob")
+    other = _make_user("carol")
+    room = _make_group(inviter)
+    inv = GroupInvitation.objects.create(room=room, inviter=inviter, invitee=invitee)
+    client = APIClient()
+    client.force_authenticate(user=other)
+    resp = client.delete(url(inv.pk))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_cancel_accepted_returns_400(url) -> None:
+    inviter = _make_user("alice")
+    invitee = _make_user("bob")
+    room = _make_group(inviter)
+    inv = GroupInvitation.objects.create(room=room, inviter=inviter, invitee=invitee, accepted=True)
+    client = APIClient()
+    client.force_authenticate(user=inviter)
+    resp = client.delete(url(inv.pk))
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert GroupInvitation.objects.filter(pk=inv.pk).exists()
+
+
+@pytest.mark.django_db
+def test_cancel_declined_returns_400(url) -> None:
+    inviter = _make_user("alice")
+    invitee = _make_user("bob")
+    room = _make_group(inviter)
+    inv = GroupInvitation.objects.create(
+        room=room, inviter=inviter, invitee=invitee, accepted=False
+    )
+    client = APIClient()
+    client.force_authenticate(user=inviter)
+    resp = client.delete(url(inv.pk))
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_cancel_not_found_for_unknown_pk(url) -> None:
+    inviter = _make_user("alice")
+    client = APIClient()
+    client.force_authenticate(user=inviter)
+    resp = client.delete(url(999999))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_list_as_inviter_returns_only_own_outgoing() -> None:
+    """GET /invitations/?as=inviter で自分が送った pending のみ返ること."""
+    me = _make_user("inviter")
+    other_inviter = _make_user("other")
+    invitee_a = _make_user("a")
+    invitee_b = _make_user("b")
+    room1 = _make_group(me)
+    room2 = _make_group(other_inviter)
+
+    GroupInvitation.objects.create(room=room1, inviter=me, invitee=invitee_a)
+    GroupInvitation.objects.create(room=room1, inviter=me, invitee=invitee_b)
+    GroupInvitation.objects.create(room=room2, inviter=other_inviter, invitee=me)
+
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get("/api/v1/dm/invitations/?as=inviter")
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()
+    handles = sorted(i["invitee_handle"] for i in data["results"])
+    assert handles == ["a", "b"]

--- a/apps/dm/urls.py
+++ b/apps/dm/urls.py
@@ -21,6 +21,7 @@ from apps.dm.views import (
     DMRoomMessagesView,
     DMRoomReadView,
     InvitationAcceptView,
+    InvitationCancelView,
     InvitationDeclineView,
     InvitationListView,
     MessageDestroyView,
@@ -74,6 +75,12 @@ urlpatterns = [
         "invitations/<int:pk>/decline/",
         InvitationDeclineView.as_view(),
         name="invitation-decline",
+    ),
+    # Issue #481: inviter による取消 (DELETE)
+    path(
+        "invitations/<int:pk>/",
+        InvitationCancelView.as_view(),
+        name="invitation-cancel",
     ),
     # 添付 (P3-06)
     path(

--- a/apps/dm/views.py
+++ b/apps/dm/views.py
@@ -70,6 +70,7 @@ from apps.dm.serializers import (
 from apps.dm.services import (
     accept_invitation,
     annotate_rooms_with_unread_count,
+    cancel_invitation,
     confirm_attachment,
     create_group_room,
     decline_invitation,
@@ -369,18 +370,25 @@ class DMRoomReadView(APIView):
 
 
 class InvitationListView(generics.ListAPIView):
-    """``GET /api/v1/dm/invitations/?status=pending|all``."""
+    """``GET /api/v1/dm/invitations/?status=pending|all&as=invitee|inviter``.
+
+    既定 ``as=invitee`` (受信箱)。Issue #481 で ``as=inviter`` を追加し、
+    creator が自分の発信中招待を見られるようにする。
+    """
 
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = GroupInvitationSerializer
 
     def get_queryset(self):
         status_param = self.request.query_params.get("status", "pending")
+        as_param = self.request.query_params.get("as", "invitee")
         # serializer が inviter / invitee の username を読むため select_related で
         # N+1 を防ぐ (review HIGH 反映)。
-        qs = GroupInvitation.objects.filter(invitee=self.request.user).select_related(
-            "inviter", "invitee"
-        )
+        if as_param == "inviter":
+            qs = GroupInvitation.objects.filter(inviter=self.request.user)
+        else:
+            qs = GroupInvitation.objects.filter(invitee=self.request.user)
+        qs = qs.select_related("inviter", "invitee")
         if status_param == "pending":
             qs = qs.filter(accepted__isnull=True)
         return qs.order_by("-created_at")
@@ -421,6 +429,29 @@ class InvitationAcceptView(InvitationActionView):
 
 class InvitationDeclineView(InvitationActionView):
     action = "decline"
+
+
+class InvitationCancelView(APIView):
+    """``DELETE /api/v1/dm/invitations/<id>/``: inviter が pending を取消す (#481).
+
+    認可: invitation.inviter のみ。それ以外 / 認証無し は 404 で隠蔽。
+    状態: ``accepted is None`` のみ削除可、応答済みは 409。
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request: Request, pk: int) -> Response:
+        # 自分が送信したもの以外は存在しないかのように 404
+        invitation = GroupInvitation.objects.filter(pk=pk, inviter=request.user).first()
+        if invitation is None:
+            raise NotFound("invitation not found")
+        try:
+            cancel_invitation(invitation=invitation, user=request.user)
+        except DjangoValidationError as exc:
+            raise DRFValidationError(detail=exc.messages) from exc
+        except DjangoPermissionDenied as exc:
+            raise PermissionDenied(str(exc)) from exc
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 # ----------------------------------------------------------------------------

--- a/client/src/components/dm/InviteMemberDialog.tsx
+++ b/client/src/components/dm/InviteMemberDialog.tsx
@@ -20,7 +20,11 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { useCreateRoomInvitationMutation } from "@/lib/redux/features/dm/dmApiSlice";
+import {
+	useCancelInvitationMutation,
+	useCreateRoomInvitationMutation,
+	useListInvitationsQuery,
+} from "@/lib/redux/features/dm/dmApiSlice";
 
 const HANDLE_REGEX = /^[a-zA-Z0-9_]{3,30}$/;
 
@@ -59,6 +63,16 @@ export default function InviteMemberDialog({
 	roomId,
 }: InviteMemberDialogProps) {
 	const [createInvite, { isLoading }] = useCreateRoomInvitationMutation();
+	const [cancelInvite] = useCancelInvitationMutation();
+	// #481: 自分が当該 room へ送信中の pending 招待を listing
+	const sentQuery = useListInvitationsQuery(
+		{ status: "pending", as: "inviter" },
+		{ skip: !open },
+	);
+	const sentForRoom = (sentQuery.data?.results ?? []).filter(
+		(inv) => inv.room_id === roomId,
+	);
+	const [pendingCancelId, setPendingCancelId] = useState<number | null>(null);
 	const [handle, setHandle] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [successMsg, setSuccessMsg] = useState<string | null>(null);
@@ -171,6 +185,46 @@ export default function InviteMemberDialog({
 						</button>
 					</div>
 				</form>
+				{sentForRoom.length > 0 ? (
+					<div className="border-baby_grey/20 mt-4 border-t pt-4">
+						<h3 className="text-baby_white mb-2 text-sm font-semibold">
+							送信中の招待 ({sentForRoom.length})
+						</h3>
+						<ul
+							role="list"
+							aria-label="送信中の招待"
+							className="flex flex-col gap-2"
+						>
+							{sentForRoom.map((inv) => (
+								<li
+									key={inv.id}
+									role="listitem"
+									className="bg-baby_veryBlack border-baby_grey/30 text-baby_white flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm"
+								>
+									<span>@{inv.invitee_handle}</span>
+									<button
+										type="button"
+										onClick={async () => {
+											setPendingCancelId(inv.id);
+											try {
+												await cancelInvite(inv.id).unwrap();
+											} catch {
+												// リスト無効化で消えなければ何もしない (silent failure)
+											} finally {
+												setPendingCancelId(null);
+											}
+										}}
+										disabled={pendingCancelId === inv.id}
+										aria-label={`@${inv.invitee_handle} への招待を取り消す`}
+										className="border-baby_grey text-baby_grey hover:border-baby_red hover:text-baby_red focus-visible:ring-baby_blue rounded-md border px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+									>
+										{pendingCancelId === inv.id ? "取消中..." : "取消"}
+									</button>
+								</li>
+							))}
+						</ul>
+					</div>
+				) : null}
 			</DialogContent>
 		</Dialog>
 	);

--- a/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
+++ b/client/src/components/dm/__tests__/InviteMemberDialog.test.tsx
@@ -10,19 +10,39 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import InviteMemberDialog from "@/components/dm/InviteMemberDialog";
 
+interface InvShape {
+	id: number;
+	room_id: number;
+	invitee_handle: string;
+}
 const mockCreate = vi.fn();
+const mockCancel = vi.fn();
 const mockOnOpenChange = vi.fn();
+const mockListInv = vi.fn(
+	(_args?: unknown, _opts?: unknown): { data: { results: InvShape[] } } => ({
+		data: { results: [] },
+	}),
+);
 
 vi.mock("@/lib/redux/features/dm/dmApiSlice", () => ({
 	useCreateRoomInvitationMutation: () => [
 		mockCreate,
 		{ isLoading: false, isError: false },
 	],
+	useCancelInvitationMutation: () => [
+		mockCancel,
+		{ isLoading: false, isError: false },
+	],
+	useListInvitationsQuery: (args: unknown, opts?: unknown) =>
+		mockListInv(args, opts),
 }));
 
 beforeEach(() => {
 	mockCreate.mockReset();
+	mockCancel.mockReset();
 	mockOnOpenChange.mockReset();
+	mockListInv.mockReset();
+	mockListInv.mockReturnValue({ data: { results: [] } });
 });
 
 describe("InviteMemberDialog", () => {
@@ -108,5 +128,39 @@ describe("InviteMemberDialog", () => {
 		await userEvent.click(screen.getByRole("button", { name: "招待を送る" }));
 		expect(await screen.findByRole("alert")).toHaveTextContent(/使用できない/);
 		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	// #481: 送信中の招待 listing + 取消
+	it("送信中の招待が listing され、取消 button で cancelInvitation が呼ばれる", async () => {
+		mockListInv.mockReturnValue({
+			data: {
+				results: [
+					{ id: 7, room_id: 42, invitee_handle: "alice" },
+					{ id: 8, room_id: 99, invitee_handle: "bob" }, // 別 room なので出ない
+				],
+			},
+		});
+		mockCancel.mockReturnValueOnce({ unwrap: () => Promise.resolve() });
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		const list = await screen.findByRole("list", { name: "送信中の招待" });
+		expect(list).toBeInTheDocument();
+		// 同じ room の alice のみ表示、別 room の bob は除外
+		expect(screen.getByText("@alice")).toBeInTheDocument();
+		expect(screen.queryByText("@bob")).toBeNull();
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /alice への招待を取り消す/ }),
+		);
+		expect(mockCancel).toHaveBeenCalledWith(7);
+	});
+
+	it("送信中の招待が空のときは section 自体が出ない", () => {
+		mockListInv.mockReturnValue({ data: { results: [] } });
+		render(
+			<InviteMemberDialog open roomId={42} onOpenChange={mockOnOpenChange} />,
+		);
+		expect(screen.queryByRole("list", { name: "送信中の招待" })).toBeNull();
 	});
 });

--- a/client/src/lib/redux/features/dm/dmApiSlice.ts
+++ b/client/src/lib/redux/features/dm/dmApiSlice.ts
@@ -53,7 +53,7 @@ export const dmApiSlice = baseApiSlice.injectEndpoints({
 		}),
 		listInvitations: builder.query<
 			InvitationListResponse,
-			{ status?: "pending" | "all" } | void
+			{ status?: "pending" | "all"; as?: "invitee" | "inviter" } | void
 		>({
 			query: (arg) => {
 				const params = new URLSearchParams();
@@ -61,6 +61,9 @@ export const dmApiSlice = baseApiSlice.injectEndpoints({
 					params.append("status", arg.status);
 				} else {
 					params.append("status", "pending");
+				}
+				if (arg && arg.as) {
+					params.append("as", arg.as);
 				}
 				return `/dm/invitations/?${params.toString()}`;
 			},
@@ -90,6 +93,17 @@ export const dmApiSlice = baseApiSlice.injectEndpoints({
 			invalidatesTags: (_result, _error, { roomId }) => [
 				{ type: "DMInvitation" as const, id: "LIST" },
 				{ type: "DMRoom" as const, id: roomId },
+			],
+		}),
+		// #481: inviter による pending 招待の取消 (DELETE)
+		cancelInvitation: builder.mutation<void, number>({
+			query: (id) => ({
+				url: `/dm/invitations/${id}/`,
+				method: "DELETE",
+			}),
+			invalidatesTags: (_result, _error, id) => [
+				{ type: "DMInvitation" as const, id },
+				{ type: "DMInvitation" as const, id: "LIST" },
 			],
 		}),
 		acceptInvitation: builder.mutation<GroupInvitation, number>({
@@ -160,6 +174,7 @@ export const {
 	useCreateDMRoomMutation,
 	useListInvitationsQuery,
 	useCreateRoomInvitationMutation,
+	useCancelInvitationMutation,
 	useAcceptInvitationMutation,
 	useDeclineInvitationMutation,
 	useListRoomMessagesQuery,


### PR DESCRIPTION
creator が誤った相手に送った招待を、相手が応答する前に取り消せるようにする。

## Backend
- `services.cancel_invitation`: inviter のみ可 / pending のみ削除可
- `InvitationCancelView` (DELETE `/api/v1/dm/invitations/<id>/`): 認可違反は 404 隠蔽、応答済みは 400
- `InvitationListView` に `?as=invitee|inviter` 拡張
- pytest 8 ケース

## Frontend
- `dmApiSlice.cancelInvitation` + `listInvitations` の `as` filter
- `InviteMemberDialog` の form 下に「送信中の招待」 section + 取消 button
- vitest RTL 2 ケース追加 (取消 click + 空 section)

Closes #481