### PR TITLE
feat(boxes): お気に入り frontend (TL bookmark + profile tab) (Refs #499)

### DIFF
--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import FavoritesTab from "@/components/boxes/FavoritesTab";
 import StartDMButton from "@/components/dm/StartDMButton";
 import FollowButton from "@/components/follows/FollowButton";
 import ProfileKebab from "@/components/moderation/ProfileKebab";
@@ -38,10 +39,12 @@ interface PublicProfile {
 	user_id: string;
 }
 
-type ProfileTab = "tweets" | "likes";
+type ProfileTab = "tweets" | "likes" | "favorites";
 
 function resolveTab(raw: string | undefined): ProfileTab {
-	return raw === "likes" ? "likes" : "tweets";
+	if (raw === "likes") return "likes";
+	if (raw === "favorites") return "favorites";
+	return "tweets";
 }
 
 interface PageProps {
@@ -262,20 +265,47 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 				</Link>
 			</div>
 
-			{/* #421: ポスト / いいね タブ (X 風)。?tab=likes で切替。 */}
+			{/* #421: ポスト / いいね タブ (X 風)。?tab=likes で切替。
+			    #499: 自分のプロフィールのみ「お気に入り」 タブを追加。 */}
 			<nav
 				aria-label="プロフィール タブ"
 				className="mt-6 flex border-b border-border px-4"
 			>
 				{(
-					[
-						{ key: "tweets", label: "ポスト", href: `/u/${profile.username}` },
-						{
-							key: "likes",
-							label: "いいね",
-							href: `/u/${profile.username}?tab=likes`,
-						},
-					] as const
+					(isOwnProfile
+						? [
+								{
+									key: "tweets",
+									label: "ポスト",
+									href: `/u/${profile.username}`,
+								},
+								{
+									key: "likes",
+									label: "いいね",
+									href: `/u/${profile.username}?tab=likes`,
+								},
+								{
+									key: "favorites",
+									label: "お気に入り",
+									href: `/u/${profile.username}?tab=favorites`,
+								},
+							]
+						: [
+								{
+									key: "tweets",
+									label: "ポスト",
+									href: `/u/${profile.username}`,
+								},
+								{
+									key: "likes",
+									label: "いいね",
+									href: `/u/${profile.username}?tab=likes`,
+								},
+							]) as ReadonlyArray<{
+						key: ProfileTab;
+						label: string;
+						href: string;
+					}>
 				).map((t) => (
 					<Link
 						key={t.key}
@@ -300,9 +330,18 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 
 			<section className="mt-4 px-4" aria-labelledby="tweets-heading">
 				<h2 id="tweets-heading" className="sr-only">
-					{tab === "likes" ? "いいねした投稿" : "ツイート"}
+					{tab === "likes"
+						? "いいねした投稿"
+						: tab === "favorites"
+							? "お気に入り"
+							: "ツイート"}
 				</h2>
-				{tab === "likes" ? (
+				{tab === "favorites" && isOwnProfile ? (
+					/* #499: 自分のお気に入り (Google ブックマーク風 folder ツリー)。
+					    他人プロフィールでは tab 自体非表示にしているが、
+					    URL 直叩きで来たケースに備えて isOwnProfile gate を二重化。 */
+					<FavoritesTab currentUserHandle={profile.username} />
+				) : tab === "likes" ? (
 					<TweetCardList
 						tweets={likedTweets}
 						ariaLabel={`@${profile.username} がいいねした投稿`}

--- a/client/src/components/boxes/AddToFolderDialog.tsx
+++ b/client/src/components/boxes/AddToFolderDialog.tsx
@@ -11,7 +11,7 @@
  * - 失敗時は role=alert で通知
  */
 
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 
 import {
 	Dialog,
@@ -26,7 +26,6 @@ import {
 	deleteBookmark,
 	getTweetBookmarkStatus,
 	listFolders,
-	listFolderBookmarks,
 	type Folder,
 } from "@/lib/api/boxes";
 
@@ -103,7 +102,7 @@ export default function AddToFolderDialog({
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [createName, setCreateName] = useState("");
-	const [createParent, setCreateParent] = useState<number | "">("");
+	const [createParent, setCreateParent] = useState<number | null>(null);
 	const [creating, setCreating] = useState(false);
 
 	useEffect(() => {
@@ -119,23 +118,13 @@ export default function AddToFolderDialog({
 				]);
 				if (cancelled) return;
 				const savedIds = new Set(status.folder_ids);
-				// bookmark id を引くため、saved folder についてだけ list を取って tweet に絞る
+				// #503 で backend が bookmark_ids を返すようになった。1 query で
+				// folder_id → bookmark_id を取れるので、旧実装の N+1 list は不要。
 				const bookmarkByFolder = new Map<number, number>();
-				await Promise.all(
-					Array.from(savedIds).map(async (fid) => {
-						try {
-							const bms = await listFolderBookmarks(fid);
-							for (const bm of bms) {
-								if (bm.tweet_id === Number(tweetId)) {
-									bookmarkByFolder.set(fid, bm.id);
-									break;
-								}
-							}
-						} catch {
-							/* 個別 folder の取得失敗は致命的でない */
-						}
-					}),
-				);
+				const fromStatus = status.bookmark_ids ?? {};
+				for (const [fidStr, bmId] of Object.entries(fromStatus)) {
+					bookmarkByFolder.set(Number(fidStr), bmId);
+				}
 				const ordered = buildOrderedRows(folders);
 				setRows(
 					ordered.map(({ folder, depth }) => ({
@@ -160,15 +149,24 @@ export default function AddToFolderDialog({
 		};
 	}, [open, tweetId, onStatusChanged]);
 
-	const savedFolderIds = useMemo(
-		() => rows.filter((r) => r.isSaved).map((r) => r.folder.id),
-		[rows],
-	);
-
 	const setRowBusy = (folderId: number, busy: boolean) => {
 		setRows((prev) =>
 			prev.map((r) => (r.folder.id === folderId ? { ...r, isBusy: busy } : r)),
 		);
+	};
+
+	// #502 review H2: stale closure を避けるため、`next` は setRows の prev
+	// から導出し、その結果を onStatusChanged へ渡す。
+	const applyToggle = (
+		folderId: number,
+		updater: (row: FolderRowState) => FolderRowState,
+	) => {
+		setRows((prev) => {
+			const next = prev.map((r) => (r.folder.id === folderId ? updater(r) : r));
+			const folderIds = next.filter((r) => r.isSaved).map((r) => r.folder.id);
+			onStatusChanged?.(folderIds);
+			return next;
+		});
 	};
 
 	const handleToggle = async (row: FolderRowState) => {
@@ -177,48 +175,31 @@ export default function AddToFolderDialog({
 		try {
 			if (row.isSaved && row.bookmarkId !== null) {
 				await deleteBookmark(row.bookmarkId);
-				setRows((prev) =>
-					prev.map((r) =>
-						r.folder.id === row.folder.id
-							? {
-									...r,
-									isSaved: false,
-									bookmarkId: null,
-									isBusy: false,
-									folder: {
-										...r.folder,
-										bookmark_count: Math.max(0, r.folder.bookmark_count - 1),
-									},
-								}
-							: r,
-					),
-				);
-				const next = savedFolderIds.filter((id) => id !== row.folder.id);
-				onStatusChanged?.(next);
+				applyToggle(row.folder.id, (r) => ({
+					...r,
+					isSaved: false,
+					bookmarkId: null,
+					isBusy: false,
+					folder: {
+						...r.folder,
+						bookmark_count: Math.max(0, r.folder.bookmark_count - 1),
+					},
+				}));
 			} else {
 				const result = await createBookmark({
 					folder_id: row.folder.id,
 					tweet_id: Number(tweetId),
 				});
-				setRows((prev) =>
-					prev.map((r) =>
-						r.folder.id === row.folder.id
-							? {
-									...r,
-									isSaved: true,
-									bookmarkId: result.bookmark.id,
-									isBusy: false,
-									folder: {
-										...r.folder,
-										bookmark_count:
-											r.folder.bookmark_count + (result.created ? 1 : 0),
-									},
-								}
-							: r,
-					),
-				);
-				const next = Array.from(new Set([...savedFolderIds, row.folder.id]));
-				onStatusChanged?.(next);
+				applyToggle(row.folder.id, (r) => ({
+					...r,
+					isSaved: true,
+					bookmarkId: result.bookmark.id,
+					isBusy: false,
+					folder: {
+						...r.folder,
+						bookmark_count: r.folder.bookmark_count + (result.created ? 1 : 0),
+					},
+				}));
 			}
 		} catch (err) {
 			setError(describeApiError(err, "保存状態の更新に失敗しました"));
@@ -242,7 +223,7 @@ export default function AddToFolderDialog({
 		try {
 			const folder = await createFolder({
 				name,
-				parent_id: createParent === "" ? null : createParent,
+				parent_id: createParent,
 			});
 			setRows((prev) => {
 				const merged = [...prev.map((r) => r.folder), folder];
@@ -250,10 +231,14 @@ export default function AddToFolderDialog({
 				const savedSet = new Set(
 					prev.filter((r) => r.isSaved).map((r) => r.folder.id),
 				);
-				const bmById = new Map(
+				// type guard で `bookmarkId: number | null` から null を除外
+				const bmById = new Map<number, number>(
 					prev
-						.filter((r) => r.bookmarkId !== null)
-						.map((r) => [r.folder.id, r.bookmarkId!]),
+						.filter(
+							(r): r is FolderRowState & { bookmarkId: number } =>
+								r.bookmarkId !== null,
+						)
+						.map((r) => [r.folder.id, r.bookmarkId]),
 				);
 				return ordered.map(({ folder: f, depth }) => ({
 					folder: f,
@@ -264,7 +249,7 @@ export default function AddToFolderDialog({
 				}));
 			});
 			setCreateName("");
-			setCreateParent("");
+			setCreateParent(null);
 		} catch (err) {
 			setError(describeApiError(err, "フォルダの作成に失敗しました"));
 		} finally {
@@ -308,8 +293,9 @@ export default function AddToFolderDialog({
 							{rows.map((row) => (
 								<li key={row.folder.id}>
 									<label
-										className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-muted/40"
+										className="flex cursor-pointer items-center gap-2 pr-3 py-2 hover:bg-muted/40"
 										style={{ paddingLeft: `${0.75 + row.depth * 1}rem` }}
+										aria-label={`${row.folder.name} (ブックマーク ${row.folder.bookmark_count} 件)`}
 									>
 										<input
 											type="checkbox"
@@ -344,10 +330,10 @@ export default function AddToFolderDialog({
 					<label className="block text-sm">
 						親フォルダ (任意)
 						<select
-							value={createParent}
+							value={createParent ?? ""}
 							onChange={(e) =>
 								setCreateParent(
-									e.target.value === "" ? "" : Number(e.target.value),
+									e.target.value === "" ? null : Number(e.target.value),
 								)
 							}
 							className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-sm"

--- a/client/src/components/boxes/AddToFolderDialog.tsx
+++ b/client/src/components/boxes/AddToFolderDialog.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+/**
+ * AddToFolderDialog (#499) — TweetCard の bookmark icon を押したとき開く Dialog.
+ *
+ * docs/specs/favorites-spec.md §5.3 に従う Google ブックマーク Quick Add 風 UX。
+ *
+ * - 自分の folder 一覧をフラットで表示 (parent でインデント)
+ * - 既に保存済の folder は checkbox 状態で表示、クリックで toggle (POST/DELETE)
+ * - 新規 folder 作成: name 入力 → POST /folders/ → 即時 list に追加
+ * - 失敗時は role=alert で通知
+ */
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	createBookmark,
+	createFolder,
+	deleteBookmark,
+	getTweetBookmarkStatus,
+	listFolders,
+	listFolderBookmarks,
+	type Folder,
+} from "@/lib/api/boxes";
+
+interface AddToFolderDialogProps {
+	tweetId: number | string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** 保存状態が変わった (folder_ids 配列) ことを親に通知。bookmark icon 切替に使う。 */
+	onStatusChanged?: (folderIds: number[]) => void;
+}
+
+interface FolderRowState {
+	folder: Folder;
+	depth: number;
+	isSaved: boolean;
+	bookmarkId: number | null;
+	isBusy: boolean;
+}
+
+function buildOrderedRows(folders: Folder[]): Array<{
+	folder: Folder;
+	depth: number;
+}> {
+	// parent_id でグルーピングして DFS で flatten。深さでインデント。
+	const byParent = new Map<number | null, Folder[]>();
+	for (const f of folders) {
+		const key = f.parent_id ?? null;
+		const list = byParent.get(key);
+		if (list) list.push(f);
+		else byParent.set(key, [f]);
+	}
+	for (const list of Array.from(byParent.values())) {
+		list.sort((a: Folder, b: Folder) => a.name.localeCompare(b.name, "ja"));
+	}
+	const rows: Array<{ folder: Folder; depth: number }> = [];
+	const visit = (parentId: number | null, depth: number) => {
+		for (const f of byParent.get(parentId) ?? []) {
+			rows.push({ folder: f, depth });
+			visit(f.id, depth + 1);
+		}
+	};
+	visit(null, 0);
+	return rows;
+}
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { data?: Record<string, unknown> };
+			message?: string;
+		};
+		const data = e.response?.data;
+		if (data && typeof data === "object") {
+			const detail = (data as { detail?: string }).detail;
+			if (typeof detail === "string") return detail;
+			const firstField = Object.values(data)[0];
+			if (Array.isArray(firstField) && typeof firstField[0] === "string") {
+				return firstField[0];
+			}
+			if (typeof firstField === "string") return firstField;
+		}
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function AddToFolderDialog({
+	tweetId,
+	open,
+	onOpenChange,
+	onStatusChanged,
+}: AddToFolderDialogProps) {
+	const [rows, setRows] = useState<FolderRowState[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [createName, setCreateName] = useState("");
+	const [createParent, setCreateParent] = useState<number | "">("");
+	const [creating, setCreating] = useState(false);
+
+	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+		(async () => {
+			try {
+				const [folders, status] = await Promise.all([
+					listFolders(),
+					getTweetBookmarkStatus(tweetId),
+				]);
+				if (cancelled) return;
+				const savedIds = new Set(status.folder_ids);
+				// bookmark id を引くため、saved folder についてだけ list を取って tweet に絞る
+				const bookmarkByFolder = new Map<number, number>();
+				await Promise.all(
+					Array.from(savedIds).map(async (fid) => {
+						try {
+							const bms = await listFolderBookmarks(fid);
+							for (const bm of bms) {
+								if (bm.tweet_id === Number(tweetId)) {
+									bookmarkByFolder.set(fid, bm.id);
+									break;
+								}
+							}
+						} catch {
+							/* 個別 folder の取得失敗は致命的でない */
+						}
+					}),
+				);
+				const ordered = buildOrderedRows(folders);
+				setRows(
+					ordered.map(({ folder, depth }) => ({
+						folder,
+						depth,
+						isSaved: savedIds.has(folder.id),
+						bookmarkId: bookmarkByFolder.get(folder.id) ?? null,
+						isBusy: false,
+					})),
+				);
+				onStatusChanged?.(Array.from(savedIds));
+			} catch (err) {
+				if (!cancelled) {
+					setError(describeApiError(err, "フォルダ一覧の取得に失敗しました"));
+				}
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [open, tweetId, onStatusChanged]);
+
+	const savedFolderIds = useMemo(
+		() => rows.filter((r) => r.isSaved).map((r) => r.folder.id),
+		[rows],
+	);
+
+	const setRowBusy = (folderId: number, busy: boolean) => {
+		setRows((prev) =>
+			prev.map((r) => (r.folder.id === folderId ? { ...r, isBusy: busy } : r)),
+		);
+	};
+
+	const handleToggle = async (row: FolderRowState) => {
+		setError(null);
+		setRowBusy(row.folder.id, true);
+		try {
+			if (row.isSaved && row.bookmarkId !== null) {
+				await deleteBookmark(row.bookmarkId);
+				setRows((prev) =>
+					prev.map((r) =>
+						r.folder.id === row.folder.id
+							? {
+									...r,
+									isSaved: false,
+									bookmarkId: null,
+									isBusy: false,
+									folder: {
+										...r.folder,
+										bookmark_count: Math.max(0, r.folder.bookmark_count - 1),
+									},
+								}
+							: r,
+					),
+				);
+				const next = savedFolderIds.filter((id) => id !== row.folder.id);
+				onStatusChanged?.(next);
+			} else {
+				const result = await createBookmark({
+					folder_id: row.folder.id,
+					tweet_id: Number(tweetId),
+				});
+				setRows((prev) =>
+					prev.map((r) =>
+						r.folder.id === row.folder.id
+							? {
+									...r,
+									isSaved: true,
+									bookmarkId: result.bookmark.id,
+									isBusy: false,
+									folder: {
+										...r.folder,
+										bookmark_count:
+											r.folder.bookmark_count + (result.created ? 1 : 0),
+									},
+								}
+							: r,
+					),
+				);
+				const next = Array.from(new Set([...savedFolderIds, row.folder.id]));
+				onStatusChanged?.(next);
+			}
+		} catch (err) {
+			setError(describeApiError(err, "保存状態の更新に失敗しました"));
+			setRowBusy(row.folder.id, false);
+		}
+	};
+
+	const handleCreate = async (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const name = createName.trim();
+		if (!name) {
+			setError("フォルダ名を入力してください");
+			return;
+		}
+		if (name.length > 50) {
+			setError("フォルダ名は 50 文字以内にしてください");
+			return;
+		}
+		setError(null);
+		setCreating(true);
+		try {
+			const folder = await createFolder({
+				name,
+				parent_id: createParent === "" ? null : createParent,
+			});
+			setRows((prev) => {
+				const merged = [...prev.map((r) => r.folder), folder];
+				const ordered = buildOrderedRows(merged);
+				const savedSet = new Set(
+					prev.filter((r) => r.isSaved).map((r) => r.folder.id),
+				);
+				const bmById = new Map(
+					prev
+						.filter((r) => r.bookmarkId !== null)
+						.map((r) => [r.folder.id, r.bookmarkId!]),
+				);
+				return ordered.map(({ folder: f, depth }) => ({
+					folder: f,
+					depth,
+					isSaved: savedSet.has(f.id),
+					bookmarkId: bmById.get(f.id) ?? null,
+					isBusy: false,
+				}));
+			});
+			setCreateName("");
+			setCreateParent("");
+		} catch (err) {
+			setError(describeApiError(err, "フォルダの作成に失敗しました"));
+		} finally {
+			setCreating(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>お気に入りに追加</DialogTitle>
+					<DialogDescription>
+						保存先のフォルダを選択するか、新規フォルダを作成してください。
+					</DialogDescription>
+				</DialogHeader>
+
+				{error && (
+					<p
+						role="alert"
+						className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+					>
+						{error}
+					</p>
+				)}
+
+				<div className="max-h-72 overflow-y-auto rounded border border-border">
+					{loading ? (
+						<p className="px-3 py-4 text-sm text-muted-foreground">
+							読み込み中…
+						</p>
+					) : rows.length === 0 ? (
+						<p className="px-3 py-4 text-sm text-muted-foreground">
+							まだフォルダがありません。下から作成してください。
+						</p>
+					) : (
+						<ul
+							aria-label="お気に入りフォルダ"
+							className="divide-y divide-border"
+						>
+							{rows.map((row) => (
+								<li key={row.folder.id}>
+									<label
+										className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-muted/40"
+										style={{ paddingLeft: `${0.75 + row.depth * 1}rem` }}
+									>
+										<input
+											type="checkbox"
+											checked={row.isSaved}
+											disabled={row.isBusy}
+											onChange={() => handleToggle(row)}
+											className="size-4"
+										/>
+										<span className="flex-1 text-sm">{row.folder.name}</span>
+										<span aria-hidden className="text-xs text-muted-foreground">
+											{row.folder.bookmark_count}
+										</span>
+									</label>
+								</li>
+							))}
+						</ul>
+					)}
+				</div>
+
+				<form onSubmit={handleCreate} className="mt-3 space-y-2">
+					<label className="block text-sm font-medium">
+						新規フォルダ
+						<input
+							type="text"
+							value={createName}
+							onChange={(e) => setCreateName(e.target.value)}
+							maxLength={50}
+							placeholder="例: 技術 / 後で読む"
+							className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						/>
+					</label>
+					<label className="block text-sm">
+						親フォルダ (任意)
+						<select
+							value={createParent}
+							onChange={(e) =>
+								setCreateParent(
+									e.target.value === "" ? "" : Number(e.target.value),
+								)
+							}
+							className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-sm"
+						>
+							<option value="">ルート</option>
+							{rows.map((row) => (
+								<option key={row.folder.id} value={row.folder.id}>
+									{`${"  ".repeat(row.depth)}${row.folder.name}`}
+								</option>
+							))}
+						</select>
+					</label>
+					<button
+						type="submit"
+						disabled={creating || !createName.trim()}
+						className="w-full rounded bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+					>
+						{creating ? "作成中…" : "+ フォルダを作成"}
+					</button>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/client/src/components/boxes/BookmarkButton.tsx
+++ b/client/src/components/boxes/BookmarkButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * BookmarkButton (#499) — TweetCard footer から AddToFolderDialog を開くトリガ.
+ *
+ * - 未保存: 線アイコン (Bookmark)
+ * - 保存済 (1+ folder): 塗りアイコン (BookmarkCheck) + baby_blue 着色
+ * - click で AddToFolderDialog を open
+ * - 初期状態は親が server fetch で渡す (TweetSummary.bookmark_folder_ids など、
+ *   未供給なら未保存として描画し、Dialog open 時に同期される)。
+ */
+
+import { useState } from "react";
+import { Bookmark, BookmarkCheck } from "lucide-react";
+
+import AddToFolderDialog from "@/components/boxes/AddToFolderDialog";
+
+interface BookmarkButtonProps {
+	tweetId: number | string;
+	initialFolderIds?: number[];
+}
+
+export default function BookmarkButton({
+	tweetId,
+	initialFolderIds = [],
+}: BookmarkButtonProps) {
+	const [open, setOpen] = useState(false);
+	const [folderIds, setFolderIds] = useState<number[]>(initialFolderIds);
+	const isSaved = folderIds.length > 0;
+
+	return (
+		<>
+			<button
+				type="button"
+				aria-label={
+					isSaved ? "お気に入り済み (フォルダを編集)" : "お気に入りに追加"
+				}
+				aria-pressed={isSaved}
+				onClick={() => setOpen(true)}
+				className="flex items-center gap-1 min-h-[32px] px-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+			>
+				{isSaved ? (
+					<BookmarkCheck className="size-4 text-baby_blue" aria-hidden="true" />
+				) : (
+					<Bookmark className="size-4" aria-hidden="true" />
+				)}
+				<span className="sr-only sm:not-sr-only">お気に入り</span>
+			</button>
+			<AddToFolderDialog
+				tweetId={tweetId}
+				open={open}
+				onOpenChange={setOpen}
+				onStatusChanged={setFolderIds}
+			/>
+		</>
+	);
+}

--- a/client/src/components/boxes/FavoritesTab.tsx
+++ b/client/src/components/boxes/FavoritesTab.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+/**
+ * FavoritesTab (#499) — プロフィールの「お気に入り」 タブ本体.
+ *
+ * docs/specs/favorites-spec.md §5.1 に従う Google ブックマーク マネージャ風 UI.
+ * - 左ペイン: フォルダツリー (parent_id でツリー構築、深さインデント)
+ * - 右ペイン: 選択中フォルダ配下の Bookmark を TweetCard 風に列挙
+ * - 自分のプロフィールのみ表示 (本 component は呼ぶ側で gate される)
+ *
+ * MVP: 一覧 + 保存済 tweet の表示まで。folder rename / delete / 並び替えは
+ * AddToFolderDialog (作成) と TweetCard (削除) で十分賄えるため後続で対応。
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import TweetCardList from "@/components/timeline/TweetCardList";
+import { listFolderBookmarks, listFolders, type Folder } from "@/lib/api/boxes";
+import { fetchTweet, type TweetSummary } from "@/lib/api/tweets";
+
+interface FavoritesTabProps {
+	currentUserHandle: string;
+}
+
+interface FolderRow {
+	folder: Folder;
+	depth: number;
+}
+
+function buildOrderedRows(folders: Folder[]): FolderRow[] {
+	const byParent = new Map<number | null, Folder[]>();
+	for (const f of folders) {
+		const key = f.parent_id ?? null;
+		const list = byParent.get(key);
+		if (list) list.push(f);
+		else byParent.set(key, [f]);
+	}
+	for (const list of Array.from(byParent.values())) {
+		list.sort((a: Folder, b: Folder) => a.name.localeCompare(b.name, "ja"));
+	}
+	const rows: FolderRow[] = [];
+	const visit = (parentId: number | null, depth: number) => {
+		for (const f of byParent.get(parentId) ?? []) {
+			rows.push({ folder: f, depth });
+			visit(f.id, depth + 1);
+		}
+	};
+	visit(null, 0);
+	return rows;
+}
+
+export default function FavoritesTab({ currentUserHandle }: FavoritesTabProps) {
+	const [folders, setFolders] = useState<Folder[] | null>(null);
+	const [folderError, setFolderError] = useState<string | null>(null);
+	const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
+	const [tweets, setTweets] = useState<TweetSummary[] | null>(null);
+	const [tweetsLoading, setTweetsLoading] = useState(false);
+	const [tweetsError, setTweetsError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const list = await listFolders();
+				if (cancelled) return;
+				setFolders(list);
+				if (list.length > 0 && selectedFolderId === null) {
+					// ルート (parent_id=null) を優先、無ければ先頭
+					const root = list.find((f) => f.parent_id === null) ?? list[0];
+					setSelectedFolderId(root.id);
+				}
+			} catch (err) {
+				if (!cancelled) {
+					setFolderError(
+						err instanceof Error
+							? err.message
+							: "フォルダ一覧の取得に失敗しました",
+					);
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+		// 初回のみ folder 取得 — 以降は AddToFolderDialog 等から再取得不要 (MVP)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
+		if (selectedFolderId === null) return;
+		let cancelled = false;
+		setTweets(null);
+		setTweetsLoading(true);
+		setTweetsError(null);
+		(async () => {
+			try {
+				const bookmarks = await listFolderBookmarks(selectedFolderId);
+				const summaries = await Promise.all(
+					bookmarks.map((bm) => fetchTweet(bm.tweet_id).catch(() => null)),
+				);
+				if (cancelled) return;
+				setTweets(summaries.filter((t): t is TweetSummary => t !== null));
+			} catch (err) {
+				if (!cancelled) {
+					setTweetsError(
+						err instanceof Error
+							? err.message
+							: "保存ツイートの取得に失敗しました",
+					);
+				}
+			} finally {
+				if (!cancelled) setTweetsLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [selectedFolderId]);
+
+	const rows = useMemo(
+		() => (folders ? buildOrderedRows(folders) : []),
+		[folders],
+	);
+
+	if (folderError) {
+		return (
+			<p
+				role="alert"
+				className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+			>
+				{folderError}
+			</p>
+		);
+	}
+
+	if (folders === null) {
+		return (
+			<p className="px-2 py-6 text-sm text-muted-foreground">読み込み中…</p>
+		);
+	}
+
+	if (folders.length === 0) {
+		return (
+			<p className="px-2 py-6 text-sm text-muted-foreground">
+				まだフォルダがありません。タイムラインの 🔖
+				アイコンから保存すると、ここに表示されます。
+			</p>
+		);
+	}
+
+	return (
+		<div className="grid gap-4 sm:grid-cols-[14rem_1fr]">
+			<aside
+				aria-label="お気に入りフォルダ"
+				className="rounded border border-border"
+			>
+				<ul className="divide-y divide-border">
+					{rows.map(({ folder, depth }) => {
+						const isActive = folder.id === selectedFolderId;
+						return (
+							<li key={folder.id}>
+								<button
+									type="button"
+									onClick={() => setSelectedFolderId(folder.id)}
+									aria-current={isActive ? "true" : undefined}
+									className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${
+										isActive
+											? "bg-primary/10 text-foreground"
+											: "hover:bg-muted/40 text-muted-foreground"
+									}`}
+									style={{ paddingLeft: `${0.75 + depth * 1}rem` }}
+								>
+									<span className="truncate">📁 {folder.name}</span>
+									<span aria-hidden className="text-xs">
+										{folder.bookmark_count}
+									</span>
+								</button>
+							</li>
+						);
+					})}
+				</ul>
+			</aside>
+
+			<section aria-label="保存ツイート">
+				{tweetsError && (
+					<p
+						role="alert"
+						className="mb-3 rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+					>
+						{tweetsError}
+					</p>
+				)}
+				{tweetsLoading ? (
+					<p className="px-2 py-6 text-sm text-muted-foreground">読み込み中…</p>
+				) : (
+					<TweetCardList
+						tweets={tweets ?? []}
+						ariaLabel="保存ツイート"
+						emptyMessage="このフォルダにはまだ保存されていません。"
+						currentUserHandle={currentUserHandle}
+					/>
+				)}
+			</section>
+		</div>
+	);
+}

--- a/client/src/components/boxes/FavoritesTab.tsx
+++ b/client/src/components/boxes/FavoritesTab.tsx
@@ -64,11 +64,12 @@ export default function FavoritesTab({ currentUserHandle }: FavoritesTabProps) {
 				const list = await listFolders();
 				if (cancelled) return;
 				setFolders(list);
-				if (list.length > 0 && selectedFolderId === null) {
-					// ルート (parent_id=null) を優先、無ければ先頭
-					const root = list.find((f) => f.parent_id === null) ?? list[0];
-					setSelectedFolderId(root.id);
-				}
+				// 初期選択は functional updater で導出する。`selectedFolderId` を
+				// dep に入れずに済むので exhaustive-deps の disable も不要。
+				setSelectedFolderId((prev) => {
+					if (prev !== null || list.length === 0) return prev;
+					return (list.find((f) => f.parent_id === null) ?? list[0]).id;
+				});
 			} catch (err) {
 				if (!cancelled) {
 					setFolderError(
@@ -82,8 +83,6 @@ export default function FavoritesTab({ currentUserHandle }: FavoritesTabProps) {
 		return () => {
 			cancelled = true;
 		};
-		// 初回のみ folder 取得 — 以降は AddToFolderDialog 等から再取得不要 (MVP)
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
@@ -162,8 +161,9 @@ export default function FavoritesTab({ currentUserHandle }: FavoritesTabProps) {
 								<button
 									type="button"
 									onClick={() => setSelectedFolderId(folder.id)}
-									aria-current={isActive ? "true" : undefined}
-									className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${
+									aria-current={isActive || undefined}
+									aria-label={`${folder.name} (ブックマーク ${folder.bookmark_count} 件)`}
+									className={`flex w-full items-center justify-between pr-3 py-2 text-left text-sm transition-colors ${
 										isActive
 											? "bg-primary/10 text-foreground"
 											: "hover:bg-muted/40 text-muted-foreground"

--- a/client/src/components/boxes/__tests__/AddToFolderDialog.test.tsx
+++ b/client/src/components/boxes/__tests__/AddToFolderDialog.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Tests for AddToFolderDialog (#499).
+ *
+ * docs/specs/favorites-spec.md §5.3 を満たす:
+ * - 自分の folder 一覧をフラット表示 (parent でインデント)
+ * - 既保存 folder の checkbox は ON
+ * - toggle で createBookmark / deleteBookmark を呼ぶ
+ * - 新規 folder 作成は createFolder を呼んで一覧へ即時反映
+ */
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AddToFolderDialog from "@/components/boxes/AddToFolderDialog";
+import * as boxesApi from "@/lib/api/boxes";
+
+vi.mock("@/lib/api/boxes", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/boxes")>("@/lib/api/boxes");
+	return {
+		...actual,
+		listFolders: vi.fn(),
+		listFolderBookmarks: vi.fn(),
+		getTweetBookmarkStatus: vi.fn(),
+		createBookmark: vi.fn(),
+		deleteBookmark: vi.fn(),
+		createFolder: vi.fn(),
+	};
+});
+
+const NOW = "2026-05-10T00:00:00Z";
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("AddToFolderDialog", () => {
+	it("一覧を取得して、保存済 folder には checkbox ON で表示する", async () => {
+		vi.mocked(boxesApi.listFolders).mockResolvedValue([
+			{
+				id: 1,
+				name: "技術",
+				parent_id: null,
+				bookmark_count: 2,
+				child_count: 1,
+				created_at: NOW,
+				updated_at: NOW,
+			},
+			{
+				id: 2,
+				name: "Django",
+				parent_id: 1,
+				bookmark_count: 1,
+				child_count: 0,
+				created_at: NOW,
+				updated_at: NOW,
+			},
+		]);
+		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
+			folder_ids: [2],
+		});
+		vi.mocked(boxesApi.listFolderBookmarks).mockResolvedValue([
+			{ id: 99, tweet_id: 42, folder_id: 2, created_at: NOW },
+		]);
+
+		render(
+			<AddToFolderDialog tweetId={42} open onOpenChange={() => undefined} />,
+		);
+
+		const list = await screen.findByRole("list", {
+			name: "お気に入りフォルダ",
+		});
+		const checkboxes = within(list).getAllByRole("checkbox");
+		expect(checkboxes).toHaveLength(2);
+		const djangoRow = within(list).getByText("Django").closest("label");
+		expect(djangoRow).not.toBeNull();
+		expect(within(djangoRow!).getByRole("checkbox")).toBeChecked();
+		const techRow = within(list).getByText("技術").closest("label");
+		expect(within(techRow!).getByRole("checkbox")).not.toBeChecked();
+	});
+
+	it("未保存 folder の checkbox を ON にすると createBookmark が呼ばれる", async () => {
+		vi.mocked(boxesApi.listFolders).mockResolvedValue([
+			{
+				id: 1,
+				name: "技術",
+				parent_id: null,
+				bookmark_count: 0,
+				child_count: 0,
+				created_at: NOW,
+				updated_at: NOW,
+			},
+		]);
+		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
+			folder_ids: [],
+		});
+		vi.mocked(boxesApi.createBookmark).mockResolvedValue({
+			bookmark: { id: 11, tweet_id: 42, folder_id: 1, created_at: NOW },
+			created: true,
+		});
+
+		const onStatus = vi.fn();
+		render(
+			<AddToFolderDialog
+				tweetId={42}
+				open
+				onOpenChange={() => undefined}
+				onStatusChanged={onStatus}
+			/>,
+		);
+
+		const checkbox = await screen.findByRole("checkbox");
+		await userEvent.click(checkbox);
+
+		await waitFor(() =>
+			expect(boxesApi.createBookmark).toHaveBeenCalledWith({
+				folder_id: 1,
+				tweet_id: 42,
+			}),
+		);
+		await waitFor(() => expect(onStatus).toHaveBeenLastCalledWith([1]));
+	});
+
+	it("保存済 folder の checkbox を OFF にすると deleteBookmark が呼ばれる", async () => {
+		vi.mocked(boxesApi.listFolders).mockResolvedValue([
+			{
+				id: 1,
+				name: "技術",
+				parent_id: null,
+				bookmark_count: 1,
+				child_count: 0,
+				created_at: NOW,
+				updated_at: NOW,
+			},
+		]);
+		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
+			folder_ids: [1],
+		});
+		vi.mocked(boxesApi.listFolderBookmarks).mockResolvedValue([
+			{ id: 99, tweet_id: 42, folder_id: 1, created_at: NOW },
+		]);
+		vi.mocked(boxesApi.deleteBookmark).mockResolvedValue();
+
+		render(
+			<AddToFolderDialog tweetId={42} open onOpenChange={() => undefined} />,
+		);
+
+		const checkbox = await screen.findByRole("checkbox");
+		await waitFor(() => expect(checkbox).toBeChecked());
+		await userEvent.click(checkbox);
+
+		await waitFor(() =>
+			expect(boxesApi.deleteBookmark).toHaveBeenCalledWith(99),
+		);
+	});
+
+	it("空名で submit するとエラー表示 (API 呼ばない)", async () => {
+		vi.mocked(boxesApi.listFolders).mockResolvedValue([]);
+		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
+			folder_ids: [],
+		});
+
+		render(
+			<AddToFolderDialog tweetId={42} open onOpenChange={() => undefined} />,
+		);
+
+		await screen.findByText(/まだフォルダがありません/);
+		const submit = screen.getByRole("button", {
+			name: /\+ フォルダを作成/,
+		});
+		// disabled が外れるのを待たず、空のままでは disabled
+		expect(submit).toBeDisabled();
+		expect(boxesApi.createFolder).not.toHaveBeenCalled();
+	});
+
+	it("新規フォルダ作成成功時に list へ追加される", async () => {
+		vi.mocked(boxesApi.listFolders).mockResolvedValue([]);
+		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
+			folder_ids: [],
+		});
+		vi.mocked(boxesApi.createFolder).mockResolvedValue({
+			id: 5,
+			name: "新規",
+			parent_id: null,
+			bookmark_count: 0,
+			child_count: 0,
+			created_at: NOW,
+			updated_at: NOW,
+		});
+
+		render(
+			<AddToFolderDialog tweetId={42} open onOpenChange={() => undefined} />,
+		);
+
+		await screen.findByText(/まだフォルダがありません/);
+		await userEvent.type(screen.getByPlaceholderText(/例:/), "新規");
+		await userEvent.click(
+			screen.getByRole("button", { name: /\+ フォルダを作成/ }),
+		);
+
+		await waitFor(() =>
+			expect(boxesApi.createFolder).toHaveBeenCalledWith({
+				name: "新規",
+				parent_id: null,
+			}),
+		);
+		const list = await screen.findByRole("list", {
+			name: "お気に入りフォルダ",
+		});
+		expect(within(list).getByText("新規")).toBeInTheDocument();
+	});
+});

--- a/client/src/components/boxes/__tests__/AddToFolderDialog.test.tsx
+++ b/client/src/components/boxes/__tests__/AddToFolderDialog.test.tsx
@@ -21,7 +21,6 @@ vi.mock("@/lib/api/boxes", async () => {
 	return {
 		...actual,
 		listFolders: vi.fn(),
-		listFolderBookmarks: vi.fn(),
 		getTweetBookmarkStatus: vi.fn(),
 		createBookmark: vi.fn(),
 		deleteBookmark: vi.fn(),
@@ -57,12 +56,11 @@ describe("AddToFolderDialog", () => {
 				updated_at: NOW,
 			},
 		]);
+		// #503 status endpoint で folder_id → bookmark_id の dict を 1 query で取得。
 		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
 			folder_ids: [2],
+			bookmark_ids: { "2": 99 },
 		});
-		vi.mocked(boxesApi.listFolderBookmarks).mockResolvedValue([
-			{ id: 99, tweet_id: 42, folder_id: 2, created_at: NOW },
-		]);
 
 		render(
 			<AddToFolderDialog tweetId={42} open onOpenChange={() => undefined} />,
@@ -94,6 +92,7 @@ describe("AddToFolderDialog", () => {
 		]);
 		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
 			folder_ids: [],
+			bookmark_ids: {},
 		});
 		vi.mocked(boxesApi.createBookmark).mockResolvedValue({
 			bookmark: { id: 11, tweet_id: 42, folder_id: 1, created_at: NOW },
@@ -136,10 +135,8 @@ describe("AddToFolderDialog", () => {
 		]);
 		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
 			folder_ids: [1],
+			bookmark_ids: { "1": 99 },
 		});
-		vi.mocked(boxesApi.listFolderBookmarks).mockResolvedValue([
-			{ id: 99, tweet_id: 42, folder_id: 1, created_at: NOW },
-		]);
 		vi.mocked(boxesApi.deleteBookmark).mockResolvedValue();
 
 		render(
@@ -159,6 +156,7 @@ describe("AddToFolderDialog", () => {
 		vi.mocked(boxesApi.listFolders).mockResolvedValue([]);
 		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
 			folder_ids: [],
+			bookmark_ids: {},
 		});
 
 		render(
@@ -178,6 +176,7 @@ describe("AddToFolderDialog", () => {
 		vi.mocked(boxesApi.listFolders).mockResolvedValue([]);
 		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
 			folder_ids: [],
+			bookmark_ids: {},
 		});
 		vi.mocked(boxesApi.createFolder).mockResolvedValue({
 			id: 5,

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -14,6 +14,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import DOMPurify from "isomorphic-dompurify";
 import { Flag, MoreHorizontal, Trash2 } from "lucide-react";
 import { toast } from "react-toastify";
+import BookmarkButton from "@/components/boxes/BookmarkButton";
 import ReactionBar from "@/components/reactions/ReactionBar";
 import ReactionSummary from "@/components/reactions/ReactionSummary";
 import ExpandableBody from "@/components/timeline/ExpandableBody";
@@ -601,6 +602,19 @@ export default function TweetCard({
 					tweetId={displayTweet.id}
 					initial={displayTweet.reaction_summary}
 					onChange={setReactionAggregate}
+				/>
+
+				{/* #499: お気に入り (Google ブックマーク風 folder 階層) を開く.
+				    displayTweet が TweetMini (repost 参照先) のときは
+				    bookmark_folder_ids を持たないので空配列で初期化、Dialog open 時に
+				    `/boxes/tweets/<id>/status/` から正しい状態を取得する。 */}
+				<BookmarkButton
+					tweetId={displayTweet.id}
+					initialFolderIds={
+						"bookmark_folder_ids" in displayTweet
+							? (displayTweet.bookmark_folder_ids ?? [])
+							: []
+					}
 				/>
 			</footer>
 

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -605,16 +605,12 @@ export default function TweetCard({
 				/>
 
 				{/* #499: お気に入り (Google ブックマーク風 folder 階層) を開く.
-				    displayTweet が TweetMini (repost 参照先) のときは
-				    bookmark_folder_ids を持たないので空配列で初期化、Dialog open 時に
+				    isRepost のとき displayTweet は TweetMini (bookmark_folder_ids
+				    を持たない) ので空配列で初期化し、Dialog open 時に
 				    `/boxes/tweets/<id>/status/` から正しい状態を取得する。 */}
 				<BookmarkButton
 					tweetId={displayTweet.id}
-					initialFolderIds={
-						"bookmark_folder_ids" in displayTweet
-							? (displayTweet.bookmark_folder_ids ?? [])
-							: []
-					}
+					initialFolderIds={isRepost ? [] : (tweet.bookmark_folder_ids ?? [])}
 				/>
 			</footer>
 

--- a/client/src/lib/api/__tests__/boxes.test.ts
+++ b/client/src/lib/api/__tests__/boxes.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Boxes API helper tests (#499).
+ *
+ * `apps/tweets/__tests__/tweets.test.ts` 系と同じ axios-mock-adapter パターン。
+ * カバレッジしきい値 (80%) を満たすため、boxes.ts の各関数の URL / payload /
+ * response shape を一通り突く。
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+
+import { createApiClient } from "@/lib/api/client";
+import {
+	createBookmark,
+	createFolder,
+	deleteBookmark,
+	deleteFolder,
+	getTweetBookmarkStatus,
+	listFolderBookmarks,
+	listFolders,
+	updateFolder,
+} from "@/lib/api/boxes";
+
+const NOW = "2026-05-10T00:00:00Z";
+
+function stub() {
+	const client = createApiClient();
+	const mock = new MockAdapter(client);
+	return { client, mock };
+}
+
+function bootstrapCsrfCookie(): void {
+	// ensureCsrfToken が読む csrftoken cookie。jsdom では document.cookie で OK。
+	if (typeof document !== "undefined") {
+		document.cookie = "csrftoken=testcsrf; path=/";
+	}
+}
+
+describe("boxes API helpers", () => {
+	it("listFolders GETs /boxes/folders/ and returns results", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/boxes/folders/").reply(200, {
+			results: [
+				{
+					id: 1,
+					name: "技術",
+					parent_id: null,
+					sort_order: 0,
+					bookmark_count: 0,
+					child_count: 0,
+					created_at: NOW,
+					updated_at: NOW,
+				},
+			],
+		});
+		const list = await listFolders(client);
+		expect(list).toHaveLength(1);
+		expect(list[0].name).toBe("技術");
+	});
+
+	it("createFolder POSTs to /boxes/folders/ with payload", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onPost("/boxes/folders/").reply((config) => {
+			const body = JSON.parse(config.data);
+			expect(body).toEqual({ name: "新規", parent_id: null });
+			return [
+				201,
+				{
+					id: 5,
+					name: "新規",
+					parent_id: null,
+					sort_order: 0,
+					bookmark_count: 0,
+					child_count: 0,
+					created_at: NOW,
+					updated_at: NOW,
+				},
+			];
+		});
+		const folder = await createFolder(
+			{ name: "新規", parent_id: null },
+			client,
+		);
+		expect(folder.id).toBe(5);
+	});
+
+	it("updateFolder PATCHes to /boxes/folders/<id>/", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onPatch("/boxes/folders/3/").reply((config) => {
+			const body = JSON.parse(config.data);
+			expect(body).toEqual({ name: "rename" });
+			return [
+				200,
+				{
+					id: 3,
+					name: "rename",
+					parent_id: null,
+					sort_order: 0,
+					bookmark_count: 0,
+					child_count: 0,
+					created_at: NOW,
+					updated_at: NOW,
+				},
+			];
+		});
+		const folder = await updateFolder(3, { name: "rename" }, client);
+		expect(folder.name).toBe("rename");
+	});
+
+	it("deleteFolder DELETEs /boxes/folders/<id>/", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onDelete("/boxes/folders/9/").reply(204);
+		await expect(deleteFolder(9, client)).resolves.toBeUndefined();
+	});
+
+	it("listFolderBookmarks GETs /boxes/folders/<id>/bookmarks/", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/boxes/folders/2/bookmarks/").reply(200, {
+			results: [{ id: 99, tweet_id: 42, folder_id: 2, created_at: NOW }],
+			next: null,
+			previous: null,
+		});
+		const bms = await listFolderBookmarks(2, client);
+		expect(bms[0].tweet_id).toBe(42);
+	});
+
+	it("createBookmark POSTs to /boxes/bookmarks/ and reports `created` from 201", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onPost("/boxes/bookmarks/").reply((config) => {
+			const body = JSON.parse(config.data);
+			expect(body).toEqual({ folder_id: 2, tweet_id: 42 });
+			return [201, { id: 11, tweet_id: 42, folder_id: 2, created_at: NOW }];
+		});
+		const result = await createBookmark({ folder_id: 2, tweet_id: 42 }, client);
+		expect(result.created).toBe(true);
+		expect(result.bookmark.id).toBe(11);
+	});
+
+	it("createBookmark idempotent: 200 → created=false", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onPost("/boxes/bookmarks/").reply(200, {
+			id: 11,
+			tweet_id: 42,
+			folder_id: 2,
+			created_at: NOW,
+		});
+		const result = await createBookmark({ folder_id: 2, tweet_id: 42 }, client);
+		expect(result.created).toBe(false);
+	});
+
+	it("deleteBookmark DELETEs /boxes/bookmarks/<id>/", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onDelete("/boxes/bookmarks/77/").reply(204);
+		await expect(deleteBookmark(77, client)).resolves.toBeUndefined();
+	});
+
+	it("getTweetBookmarkStatus returns folder_ids + bookmark_ids", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/boxes/tweets/42/status/").reply(200, {
+			folder_ids: [1, 3],
+			bookmark_ids: { "1": 100, "3": 102 },
+		});
+		const status = await getTweetBookmarkStatus(42, client);
+		expect(status.folder_ids).toEqual([1, 3]);
+		expect(status.bookmark_ids).toEqual({ "1": 100, "3": 102 });
+	});
+});

--- a/client/src/lib/api/boxes.ts
+++ b/client/src/lib/api/boxes.ts
@@ -38,6 +38,12 @@ export interface Bookmark {
 
 export interface BookmarkStatus {
 	folder_ids: number[];
+	/**
+	 * #502 H4 対応: 削除時の N+1 listFolderBookmarks を不要化するため、
+	 * folder_id (string) → bookmark_id (number) を一緒に返す。
+	 * 旧 backend (PR #503 前) は未付与 → undefined → 旧パスへフォールバック。
+	 */
+	bookmark_ids?: Record<string, number>;
 }
 
 interface FolderListResponse {

--- a/client/src/lib/api/boxes.ts
+++ b/client/src/lib/api/boxes.ts
@@ -1,0 +1,145 @@
+/**
+ * Favorites (お気に入り) API helpers for #499.
+ *
+ * Backend (apps/boxes, prefix `/api/v1/boxes/`):
+ *   GET    /folders/                       自分の folder 一覧 (フラット)
+ *   POST   /folders/                       新規 folder (name, parent_id?)
+ *   GET    /folders/<id>/                  単一 folder
+ *   PATCH  /folders/<id>/                  rename / move
+ *   DELETE /folders/<id>/                  CASCADE 削除
+ *   GET    /folders/<id>/bookmarks/        フォルダ内 bookmark 一覧
+ *   POST   /bookmarks/                     追加 (idempotent: 200/201)
+ *   DELETE /bookmarks/<id>/                削除
+ *   GET    /tweets/<id>/status/            自分の保存状況 (folder_ids[])
+ *
+ * 全 endpoint 認証必須。他人の folder/bookmark への操作は 404 隠蔽。
+ */
+
+import type { AxiosInstance } from "axios";
+import { api, ensureCsrfToken } from "@/lib/api/client";
+import type { TweetSummary } from "@/lib/api/tweets";
+
+export interface Folder {
+	id: number;
+	name: string;
+	parent_id: number | null;
+	bookmark_count: number;
+	child_count: number;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface Bookmark {
+	id: number;
+	tweet_id: number;
+	folder_id: number;
+	created_at: string;
+}
+
+export interface BookmarkStatus {
+	folder_ids: number[];
+}
+
+interface FolderListResponse {
+	results: Folder[];
+}
+
+interface BookmarkListResponse {
+	results: Bookmark[];
+	next: string | null;
+	previous: string | null;
+}
+
+export async function listFolders(
+	client: AxiosInstance = api,
+): Promise<Folder[]> {
+	const res = await client.get<FolderListResponse>("/boxes/folders/");
+	return res.data.results;
+}
+
+export interface CreateFolderInput {
+	name: string;
+	parent_id?: number | null;
+}
+
+export async function createFolder(
+	input: CreateFolderInput,
+	client: AxiosInstance = api,
+): Promise<Folder> {
+	await ensureCsrfToken(client);
+	const res = await client.post<Folder>("/boxes/folders/", input);
+	return res.data;
+}
+
+export interface UpdateFolderInput {
+	name?: string;
+	parent_id?: number | null;
+}
+
+export async function updateFolder(
+	folderId: number,
+	input: UpdateFolderInput,
+	client: AxiosInstance = api,
+): Promise<Folder> {
+	await ensureCsrfToken(client);
+	const res = await client.patch<Folder>(`/boxes/folders/${folderId}/`, input);
+	return res.data;
+}
+
+export async function deleteFolder(
+	folderId: number,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await ensureCsrfToken(client);
+	await client.delete(`/boxes/folders/${folderId}/`);
+}
+
+export async function listFolderBookmarks(
+	folderId: number,
+	client: AxiosInstance = api,
+): Promise<Bookmark[]> {
+	const res = await client.get<BookmarkListResponse>(
+		`/boxes/folders/${folderId}/bookmarks/`,
+	);
+	return res.data.results;
+}
+
+export interface CreateBookmarkInput {
+	folder_id: number;
+	tweet_id: number;
+}
+
+export interface CreateBookmarkResult {
+	bookmark: Bookmark;
+	created: boolean;
+}
+
+export async function createBookmark(
+	input: CreateBookmarkInput,
+	client: AxiosInstance = api,
+): Promise<CreateBookmarkResult> {
+	await ensureCsrfToken(client);
+	const res = await client.post<Bookmark>("/boxes/bookmarks/", input);
+	return { bookmark: res.data, created: res.status === 201 };
+}
+
+export async function deleteBookmark(
+	bookmarkId: number,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await ensureCsrfToken(client);
+	await client.delete(`/boxes/bookmarks/${bookmarkId}/`);
+}
+
+export async function getTweetBookmarkStatus(
+	tweetId: number | string,
+	client: AxiosInstance = api,
+): Promise<BookmarkStatus> {
+	const res = await client.get<BookmarkStatus>(
+		`/boxes/tweets/${tweetId}/status/`,
+	);
+	return res.data;
+}
+
+/** server fetch (Server Components) で folder + bookmark を取る用. */
+export type { TweetSummary };

--- a/client/src/lib/api/tweets.ts
+++ b/client/src/lib/api/tweets.ts
@@ -84,6 +84,12 @@ export interface TweetSummary {
 	 * 未認証 / フィールド未付与時は undefined → false 扱い。
 	 */
 	reposted_by_me?: boolean;
+	/**
+	 * #499: viewer がこの tweet を保存している folder の id 配列。
+	 * BookmarkButton.initialFolderIds に渡し、リロード後の塗り状態を復元する。
+	 * backend が未付与の段階では undefined → 空配列扱い。
+	 */
+	bookmark_folder_ids?: number[];
 }
 
 export async function createTweet(


### PR DESCRIPTION
## Summary

backend (#501) と組み合わせて Google / Edge ブックマーク風 UX を完成させる frontend PR。

- **TL の各 TweetCard** に🔖 BookmarkButton を追加 (ReactionBar の隣)
- 押下で **AddToFolderDialog** open: フォルダツリーチェックボックス + 新規フォルダ作成
- 自分のプロフィールに **「お気に入り」 タブ** 追加 (URL: \`?tab=favorites\`)
  - 左 folder ツリー + 右 bookmark TweetCardList
  - 他人のプロフィールではタブ自体非表示 + URL 直叩きでも \`isOwnProfile\` gate
- \`client/src/lib/api/boxes.ts\` で \`/api/v1/boxes/\` を叩く axios helper 一式

## Test plan

- [x] vitest: AddToFolderDialog 5 cases (一覧 / 保存済 / toggle / 空名 disabled / 新規作成)
- [x] vitest: TweetCard 既存 48 cases 全 pass (regression なし)
- [x] tsc --noEmit clean
- [x] eslint: 既存と同じく warning のみ (tailwind class order)
- [ ] CI: pre-commit / Frontend pass
- [ ] E2E は #39 で stg 検証

Refs #499