### PR TITLE
fix(notifications): apps/notifications/signals.py に emit_notification bridge 実装 (Closes #487)

### DIFF
--- a/apps/notifications/signals.py
+++ b/apps/notifications/signals.py
@@ -1,0 +1,85 @@
+"""DM / 他アプリ → 通知ディスパッチ統一ブリッジ (#487, Phase 4A 着工).
+
+`apps/dm/integrations/notifications.py` の `_dispatch_or_noop` がプロセス起動時に
+**動的 import** で本モジュールの :func:`emit_notification` を resolve する。
+
+- 本モジュールが存在しない → import 失敗 → DM 側は silent no-op (Phase 3 期待)
+- 本モジュールがある (Phase 4A 以降) → emit_notification 経由で
+  ``apps.notifications.services.create_notification`` を呼び DB に永続化
+
+呼び出し側は `recipient_id`, `kind`, **payload (actor_id / room_id / message_id /
+invitation_id 等) を渡す。本モジュールで kind ごとの target_type / target_id へ
+マッピングする。
+
+注意: `_resolve_emit_notification` は**プロセス起動時 1 回だけ resolve** するため、
+本モジュールを後から追加した場合は **プロセス再起動が必要** (zero-downtime hot
+reload では reflect されない)。stg / prod は通常 deploy = ECS rolling 起動で活性化。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.contrib.auth import get_user_model
+
+from apps.notifications.services import create_notification
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+# kind → (target_type, payload キー名) のマッピング。
+# `apps/dm/integrations/notifications.py` が渡す payload キーと整合させる。
+_TARGET_FOR_KIND: dict[str, tuple[str, str | None]] = {
+    "dm_invite": ("invitation", "invitation_id"),
+    "dm_message": ("message", "message_id"),
+    # Phase 4A 既存の like / repost / quote / reply / mention / follow は各
+    # caller (apps/reactions, apps/follows 等) が直接 create_notification を
+    # 呼んでいるため、ここでマッピングは必要ない。本テーブルは「DM bridge から
+    # _dispatch_or_noop 経由で来る kind」 専用。
+}
+
+
+def emit_notification(
+    *,
+    recipient_id: int | str,
+    kind: str,
+    actor_id: int | str | None = None,
+    **payload: Any,
+) -> None:
+    """DM bridge / 他アプリからの通知ディスパッチ統一エントリ (#487).
+
+    `recipient_id` / `actor_id` は user の pkid (int) を想定するが、
+    フォワード互換のため UUID 文字列も受け付ける (User.objects.filter で resolve)。
+
+    Notification 作成のロジック (self-skip / 設定 OFF skip / dedup / Block / Mute) は
+    すべて `create_notification` 側に委譲する。例外は飲み込まず logger.exception で
+    Sentry に送る (architect HIGH 反映、silent failure 抑制)。
+    """
+
+    target_type, payload_key = _TARGET_FOR_KIND.get(kind, ("", None))
+    target_id = payload.get(payload_key) if payload_key else None
+
+    try:
+        recipient = User.objects.filter(pk=recipient_id).first()
+        if recipient is None:
+            logger.warning(
+                "emit_notification: recipient not found",
+                extra={"kind": kind, "recipient_id": recipient_id},
+            )
+            return
+        actor = User.objects.filter(pk=actor_id).first() if actor_id is not None else None
+        create_notification(
+            kind=kind,
+            recipient=recipient,
+            actor=actor,
+            target_type=target_type,
+            target_id=target_id,
+        )
+    except Exception:  # pragma: no cover - 想定外 DB 障害
+        logger.exception(
+            "emit_notification dispatch failed",
+            extra={"kind": kind, "recipient_id": recipient_id},
+        )

--- a/apps/notifications/tests/test_signals_bridge.py
+++ b/apps/notifications/tests/test_signals_bridge.py
@@ -1,0 +1,114 @@
+"""apps/notifications/signals.py の emit_notification ブリッジ (#487).
+
+`apps/dm/integrations/notifications.py` が呼ぶ統一エントリ。Notification を
+`create_notification` 経由で永続化する。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.notifications.models import Notification
+from apps.notifications.signals import emit_notification
+
+User = get_user_model()
+
+
+def _make_user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+@pytest.mark.django_db
+def test_emit_notification_dm_invite_creates_record() -> None:
+    inviter = _make_user("inviter")
+    invitee = _make_user("invitee")
+
+    emit_notification(
+        recipient_id=invitee.pk,
+        kind="dm_invite",
+        actor_id=inviter.pk,
+        room_id=1,
+        invitation_id=42,
+    )
+
+    notif = Notification.objects.filter(recipient=invitee, kind="dm_invite").first()
+    assert notif is not None
+    assert notif.actor == inviter
+    assert notif.target_type == "invitation"
+    assert notif.target_id == "42"
+
+
+@pytest.mark.django_db
+def test_emit_notification_dm_message_creates_record() -> None:
+    sender = _make_user("sender")
+    recipient = _make_user("recipient")
+
+    emit_notification(
+        recipient_id=recipient.pk,
+        kind="dm_message",
+        actor_id=sender.pk,
+        room_id=7,
+        message_id=99,
+    )
+
+    notif = Notification.objects.filter(recipient=recipient, kind="dm_message").first()
+    assert notif is not None
+    assert notif.target_type == "message"
+    assert notif.target_id == "99"
+
+
+@pytest.mark.django_db
+def test_emit_notification_self_skip() -> None:
+    """create_notification の self-notify guard が効くこと (recipient == actor)."""
+    me = _make_user("me")
+
+    emit_notification(
+        recipient_id=me.pk,
+        kind="dm_invite",
+        actor_id=me.pk,
+        room_id=1,
+        invitation_id=1,
+    )
+
+    assert Notification.objects.filter(recipient=me, kind="dm_invite").count() == 0
+
+
+@pytest.mark.django_db
+def test_emit_notification_unknown_recipient_silent() -> None:
+    """recipient が存在しない id でも例外を上げず silent に no-op."""
+    emit_notification(
+        recipient_id=999999,
+        kind="dm_invite",
+        actor_id=None,
+        invitation_id=1,
+    )
+    # 例外なく完了 + Notification 作成されない
+    assert Notification.objects.filter(kind="dm_invite").count() == 0
+
+
+@pytest.mark.django_db
+def test_emit_notification_dedup_within_24h() -> None:
+    inviter = _make_user("inviter2")
+    invitee = _make_user("invitee2")
+
+    emit_notification(
+        recipient_id=invitee.pk,
+        kind="dm_invite",
+        actor_id=inviter.pk,
+        invitation_id=42,
+    )
+    emit_notification(
+        recipient_id=invitee.pk,
+        kind="dm_invite",
+        actor_id=inviter.pk,
+        invitation_id=42,
+    )
+    # dedup 24h 窓で 2 回目は skip
+    assert Notification.objects.filter(recipient=invitee, kind="dm_invite").count() == 1

--- a/client/e2e/dm-room-invite.spec.ts
+++ b/client/e2e/dm-room-invite.spec.ts
@@ -135,6 +135,25 @@ test.describe("DM ルーム内 招待 UI E2E (#476)", () => {
 		const ctx2 = await browser.newContext();
 		const page2 = await ctx2.newPage();
 		await loginViaApi(ctx2.request, USER2);
+
+		// #487: 通知 dispatch 検証 — invite 送信後 1〜2 秒で
+		// transaction.on_commit → emit_dm_invite → create_notification が
+		// 動くため、USER2 の /api/v1/notifications/ に dm_invite kind の
+		// エントリが現れているはず。SPEC §7.5 / §8.1 担保。
+		const notifResp = await ctx2.request.get(
+			`${BASE}/api/v1/notifications/?limit=10`,
+		);
+		expect(notifResp.status()).toBe(200);
+		const notifData = (await notifResp.json()) as {
+			results: { kind: string; actor?: { handle?: string } | null }[];
+		};
+		const dmInvite = notifData.results.find(
+			(n) =>
+				n.kind === "dm_invite" &&
+				(n.actor?.handle === USER1.handle || USER1.handle === ""),
+		);
+		expect(dmInvite, "dm_invite 通知が test3 に届いていること").toBeTruthy();
+
 		await page2.goto(`${BASE}/messages/invitations`);
 
 		// invitation listing に該当 room (= GROUP_ROOM_ID) のエントリ

--- a/docs/specs/dm-room-invite-spec.md
+++ b/docs/specs/dm-room-invite-spec.md
@@ -144,11 +144,28 @@ stg 上で 2 ユーザー (USER1=test2 = creator、USER2=test3 = invitee) を使
 
 1. USER1 として login → 既存 group room (PLAYWRIGHT\*GROUP_ROOM_ID) を開く → 「招待」button 押下 → modal 出る
 2. modal で `@test3` 入力 → 送信 → success status
-3. USER1 logout、USER2 として login → `/messages/invitations` を開く → 該当招待が listing に存在
-4. 「承諾」押下 → invitee side で room が見えるようになることを確認
-5. クリーンアップ: USER2 が room から leave (もしくは USER1 が group を delete) — 現状 leave/delete API があれば呼ぶ、無ければ stg 状態をそのまま
+3. **(NEW) #487 通知検証**: USER2 として login し `GET /api/v1/notifications/` を fetch、`kind=dm_invite` のエントリが存在し `actor.handle === "test2"` であることを assert。SPEC §7.5 / §8.1 のアプリ内通知配信を担保する。
+4. USER1 logout、USER2 として login → `/messages/invitations` を開く → 該当招待が listing に存在
+5. 「承諾」押下 → invitee side で room が見えるようになることを確認
+6. クリーンアップ: USER2 が room から leave (もしくは USER1 が group を delete) — 現状 leave/delete API があれば呼ぶ、無ければ stg 状態をそのまま
 
 > ⚠️ stg DB の汚染を最小化するため、E2E 開始時に既存の pending invitation を accept/decline で消すクリーンアップ step を入れる。
+> 加えて、#487 検証のため事前に test3 の `dm_invite` 既存通知も clear しておく (`/notifications/<id>/` mark-as-read で十分。完全削除は API 無し)。
+
+### 6.3 通知配信 (#487 — Phase 4A bridge)
+
+backend は招待作成時に `apps/dm/services.py:invite_user_to_room` 内で
+`transaction.on_commit(lambda: emit_dm_invite(invitation))` を fire する。
+`apps/dm/integrations/notifications.py` がプロセス起動時に
+`apps.notifications.signals.emit_notification` を resolve し、解決できれば
+`create_notification(recipient, kind, actor, target_type, target_id)` で
+`Notification` を永続化する。
+
+- target_type = `"invitation"`、target_id = `invitation.pk`
+- self-skip / 設定 OFF skip / dedup 24h / Block / Mute フィルタは
+  `create_notification` 側で適用 (本 spec 範囲外、別 SPEC §8 参照)
+- pytest: `apps/notifications/tests/test_signals_bridge.py` で bridge を直接検証
+- E2E: §6.2 step 3 で実機検証
 
 ## 7. UI 不足 / 既出来 切り分け表
 


### PR DESCRIPTION
## 問題

`apps/dm/integrations/notifications.py` が起動時に `apps.notifications.signals.emit_notification` を resolve するが **当該モジュールが存在せず** ImportError → silent no-op fallback。結果として `dm_invite` / `dm_message` が **DB に永続化されない** (SPEC §7.5 / §8.1 違反)。

## stg 実機確認

ハルナさんの指摘で、本セッションで invite してきた test3 の `/api/v1/notifications/` を確認 → `dm_invite` 通知ゼロ件 (`follow` のみ)。即時再現できる。

## 修正

- 新規 `apps/notifications/signals.py` に `emit_notification(*, recipient_id, kind, actor_id=None, **payload)` を実装
  - User を id から resolve、kind から target_type / target_id を mapping
  - `apps.notifications.services.create_notification` に dispatch (self-skip / 設定 OFF skip / dedup / Block / Mute は service 側委譲)
  - 例外は `logger.exception` で Sentry に流して silent failure 抑制

## テスト

- pytest 5 ケース (`apps/notifications/tests/test_signals_bridge.py`):
  dm_invite 永続化 / dm_message 永続化 / self-skip / unknown recipient silent / dedup 24h
- 既存 `apps/dm/tests/test_integrations.py` は assert 「例外なし」のみで挙動 unchanged
- spec `docs/specs/dm-room-invite-spec.md` § 6.2 (E2E step) + § 6.3 (通知配信) 追加
- E2E `client/e2e/dm-room-invite.spec.ts` に「USER2 の `/notifications/` に `dm_invite` が現れる」 assert 追加

## Test plan

- [x] pytest 新規 5 ケース (CI 確認)
- [ ] CI 全 green
- [ ] CD stg 後 stg E2E 再走 → notification 検証 step が pass
- [ ] 実機 `/api/v1/notifications/` で `dm_invite` が降ってくることを curl 直叩きで確認

## 注意

本モジュール追加は **プロセス再起動が必要** (動的 import を起動時 1 回しか走らせない設計のため)。stg / prod は ECS rolling deploy で自動活性化。

Closes #487