### PR TITLE
fix(dm): kick button の視認性を上げる (#492 の発見性改善)

### DIFF
--- a/client/src/components/dm/RoomMembersDialog.tsx
+++ b/client/src/components/dm/RoomMembersDialog.tsx
@@ -153,9 +153,11 @@ export default function RoomMembersDialog({
 												onClick={() => onKick(m)}
 												disabled={pendingKickId === m.user_id}
 												aria-label={`@${m.handle} を削除`}
-												className="border-baby_grey text-baby_grey hover:border-baby_red hover:text-baby_red focus-visible:ring-baby_blue rounded-md border px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
+												className="border-baby_red/60 bg-baby_red/10 text-baby_red hover:bg-baby_red hover:text-baby_white focus-visible:ring-baby_red rounded-md border px-3 py-1.5 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50"
 											>
-												{pendingKickId === m.user_id ? "削除中..." : "削除"}
+												{pendingKickId === m.user_id
+													? "削除中..."
+													: "メンバーから削除"}
 											</button>
 										) : null}
 									</div>


### PR DESCRIPTION
ハルナさん指摘 "どこ？削除ボタン" への対応。

## 原因

stg `/messages/13` のメンバー dialog で、test3 行の右に `削除` button は **DOM 上には実在** していたが、CSS が薄い灰色 (text-baby_grey + border-baby_grey) で dark 背景に溶け込み、**視覚的に発見できないレベル**だった。Playwright + DOM dump で button の存在は確認済 (`aria-label='@test3 を削除'` 検出)。

## 修正

- 色: `text-baby_grey + border-baby_grey` → `text-baby_red + border-baby_red/60 + bg-baby_red/10` (destructive action と分かる赤系)
- サイズ: `px-2 py-1` → `px-3 py-1.5` (タップ領域拡大)
- ラベル: `削除` → `メンバーから削除` (button だけ見たときの曖昧さ解消)
- hover: `bg-baby_red + text-baby_white` の反転で視覚フィードバック強化

## Test plan

- [x] vitest 10/10 GREEN (RoomMembersButton 既存テストの aria-label 正規表現が「メンバーから削除」 にも match)
- [x] tsc / eslint clean
- [ ] CI 全 green
- [ ] stg deploy 後 visual 確認