### PR TITLE
fix(boxes): AddToFolderDialog に Google/Edge 風『完了』 button を追加 (Closes #507)

### DIFF
--- a/client/src/components/boxes/AddToFolderDialog.tsx
+++ b/client/src/components/boxes/AddToFolderDialog.tsx
@@ -349,11 +349,27 @@ export default function AddToFolderDialog({
 					<button
 						type="submit"
 						disabled={creating || !createName.trim()}
-						className="w-full rounded bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+						className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-semibold text-foreground hover:bg-muted disabled:opacity-50"
 					>
 						{creating ? "作成中…" : "+ フォルダを作成"}
 					</button>
 				</form>
+
+				{/*
+				 * #507: Google Chrome / Microsoft Edge のブックマーク popover に倣い、
+				 * dialog 下部に「完了」 button を置く。checkbox toggle 自体は即時 API
+				 * (Google/Edge も同じ) だが、明示的な完了 button が無いと「これで保存
+				 * できたのか / どうやって閉じれば良いか」 が初見ユーザーに伝わらない。
+				 */}
+				<div className="mt-2 flex justify-end">
+					<button
+						type="button"
+						onClick={() => onOpenChange(false)}
+						className="rounded bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+					>
+						完了
+					</button>
+				</div>
 			</DialogContent>
 		</Dialog>
 	);

--- a/client/src/components/boxes/__tests__/AddToFolderDialog.test.tsx
+++ b/client/src/components/boxes/__tests__/AddToFolderDialog.test.tsx
@@ -209,4 +209,31 @@ describe("AddToFolderDialog", () => {
 		});
 		expect(within(list).getByText("新規")).toBeInTheDocument();
 	});
+
+	it("Google/Edge 風: 『完了』 button click で onOpenChange(false) が呼ばれる (#507)", async () => {
+		vi.mocked(boxesApi.listFolders).mockResolvedValue([
+			{
+				id: 1,
+				name: "技術",
+				parent_id: null,
+				bookmark_count: 0,
+				child_count: 0,
+				created_at: NOW,
+				updated_at: NOW,
+			},
+		]);
+		vi.mocked(boxesApi.getTweetBookmarkStatus).mockResolvedValue({
+			folder_ids: [],
+			bookmark_ids: {},
+		});
+
+		const onOpenChange = vi.fn();
+		render(<AddToFolderDialog tweetId={42} open onOpenChange={onOpenChange} />);
+
+		await screen.findByRole("list", { name: "お気に入りフォルダ" });
+		const doneBtn = screen.getByRole("button", { name: "完了" });
+		expect(doneBtn).toBeInTheDocument();
+		await userEvent.click(doneBtn);
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
 });


### PR DESCRIPTION
## Summary

stg 実機検証中にハルナさんから「**保存できた？保存ボタンがどこにあったか分からなかった**」 と指摘。現実装は checkbox toggle で即時 API が走るが、明示的な「完了」 button が無いと初見ユーザーには伝わらない。Google Chrome / Microsoft Edge の bookmark popover が両方とも「完了」 button を出している (#499 仕様時に Google/Edge 風と明示) のに揃える。

## 修正

- AddToFolderDialog 下部に primary 風「**完了**」 button を追加
- click で \`onOpenChange(false)\` → close (Google/Edge と同じ)
- checkbox の即時 toggle 動作は維持
- 「+ フォルダを作成」 を二次 button (border-only) に格下げて hierarchy を整理

## Test

- [x] vitest TDD: 「完了 button click → onOpenChange(false) 呼ばれる」 (RED → GREEN)
- [x] 既存 5 ケースも通る (合計 6/6)
- [x] tsc + lint clean
- [ ] CI 緑
- [ ] stg 実機検証 (Playwright MCP) で完了 button が現れて閉じることを確認

Closes #507
Refs #499