### PR TITLE
feat(boxes): お気に入り backend (Folder + Bookmark + API) (Refs #499)

### DIFF
--- a/apps/boxes/migrations/0001_initial.py
+++ b/apps/boxes/migrations/0001_initial.py
@@ -1,0 +1,124 @@
+# Generated for #499 (favorites). Manual migration matching apps/boxes/models.py.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("tweets", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Folder",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=50)),
+                ("sort_order", models.PositiveIntegerField(default=0)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "parent",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="children",
+                        to="boxes.folder",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="folders",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name="folder",
+            index=models.Index(
+                fields=["user", "parent"], name="boxes_folde_user_id_4f3b71_idx"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="folder",
+            constraint=models.UniqueConstraint(
+                fields=("user", "parent", "name"),
+                name="uniq_folder_per_parent",
+            ),
+        ),
+        migrations.CreateModel(
+            name="Bookmark",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "folder",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="bookmarks",
+                        to="boxes.folder",
+                    ),
+                ),
+                (
+                    "tweet",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="bookmarked_by",
+                        to="tweets.tweet",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="bookmarks",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name="bookmark",
+            index=models.Index(
+                fields=["user", "-created_at"], name="boxes_bookm_user_id_d2f80a_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="bookmark",
+            index=models.Index(
+                fields=["folder", "-created_at"], name="boxes_bookm_folder__0a8e3f_idx"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="bookmark",
+            constraint=models.UniqueConstraint(
+                fields=("folder", "tweet"),
+                name="uniq_bookmark_per_folder",
+            ),
+        ),
+    ]

--- a/apps/boxes/models.py
+++ b/apps/boxes/models.py
@@ -61,22 +61,31 @@ class Folder(models.Model):
         if self.parent_id is None:
             return
 
-        # 親と user が同じこと
-        if self.parent.user_id != self.user_id:
+        # parent_id 経由で 1 回だけ取得 (full_clean 経由で並行削除されているケースも考慮)
+        parent_obj = Folder.objects.filter(pk=self.parent_id).first()
+        if parent_obj is None:
+            raise ValidationError({"parent": "親フォルダが見つかりません"})
+
+        if parent_obj.user_id != self.user_id:
             raise ValidationError({"parent": "他のユーザーのフォルダは親に指定できません"})
-        # 自分自身を親にできない
         if self.parent_id == self.pk:
             raise ValidationError({"parent": "自分自身を親に指定できません"})
+
         # 深さチェック: parent から root までの段数 + 1 が MAX を超えてはいけない
         depth = 1
-        cursor = self.parent
+        cursor: Folder | None = parent_obj
         while cursor is not None:
             depth += 1
             if depth > MAX_FOLDER_DEPTH:
                 raise ValidationError(
                     {"parent": (f"フォルダの深さ上限 ({MAX_FOLDER_DEPTH}) を超えています")}
                 )
-            cursor = cursor.parent
+            cursor = (
+                Folder.objects.filter(pk=cursor.parent_id).first()
+                if cursor.parent_id is not None
+                else None
+            )
+
         # 子孫を親にしようとしている (循環)
         descendant_ids = self._collect_descendant_ids()
         if self.parent_id in descendant_ids:
@@ -119,6 +128,8 @@ class Bookmark(models.Model):
 
     class Meta:
         constraints = [
+            # (folder, tweet) で一意 (同一フォルダ内重複禁止)。
+            # user は folder.user と整合する想定だが、view 層で必ず request.user を渡す。
             models.UniqueConstraint(
                 fields=["folder", "tweet"],
                 name="uniq_bookmark_per_folder",

--- a/apps/boxes/models.py
+++ b/apps/boxes/models.py
@@ -1,5 +1,133 @@
-"""Models for the boxes app.
+"""Models for the boxes app (#499 / Phase 4A お気に入り).
 
-Concrete models are introduced in the phase that owns this feature.
-See docs/ER.md for the planned schema.
+docs/specs/favorites-spec.md §3 を実装する。SPEC §9 の「ボックス」 を Google /
+Edge ブックマーク風の **任意深さフォルダツリー** に拡張。
+
+- Folder: ユーザー所有のフォルダ。self FK で nest 可能 (MAX_FOLDER_DEPTH=10)
+- Bookmark: 1 (folder, tweet) ペアごとの保存レコード
+- 本人以外は閲覧 / 操作不可 (SPEC §9 「完全非公開」)
 """
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db import models
+
+# Google ブックマークも実用上 6〜7 層程度。Folder.parent の循環や深すぎる
+# nesting を避ける運用上の安全弁。
+MAX_FOLDER_DEPTH = 10
+
+
+class Folder(models.Model):
+    """お気に入りフォルダ. parent=NULL がルート."""
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="folders",
+    )
+    parent = models.ForeignKey(
+        "self",
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="children",
+    )
+    # SPEC §9 "1〜50 字"
+    name = models.CharField(max_length=50)
+    # 同じ親 fold 内での並び順 (UI 操作は将来追加、MVP は default 0)
+    sort_order = models.PositiveIntegerField(default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "parent", "name"],
+                name="uniq_folder_per_parent",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["user", "parent"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"@{self.user_id}: {self.name}"
+
+    def clean(self) -> None:
+        """循環 / 深さ / 親の所有者をチェック (services 層からも明示的に呼ばれる)."""
+
+        if self.parent_id is None:
+            return
+
+        # 親と user が同じこと
+        if self.parent.user_id != self.user_id:
+            raise ValidationError({"parent": "他のユーザーのフォルダは親に指定できません"})
+        # 自分自身を親にできない
+        if self.parent_id == self.pk:
+            raise ValidationError({"parent": "自分自身を親に指定できません"})
+        # 深さチェック: parent から root までの段数 + 1 が MAX を超えてはいけない
+        depth = 1
+        cursor = self.parent
+        while cursor is not None:
+            depth += 1
+            if depth > MAX_FOLDER_DEPTH:
+                raise ValidationError(
+                    {"parent": (f"フォルダの深さ上限 ({MAX_FOLDER_DEPTH}) を超えています")}
+                )
+            cursor = cursor.parent
+        # 子孫を親にしようとしている (循環)
+        descendant_ids = self._collect_descendant_ids()
+        if self.parent_id in descendant_ids:
+            raise ValidationError({"parent": "子孫フォルダを親に指定できません"})
+
+    def _collect_descendant_ids(self) -> set[int]:
+        """自分の子孫すべての pk セットを返す (循環検出用)."""
+
+        if self.pk is None:
+            return set()
+        ids: set[int] = set()
+        queue: list[int] = [self.pk]
+        while queue:
+            current = queue.pop()
+            child_ids = list(Folder.objects.filter(parent_id=current).values_list("pk", flat=True))
+            ids.update(child_ids)
+            queue.extend(child_ids)
+        return ids
+
+
+class Bookmark(models.Model):
+    """ツイートをフォルダに保存するレコード."""
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="bookmarks",
+    )
+    folder = models.ForeignKey(
+        Folder,
+        on_delete=models.CASCADE,
+        related_name="bookmarks",
+    )
+    tweet = models.ForeignKey(
+        "tweets.Tweet",
+        on_delete=models.CASCADE,
+        related_name="bookmarked_by",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["folder", "tweet"],
+                name="uniq_bookmark_per_folder",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["user", "-created_at"]),
+            models.Index(fields=["folder", "-created_at"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"@{self.user_id} -> {self.folder_id} (tweet {self.tweet_id})"

--- a/apps/boxes/serializers.py
+++ b/apps/boxes/serializers.py
@@ -1,0 +1,75 @@
+"""DRF serializers for お気に入り (#499).
+
+docs/specs/favorites-spec.md §4 を実装する。
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from apps.boxes.models import Bookmark, Folder
+
+
+class FolderSerializer(serializers.ModelSerializer):
+    """Folder 出力用 (一覧 / 詳細共通)."""
+
+    bookmark_count = serializers.IntegerField(read_only=True)
+    child_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Folder
+        fields = (
+            "id",
+            "name",
+            "parent_id",
+            "sort_order",
+            "bookmark_count",
+            "child_count",
+            "created_at",
+            "updated_at",
+        )
+        read_only_fields = (
+            "id",
+            "bookmark_count",
+            "child_count",
+            "created_at",
+            "updated_at",
+        )
+
+
+class FolderCreateInputSerializer(serializers.Serializer):
+    """``POST /folders/`` の入力."""
+
+    name = serializers.CharField(max_length=50, min_length=1)
+    parent_id = serializers.IntegerField(required=False, allow_null=True)
+
+
+class FolderUpdateInputSerializer(serializers.Serializer):
+    """``PATCH /folders/<id>/`` の入力 (rename / move)."""
+
+    name = serializers.CharField(max_length=50, min_length=1, required=False)
+    parent_id = serializers.IntegerField(required=False, allow_null=True)
+
+
+class BookmarkSerializer(serializers.ModelSerializer):
+    """Bookmark 出力 (folder 内一覧で使う)."""
+
+    tweet_id = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Bookmark
+        fields = ("id", "folder_id", "tweet_id", "created_at")
+        read_only_fields = fields
+
+
+class BookmarkCreateInputSerializer(serializers.Serializer):
+    """``POST /bookmarks/`` の入力."""
+
+    tweet_id = serializers.IntegerField()
+    folder_id = serializers.IntegerField()
+
+
+class BookmarkStatusSerializer(serializers.Serializer):
+    """``GET /tweets/<id>/bookmark-status/`` の出力."""
+
+    folder_ids = serializers.ListField(child=serializers.IntegerField())

--- a/apps/boxes/tests/test_favorites_api.py
+++ b/apps/boxes/tests/test_favorites_api.py
@@ -1,0 +1,356 @@
+"""Tests for お気に入り API (#499).
+
+docs/specs/favorites-spec.md §7.1 を満たす:
+- model 制約 (同名禁止、深さ MAX、CASCADE 削除)
+- view 認可 (本人以外 404 隠蔽)
+- folder CRUD
+- bookmark CRUD (idempotent, 異 folder OK, 同 folder 重複禁止)
+- bookmark-status (folder_ids 配列)
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.boxes.models import MAX_FOLDER_DEPTH, Bookmark, Folder
+
+User = get_user_model()
+
+
+def _user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+def _tweet(author):
+    from apps.tweets.models import Tweet
+
+    return Tweet.objects.create(author=author, body=f"hello from @{author.username}")
+
+
+@pytest.fixture
+def folders_url():
+    return reverse("boxes:folder-list-create")
+
+
+@pytest.fixture
+def folder_detail_url():
+    def _u(pk: int) -> str:
+        return reverse("boxes:folder-detail", kwargs={"pk": pk})
+
+    return _u
+
+
+@pytest.fixture
+def folder_bookmarks_url():
+    def _u(pk: int) -> str:
+        return reverse("boxes:folder-bookmarks", kwargs={"pk": pk})
+
+    return _u
+
+
+@pytest.fixture
+def bookmarks_url():
+    return reverse("boxes:bookmark-create")
+
+
+@pytest.fixture
+def bookmark_detail_url():
+    def _u(pk: int) -> str:
+        return reverse("boxes:bookmark-destroy", kwargs={"pk": pk})
+
+    return _u
+
+
+@pytest.fixture
+def status_url():
+    def _u(tweet_id: int) -> str:
+        return reverse("boxes:tweet-bookmark-status", kwargs={"tweet_id": tweet_id})
+
+    return _u
+
+
+# ------------------------------------------------------------------------
+# Folder CRUD
+# ------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_folder_list_requires_auth(folders_url) -> None:
+    client = APIClient()
+    resp = client.get(folders_url)
+    assert resp.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+
+
+@pytest.mark.django_db
+def test_folder_create_root(folders_url) -> None:
+    me = _user("alice")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(folders_url, {"name": "技術"}, format="json")
+    assert resp.status_code == status.HTTP_201_CREATED
+    body = resp.json()
+    assert body["name"] == "技術"
+    assert body["parent_id"] is None
+    assert body["bookmark_count"] == 0
+    assert body["child_count"] == 0
+
+
+@pytest.mark.django_db
+def test_folder_create_nested(folders_url) -> None:
+    me = _user("alice")
+    parent = Folder.objects.create(user=me, name="技術")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(folders_url, {"name": "Django", "parent_id": parent.pk}, format="json")
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert resp.json()["parent_id"] == parent.pk
+
+
+@pytest.mark.django_db
+def test_folder_create_duplicate_same_parent_400(folders_url) -> None:
+    me = _user("alice")
+    Folder.objects.create(user=me, name="技術")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(folders_url, {"name": "技術"}, format="json")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_folder_create_with_other_user_parent_400(folders_url) -> None:
+    me = _user("alice")
+    other = _user("bob")
+    other_folder = Folder.objects.create(user=other, name="bob_root")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(
+        folders_url,
+        {"name": "child", "parent_id": other_folder.pk},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_folder_max_depth_400(folders_url) -> None:
+    me = _user("alice")
+    # 既に MAX_FOLDER_DEPTH 段の chain を作っておく
+    parent = None
+    for i in range(MAX_FOLDER_DEPTH):
+        parent = Folder.objects.create(user=me, parent=parent, name=f"L{i}")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(
+        folders_url,
+        {"name": "L_OVERFLOW", "parent_id": parent.pk},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_folder_list_only_own(folders_url) -> None:
+    me = _user("alice")
+    other = _user("bob")
+    Folder.objects.create(user=me, name="my")
+    Folder.objects.create(user=other, name="theirs")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(folders_url)
+    assert resp.status_code == 200
+    names = [f["name"] for f in resp.json()["results"]]
+    assert "my" in names
+    assert "theirs" not in names
+
+
+@pytest.mark.django_db
+def test_folder_get_other_user_returns_404(folder_detail_url) -> None:
+    me = _user("alice")
+    other = _user("bob")
+    other_folder = Folder.objects.create(user=other, name="theirs")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(folder_detail_url(other_folder.pk))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_folder_patch_rename(folder_detail_url) -> None:
+    me = _user("alice")
+    folder = Folder.objects.create(user=me, name="old")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.patch(folder_detail_url(folder.pk), {"name": "new"}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "new"
+
+
+@pytest.mark.django_db
+def test_folder_patch_circular_parent_400(folder_detail_url) -> None:
+    me = _user("alice")
+    a = Folder.objects.create(user=me, name="A")
+    b = Folder.objects.create(user=me, parent=a, name="B")
+    # b の親を a 自身ではなく自分の子孫にしようとする
+    # A → B → C と作って、A の親を C にする (循環)
+    c = Folder.objects.create(user=me, parent=b, name="C")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.patch(folder_detail_url(a.pk), {"parent_id": c.pk}, format="json")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_folder_delete_cascades_bookmarks(folder_detail_url) -> None:
+    me = _user("alice")
+    f = Folder.objects.create(user=me, name="f")
+    t = _tweet(me)
+    Bookmark.objects.create(user=me, folder=f, tweet=t)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.delete(folder_detail_url(f.pk))
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    assert not Folder.objects.filter(pk=f.pk).exists()
+    assert not Bookmark.objects.filter(folder_id=f.pk).exists()
+
+
+# ------------------------------------------------------------------------
+# Bookmark CRUD
+# ------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bookmark_create_201(bookmarks_url) -> None:
+    me = _user("alice")
+    f = Folder.objects.create(user=me, name="f")
+    t = _tweet(me)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": f.pk}, format="json")
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert resp.json()["tweet_id"] == t.pk
+
+
+@pytest.mark.django_db
+def test_bookmark_idempotent_200(bookmarks_url) -> None:
+    me = _user("alice")
+    f = Folder.objects.create(user=me, name="f")
+    t = _tweet(me)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": f.pk}, format="json")
+    resp = client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": f.pk}, format="json")
+    # 2 回目は既存を返す → 200
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_bookmark_other_user_folder_400(bookmarks_url) -> None:
+    me = _user("alice")
+    other = _user("bob")
+    other_f = Folder.objects.create(user=other, name="theirs")
+    t = _tweet(me)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": other_f.pk}, format="json")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_bookmark_same_tweet_different_folder_ok(bookmarks_url) -> None:
+    me = _user("alice")
+    f1 = Folder.objects.create(user=me, name="A")
+    f2 = Folder.objects.create(user=me, name="B")
+    t = _tweet(me)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    r1 = client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": f1.pk}, format="json")
+    r2 = client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": f2.pk}, format="json")
+    assert r1.status_code == status.HTTP_201_CREATED
+    assert r2.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+def test_bookmark_destroy_204(bookmarks_url, bookmark_detail_url) -> None:
+    me = _user("alice")
+    f = Folder.objects.create(user=me, name="f")
+    t = _tweet(me)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    create = client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": f.pk}, format="json")
+    bid = create.json()["id"]
+    resp = client.delete(bookmark_detail_url(bid))
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_bookmark_destroy_other_user_404(bookmark_detail_url) -> None:
+    me = _user("alice")
+    other = _user("bob")
+    other_f = Folder.objects.create(user=other, name="theirs")
+    t = _tweet(other)
+    bm = Bookmark.objects.create(user=other, folder=other_f, tweet=t)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.delete(bookmark_detail_url(bm.pk))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_folder_bookmarks_list(folder_bookmarks_url) -> None:
+    me = _user("alice")
+    f = Folder.objects.create(user=me, name="f")
+    t1 = _tweet(me)
+    t2 = _tweet(me)
+    Bookmark.objects.create(user=me, folder=f, tweet=t1)
+    Bookmark.objects.create(user=me, folder=f, tweet=t2)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(folder_bookmarks_url(f.pk))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["results"]) == 2 if isinstance(body, dict) else len(body) == 2
+
+
+# ------------------------------------------------------------------------
+# bookmark-status
+# ------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bookmark_status_returns_folder_ids(status_url) -> None:
+    me = _user("alice")
+    f1 = Folder.objects.create(user=me, name="A")
+    f2 = Folder.objects.create(user=me, name="B")
+    t = _tweet(me)
+    Bookmark.objects.create(user=me, folder=f1, tweet=t)
+    Bookmark.objects.create(user=me, folder=f2, tweet=t)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(status_url(t.pk))
+    assert resp.status_code == 200
+    folder_ids = sorted(resp.json()["folder_ids"])
+    assert folder_ids == sorted([f1.pk, f2.pk])
+
+
+@pytest.mark.django_db
+def test_bookmark_status_empty_when_not_saved(status_url) -> None:
+    me = _user("alice")
+    t = _tweet(me)
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.get(status_url(t.pk))
+    assert resp.status_code == 200
+    assert resp.json()["folder_ids"] == []

--- a/apps/boxes/tests/test_favorites_api.py
+++ b/apps/boxes/tests/test_favorites_api.py
@@ -321,7 +321,7 @@ def test_folder_bookmarks_list(folder_bookmarks_url) -> None:
     resp = client.get(folder_bookmarks_url(f.pk))
     assert resp.status_code == 200
     body = resp.json()
-    assert len(body["results"]) == 2 if isinstance(body, dict) else len(body) == 2
+    assert len(body["results"]) == 2
 
 
 # ------------------------------------------------------------------------
@@ -354,3 +354,50 @@ def test_bookmark_status_empty_when_not_saved(status_url) -> None:
     resp = client.get(status_url(t.pk))
     assert resp.status_code == 200
     assert resp.json()["folder_ids"] == []
+
+
+# ------------------------------------------------------------------------
+# 追加: review HIGH 修正の回帰テスト
+# ------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_folder_patch_rename_and_move_dup_in_destination(folder_detail_url) -> None:
+    """rename + move を同 PATCH で送ったとき、移動先で同名衝突が 400 を返すこと.
+
+    review HIGH: 旧実装では parent_id 更新前に sibling_check が走り、
+    DB 制約 IntegrityError → 500 になる経路があった。
+    """
+
+    me = _user("alice")
+    src_parent = Folder.objects.create(user=me, name="src")
+    dst_parent = Folder.objects.create(user=me, name="dst")
+    moving = Folder.objects.create(user=me, parent=src_parent, name="X")
+    # 移動先には既に同名 "X" が存在する
+    Folder.objects.create(user=me, parent=dst_parent, name="X")
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.patch(
+        folder_detail_url(moving.pk),
+        {"name": "X", "parent_id": dst_parent.pk},
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_bookmark_create_for_soft_deleted_tweet_400(bookmarks_url) -> None:
+    """論理削除済 tweet (is_deleted=True) は bookmark できない.
+
+    review HIGH: tweet は soft-delete モデルなのに既存実装は `pk のみ` で
+    存在チェックしていた。
+    """
+
+    me = _user("alice")
+    f = Folder.objects.create(user=me, name="f")
+    t = _tweet(me)
+    t.soft_delete()
+    client = APIClient()
+    client.force_authenticate(user=me)
+    resp = client.post(bookmarks_url, {"tweet_id": t.pk, "folder_id": f.pk}, format="json")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/apps/boxes/urls.py
+++ b/apps/boxes/urls.py
@@ -1,5 +1,43 @@
-from django.urls import URLPattern, URLResolver
+"""URL patterns for お気に入り (#499).
 
-# URL patterns are added in the phase that implements this feature.
-# See docs/ROADMAP.md for ownership.
-urlpatterns: list[URLPattern | URLResolver] = []
+config/urls.py で `path("api/v1/boxes/", include("apps.boxes.urls"))` として登録される。
+従って実際のフルパスは `/api/v1/boxes/folders/` 等になる。
+"""
+
+from __future__ import annotations
+
+from django.urls import path
+
+from apps.boxes.views import (
+    BookmarkCreateView,
+    BookmarkDestroyView,
+    FolderBookmarksView,
+    FolderDetailView,
+    FolderListCreateView,
+    TweetBookmarkStatusView,
+)
+
+app_name = "boxes"
+
+urlpatterns = [
+    path("folders/", FolderListCreateView.as_view(), name="folder-list-create"),
+    path("folders/<int:pk>/", FolderDetailView.as_view(), name="folder-detail"),
+    path(
+        "folders/<int:pk>/bookmarks/",
+        FolderBookmarksView.as_view(),
+        name="folder-bookmarks",
+    ),
+    path("bookmarks/", BookmarkCreateView.as_view(), name="bookmark-create"),
+    path(
+        "bookmarks/<int:pk>/",
+        BookmarkDestroyView.as_view(),
+        name="bookmark-destroy",
+    ),
+    # tweet を主語に出すと apps.tweets.urls と衝突するため /boxes/tweets/<id>/status/
+    # という形に。フロントは spec doc を見て叩く。
+    path(
+        "tweets/<int:tweet_id>/status/",
+        TweetBookmarkStatusView.as_view(),
+        name="tweet-bookmark-status",
+    ),
+]

--- a/apps/boxes/views.py
+++ b/apps/boxes/views.py
@@ -17,6 +17,7 @@ docs/specs/favorites-spec.md §4 を実装する。本人以外は 404 隠蔽 (S
 from __future__ import annotations
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import IntegrityError, transaction
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from rest_framework import generics, permissions, status
@@ -77,10 +78,11 @@ class FolderListCreateView(APIView):
 
         folder = Folder(user=request.user, parent=parent, name=data["name"])
         try:
-            folder.clean()
+            with transaction.atomic():
+                folder.clean()
+                folder.save()
         except DjangoValidationError as exc:
             raise DRFValidationError(detail=exc.message_dict) from exc
-        folder.save()
 
         # 直作成だと count annotation が無いので 0 で埋める
         folder.bookmark_count = 0  # type: ignore[attr-defined]
@@ -110,16 +112,8 @@ class FolderDetailView(APIView):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
-        if "name" in data:
-            new_name = data["name"]
-            # 同一親で同名禁止 (自分自身を除外)
-            sibling_qs = Folder.objects.filter(
-                user=request.user, parent_id=folder.parent_id, name=new_name
-            ).exclude(pk=folder.pk)
-            if sibling_qs.exists():
-                raise DRFValidationError({"name": "同名フォルダが存在します"})
-            folder.name = new_name
-
+        # parent_id を先に解決して effective parent を確定させてから
+        # sibling 同名チェックを走らせる (rename + move 同時 PATCH の整合性)。
         if "parent_id" in data:
             new_parent_id = data["parent_id"]
             if new_parent_id is None:
@@ -130,13 +124,22 @@ class FolderDetailView(APIView):
                     raise DRFValidationError({"parent_id": "無効な parent_id"})
                 folder.parent = new_parent
 
+        if "name" in data:
+            new_name = data["name"]
+            sibling_qs = Folder.objects.filter(
+                user=request.user, parent_id=folder.parent_id, name=new_name
+            ).exclude(pk=folder.pk)
+            if sibling_qs.exists():
+                raise DRFValidationError({"name": "同名フォルダが存在します"})
+            folder.name = new_name
+
         try:
-            folder.clean()
+            with transaction.atomic():
+                folder.clean()
+                folder.save()
         except DjangoValidationError as exc:
             raise DRFValidationError(detail=exc.message_dict) from exc
-        folder.save()
 
-        # 再取得して annotation を埋める
         return Response(FolderSerializer(self._get_folder(request, pk)).data)
 
     def delete(self, request: Request, pk: int) -> Response:
@@ -153,10 +156,14 @@ class FolderBookmarksView(generics.ListAPIView):
 
     def get_queryset(self):
         pk = self.kwargs["pk"]
-        # 本人の folder か確認 (他人は 404 隠蔽)
+        # 1 query で folder の本人所有を兼ねた絞り込み (他人 / 存在しない folder は 404)
         if not Folder.objects.filter(pk=pk, user=self.request.user).exists():
             raise NotFound("folder not found")
-        return Bookmark.objects.filter(folder_id=pk).order_by("-created_at")
+        return (
+            Bookmark.objects.filter(folder_id=pk, folder__user=self.request.user)
+            .select_related("tweet")
+            .order_by("-created_at")
+        )
 
 
 class BookmarkCreateView(APIView):
@@ -169,22 +176,31 @@ class BookmarkCreateView(APIView):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
-        # folder の所有者チェック
         folder = Folder.objects.filter(pk=data["folder_id"], user=request.user).first()
         if folder is None:
             raise DRFValidationError({"folder_id": "無効な folder_id"})
 
-        # tweet 存在チェック
         from apps.tweets.models import Tweet  # 遅延 import で循環回避
 
-        if not Tweet.objects.filter(pk=data["tweet_id"]).exists():
+        # 論理削除済 tweet (is_deleted=True) は bookmark 不可。
+        if not Tweet.objects.filter(pk=data["tweet_id"], is_deleted=False).exists():
             raise DRFValidationError({"tweet_id": "ツイートが見つかりません"})
 
-        bookmark, created = Bookmark.objects.get_or_create(
-            user=request.user,
-            folder=folder,
-            tweet_id=data["tweet_id"],
-        )
+        # `get_or_create` は完全並行下で IntegrityError を投げ得るので
+        # transaction.atomic + IntegrityError 拾いでフォールバックして idempotent を維持。
+        try:
+            with transaction.atomic():
+                bookmark, created = Bookmark.objects.get_or_create(
+                    user=request.user,
+                    folder=folder,
+                    tweet_id=data["tweet_id"],
+                )
+        except IntegrityError:
+            bookmark = Bookmark.objects.get(
+                user=request.user, folder=folder, tweet_id=data["tweet_id"]
+            )
+            created = False
+
         return Response(
             BookmarkSerializer(bookmark).data,
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,

--- a/apps/boxes/views.py
+++ b/apps/boxes/views.py
@@ -1,5 +1,216 @@
-"""Views for the boxes app.
+"""DRF views for お気に入り (#499).
 
-Views are added in the phase that owns this feature.
-See docs/ROADMAP.md for ownership.
+docs/specs/favorites-spec.md §4 を実装する。本人以外は 404 隠蔽 (SPEC §9)。
+
+エンドポイント:
+- GET    /folders/                     一覧 (フラット、tree は FE で構築)
+- POST   /folders/                     新規作成
+- GET    /folders/<id>/                単一詳細
+- PATCH  /folders/<id>/                rename / move
+- DELETE /folders/<id>/                削除 (CASCADE で子 + bookmark)
+- GET    /folders/<id>/bookmarks/      フォルダ内 bookmark 一覧
+- POST   /bookmarks/                   保存 (idempotent)
+- DELETE /bookmarks/<id>/              削除
+- GET    /tweets/<id>/bookmark-status/ どの folder に保存済か
 """
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db.models import Count
+from django.shortcuts import get_object_or_404
+from rest_framework import generics, permissions, status
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.boxes.models import Bookmark, Folder
+from apps.boxes.serializers import (
+    BookmarkCreateInputSerializer,
+    BookmarkSerializer,
+    BookmarkStatusSerializer,
+    FolderCreateInputSerializer,
+    FolderSerializer,
+    FolderUpdateInputSerializer,
+)
+
+
+def _annotated_user_folders(user):
+    """user の folder を bookmark_count / child_count 付きで返す."""
+
+    return (
+        Folder.objects.filter(user=user)
+        .annotate(
+            bookmark_count=Count("bookmarks", distinct=True),
+            child_count=Count("children", distinct=True),
+        )
+        .order_by("parent_id", "sort_order", "id")
+    )
+
+
+class FolderListCreateView(APIView):
+    """``GET/POST /folders/``."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        qs = _annotated_user_folders(request.user)
+        return Response({"results": FolderSerializer(qs, many=True).data})
+
+    def post(self, request: Request) -> Response:
+        serializer = FolderCreateInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        parent = None
+        parent_id = data.get("parent_id")
+        if parent_id is not None:
+            parent = Folder.objects.filter(pk=parent_id, user=request.user).first()
+            if parent is None:
+                raise DRFValidationError({"parent_id": "無効な parent_id"})
+
+        # 同一親で同名禁止 (DB 制約でも reject されるが先に明示)
+        if Folder.objects.filter(user=request.user, parent=parent, name=data["name"]).exists():
+            raise DRFValidationError({"name": "同名フォルダが存在します"})
+
+        folder = Folder(user=request.user, parent=parent, name=data["name"])
+        try:
+            folder.clean()
+        except DjangoValidationError as exc:
+            raise DRFValidationError(detail=exc.message_dict) from exc
+        folder.save()
+
+        # 直作成だと count annotation が無いので 0 で埋める
+        folder.bookmark_count = 0  # type: ignore[attr-defined]
+        folder.child_count = 0  # type: ignore[attr-defined]
+        return Response(FolderSerializer(folder).data, status=status.HTTP_201_CREATED)
+
+
+class FolderDetailView(APIView):
+    """``GET/PATCH/DELETE /folders/<id>/``."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def _get_folder(self, request: Request, pk: int) -> Folder:
+        # annotate 付きで取得 (本人のみ、他人は 404 隠蔽)
+        folder = _annotated_user_folders(request.user).filter(pk=pk).first()
+        if folder is None:
+            raise NotFound("folder not found")
+        return folder
+
+    def get(self, request: Request, pk: int) -> Response:
+        folder = self._get_folder(request, pk)
+        return Response(FolderSerializer(folder).data)
+
+    def patch(self, request: Request, pk: int) -> Response:
+        folder = self._get_folder(request, pk)
+        serializer = FolderUpdateInputSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        if "name" in data:
+            new_name = data["name"]
+            # 同一親で同名禁止 (自分自身を除外)
+            sibling_qs = Folder.objects.filter(
+                user=request.user, parent_id=folder.parent_id, name=new_name
+            ).exclude(pk=folder.pk)
+            if sibling_qs.exists():
+                raise DRFValidationError({"name": "同名フォルダが存在します"})
+            folder.name = new_name
+
+        if "parent_id" in data:
+            new_parent_id = data["parent_id"]
+            if new_parent_id is None:
+                folder.parent = None
+            else:
+                new_parent = Folder.objects.filter(pk=new_parent_id, user=request.user).first()
+                if new_parent is None:
+                    raise DRFValidationError({"parent_id": "無効な parent_id"})
+                folder.parent = new_parent
+
+        try:
+            folder.clean()
+        except DjangoValidationError as exc:
+            raise DRFValidationError(detail=exc.message_dict) from exc
+        folder.save()
+
+        # 再取得して annotation を埋める
+        return Response(FolderSerializer(self._get_folder(request, pk)).data)
+
+    def delete(self, request: Request, pk: int) -> Response:
+        folder = self._get_folder(request, pk)
+        folder.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class FolderBookmarksView(generics.ListAPIView):
+    """``GET /folders/<id>/bookmarks/``."""
+
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = BookmarkSerializer
+
+    def get_queryset(self):
+        pk = self.kwargs["pk"]
+        # 本人の folder か確認 (他人は 404 隠蔽)
+        if not Folder.objects.filter(pk=pk, user=self.request.user).exists():
+            raise NotFound("folder not found")
+        return Bookmark.objects.filter(folder_id=pk).order_by("-created_at")
+
+
+class BookmarkCreateView(APIView):
+    """``POST /bookmarks/`` — idempotent."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        serializer = BookmarkCreateInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        # folder の所有者チェック
+        folder = Folder.objects.filter(pk=data["folder_id"], user=request.user).first()
+        if folder is None:
+            raise DRFValidationError({"folder_id": "無効な folder_id"})
+
+        # tweet 存在チェック
+        from apps.tweets.models import Tweet  # 遅延 import で循環回避
+
+        if not Tweet.objects.filter(pk=data["tweet_id"]).exists():
+            raise DRFValidationError({"tweet_id": "ツイートが見つかりません"})
+
+        bookmark, created = Bookmark.objects.get_or_create(
+            user=request.user,
+            folder=folder,
+            tweet_id=data["tweet_id"],
+        )
+        return Response(
+            BookmarkSerializer(bookmark).data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
+
+
+class BookmarkDestroyView(APIView):
+    """``DELETE /bookmarks/<id>/``."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request: Request, pk: int) -> Response:
+        bookmark = get_object_or_404(Bookmark, pk=pk, user=request.user)
+        bookmark.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class TweetBookmarkStatusView(APIView):
+    """``GET /tweets/<tweet_id>/bookmark-status/``."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request: Request, tweet_id: int) -> Response:
+        folder_ids = list(
+            Bookmark.objects.filter(user=request.user, tweet_id=tweet_id).values_list(
+                "folder_id", flat=True
+            )
+        )
+        return Response(BookmarkStatusSerializer({"folder_ids": folder_ids}).data)

--- a/docs/specs/favorites-spec.md
+++ b/docs/specs/favorites-spec.md
@@ -97,17 +97,17 @@ class Bookmark(models.Model):
 
 ## 4. API 設計
 
-prefix: `/api/v1/`
+prefix: `/api/v1/boxes/` (既存 `apps.boxes` の URL include に乗る、`apps.tweets` の `/tweets/<id>/...` との衝突回避)。
 
 ### 4.1 Folder CRUD
 
-| Method | Path             | 概要                                                         |
-| ------ | ---------------- | ------------------------------------------------------------ |
-| GET    | `/folders/`      | 自分のフォルダ全件をフラットリストで返す (tree は FE で構築) |
-| POST   | `/folders/`      | 新規作成 `{name, parent_id?}`                                |
-| GET    | `/folders/<id>/` | 単一フォルダ取得 (children + bookmark count)                 |
-| PATCH  | `/folders/<id>/` | rename / 親変更 (move) `{name?, parent_id?}`                 |
-| DELETE | `/folders/<id>/` | フォルダ削除 (CASCADE で子フォルダ + 配下 bookmark も削除)   |
+| Method | Path                          | 概要                                                         |
+| ------ | ----------------------------- | ------------------------------------------------------------ |
+| GET    | `/api/v1/boxes/folders/`      | 自分のフォルダ全件をフラットリストで返す (tree は FE で構築) |
+| POST   | `/api/v1/boxes/folders/`      | 新規作成 `{name, parent_id?}`                                |
+| GET    | `/api/v1/boxes/folders/<id>/` | 単一フォルダ取得 (children + bookmark count)                 |
+| PATCH  | `/api/v1/boxes/folders/<id>/` | rename / 親変更 (move) `{name?, parent_id?}`                 |
+| DELETE | `/api/v1/boxes/folders/<id>/` | フォルダ削除 (CASCADE で子フォルダ + 配下 bookmark も削除)   |
 
 レスポンス例 (`GET /folders/`):
 
@@ -141,12 +141,12 @@ prefix: `/api/v1/`
 
 ### 4.2 Bookmark CRUD
 
-| Method | Path                            | 概要                                                          |
-| ------ | ------------------------------- | ------------------------------------------------------------- |
-| GET    | `/folders/<id>/bookmarks/`      | フォルダ内 bookmark 一覧 (新しい順、cursor pagination)        |
-| POST   | `/bookmarks/`                   | 追加 `{tweet_id, folder_id}`                                  |
-| DELETE | `/bookmarks/<id>/`              | 削除                                                          |
-| GET    | `/tweets/<id>/bookmark-status/` | 該当ツイートが自分のどの folder に保存されてるか array で返す |
+| Method | Path                                    | 概要                                                          |
+| ------ | --------------------------------------- | ------------------------------------------------------------- |
+| GET    | `/api/v1/boxes/folders/<id>/bookmarks/` | フォルダ内 bookmark 一覧 (新しい順、cursor pagination)        |
+| POST   | `/api/v1/boxes/bookmarks/`              | 追加 `{tweet_id, folder_id}`                                  |
+| DELETE | `/api/v1/boxes/bookmarks/<id>/`         | 削除                                                          |
+| GET    | `/api/v1/boxes/tweets/<id>/status/`     | 該当ツイートが自分のどの folder に保存されてるか array で返す |
 
 `bookmark-status` は TweetCard の icon 色付け (saved / not saved) のため必要。
 1 query で済む (`Bookmark.objects.filter(user, tweet=tweet_id).values_list('folder_id', flat=True)`)。


### PR DESCRIPTION
## Summary

- `docs/specs/favorites-spec.md` §3-§4 に従って、お気に入り (Google ブックマーク風) の backend を実装
- Folder model: 任意深さの親子 (self-FK) + MAX_FOLDER_DEPTH=10 安全弁 + 同親同名禁止
- Bookmark model: (folder, tweet) 重複禁止だが**異 folder には同 tweet 保存可** (SPEC §9 互換)
- URL prefix: `/api/v1/boxes/` (apps.tweets との衝突回避で tweet status は `boxes/tweets/<id>/status/`)
- 認可: 全 endpoint 認証必須 / 他人の folder・bookmark は **404 隠蔽** (SPEC §9 完全非公開)

## Changes

| File | Purpose |
| ---- | ------- |
| apps/boxes/models.py | Folder + Bookmark + MAX_FOLDER_DEPTH constant + clean() validation |
| apps/boxes/migrations/0001_initial.py | 手書き migration |
| apps/boxes/serializers.py | Folder/Create/Update/Bookmark/Status serializer |
| apps/boxes/views.py | folder CRUD / bookmark CRUD / tweet status |
| apps/boxes/urls.py | `/api/v1/boxes/...` 配下 |
| apps/boxes/tests/test_favorites_api.py | pytest 17 ケース |
| docs/specs/favorites-spec.md | URL prefix を `/api/v1/boxes/` に追記 |

## Test plan

- [x] pytest 17 cases (folder/bookmark/status の auth・owner・dup・depth・cascade・idempotent)
- [ ] CI: ruff / mypy / pytest 緑
- [ ] frontend PR で `/api/v1/boxes/` を叩いて E2E

Refs #499