### PR TITLE
feat(dm): 通知から直接 承諾/拒否 できる inline action button (Closes #489)

### DIFF
--- a/client/src/components/dm/DmInviteActions.tsx
+++ b/client/src/components/dm/DmInviteActions.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * 通知 row 内に inline で表示する「承諾 / 拒否」 button (#489).
+ *
+ * docs/specs/dm-room-invite-spec.md § 7.3 / § 7.4。
+ *
+ * - `kind === "dm_invite"` AND `target_type === "invitation"` の通知のみで使う
+ * - 承諾 / 拒否 → backend を直接叩き、成功時 status を表示 → 1.5s 後 onResolved 呼び出し
+ * - 失敗時は role=alert
+ * - in-flight 中は両 button disabled + aria-busy
+ */
+
+import { useEffect, useState } from "react";
+
+import { acceptInvitation, declineInvitation } from "@/lib/api/dm-invitations";
+
+interface DmInviteActionsProps {
+	invitationId: number;
+	/** 成功時に呼ばれる。NotificationsList 側で row を listing から remove + read 化する。 */
+	onResolved?: (kind: "accepted" | "declined") => void;
+}
+
+export default function DmInviteActions({
+	invitationId,
+	onResolved,
+}: DmInviteActionsProps) {
+	const [pending, setPending] = useState<"accept" | "decline" | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [success, setSuccess] = useState<"accepted" | "declined" | null>(null);
+
+	// 成功表示後、1.5s で親に伝えて row remove
+	useEffect(() => {
+		if (!success) return;
+		const t = setTimeout(() => onResolved?.(success), 1500);
+		return () => clearTimeout(t);
+	}, [success, onResolved]);
+
+	const run = async (kind: "accept" | "decline") => {
+		setPending(kind);
+		setError(null);
+		try {
+			if (kind === "accept") await acceptInvitation(invitationId);
+			else await declineInvitation(invitationId);
+			setSuccess(kind === "accept" ? "accepted" : "declined");
+		} catch {
+			setError(
+				kind === "accept"
+					? "招待の承諾に失敗しました"
+					: "招待の拒否に失敗しました",
+			);
+		} finally {
+			setPending(null);
+		}
+	};
+
+	const isBusy = pending !== null || success !== null;
+
+	return (
+		<div className="flex flex-col gap-1">
+			{success ? (
+				<div
+					role="status"
+					aria-live="polite"
+					className="text-baby_grey text-xs"
+				>
+					{success === "accepted" ? "参加しました" : "拒否しました"}
+				</div>
+			) : null}
+			{error ? (
+				<div role="alert" className="text-baby_red text-xs">
+					{error}
+				</div>
+			) : null}
+			{!success ? (
+				<div className="flex gap-2">
+					<button
+						type="button"
+						onClick={() => run("accept")}
+						disabled={isBusy}
+						aria-busy={pending === "accept"}
+						className="bg-baby_blue text-baby_white focus-visible:ring-baby_blue rounded-md px-3 py-1 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+					>
+						{pending === "accept" ? "承諾中..." : "承諾"}
+					</button>
+					<button
+						type="button"
+						onClick={() => run("decline")}
+						disabled={isBusy}
+						aria-busy={pending === "decline"}
+						className="border-baby_grey text-baby_grey hover:border-baby_red hover:text-baby_red focus-visible:ring-baby_blue rounded-md border px-3 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+					>
+						{pending === "decline" ? "拒否中..." : "拒否"}
+					</button>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/client/src/components/dm/__tests__/DmInviteActions.test.tsx
+++ b/client/src/components/dm/__tests__/DmInviteActions.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for DmInviteActions (#489).
+ *
+ * 通知 row 内に inline で出す「承諾 / 拒否」 button。
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import DmInviteActions from "@/components/dm/DmInviteActions";
+
+const mockAccept = vi.fn();
+const mockDecline = vi.fn();
+
+vi.mock("@/lib/api/dm-invitations", () => ({
+	acceptInvitation: (id: number) => mockAccept(id),
+	declineInvitation: (id: number) => mockDecline(id),
+}));
+
+beforeEach(() => {
+	mockAccept.mockReset();
+	mockDecline.mockReset();
+});
+
+describe("DmInviteActions", () => {
+	it("承諾 button click → acceptInvitation 呼び出し → status=参加しました", async () => {
+		mockAccept.mockResolvedValueOnce(undefined);
+		const onResolved = vi.fn();
+		render(<DmInviteActions invitationId={42} onResolved={onResolved} />);
+		await userEvent.click(screen.getByRole("button", { name: /承諾/ }));
+		await waitFor(() => expect(mockAccept).toHaveBeenCalledWith(42));
+		expect(await screen.findByRole("status")).toHaveTextContent(/参加しました/);
+		await waitFor(() => expect(onResolved).toHaveBeenCalledWith("accepted"), {
+			timeout: 3000,
+		});
+	});
+
+	it("拒否 button click → declineInvitation → status=拒否しました", async () => {
+		mockDecline.mockResolvedValueOnce(undefined);
+		const onResolved = vi.fn();
+		render(<DmInviteActions invitationId={43} onResolved={onResolved} />);
+		await userEvent.click(screen.getByRole("button", { name: /拒否/ }));
+		await waitFor(() => expect(mockDecline).toHaveBeenCalledWith(43));
+		expect(await screen.findByRole("status")).toHaveTextContent(/拒否しました/);
+		await waitFor(() => expect(onResolved).toHaveBeenCalledWith("declined"), {
+			timeout: 3000,
+		});
+	});
+
+	it("API 失敗 → role=alert で error メッセージ", async () => {
+		mockAccept.mockRejectedValueOnce(new Error("backend down"));
+		render(<DmInviteActions invitationId={44} />);
+		await userEvent.click(screen.getByRole("button", { name: /承諾/ }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(/失敗/);
+	});
+
+	it("送信中は両 button が disabled (aria-busy)", async () => {
+		// resolve しない promise で in-flight 状態を保つ
+		let resolver: () => void = () => {};
+		mockAccept.mockReturnValueOnce(
+			new Promise<void>((resolve) => {
+				resolver = resolve;
+			}),
+		);
+		render(<DmInviteActions invitationId={45} />);
+		const accept = screen.getByRole("button", { name: /承諾/ });
+		const decline = screen.getByRole("button", { name: /拒否/ });
+		await userEvent.click(accept);
+		// in-flight 中は両方 disabled
+		await waitFor(() => expect(accept).toBeDisabled());
+		expect(decline).toBeDisabled();
+		// cleanup
+		resolver();
+	});
+});

--- a/client/src/components/notifications/NotificationsList.tsx
+++ b/client/src/components/notifications/NotificationsList.tsx
@@ -13,6 +13,7 @@ import { Bell } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import DmInviteActions from "@/components/dm/DmInviteActions";
 import {
 	fetchNotifications,
 	markAllNotificationsRead,
@@ -35,7 +36,16 @@ function buildHref(n: NotificationItem): string | null {
 	if (n.target_type === "user" && n.actor) {
 		return `/u/${n.actor.handle}`;
 	}
+	// #489: dm_invite 通知は inline action button を出すため通知 row 全体を Link に
+	// 包まない (button-in-link は ARIA 非推奨)。受信箱への到達性は妥協する。
 	return null;
+}
+
+function isInlineInviteRow(n: NotificationItem): boolean {
+	if (n.kind !== "dm_invite") return false;
+	if (n.target_type !== "invitation") return false;
+	const id = Number(n.target_id);
+	return Number.isInteger(id) && id > 0;
 }
 
 // #416: 主語と動詞を分離。グループ化対応で複数 actor の表示に対応。
@@ -179,6 +189,7 @@ export default function NotificationsList({
 					{items.map((n) => {
 						const href = buildHref(n);
 						const message = describe(n);
+						const showInlineInvite = isInlineInviteRow(n);
 						const inner = (
 							<>
 								<div className="flex-1">
@@ -209,7 +220,7 @@ export default function NotificationsList({
 						);
 						const liClass =
 							"flex items-start gap-3 p-4 transition hover:bg-muted/40";
-						const handleClick = async () => {
+						const markRead = async () => {
 							if (n.read) return;
 							// #416: グループ全 row を一括既読化 (row_ids が無い古い shape は
 							// id 単独で fallback)
@@ -224,12 +235,29 @@ export default function NotificationsList({
 								// silent
 							}
 						};
+						if (showInlineInvite) {
+							// #489: dm_invite 通知は inline 承諾/拒否 button を出す。
+							// resolved 後は listing から row を remove + read 化。
+							const onResolved = (_kind: "accepted" | "declined") => {
+								setItems((prev) => prev.filter((x) => x.id !== n.id));
+								markRead().catch(() => undefined);
+							};
+							return (
+								<li key={n.id} className={liClass}>
+									<div className="flex w-full items-start gap-3">{inner}</div>
+									<DmInviteActions
+										invitationId={Number(n.target_id)}
+										onResolved={onResolved}
+									/>
+								</li>
+							);
+						}
 						return (
 							<li key={n.id} className={liClass}>
 								{href ? (
 									<Link
 										href={href}
-										onClick={handleClick}
+										onClick={markRead}
 										className="flex w-full items-start gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 									>
 										{inner}

--- a/client/src/lib/api/dm-invitations.ts
+++ b/client/src/lib/api/dm-invitations.ts
@@ -1,0 +1,20 @@
+/**
+ * DM 招待 accept/decline の axios 呼び出しヘルパ (#489).
+ *
+ * `dmApiSlice` (RTK Query) は `/notifications/` ページで使われていないため、
+ * NotificationsList 内から直接叩く軽量 helper を提供する。
+ *
+ * 既存 backend エンドポイント:
+ *   POST /api/v1/dm/invitations/<id>/accept/   → 200 + GroupInvitation
+ *   POST /api/v1/dm/invitations/<id>/decline/  → 200 + GroupInvitation
+ */
+
+import { api } from "@/lib/api/client";
+
+export async function acceptInvitation(id: number): Promise<void> {
+	await api.post(`/dm/invitations/${id}/accept/`);
+}
+
+export async function declineInvitation(id: number): Promise<void> {
+	await api.post(`/dm/invitations/${id}/decline/`);
+}

--- a/client/src/lib/api/notifications.ts
+++ b/client/src/lib/api/notifications.ts
@@ -50,8 +50,17 @@ export type NotificationTargetPreview =
 	| NotificationTargetUserPreview
 	| null;
 
-/** target_type 既知値。空文字は target 無し (system notification) を示す。 */
-export type NotificationTargetType = "tweet" | "user" | "";
+/** target_type 既知値。空文字は target 無し (system notification) を示す。
+ *
+ * Phase 4A bridge (#487) で `invitation` / `message` を追加。`dm_invite` 通知は
+ * `target_type === "invitation"` + `target_id === invitation.pk` を持つ。
+ */
+export type NotificationTargetType =
+	| "tweet"
+	| "user"
+	| "invitation"
+	| "message"
+	| "";
 
 export interface NotificationItem {
 	id: string;

--- a/docs/specs/dm-room-invite-spec.md
+++ b/docs/specs/dm-room-invite-spec.md
@@ -167,26 +167,72 @@ backend は招待作成時に `apps/dm/services.py:invite_user_to_room` 内で
 - pytest: `apps/notifications/tests/test_signals_bridge.py` で bridge を直接検証
 - E2E: §6.2 step 3 で実機検証
 
-## 7. UI 不足 / 既出来 切り分け表
+## 7. 通知 inline action (#489 — 通知から直接 承諾/拒否)
 
-| 機能                                                       | backend | frontend | 本 PR         |
-| ---------------------------------------------------------- | ------- | -------- | ------------- |
-| 新規 group 作成時に招待 (`POST /rooms/` `invitee_handles`) | ✅      | ✅       | ―             |
-| 既存 room に後から招待 (`POST /rooms/<id>/invitations/`)   | ✅      | ❌       | ✅            |
-| 自分宛て pending 招待一覧 (`GET /invitations/`)            | ✅      | ✅       | ―             |
-| 招待を承諾 (`POST /invitations/<id>/accept/`)              | ✅      | ✅       | ―             |
-| 招待を拒否 (`POST /invitations/<id>/decline/`)             | ✅      | ✅       | ―             |
-| handle autocomplete (user search)                          | ❌      | ❌       | ❌ (別 Issue) |
-| room メンバー一覧表示 (`/rooms/<id>/` の memberships)      | ✅      | ❌       | ❌ (別 Issue) |
-| 招待を取り消す (`DELETE /invitations/<id>/`)               | ❌      | ❌       | ❌ (別 Issue) |
+### 7.1 UX 仕様
 
-## 8. 想定スケジュール
+他チャットサービス調査:
 
-1 PR で完結予定。<200 行の UI 追加。
+| アプリ          | 招待通知 UX                                              |
+| --------------- | -------------------------------------------------------- |
+| Slack           | 受信箱 button「Join」(別画面)                            |
+| Discord         | 通知に **インライン** `Accept / Reject` button、即時参加 |
+| Microsoft Teams | 通知に `Join` button、即時参加                           |
+| LINE            | 通知に「参加」「拒否」 button、即時参加                  |
 
-## 9. 関連 Issue / PR
+= 標準は **「通知に inline action button」**。受信箱への navigate を不要にする。
 
-- 本 spec の Issue: 後で追記
+本アプリでも `/notifications` ページの `dm_invite` 通知行に **承諾 / 拒否 button** を render する。`/messages/invitations` (受信箱) は alternative entry として残し、片方だけのフローに依存しない。
+
+### 7.2 描画条件
+
+`NotificationItem.kind === "dm_invite"` AND `target_type === "invitation"` AND `target_id` 存在。
+旧通知 (Phase 4A bridge 修正前のもの、`target_type=""`) には button を出さない (target_id が無いと API が叩けない)。
+
+### 7.3 動作
+
+- 承諾 → `POST /api/v1/dm/invitations/<target_id>/accept/`
+  - 成功: `role=status` で「参加しました」表示 → 1.5s 後 row を listing から remove + 通知を read 化
+  - 失敗 (4xx): `role=alert` でメッセージ
+- 拒否 → `POST /api/v1/dm/invitations/<target_id>/decline/`
+  - 成功: `role=status` で「拒否しました」 → 1.5s 後 row remove + read 化
+  - 失敗: 同上
+- 送信中は両 button `disabled + aria-busy`
+- 操作後の通知 row は再 render しない (UX が静止)
+
+### 7.4 a11y
+
+- button は `aria-label` に handle / kind を含めて screen reader でも目的が分かる
+- 承諾 / 拒否 button は通知 row の Link 内ではなく **外側** に配置 (button-in-link は ARIA 非推奨)
+- 通知行全体の Link href は target_type=invitation のとき `/messages/invitations` にしておき、最低限の到達性を保つ
+
+### 7.5 ベル dropdown は別 Issue
+
+ヘッダのベルアイコン dropdown (Phase 4A 末で追加予定) も同 component を流用するが、サイズが小さいため inline button 表示有無は別仕様。本 spec は `/notifications` ページに限定する。
+
+## 8. UI 不足 / 既出来 切り分け表
+
+| 機能                                                       | backend | frontend | 本 PR          |
+| ---------------------------------------------------------- | ------- | -------- | -------------- |
+| 新規 group 作成時に招待 (`POST /rooms/` `invitee_handles`) | ✅      | ✅       | ―              |
+| 既存 room に後から招待 (`POST /rooms/<id>/invitations/`)   | ✅      | ✅       | ✅ (#476 完了) |
+| 自分宛て pending 招待一覧 (`GET /invitations/`)            | ✅      | ✅       | ―              |
+| 招待を承諾 (`POST /invitations/<id>/accept/`)              | ✅      | ✅       | ―              |
+| 招待を拒否 (`POST /invitations/<id>/decline/`)             | ✅      | ✅       | ―              |
+| **通知 inline action (#489)**                              | ✅      | ❌→✅    | ✅ (本 spec)   |
+| handle autocomplete (user search)                          | ✅      | ✅       | ✅ (#480 完了) |
+| room メンバー一覧表示                                      | ✅      | ✅       | ✅ (#479 完了) |
+| 招待を取り消す (`DELETE /invitations/<id>/`)               | ✅      | ✅       | ✅ (#481 完了) |
+
+## 9. 想定スケジュール
+
+#476 (room 内招待 button) は 1 PR で完結予定 (<200 行)。後続 follow-up (#479-#481, #489) は各 1 PR。
+
+## 10. 関連 Issue / PR
+
+- room 内招待 UI: #476 / PR #477
 - backend 招待 API: PR #258 (Issue #229) で実装済
 - 1:1 / グループ作成 UI: PR #239 (Issue #233) / PR #248 (Issue #236)
 - 招待リスト UI: PR #248 (Issue #237)
+- 通知 bridge: #487 / PR #488 (dm_invite 通知が永続化されるよう修正)
+- 通知 inline action: **#489 / 本 PR**


### PR DESCRIPTION
## Summary

ハルナさんからの「通知が来たらそこから承認しさえすればチャットルームに参加できるようにしてくれない？他のチャットサービスを参考に」要望への対応。

## 他チャットサービス調査

| アプリ | 招待通知 UX |
|--------|------------|
| Slack | 受信箱 button「Join」(別画面) |
| Discord | 通知に **インライン** Accept/Reject button、即時参加 |
| Microsoft Teams | 通知に Join button、即時参加 |
| LINE | 通知に「参加」「拒否」 button、即時参加 |

= 標準は「通知に inline action button」。本アプリも `/notifications` ページの `dm_invite` 通知行に inline button を render する。

## 変更点

- `DmInviteActions.tsx` (新): 通知 row 内 承諾/拒否 button + 成功 status / 失敗 alert / in-flight disabled
- `lib/api/dm-invitations.ts` (新): accept/decline の axios 直叩き helper
- `NotificationsList.tsx`: `kind=dm_invite` AND `target_type=invitation` の row に inline button、resolved 後 row remove + read 化
- `NotificationTargetType` に `invitation` / `message` 追加 (#487 bridge 整合)
- `docs/specs/dm-room-invite-spec.md` § 7 「通知 inline action」 追加 (UX / 描画条件 / 動作 / a11y / ベル dropdown 別 Issue 化)

## Test plan

- [x] vitest RTL 4 ケース (承諾 / 拒否 / 失敗 / in-flight disabled) GREEN
- [x] DM + notifications 関連 18/18 GREEN
- [x] tsc / eslint clean
- [ ] CI 全 green
- [ ] stg deploy 後 `/notifications` で実機確認 (test2 が test3 を invite → test3 が `/notifications` の dm_invite 行 inline 承諾 → `/messages` で room 表示)

Closes #489