### PR TITLE
feat(dm): メンバー削除 (kick) + 退室 (leave) UI (Closes #492)

### DIFF
--- a/apps/dm/services.py
+++ b/apps/dm/services.py
@@ -778,3 +778,37 @@ def cancel_invitation(
     if invitation.accepted is not None:
         raise ValidationError("既に応答済みの招待は取消できません")
     invitation.delete()
+
+
+# ----------------------------------------------------------------------------
+# Issue #492: メンバー削除 (kick) — creator が他メンバーを除名
+# ----------------------------------------------------------------------------
+
+
+def kick_member(
+    *,
+    room: DMRoom,
+    kicker: AbstractBaseUser,
+    target: AbstractBaseUser,
+) -> None:
+    """``kicker`` が ``target`` を ``room`` から削除する.
+
+    ルール:
+    - room.kind=group のみ (direct は kick 不可、archive 経路で対応)
+    - kicker は room.creator のみ (それ以外は PermissionDenied → 403)
+    - target は creator 自身ではない (ownership transfer は leave_room 経由のみ)
+    - target が member でない場合は ValidationError → 400 (404 ではなく 400 で
+      "削除する対象がいない" を素直に返す。membership 直接照合)
+    """
+
+    if room.kind == DMRoom.Kind.DIRECT:
+        raise ValidationError("1:1 room ではメンバー削除はできません")
+    if room.creator_id != kicker.pk:
+        raise PermissionDenied("creator のみメンバーを削除できます")
+    if target.pk == room.creator_id:
+        raise ValidationError("creator 自身は削除できません (退室経由)")
+
+    with transaction.atomic():
+        deleted, _ = DMRoomMembership.objects.filter(room=room, user=target).delete()
+        if deleted == 0:
+            raise ValidationError("対象ユーザーはこのルームのメンバーではありません")

--- a/apps/dm/tests/test_kick_member.py
+++ b/apps/dm/tests/test_kick_member.py
@@ -1,0 +1,153 @@
+"""メンバー削除 (kick) のテスト (#492).
+
+DELETE /api/v1/dm/rooms/<id>/members/<user_id>/
+- 認証必須 (anonymous → 401/403)
+- creator のみ kick 可、それ以外は 403
+- direct room は kick 不可、400
+- target=creator は不可、400
+- target が member でない場合は 400
+- 成功時 204 + DB から membership が消える
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.dm.models import DMRoom, DMRoomMembership
+
+User = get_user_model()
+
+
+def _make_user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+def _make_group_with_member(creator, member):
+    room = DMRoom.objects.create(kind="group", name="g1", creator=creator)
+    DMRoomMembership.objects.create(room=room, user=creator)
+    DMRoomMembership.objects.create(room=room, user=member)
+    return room
+
+
+@pytest.fixture
+def url():
+    def _build(room_pk: int, user_pk: int) -> str:
+        return reverse(
+            "dm:room-member-kick",
+            kwargs={"pk": room_pk, "user_id": user_pk},
+        )
+
+    return _build
+
+
+@pytest.mark.django_db
+def test_kick_requires_auth(url) -> None:
+    creator = _make_user("alice")
+    member = _make_user("bob")
+    room = _make_group_with_member(creator, member)
+    client = APIClient()
+    resp = client.delete(url(room.pk, member.pk))
+    assert resp.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+@pytest.mark.django_db
+def test_kick_by_creator_204_and_membership_removed(url) -> None:
+    creator = _make_user("alice")
+    member = _make_user("bob")
+    room = _make_group_with_member(creator, member)
+    client = APIClient()
+    client.force_authenticate(user=creator)
+    resp = client.delete(url(room.pk, member.pk))
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    assert not DMRoomMembership.objects.filter(room=room, user=member).exists()
+    # creator の membership は残る
+    assert DMRoomMembership.objects.filter(room=room, user=creator).exists()
+
+
+@pytest.mark.django_db
+def test_kick_by_non_creator_returns_403(url) -> None:
+    creator = _make_user("alice")
+    member = _make_user("bob")
+    other = _make_user("carol")
+    room = _make_group_with_member(creator, member)
+    DMRoomMembership.objects.create(room=room, user=other)
+    client = APIClient()
+    client.force_authenticate(user=other)
+    resp = client.delete(url(room.pk, member.pk))
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+    assert DMRoomMembership.objects.filter(room=room, user=member).exists()
+
+
+@pytest.mark.django_db
+def test_kick_outsider_returns_404(url) -> None:
+    """kicker が room メンバーでない → 404 (room 隠蔽)."""
+    creator = _make_user("alice")
+    member = _make_user("bob")
+    outsider = _make_user("dave")
+    room = _make_group_with_member(creator, member)
+    client = APIClient()
+    client.force_authenticate(user=outsider)
+    resp = client.delete(url(room.pk, member.pk))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_kick_creator_self_returns_400(url) -> None:
+    creator = _make_user("alice")
+    member = _make_user("bob")
+    room = _make_group_with_member(creator, member)
+    client = APIClient()
+    client.force_authenticate(user=creator)
+    resp = client.delete(url(room.pk, creator.pk))
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    # creator membership はそのまま
+    assert DMRoomMembership.objects.filter(room=room, user=creator).exists()
+
+
+@pytest.mark.django_db
+def test_kick_non_member_returns_400(url) -> None:
+    creator = _make_user("alice")
+    member = _make_user("bob")
+    not_member = _make_user("eve")
+    room = _make_group_with_member(creator, member)
+    client = APIClient()
+    client.force_authenticate(user=creator)
+    resp = client.delete(url(room.pk, not_member.pk))
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_kick_in_direct_room_returns_400(url) -> None:
+    creator = _make_user("alice")
+    other = _make_user("bob")
+    room = DMRoom.objects.create(kind="direct", creator=creator)
+    DMRoomMembership.objects.create(room=room, user=creator)
+    DMRoomMembership.objects.create(room=room, user=other)
+    client = APIClient()
+    client.force_authenticate(user=creator)
+    resp = client.delete(url(room.pk, other.pk))
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_kick_unknown_user_returns_404(url) -> None:
+    creator = _make_user("alice")
+    member = _make_user("bob")
+    room = _make_group_with_member(creator, member)
+    client = APIClient()
+    client.force_authenticate(user=creator)
+    resp = client.delete(url(room.pk, 999999))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/dm/urls.py
+++ b/apps/dm/urls.py
@@ -16,6 +16,7 @@ from apps.dm.views import (
     ConfirmAttachmentView,
     DMRoomDetailView,
     DMRoomInvitationsCreateView,
+    DMRoomKickMemberView,
     DMRoomListCreateView,
     DMRoomMembershipDeleteView,
     DMRoomMessagesView,
@@ -54,6 +55,12 @@ urlpatterns = [
         "rooms/<int:pk>/membership/",
         DMRoomMembershipDeleteView.as_view(),
         name="room-membership-delete",
+    ),
+    # Issue #492: creator が他メンバーを kick
+    path(
+        "rooms/<int:pk>/members/<int:user_id>/",
+        DMRoomKickMemberView.as_view(),
+        name="room-member-kick",
     ),
     path(
         "rooms/<int:pk>/read/",

--- a/apps/dm/views.py
+++ b/apps/dm/views.py
@@ -76,6 +76,7 @@ from apps.dm.services import (
     decline_invitation,
     get_or_create_direct_room,
     invite_user_to_room,
+    kick_member,
     leave_room,
     mark_room_read,
 )
@@ -303,6 +304,32 @@ class DMRoomMembershipDeleteView(APIView):
             leave_room(room=room, user=request.user)
         except DjangoValidationError as exc:
             raise DRFValidationError(detail=exc.messages) from exc
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class DMRoomKickMemberView(APIView):
+    """``DELETE /api/v1/dm/rooms/<id>/members/<user_id>/`` (#492):
+    creator が他メンバーを kick する。
+
+    認可: room creator のみ。それ以外は 404 で隠蔽 (sec)。
+    `_get_room_for_member` で room 存在 + kicker membership を確認。
+    creator 判定 / target=creator 不可 / target が member でない の三段は
+    `kick_member` service 内で ValidationError → 400 / PermissionDenied → 403。
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request: Request, pk: int, user_id: int) -> Response:
+        room = _get_room_for_member(room_id=pk, user=request.user)
+        target = User.objects.filter(pk=user_id, is_active=True).first()
+        if target is None:
+            raise NotFound("対象ユーザーが見つかりません")
+        try:
+            kick_member(room=room, kicker=request.user, target=target)
+        except DjangoValidationError as exc:
+            raise DRFValidationError(detail=exc.messages) from exc
+        except DjangoPermissionDenied as exc:
+            raise PermissionDenied(str(exc)) from exc
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -16,6 +16,7 @@
  */
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import InviteMemberButton from "@/components/dm/InviteMemberButton";
@@ -39,6 +40,7 @@ interface RoomChatProps {
 }
 
 export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
+	const router = useRouter();
 	const roomQuery = useGetDMRoomQuery(roomId);
 	const messagesQuery = useListRoomMessagesQuery({ roomId });
 	const [markRoomRead] = useMarkRoomReadMutation();
@@ -170,7 +172,11 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 					</h1>
 				</div>
 				<div className="flex items-center gap-2">
-					<RoomMembersButton room={roomQuery.data} />
+					<RoomMembersButton
+						room={roomQuery.data}
+						currentUserId={currentUserId}
+						onLeftRoom={() => router.push("/messages")}
+					/>
 					<InviteMemberButton
 						room={roomQuery.data}
 						currentUserId={currentUserId}

--- a/client/src/components/dm/RoomMembersButton.tsx
+++ b/client/src/components/dm/RoomMembersButton.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 /**
- * RoomChat header に置く「メンバー」 button + RoomMembersDialog wrapper (#479).
+ * RoomChat header に置く「メンバー」 button + RoomMembersDialog wrapper (#479 / #492).
  *
  * 表示条件: `room.kind === "group"` (direct は peer header で十分なので非表示)。
+ * #492 で kick / leave のため currentUserId と onLeftRoom を渡せるよう拡張。
  */
 
 import { useState } from "react";
@@ -13,9 +14,18 @@ import type { DMRoom } from "@/lib/redux/features/dm/types";
 
 interface RoomMembersButtonProps {
 	room: DMRoom | undefined;
+	currentUserId: number;
+	/**
+	 * 自分が退室成功したときに呼ばれる。RoomChat 側で `/messages` に navigate するなど。
+	 */
+	onLeftRoom?: () => void;
 }
 
-export default function RoomMembersButton({ room }: RoomMembersButtonProps) {
+export default function RoomMembersButton({
+	room,
+	currentUserId,
+	onLeftRoom,
+}: RoomMembersButtonProps) {
 	const [open, setOpen] = useState(false);
 
 	if (!room) return null;
@@ -32,7 +42,16 @@ export default function RoomMembersButton({ room }: RoomMembersButtonProps) {
 			>
 				メンバー {count > 0 ? count : ""}
 			</button>
-			<RoomMembersDialog open={open} onOpenChange={setOpen} room={room} />
+			<RoomMembersDialog
+				open={open}
+				onOpenChange={setOpen}
+				room={room}
+				currentUserId={currentUserId}
+				onLeftRoom={() => {
+					setOpen(false);
+					onLeftRoom?.();
+				}}
+			/>
 		</>
 	);
 }

--- a/client/src/components/dm/RoomMembersDialog.tsx
+++ b/client/src/components/dm/RoomMembersDialog.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 /**
- * Group room の現メンバー一覧 dialog (#479).
+ * Group room の現メンバー一覧 dialog (#479 / #492).
  *
  * SPEC §7.1 / docs/specs/dm-room-invite-spec.md。
  *
  * - room.memberships を listing
  * - creator には「(作成者)」バッジ
  * - 各行 handle + 参加日
+ * - #492 creator 視点: 非 creator member 行に「削除」 button
+ * - #492 全員: ダイアログ最下部に「このグループを退室」 button
  * - direct room ではこの button 自体を出さない (RoomMembersButton 側で制御)
  */
+
+import { useState } from "react";
 
 import {
 	Dialog,
@@ -17,12 +21,19 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import {
+	useKickMemberMutation,
+	useLeaveRoomMutation,
+} from "@/lib/redux/features/dm/dmApiSlice";
 import type { DMRoom, DMRoomMembership } from "@/lib/redux/features/dm/types";
 
 interface RoomMembersDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	room: DMRoom;
+	currentUserId: number;
+	/** 自分が退室に成功したとき呼ばれる (RoomChat → /messages へ navigate)。 */
+	onLeftRoom?: () => void;
 }
 
 function formatJoinDate(iso: string): string {
@@ -38,14 +49,63 @@ export default function RoomMembersDialog({
 	open,
 	onOpenChange,
 	room,
+	currentUserId,
+	onLeftRoom,
 }: RoomMembersDialogProps) {
 	const memberships: DMRoomMembership[] = room.memberships ?? [];
+	const isCurrentUserCreator = room.creator_id === currentUserId;
+	const [kickMember] = useKickMemberMutation();
+	const [leaveRoom] = useLeaveRoomMutation();
+	const [error, setError] = useState<string | null>(null);
+	const [pendingKickId, setPendingKickId] = useState<number | null>(null);
+	const [leaving, setLeaving] = useState(false);
+
+	const onKick = async (m: DMRoomMembership) => {
+		if (!window.confirm(`@${m.handle} をこのグループから削除しますか？`)) {
+			return;
+		}
+		setError(null);
+		setPendingKickId(m.user_id);
+		try {
+			await kickMember({ roomId: room.id, userId: m.user_id }).unwrap();
+		} catch {
+			setError(`@${m.handle} の削除に失敗しました`);
+		} finally {
+			setPendingKickId(null);
+		}
+	};
+
+	const onLeave = async () => {
+		if (
+			!window.confirm(
+				"このグループを退室しますか？退室後はメッセージが見られなくなります。",
+			)
+		) {
+			return;
+		}
+		setError(null);
+		setLeaving(true);
+		try {
+			await leaveRoom(room.id).unwrap();
+			onLeftRoom?.();
+		} catch {
+			setError("退室に失敗しました");
+		} finally {
+			setLeaving(false);
+		}
+	};
+
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>メンバー ({memberships.length} 名)</DialogTitle>
 				</DialogHeader>
+				{error ? (
+					<div role="alert" className="text-baby_red text-xs">
+						{error}
+					</div>
+				) : null}
 				{memberships.length === 0 ? (
 					<p className="text-baby_grey text-sm">メンバーはいません。</p>
 				) : (
@@ -55,8 +115,12 @@ export default function RoomMembersDialog({
 						className="flex flex-col gap-2"
 					>
 						{memberships.map((m) => {
-							const isCreator =
+							const isCreatorRow =
 								room.creator_id !== null && m.user_id === room.creator_id;
+							const canKick =
+								isCurrentUserCreator &&
+								!isCreatorRow &&
+								m.user_id !== currentUserId;
 							return (
 								<li
 									key={m.id}
@@ -67,7 +131,7 @@ export default function RoomMembersDialog({
 										<span className="text-baby_white font-semibold">
 											@{m.handle}
 										</span>
-										{isCreator ? (
+										{isCreatorRow ? (
 											<span
 												aria-label="作成者"
 												className="bg-baby_blue/20 text-baby_blue rounded-full px-2 py-0.5 text-[10px] font-semibold"
@@ -76,17 +140,41 @@ export default function RoomMembersDialog({
 											</span>
 										) : null}
 									</div>
-									<time
-										dateTime={m.created_at}
-										className="text-baby_grey shrink-0 text-xs"
-									>
-										{formatJoinDate(m.created_at)}
-									</time>
+									<div className="flex shrink-0 items-center gap-3">
+										<time
+											dateTime={m.created_at}
+											className="text-baby_grey text-xs"
+										>
+											{formatJoinDate(m.created_at)}
+										</time>
+										{canKick ? (
+											<button
+												type="button"
+												onClick={() => onKick(m)}
+												disabled={pendingKickId === m.user_id}
+												aria-label={`@${m.handle} を削除`}
+												className="border-baby_grey text-baby_grey hover:border-baby_red hover:text-baby_red focus-visible:ring-baby_blue rounded-md border px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+											>
+												{pendingKickId === m.user_id ? "削除中..." : "削除"}
+											</button>
+										) : null}
+									</div>
 								</li>
 							);
 						})}
 					</ul>
 				)}
+				<div className="border-baby_grey/20 mt-4 border-t pt-4">
+					<button
+						type="button"
+						onClick={onLeave}
+						disabled={leaving}
+						aria-label="このグループを退室"
+						className="border-baby_red text-baby_red hover:bg-baby_red/10 focus-visible:ring-baby_red w-full rounded-md border px-3 py-2 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+					>
+						{leaving ? "退室中..." : "このグループを退室"}
+					</button>
+				</div>
 			</DialogContent>
 		</Dialog>
 	);

--- a/client/src/components/dm/__tests__/RoomMembersButton.test.tsx
+++ b/client/src/components/dm/__tests__/RoomMembersButton.test.tsx
@@ -1,13 +1,26 @@
 /**
- * Tests for RoomMembersButton (#479).
+ * Tests for RoomMembersButton (#479 + #492 kick/leave).
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import RoomMembersButton from "@/components/dm/RoomMembersButton";
 import type { DMRoom, DMRoomMembership } from "@/lib/redux/features/dm/types";
+
+const mockKick = vi.fn();
+const mockLeave = vi.fn();
+
+vi.mock("@/lib/redux/features/dm/dmApiSlice", () => ({
+	useKickMemberMutation: () => [mockKick, { isLoading: false, isError: false }],
+	useLeaveRoomMutation: () => [mockLeave, { isLoading: false, isError: false }],
+}));
+
+beforeEach(() => {
+	mockKick.mockReset();
+	mockLeave.mockReset();
+});
 
 function makeMembership(
 	overrides: Partial<DMRoomMembership> = {},
@@ -42,7 +55,7 @@ function makeRoom(overrides: Partial<DMRoom> = {}): DMRoom {
 
 describe("RoomMembersButton", () => {
 	it("group room: button が visible (件数表示)", () => {
-		render(<RoomMembersButton room={makeRoom()} />);
+		render(<RoomMembersButton room={makeRoom()} currentUserId={1} />);
 		expect(
 			screen.getByRole("button", { name: /メンバー一覧を表示 \(2 名\)/ }),
 		).toBeInTheDocument();
@@ -50,18 +63,23 @@ describe("RoomMembersButton", () => {
 
 	it("direct room: 非表示", () => {
 		const { container } = render(
-			<RoomMembersButton room={makeRoom({ kind: "direct" })} />,
+			<RoomMembersButton
+				room={makeRoom({ kind: "direct" })}
+				currentUserId={1}
+			/>,
 		);
 		expect(container).toBeEmptyDOMElement();
 	});
 
 	it("room=undefined: 非表示", () => {
-		const { container } = render(<RoomMembersButton room={undefined} />);
+		const { container } = render(
+			<RoomMembersButton room={undefined} currentUserId={1} />,
+		);
 		expect(container).toBeEmptyDOMElement();
 	});
 
 	it("button 押下で dialog が開き memberships を listing", async () => {
-		render(<RoomMembersButton room={makeRoom()} />);
+		render(<RoomMembersButton room={makeRoom()} currentUserId={1} />);
 		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
 		// memberships listing
 		expect(screen.getByText("@alice")).toBeInTheDocument();
@@ -77,9 +95,75 @@ describe("RoomMembersButton", () => {
 					creator_id: 999,
 					memberships: [makeMembership({ id: 1, user_id: 1, handle: "alice" })],
 				})}
+				currentUserId={1}
 			/>,
 		);
 		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
 		expect(screen.queryByLabelText("作成者")).toBeNull();
+	});
+
+	// #492: kick — creator のみ非 creator member 行に削除 button
+	it("creator 視点: 非 creator member 行に「削除」 button が出る", async () => {
+		render(<RoomMembersButton room={makeRoom()} currentUserId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
+		// alice (creator) には削除 button 無し / bob (member) には有り
+		expect(screen.queryByRole("button", { name: /alice を削除/ })).toBeNull();
+		expect(
+			screen.getByRole("button", { name: /bob を削除/ }),
+		).toBeInTheDocument();
+	});
+
+	it("非 creator 視点: 削除 button は出ない", async () => {
+		render(<RoomMembersButton room={makeRoom()} currentUserId={2} />);
+		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
+		expect(screen.queryByRole("button", { name: /alice を削除/ })).toBeNull();
+		expect(screen.queryByRole("button", { name: /bob を削除/ })).toBeNull();
+	});
+
+	it("削除 button → 確認 OK → kickMember 呼び出し", async () => {
+		mockKick.mockReturnValueOnce({ unwrap: () => Promise.resolve() });
+		// window.confirm を必ず true で答える
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+		render(<RoomMembersButton room={makeRoom()} currentUserId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
+		await userEvent.click(screen.getByRole("button", { name: /bob を削除/ }));
+		await waitFor(() =>
+			expect(mockKick).toHaveBeenCalledWith({ roomId: 42, userId: 2 }),
+		);
+		confirmSpy.mockRestore();
+	});
+
+	// #492: leave — group room ならどのメンバーにも退室 button
+	it("メンバー視点: 退室 button が出る、click + 確認で leaveRoom 呼ぶ", async () => {
+		mockLeave.mockReturnValueOnce({ unwrap: () => Promise.resolve() });
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+		const onLeftRoom = vi.fn();
+		render(
+			<RoomMembersButton
+				room={makeRoom()}
+				currentUserId={2}
+				onLeftRoom={onLeftRoom}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
+		await userEvent.click(
+			screen.getByRole("button", { name: /このグループを退室/ }),
+		);
+		await waitFor(() => expect(mockLeave).toHaveBeenCalledWith(42));
+		await waitFor(() => expect(onLeftRoom).toHaveBeenCalled());
+		confirmSpy.mockRestore();
+	});
+
+	it("削除 / 退室 button: 確認 cancel なら API 呼ばない", async () => {
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+		render(<RoomMembersButton room={makeRoom()} currentUserId={1} />);
+		await userEvent.click(screen.getByRole("button", { name: /メンバー一覧/ }));
+		await userEvent.click(screen.getByRole("button", { name: /bob を削除/ }));
+		expect(mockKick).not.toHaveBeenCalled();
+		await userEvent.click(
+			screen.getByRole("button", { name: /このグループを退室/ }),
+		);
+		expect(mockLeave).not.toHaveBeenCalled();
+		confirmSpy.mockRestore();
 	});
 });

--- a/client/src/lib/redux/features/dm/dmApiSlice.ts
+++ b/client/src/lib/redux/features/dm/dmApiSlice.ts
@@ -127,6 +127,29 @@ export const dmApiSlice = baseApiSlice.injectEndpoints({
 				{ type: "DMInvitation" as const, id: "LIST" },
 			],
 		}),
+		// #492: creator が他メンバーを kick する。
+		// backend は DELETE /api/v1/dm/rooms/<id>/members/<user_id>/。
+		kickMember: builder.mutation<void, { roomId: number; userId: number }>({
+			query: ({ roomId, userId }) => ({
+				url: `/dm/rooms/${roomId}/members/${userId}/`,
+				method: "DELETE",
+			}),
+			invalidatesTags: (_result, _error, { roomId }) => [
+				{ type: "DMRoom" as const, id: roomId },
+				{ type: "DMRoom" as const, id: "LIST" },
+			],
+		}),
+		// #492: 自分の退室。backend (P3-04) は DELETE /api/v1/dm/rooms/<id>/membership/。
+		leaveRoom: builder.mutation<void, number>({
+			query: (roomId) => ({
+				url: `/dm/rooms/${roomId}/membership/`,
+				method: "DELETE",
+			}),
+			invalidatesTags: (_result, _error, roomId) => [
+				{ type: "DMRoom" as const, id: roomId },
+				{ type: "DMRoom" as const, id: "LIST" },
+			],
+		}),
 		// P3-09: 履歴取得 (新しい順で limit 件、画面側で reverse して下から表示)
 		listRoomMessages: builder.query<
 			RoomMessagesResponse,
@@ -177,6 +200,8 @@ export const {
 	useCancelInvitationMutation,
 	useAcceptInvitationMutation,
 	useDeclineInvitationMutation,
+	useKickMemberMutation,
+	useLeaveRoomMutation,
 	useListRoomMessagesQuery,
 	useMarkRoomReadMutation,
 	useDeleteMessageMutation,

--- a/docs/specs/dm-room-invite-spec.md
+++ b/docs/specs/dm-room-invite-spec.md
@@ -210,29 +210,85 @@ backend は招待作成時に `apps/dm/services.py:invite_user_to_room` 内で
 
 ヘッダのベルアイコン dropdown (Phase 4A 末で追加予定) も同 component を流用するが、サイズが小さいため inline button 表示有無は別仕様。本 spec は `/notifications` ページに限定する。
 
-## 8. UI 不足 / 既出来 切り分け表
+## 8. メンバー削除 / 退室 (#492)
 
-| 機能                                                       | backend | frontend | 本 PR          |
-| ---------------------------------------------------------- | ------- | -------- | -------------- |
-| 新規 group 作成時に招待 (`POST /rooms/` `invitee_handles`) | ✅      | ✅       | ―              |
-| 既存 room に後から招待 (`POST /rooms/<id>/invitations/`)   | ✅      | ✅       | ✅ (#476 完了) |
-| 自分宛て pending 招待一覧 (`GET /invitations/`)            | ✅      | ✅       | ―              |
-| 招待を承諾 (`POST /invitations/<id>/accept/`)              | ✅      | ✅       | ―              |
-| 招待を拒否 (`POST /invitations/<id>/decline/`)             | ✅      | ✅       | ―              |
-| **通知 inline action (#489)**                              | ✅      | ❌→✅    | ✅ (本 spec)   |
-| handle autocomplete (user search)                          | ✅      | ✅       | ✅ (#480 完了) |
-| room メンバー一覧表示                                      | ✅      | ✅       | ✅ (#479 完了) |
-| 招待を取り消す (`DELETE /invitations/<id>/`)               | ✅      | ✅       | ✅ (#481 完了) |
+### 8.1 UX 仕様
 
-## 9. 想定スケジュール
+他チャットサービス調査:
 
-#476 (room 内招待 button) は 1 PR で完結予定 (<200 行)。後続 follow-up (#479-#481, #489) は各 1 PR。
+| アプリ          | kick UX                             | leave UX                      |
+| --------------- | ----------------------------------- | ----------------------------- |
+| Slack           | Channel admin が member 行 → Remove | Sidebar context menu「Leave」 |
+| Discord         | Server owner / mod が member → Kick | Server menu「Leave Server」   |
+| Microsoft Teams | Team owner が member 行 → Remove    | Team menu「Leave team」       |
+| LINE            | Admin が member 長押し → 削除       | グループ画面「退会」          |
 
-## 10. 関連 Issue / PR
+= 標準は **「member 一覧から削除/退会」**。本アプリも `RoomMembersDialog` 内で完結。
+
+### 8.2 描画条件
+
+- **kick (削除) button**: 各 member 行の右側
+  - 表示条件: `currentUser === room.creator_id` AND `member.user_id !== room.creator_id` AND `member.user_id !== currentUser`
+  - direct room では Dialog 自体が出ないため考慮不要
+- **leave (退室) button**: ダイアログ最下部
+  - 表示条件: 全メンバー (group のみ、direct は Dialog 自体出ない)
+  - creator も leave 可能 (backend `leave_room` 内で残メンバー最古から自動 ownership transfer)
+
+### 8.3 動作
+
+- 削除 → `window.confirm("@<handle> をこのグループから削除しますか？")` → OK で `DELETE /api/v1/dm/rooms/<id>/members/<user_id>/`
+  - 成功: row 自動消去 (RTK Query invalidate で再 fetch)
+  - 失敗: `role=alert` で「@<handle> の削除に失敗しました」
+- 退室 → `window.confirm("このグループを退室しますか？...")` → OK で `DELETE /api/v1/dm/rooms/<id>/membership/`
+  - 成功: Dialog close + `/messages` に redirect (`onLeftRoom` callback)
+  - 失敗: `role=alert` で「退室に失敗しました」
+- 送信中は両 button `disabled + aria-busy`
+
+### 8.4 a11y
+
+- button は `aria-label` に handle / 操作 を含む (例: `@bob を削除`、`このグループを退室`)
+- 確認 dialog はネイティブ `window.confirm` (キーボード操作対応 / SR 対応)
+- 将来的には Radix `AlertDialog` への置き換えを検討 (本 spec 範囲外)
+
+### 8.5 backend API
+
+#### `DELETE /api/v1/dm/rooms/<id>/members/<user_id>/` (新規)
+
+- 認可: room creator のみ。kicker が membership 持たない場合は 404 で room 隠蔽
+- target=creator は 400「creator 自身は削除できません」
+- target が member でない場合は 400「対象ユーザーはこのルームのメンバーではありません」
+- direct room は 400「1:1 room ではメンバー削除はできません」
+- 成功: 204 No Content、`DMRoomMembership` 物理削除
+
+#### `DELETE /api/v1/dm/rooms/<id>/membership/` (既存、P3-04)
+
+- self-leave。creator が leave すると残メンバー最古に ownership transfer
+
+## 9. UI 不足 / 既出来 切り分け表
+
+| 機能                                                       | backend | frontend | 状態       |
+| ---------------------------------------------------------- | ------- | -------- | ---------- |
+| 新規 group 作成時に招待 (`POST /rooms/` `invitee_handles`) | ✅      | ✅       | ―          |
+| 既存 room に後から招待 (`POST /rooms/<id>/invitations/`)   | ✅      | ✅       | #476 完了  |
+| 自分宛て pending 招待一覧 (`GET /invitations/`)            | ✅      | ✅       | ―          |
+| 招待を承諾 (`POST /invitations/<id>/accept/`)              | ✅      | ✅       | ―          |
+| 招待を拒否 (`POST /invitations/<id>/decline/`)             | ✅      | ✅       | ―          |
+| 通知 inline action                                         | ✅      | ✅       | #489 完了  |
+| handle autocomplete (user search)                          | ✅      | ✅       | #480 完了  |
+| room メンバー一覧表示                                      | ✅      | ✅       | #479 完了  |
+| 招待を取り消す (`DELETE /invitations/<id>/`)               | ✅      | ✅       | #481 完了  |
+| **kick (member 削除) / leave (退室) UI (#492)**            | ✅      | ✅       | ✅ (本 PR) |
+
+## 10. 想定スケジュール
+
+#476 (room 内招待 button) は 1 PR で完結予定 (<200 行)。後続 follow-up (#479-#481, #489, #492) は各 1 PR。
+
+## 11. 関連 Issue / PR
 
 - room 内招待 UI: #476 / PR #477
 - backend 招待 API: PR #258 (Issue #229) で実装済
 - 1:1 / グループ作成 UI: PR #239 (Issue #233) / PR #248 (Issue #236)
 - 招待リスト UI: PR #248 (Issue #237)
 - 通知 bridge: #487 / PR #488 (dm_invite 通知が永続化されるよう修正)
-- 通知 inline action: **#489 / 本 PR**
+- 通知 inline action: #489 / PR #490
+- メンバー削除 / 退室: **#492 / 本 PR**


### PR DESCRIPTION
## Summary

ハルナさんからの「チャットルームからメンバーを削除する機能」要望への対応。kick (creator が他メンバーを除名) は backend / frontend ともに未実装だった。leave (自分の退室) は backend は実装済 (P3-04) だったが UI なしだったので併せて追加。

## 他チャットサービス調査

| アプリ | kick UX | leave UX |
|--------|---------|----------|
| Slack | Channel admin が member 行 → Remove | Sidebar context menu "Leave" |
| Discord | Server owner / mod が member → Kick | Server menu "Leave Server" |
| Microsoft Teams | Team owner が member 行 → Remove | Team menu "Leave team" |
| LINE | Admin が member 長押し → 削除 | グループ画面「退会」 |

= 標準は「member 一覧から削除/退会」。本アプリも `RoomMembersDialog` 内で完結。

## 変更点

### Backend
- `services.kick_member` (room.creator only / target ≠ creator / target は member)
- `DMRoomKickMemberView` (`DELETE /api/v1/dm/rooms/<id>/members/<user_id>/`) + URL 登録
- pytest 8 ケース (auth / 成功 / non-creator 403 / outsider 404 / self 400 / non-member 400 / direct 400 / unknown user 404)

### Frontend
- `dmApiSlice` に `kickMember` + `leaveRoom` mutation
- `RoomMembersDialog`: 各 member 行 (creator 視点 + non-creator member) に「削除」 button、ダイアログ最下部に「このグループを退室」 button
- 確認 (window.confirm) → mutation → 成功時 RTK Query invalidate / 退室時は `onLeftRoom` callback
- `RoomMembersButton` に `currentUserId` / `onLeftRoom` prop 追加
- `RoomChat`: `onLeftRoom` で `/messages` に redirect
- vitest RTL 10 ケース GREEN (visibility / kick OK / kick cancel / leave OK / leave cancel)

### 仕様書
- `docs/specs/dm-room-invite-spec.md` § 8 「メンバー削除 / 退室」 新設
- § 9 切り分け表に行追加、§ 11 関連 Issue / PR にリンク

## Test plan

- [x] vitest 96/96 (DM 関連 14 files)
- [x] tsc / eslint clean
- [ ] CI 全 green
- [ ] stg deploy 後 Playwright で test2 → kick test3 → memberships=["test2"] 反映確認

Closes #492