### PR TITLE
fix(boxes): bookmark-status に bookmark_ids を追加 (#502 H4)

### DIFF
--- a/apps/boxes/serializers.py
+++ b/apps/boxes/serializers.py
@@ -70,6 +70,13 @@ class BookmarkCreateInputSerializer(serializers.Serializer):
 
 
 class BookmarkStatusSerializer(serializers.Serializer):
-    """``GET /tweets/<id>/bookmark-status/`` の出力."""
+    """``GET /tweets/<id>/status/`` の出力.
+
+    folder_ids は後方互換のため残しつつ、bookmark_ids は
+    ``{folder_id: bookmark_id}`` 形式で frontend が削除時に N+1 listFolderBookmarks
+    せずに bookmark_id を引けるようにする (typescript-reviewer #502 H4 対応)。
+    """
 
     folder_ids = serializers.ListField(child=serializers.IntegerField())
+    # DictField の key は str に丸まるが、value も IntegerField で型を担保。
+    bookmark_ids = serializers.DictField(child=serializers.IntegerField())

--- a/apps/boxes/tests/test_favorites_api.py
+++ b/apps/boxes/tests/test_favorites_api.py
@@ -335,14 +335,17 @@ def test_bookmark_status_returns_folder_ids(status_url) -> None:
     f1 = Folder.objects.create(user=me, name="A")
     f2 = Folder.objects.create(user=me, name="B")
     t = _tweet(me)
-    Bookmark.objects.create(user=me, folder=f1, tweet=t)
-    Bookmark.objects.create(user=me, folder=f2, tweet=t)
+    bm1 = Bookmark.objects.create(user=me, folder=f1, tweet=t)
+    bm2 = Bookmark.objects.create(user=me, folder=f2, tweet=t)
     client = APIClient()
     client.force_authenticate(user=me)
     resp = client.get(status_url(t.pk))
     assert resp.status_code == 200
-    folder_ids = sorted(resp.json()["folder_ids"])
+    body = resp.json()
+    folder_ids = sorted(body["folder_ids"])
     assert folder_ids == sorted([f1.pk, f2.pk])
+    # bookmark_ids は {folder_id (str): bookmark_id (int)} (#502 H4 対応)
+    assert body["bookmark_ids"] == {str(f1.pk): bm1.pk, str(f2.pk): bm2.pk}
 
 
 @pytest.mark.django_db
@@ -353,7 +356,9 @@ def test_bookmark_status_empty_when_not_saved(status_url) -> None:
     client.force_authenticate(user=me)
     resp = client.get(status_url(t.pk))
     assert resp.status_code == 200
-    assert resp.json()["folder_ids"] == []
+    body = resp.json()
+    assert body["folder_ids"] == []
+    assert body["bookmark_ids"] == {}
 
 
 # ------------------------------------------------------------------------

--- a/apps/boxes/views.py
+++ b/apps/boxes/views.py
@@ -224,9 +224,13 @@ class TweetBookmarkStatusView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request: Request, tweet_id: int) -> Response:
-        folder_ids = list(
-            Bookmark.objects.filter(user=request.user, tweet_id=tweet_id).values_list(
-                "folder_id", flat=True
-            )
+        # frontend が削除時に bookmark_id を直接引けるよう、folder_id → bookmark_id
+        # を返す (typescript-reviewer #502 H4 対応で N+1 listFolderBookmarks を不要化)。
+        rows = Bookmark.objects.filter(user=request.user, tweet_id=tweet_id).values_list(
+            "folder_id", "id"
         )
-        return Response(BookmarkStatusSerializer({"folder_ids": folder_ids}).data)
+        bookmark_ids = {str(folder_id): bookmark_id for folder_id, bookmark_id in rows}
+        folder_ids = sorted(int(k) for k in bookmark_ids)
+        return Response(
+            BookmarkStatusSerializer({"folder_ids": folder_ids, "bookmark_ids": bookmark_ids}).data
+        )

--- a/docs/specs/favorites-spec.md
+++ b/docs/specs/favorites-spec.md
@@ -141,15 +141,25 @@ prefix: `/api/v1/boxes/` (既存 `apps.boxes` の URL include に乗る、`apps.
 
 ### 4.2 Bookmark CRUD
 
-| Method | Path                                    | 概要                                                          |
-| ------ | --------------------------------------- | ------------------------------------------------------------- |
-| GET    | `/api/v1/boxes/folders/<id>/bookmarks/` | フォルダ内 bookmark 一覧 (新しい順、cursor pagination)        |
-| POST   | `/api/v1/boxes/bookmarks/`              | 追加 `{tweet_id, folder_id}`                                  |
-| DELETE | `/api/v1/boxes/bookmarks/<id>/`         | 削除                                                          |
-| GET    | `/api/v1/boxes/tweets/<id>/status/`     | 該当ツイートが自分のどの folder に保存されてるか array で返す |
+| Method | Path                                    | 概要                                                                     |
+| ------ | --------------------------------------- | ------------------------------------------------------------------------ |
+| GET    | `/api/v1/boxes/folders/<id>/bookmarks/` | フォルダ内 bookmark 一覧 (新しい順、cursor pagination)                   |
+| POST   | `/api/v1/boxes/bookmarks/`              | 追加 `{tweet_id, folder_id}`                                             |
+| DELETE | `/api/v1/boxes/bookmarks/<id>/`         | 削除                                                                     |
+| GET    | `/api/v1/boxes/tweets/<id>/status/`     | 該当ツイートが自分のどの folder に保存されてるか + 各 bookmark_id を返す |
 
-`bookmark-status` は TweetCard の icon 色付け (saved / not saved) のため必要。
-1 query で済む (`Bookmark.objects.filter(user, tweet=tweet_id).values_list('folder_id', flat=True)`)。
+`tweets/<id>/status/` のレスポンス例:
+
+```json
+{
+	"folder_ids": [1, 3],
+	"bookmark_ids": { "1": 100, "3": 102 }
+}
+```
+
+`bookmark_ids` は `{folder_id (str): bookmark_id (int)}` の dict。
+frontend が削除時に N+1 で list を引かずに済むよう、bookmark_id を直接公開する
+(typescript-reviewer #502 H4 対応)。
 
 ### 4.3 認可 / エラー
 


### PR DESCRIPTION
## Summary

\`typescript-reviewer\` が #502 で指摘した **H4 (data-correctness bug)** の解消。

frontend は削除時に bookmark_id が必要だったが、status エンドポイントは folder_ids しか返さなかった。AddToFolderDialog は \`listFolderBookmarks(folder_id)\` を保存済 folder ごとに呼んで bookmark_id を引いていたが、これは pagination の 1 ページ目しか見ないため、folder に大量 bookmark があると bookmarkId=null のまま残り、toggle で createBookmark が呼ばれて duplicate を作る危険があった。

## Fix

\`GET /api/v1/boxes/tweets/<id>/status/\` のレスポンスに \`bookmark_ids: {folder_id_str: bookmark_id_int}\` を追加。

\`\`\`json
{
  "folder_ids": [1, 3],
  "bookmark_ids": { "1": 100, "3": 102 }
}
\`\`\`

## Files

- apps/boxes/serializers.py — BookmarkStatusSerializer に DictField(IntegerField) 追加
- apps/boxes/views.py — \`values_list("folder_id", "id")\` で 1 query 化
- apps/boxes/tests/test_favorites_api.py — bookmark_ids 検証 (saved / empty 各 1 ケース)
- docs/specs/favorites-spec.md — §4.2 のレスポンス例を更新

## Test plan

- [x] pytest: 既存 + 更新 2 ケース
- [ ] CI 緑
- [ ] frontend (#502) を新シェイプ前提に更新

Refs #499, Refs #502