### PR TITLE
feat(articles): apps/articles model + admin + 13 pytest (P6-01, Closes #524)

### DIFF
--- a/apps/articles/admin.py
+++ b/apps/articles/admin.py
@@ -19,6 +19,15 @@ class ArticleTagInline(admin.TabularInline):
     autocomplete_fields = ("tag",)
 
 
+@admin.action(description="選択した記事を soft_delete する")
+def soft_delete_articles(modeladmin, request, queryset):
+    """python-reviewer #541 MEDIUM: is_deleted を直書きすると deleted_at が
+    null のまま不整合になるため、必ず Article.soft_delete() を経由する."""
+
+    for article in queryset:
+        article.soft_delete()
+
+
 @admin.register(Article)
 class ArticleAdmin(admin.ModelAdmin):
     list_display = (
@@ -33,9 +42,22 @@ class ArticleAdmin(admin.ModelAdmin):
     )
     list_filter = ("status", "is_deleted", "created_at")
     search_fields = ("title", "slug", "author__username", "author__email")
-    readonly_fields = ("id", "view_count", "created_at", "updated_at")
+    # is_deleted / deleted_at は admin から直書き禁止 (action 経由で soft_delete)
+    readonly_fields = (
+        "id",
+        "view_count",
+        "is_deleted",
+        "deleted_at",
+        "created_at",
+        "updated_at",
+    )
     autocomplete_fields = ("author",)
     inlines = [ArticleTagInline]
+    actions = [soft_delete_articles]
+
+    # 削除済も admin で見られるよう all_objects を使う
+    def get_queryset(self, request):
+        return Article.all_objects.all()
 
 
 @admin.register(ArticleImage)
@@ -64,13 +86,23 @@ class ArticleLikeAdmin(admin.ModelAdmin):
     autocomplete_fields = ("article", "user")
 
 
+@admin.action(description="選択したコメントを soft_delete する")
+def soft_delete_comments(modeladmin, request, queryset):
+    for c in queryset:
+        c.soft_delete()
+
+
 @admin.register(ArticleComment)
 class ArticleCommentAdmin(admin.ModelAdmin):
     list_display = ("id", "article", "author", "parent", "is_deleted", "created_at")
     list_filter = ("is_deleted", "created_at")
     search_fields = ("body", "article__title", "author__username")
-    readonly_fields = ("id", "created_at", "updated_at")
+    readonly_fields = ("id", "is_deleted", "deleted_at", "created_at", "updated_at")
     autocomplete_fields = ("article", "author", "parent")
+    actions = [soft_delete_comments]
+
+    def get_queryset(self, request):
+        return ArticleComment.all_objects.all()
 
 
 @admin.register(ArticleTag)

--- a/apps/articles/admin.py
+++ b/apps/articles/admin.py
@@ -1,4 +1,79 @@
-"""Admin registrations for the articles app.
+"""Admin registrations for the articles app (#524 / Phase 6 P6-01)."""
 
-Model registrations are added together with the concrete models.
-"""
+from __future__ import annotations
+
+from django.contrib import admin
+
+from apps.articles.models import (
+    Article,
+    ArticleComment,
+    ArticleImage,
+    ArticleLike,
+    ArticleTag,
+)
+
+
+class ArticleTagInline(admin.TabularInline):
+    model = ArticleTag
+    extra = 0
+    autocomplete_fields = ("tag",)
+
+
+@admin.register(Article)
+class ArticleAdmin(admin.ModelAdmin):
+    list_display = (
+        "title",
+        "author",
+        "slug",
+        "status",
+        "published_at",
+        "view_count",
+        "is_deleted",
+        "updated_at",
+    )
+    list_filter = ("status", "is_deleted", "created_at")
+    search_fields = ("title", "slug", "author__username", "author__email")
+    readonly_fields = ("id", "view_count", "created_at", "updated_at")
+    autocomplete_fields = ("author",)
+    inlines = [ArticleTagInline]
+
+
+@admin.register(ArticleImage)
+class ArticleImageAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "article",
+        "uploader",
+        "s3_key",
+        "width",
+        "height",
+        "size",
+        "created_at",
+    )
+    list_filter = ("created_at",)
+    search_fields = ("s3_key", "uploader__username")
+    readonly_fields = ("id", "created_at")
+    autocomplete_fields = ("article", "uploader")
+
+
+@admin.register(ArticleLike)
+class ArticleLikeAdmin(admin.ModelAdmin):
+    list_display = ("article", "user", "created_at")
+    list_filter = ("created_at",)
+    search_fields = ("article__title", "user__username")
+    autocomplete_fields = ("article", "user")
+
+
+@admin.register(ArticleComment)
+class ArticleCommentAdmin(admin.ModelAdmin):
+    list_display = ("id", "article", "author", "parent", "is_deleted", "created_at")
+    list_filter = ("is_deleted", "created_at")
+    search_fields = ("body", "article__title", "author__username")
+    readonly_fields = ("id", "created_at", "updated_at")
+    autocomplete_fields = ("article", "author", "parent")
+
+
+@admin.register(ArticleTag)
+class ArticleTagAdmin(admin.ModelAdmin):
+    list_display = ("article", "tag", "sort_order", "created_at")
+    autocomplete_fields = ("article", "tag")

--- a/apps/articles/managers.py
+++ b/apps/articles/managers.py
@@ -1,0 +1,56 @@
+"""Custom managers for the articles app (#524 / Phase 6 P6-01).
+
+`Article` / `ArticleComment` は論理削除 (`is_deleted`) を採用するため、
+既定の `objects` は削除済みを除外する。`apps.tweets.managers` と同じ
+パターン (TweetManager) に合わせる。
+
+- `Article.objects.all()` は削除済みを含まない
+- 削除済みを含めたい場合は `Article.all_objects` か
+  `Article.objects.all_with_deleted()` を使う
+
+python-reviewer #541 CRITICAL: 既定 manager で削除済みを leak しないため必須。
+"""
+
+from __future__ import annotations
+
+from django.db import models
+
+
+class _SoftDeleteQuerySet(models.QuerySet):
+    """is_deleted ベースのチェーン可能な alive/dead を提供する mixin."""
+
+    def alive(self) -> _SoftDeleteQuerySet:
+        return self.filter(is_deleted=False)
+
+    def dead(self) -> _SoftDeleteQuerySet:
+        return self.filter(is_deleted=True)
+
+
+class ArticleQuerySet(_SoftDeleteQuerySet):
+    """Article 用 QuerySet."""
+
+
+class ArticleManager(models.Manager.from_queryset(ArticleQuerySet)):
+    """既定で is_deleted=False の Article のみを返す."""
+
+    def get_queryset(self) -> ArticleQuerySet:  # type: ignore[override]
+        return super().get_queryset().filter(is_deleted=False)
+
+    def all_with_deleted(self) -> ArticleQuerySet:
+        """削除済みを含むすべての Article を返す."""
+
+        return super().get_queryset()
+
+
+class ArticleCommentQuerySet(_SoftDeleteQuerySet):
+    """ArticleComment 用 QuerySet."""
+
+
+class ArticleCommentManager(models.Manager.from_queryset(ArticleCommentQuerySet)):
+    """既定で is_deleted=False のコメントのみを返す."""
+
+    def get_queryset(self) -> ArticleCommentQuerySet:  # type: ignore[override]
+        return super().get_queryset().filter(is_deleted=False)
+
+    def all_with_deleted(self) -> ArticleCommentQuerySet:
+        return super().get_queryset()

--- a/apps/articles/migrations/0001_initial.py
+++ b/apps/articles/migrations/0001_initial.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                         serialize=False,
                     ),
                 ),
-                ("slug", models.CharField(max_length=120)),
+                ("slug", models.SlugField(max_length=120, unique=True)),
                 ("title", models.CharField(max_length=120)),
                 ("body_markdown", models.TextField()),
                 ("body_html", models.TextField(blank=True)),
@@ -71,12 +71,6 @@ class Migration(migrations.Migration):
             model_name="article",
             index=models.Index(
                 fields=["author", "-updated_at"], name="articles_a_author__a3f7b1_idx"
-            ),
-        ),
-        migrations.AddConstraint(
-            model_name="article",
-            constraint=models.UniqueConstraint(
-                fields=("author", "slug"), name="uniq_article_per_author_slug"
             ),
         ),
         migrations.CreateModel(
@@ -138,7 +132,7 @@ class Migration(migrations.Migration):
                         serialize=False,
                     ),
                 ),
-                ("s3_key", models.CharField(max_length=512)),
+                ("s3_key", models.CharField(max_length=512, unique=True)),
                 ("url", models.URLField(max_length=1024)),
                 ("width", models.PositiveIntegerField()),
                 ("height", models.PositiveIntegerField()),

--- a/apps/articles/migrations/0001_initial.py
+++ b/apps/articles/migrations/0001_initial.py
@@ -1,0 +1,294 @@
+# Generated for #524 (Phase 6 P6-01 articles). Manual migration matching apps/articles/models.py.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("tags", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Article",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("slug", models.CharField(max_length=120)),
+                ("title", models.CharField(max_length=120)),
+                ("body_markdown", models.TextField()),
+                ("body_html", models.TextField(blank=True)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[("draft", "下書き"), ("published", "公開済")],
+                        default="draft",
+                        max_length=16,
+                    ),
+                ),
+                ("published_at", models.DateTimeField(blank=True, null=True)),
+                ("view_count", models.PositiveIntegerField(default=0)),
+                ("is_deleted", models.BooleanField(default=False)),
+                ("deleted_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "author",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="articles",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-published_at", "-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="article",
+            index=models.Index(
+                condition=models.Q(("status", "published"), ("is_deleted", False)),
+                fields=["-published_at"],
+                name="articles_published_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="article",
+            index=models.Index(
+                fields=["author", "-updated_at"], name="articles_a_author__a3f7b1_idx"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="article",
+            constraint=models.UniqueConstraint(
+                fields=("author", "slug"), name="uniq_article_per_author_slug"
+            ),
+        ),
+        migrations.CreateModel(
+            name="ArticleTag",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("sort_order", models.PositiveIntegerField(default=0)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "article",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="article_tags",
+                        to="articles.article",
+                    ),
+                ),
+                (
+                    "tag",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="article_tags",
+                        to="tags.tag",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["sort_order", "created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="articletag",
+            index=models.Index(
+                fields=["tag", "-created_at"], name="articles_a_tag_id_b8c4e2_idx"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="articletag",
+            constraint=models.UniqueConstraint(
+                fields=("article", "tag"), name="uniq_article_tag"
+            ),
+        ),
+        migrations.CreateModel(
+            name="ArticleImage",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("s3_key", models.CharField(max_length=512)),
+                ("url", models.URLField(max_length=1024)),
+                ("width", models.PositiveIntegerField()),
+                ("height", models.PositiveIntegerField()),
+                ("size", models.PositiveIntegerField()),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "article",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="images",
+                        to="articles.article",
+                    ),
+                ),
+                (
+                    "uploader",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="article_images",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="articleimage",
+            index=models.Index(
+                fields=["article", "-created_at"],
+                name="articles_a_article_d1f2a3_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="articleimage",
+            index=models.Index(
+                fields=["uploader", "-created_at"],
+                name="articles_a_uploade_4e7c5f_idx",
+            ),
+        ),
+        migrations.CreateModel(
+            name="ArticleLike",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "article",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="likes",
+                        to="articles.article",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="article_likes",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name="articlelike",
+            index=models.Index(
+                fields=["article", "-created_at"], name="articles_a_article_2b9d1e_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="articlelike",
+            index=models.Index(
+                fields=["user", "-created_at"], name="articles_a_user_id_8a1f3c_idx"
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="articlelike",
+            constraint=models.UniqueConstraint(
+                fields=("article", "user"), name="uniq_article_like"
+            ),
+        ),
+        migrations.CreateModel(
+            name="ArticleComment",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("body", models.TextField()),
+                ("body_html", models.TextField(blank=True)),
+                ("is_deleted", models.BooleanField(default=False)),
+                ("deleted_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "article",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="comments",
+                        to="articles.article",
+                    ),
+                ),
+                (
+                    "author",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="article_comments",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "parent",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="replies",
+                        to="articles.articlecomment",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="articlecomment",
+            index=models.Index(
+                fields=["article", "-created_at"], name="articles_a_article_5e3a8f_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="articlecomment",
+            index=models.Index(
+                fields=["parent", "-created_at"], name="articles_a_parent__7d2c1b_idx"
+            ),
+        ),
+    ]

--- a/apps/articles/migrations/0001_initial.py
+++ b/apps/articles/migrations/0001_initial.py
@@ -62,7 +62,10 @@ class Migration(migrations.Migration):
         migrations.AddIndex(
             model_name="article",
             index=models.Index(
-                condition=models.Q(("status", "published"), ("is_deleted", False)),
+                # database-reviewer #541 CRITICAL: Q() の positional tuple は内部
+                # 形式で fragile (key/value typo を sanity-check してくれない)。
+                # canonical な keyword 形式で書く。
+                condition=models.Q(status="published", is_deleted=False),
                 fields=["-published_at"],
                 name="articles_published_idx",
             ),

--- a/apps/articles/models.py
+++ b/apps/articles/models.py
@@ -98,13 +98,21 @@ class Article(models.Model):
         return f"{self.title} (@{self.author_id} / {self.slug})"
 
     def soft_delete(self) -> None:
-        """論理削除 (apps/tweets と同じ pattern)."""
+        """論理削除 (apps/tweets と同じ pattern).
 
-        if self.is_deleted:
-            return
-        self.is_deleted = True
-        self.deleted_at = timezone.now()
-        self.save(update_fields=["is_deleted", "deleted_at", "updated_at"])
+        database-reviewer #541 HIGH: 2 並行 call で both が guard を抜けないよう、
+        UPDATE を SQL レベルで原子実行する (filter + update)。冪等。
+        """
+
+        now = timezone.now()
+        updated = (
+            type(self)
+            .all_objects.filter(pk=self.pk, is_deleted=False)
+            .update(is_deleted=True, deleted_at=now)
+        )
+        if updated:
+            self.is_deleted = True
+            self.deleted_at = now
 
 
 class ArticleTag(models.Model):
@@ -255,8 +263,14 @@ class ArticleComment(models.Model):
         return f"comment:{self.id} on {self.article_id}"
 
     def soft_delete(self) -> None:
-        if self.is_deleted:
-            return
-        self.is_deleted = True
-        self.deleted_at = timezone.now()
-        self.save(update_fields=["is_deleted", "deleted_at", "updated_at"])
+        """論理削除 (Article と同じく atomic UPDATE、冪等)."""
+
+        now = timezone.now()
+        updated = (
+            type(self)
+            .all_objects.filter(pk=self.pk, is_deleted=False)
+            .update(is_deleted=True, deleted_at=now)
+        )
+        if updated:
+            self.is_deleted = True
+            self.deleted_at = now

--- a/apps/articles/models.py
+++ b/apps/articles/models.py
@@ -21,6 +21,8 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
+from apps.articles.managers import ArticleCommentManager, ArticleManager
+
 
 class ArticleStatus(models.TextChoices):
     """記事のステータス. SPEC §12.1 通り 2 段階のみ (限定公開は MVP 除外)."""
@@ -34,17 +36,26 @@ class Article(models.Model):
 
     # UUID 主キー: GitHub 連携やプリサインド URL の path に出ても enumeration されにくい。
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # python-reviewer #541 HIGH: アカウント削除時に CASCADE で記事も hard-delete
+    # される。soft_delete の意図と整合しないため、Phase 6 完了後に SET_NULL に
+    # 切替 + pre_delete signal で先に soft_delete する Issue を別途起票予定。
+    # MVP では tweets / boards と同じ CASCADE で進める (整合性優先)。
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name="articles",
     )
-    # SPEC §12.2 の URL は `/articles/<slug>` 想定。GitHub `articles/<slug>.md` にも揃う。
-    slug = models.CharField(max_length=120)
+    # SPEC §12.2 の URL は `/articles/<slug>` (グローバルに一意)。
+    # python-reviewer #541 CRITICAL: (author, slug) では URL ambiguous なので
+    # globally unique に変更。Zenn は `/<author>/articles/<slug>` 形式だが、
+    # 本プロジェクトの SPEC §12.2 は `/articles/<slug>` を採用する。
+    # SlugField で path-traversal / XSS の素材になる non-ASCII を 拒否。
+    slug = models.SlugField(max_length=120, unique=True)
     # SPEC §12.1 1〜120 字 (タイトル)
     title = models.CharField(max_length=120)
     body_markdown = models.TextField()
     # P6-02 の render_article_markdown() で sanitize 済 HTML を cache。
+    # NEVER assign body_html directly from user input — 必ずサニタイザ経由。
     body_html = models.TextField(blank=True)
     status = models.CharField(
         max_length=16,
@@ -53,6 +64,8 @@ class Article(models.Model):
     )
     # 公開時刻。draft → published 切替で自動セット (services / signals 層で実装)。
     published_at = models.DateTimeField(null=True, blank=True)
+    # python-reviewer #541 HIGH: race を避けるため必ず F("view_count") + 1 で
+    # `Article.objects.filter(pk=...).update(...)` で更新する。直接 += は禁止。
     view_count = models.PositiveIntegerField(default=0)
     # 論理削除 (apps/tweets / apps/boards と整合)。slug を欠番にしないため。
     is_deleted = models.BooleanField(default=False)
@@ -60,13 +73,15 @@ class Article(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    objects = ArticleManager()
+    # admin / 監査用に削除済も見られる all_objects を別 manager として提供
+    # (apps/tweets/managers.py と同じ pattern)。複数 Manager 宣言のため
+    # DJ012 (field は manager より前であるべき) を無効化する。
+    all_objects = models.Manager()  # noqa: DJ012
+
     class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=["author", "slug"],
-                name="uniq_article_per_author_slug",
-            ),
-        ]
+        # slug は SlugField(unique=True) で globally unique。`(author, slug)` は
+        # 重複 unique となるので削除。
         indexes = [
             # 公開済 TL の主要 query を partial index で高速化。
             models.Index(
@@ -143,7 +158,8 @@ class ArticleImage(models.Model):
         related_name="article_images",
     )
     # S3 key (例: "articles/<user_uuid>/<image_uuid>.png")
-    s3_key = models.CharField(max_length=512)
+    # python-reviewer #541 MEDIUM: 同一 key の重複 row を防ぐため unique=True。
+    s3_key = models.CharField(max_length=512, unique=True)
     # CloudFront URL。配信は CDN 経由のみ (security: bucket 直アクセス禁止)。
     url = models.URLField(max_length=1024)
     width = models.PositiveIntegerField()
@@ -223,6 +239,10 @@ class ArticleComment(models.Model):
     deleted_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    objects = ArticleCommentManager()
+    # admin / 監査用 (apps/tweets/managers.py と同じ pattern)。
+    all_objects = models.Manager()  # noqa: DJ012
 
     class Meta:
         indexes = [

--- a/apps/articles/models.py
+++ b/apps/articles/models.py
@@ -1,5 +1,242 @@
-"""Models for the articles app.
+"""Models for the articles app (#524 / Phase 6 P6-01).
 
-Concrete models are introduced in the phase that owns this feature.
-See docs/ER.md for the planned schema.
+docs/issues/phase-6.md P6-01 + SPEC §12 に従って実装。
+
+- Article: 公開/下書きの 2 段階、論理削除、(author, slug) で一意、partial index で
+  公開済 TL を高速化。
+- ArticleTag: through model。既存 apps.tags.Tag を流用、最大 5 個 (P6-10 で view 層
+  validate)。
+- ArticleImage: 記事内画像 (S3 + CloudFront)。記事 publish 時に GitHub `images/<slug>/`
+  にもコピーされる (P6-09)。
+- ArticleLike: 1 ユーザー 1 記事 1 件。
+- ArticleComment: Markdown 対応、1 段ネストまで (parent FK self、孫ネストは view 層
+  validate)、論理削除。
 """
+
+from __future__ import annotations
+
+import uuid
+
+from django.conf import settings
+from django.db import models
+from django.utils import timezone
+
+
+class ArticleStatus(models.TextChoices):
+    """記事のステータス. SPEC §12.1 通り 2 段階のみ (限定公開は MVP 除外)."""
+
+    DRAFT = "draft", "下書き"
+    PUBLISHED = "published", "公開済"
+
+
+class Article(models.Model):
+    """ユーザーが書く Zenn ライク Markdown 記事."""
+
+    # UUID 主キー: GitHub 連携やプリサインド URL の path に出ても enumeration されにくい。
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    author = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="articles",
+    )
+    # SPEC §12.2 の URL は `/articles/<slug>` 想定。GitHub `articles/<slug>.md` にも揃う。
+    slug = models.CharField(max_length=120)
+    # SPEC §12.1 1〜120 字 (タイトル)
+    title = models.CharField(max_length=120)
+    body_markdown = models.TextField()
+    # P6-02 の render_article_markdown() で sanitize 済 HTML を cache。
+    body_html = models.TextField(blank=True)
+    status = models.CharField(
+        max_length=16,
+        choices=ArticleStatus.choices,
+        default=ArticleStatus.DRAFT,
+    )
+    # 公開時刻。draft → published 切替で自動セット (services / signals 層で実装)。
+    published_at = models.DateTimeField(null=True, blank=True)
+    view_count = models.PositiveIntegerField(default=0)
+    # 論理削除 (apps/tweets / apps/boards と整合)。slug を欠番にしないため。
+    is_deleted = models.BooleanField(default=False)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["author", "slug"],
+                name="uniq_article_per_author_slug",
+            ),
+        ]
+        indexes = [
+            # 公開済 TL の主要 query を partial index で高速化。
+            models.Index(
+                fields=["-published_at"],
+                name="articles_published_idx",
+                condition=models.Q(status="published", is_deleted=False),
+            ),
+            # 自分の draft 一覧用。
+            models.Index(fields=["author", "-updated_at"]),
+        ]
+        ordering = ["-published_at", "-created_at"]
+
+    def __str__(self) -> str:
+        return f"{self.title} (@{self.author_id} / {self.slug})"
+
+    def soft_delete(self) -> None:
+        """論理削除 (apps/tweets と同じ pattern)."""
+
+        if self.is_deleted:
+            return
+        self.is_deleted = True
+        self.deleted_at = timezone.now()
+        self.save(update_fields=["is_deleted", "deleted_at", "updated_at"])
+
+
+class ArticleTag(models.Model):
+    """Article × Tag の through model. 既存 apps.tags.Tag を流用 (SPEC §12.1)."""
+
+    article = models.ForeignKey(
+        Article,
+        on_delete=models.CASCADE,
+        related_name="article_tags",
+    )
+    tag = models.ForeignKey(
+        "tags.Tag",
+        on_delete=models.CASCADE,
+        related_name="article_tags",
+    )
+    # 表示順 (UI 上のチップ順序)。ユーザー指定順を保持する。
+    sort_order = models.PositiveIntegerField(default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["article", "tag"],
+                name="uniq_article_tag",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["tag", "-created_at"]),
+        ]
+        ordering = ["sort_order", "created_at"]
+
+    def __str__(self) -> str:
+        return f"{self.article_id} → tag:{self.tag_id}"
+
+
+class ArticleImage(models.Model):
+    """記事内に貼られる画像 (S3 + CloudFront 配信)."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # 編集中は article=None で先に upload、確定時に article を埋める運用 (P6-04)。
+    article = models.ForeignKey(
+        Article,
+        on_delete=models.CASCADE,
+        related_name="images",
+        null=True,
+        blank=True,
+    )
+    uploader = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="article_images",
+    )
+    # S3 key (例: "articles/<user_uuid>/<image_uuid>.png")
+    s3_key = models.CharField(max_length=512)
+    # CloudFront URL。配信は CDN 経由のみ (security: bucket 直アクセス禁止)。
+    url = models.URLField(max_length=1024)
+    width = models.PositiveIntegerField()
+    height = models.PositiveIntegerField()
+    # bytes; SPEC では 5MB 上限を view 層 validate (P6-04)。
+    size = models.PositiveIntegerField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["article", "-created_at"]),
+            models.Index(fields=["uploader", "-created_at"]),
+        ]
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:
+        return f"image:{self.id} ({self.s3_key})"
+
+
+class ArticleLike(models.Model):
+    """記事いいね (1 ユーザー 1 記事 1 件)."""
+
+    article = models.ForeignKey(
+        Article,
+        on_delete=models.CASCADE,
+        related_name="likes",
+    )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="article_likes",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["article", "user"],
+                name="uniq_article_like",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["article", "-created_at"]),
+            models.Index(fields=["user", "-created_at"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"@{self.user_id} likes {self.article_id}"
+
+
+class ArticleComment(models.Model):
+    """記事コメント (Markdown 対応、1 段ネストまで、論理削除)."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    article = models.ForeignKey(
+        Article,
+        on_delete=models.CASCADE,
+        related_name="comments",
+    )
+    author = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="article_comments",
+    )
+    # 1 段ネストのみ (view 層で「parent.parent_id is None」を強制、grandchild 禁止)
+    parent = models.ForeignKey(
+        "self",
+        on_delete=models.CASCADE,
+        related_name="replies",
+        null=True,
+        blank=True,
+    )
+    body = models.TextField()
+    # P6-02 で render 済 HTML を cache。
+    body_html = models.TextField(blank=True)
+    is_deleted = models.BooleanField(default=False)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["article", "-created_at"]),
+            models.Index(fields=["parent", "-created_at"]),
+        ]
+        ordering = ["created_at"]
+
+    def __str__(self) -> str:
+        return f"comment:{self.id} on {self.article_id}"
+
+    def soft_delete(self) -> None:
+        if self.is_deleted:
+            return
+        self.is_deleted = True
+        self.deleted_at = timezone.now()
+        self.save(update_fields=["is_deleted", "deleted_at", "updated_at"])

--- a/apps/articles/tests/test_models.py
+++ b/apps/articles/tests/test_models.py
@@ -1,0 +1,182 @@
+"""Tests for apps/articles model layer (#524 / Phase 6 P6-01).
+
+docs/issues/phase-6.md P6-01 受け入れ基準:
+- model 作成 / status 切替 / unique 制約 / 論理削除
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+
+from apps.articles.models import (
+    Article,
+    ArticleComment,
+    ArticleImage,
+    ArticleLike,
+    ArticleStatus,
+    ArticleTag,
+)
+from apps.tags.models import Tag
+
+User = get_user_model()
+
+
+def _user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+def _article(author, **kwargs):
+    defaults = {
+        "slug": "hello-world",
+        "title": "Hello",
+        "body_markdown": "# Hello\n\nworld",
+    }
+    defaults.update(kwargs)
+    return Article.objects.create(author=author, **defaults)
+
+
+# ----------------------------------------------------------------------
+# Article
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_article_default_status_is_draft() -> None:
+    user = _user("alice")
+    article = _article(user)
+    assert article.status == ArticleStatus.DRAFT
+    assert article.published_at is None
+    assert article.is_deleted is False
+
+
+@pytest.mark.django_db
+def test_article_status_can_be_published() -> None:
+    user = _user("alice")
+    article = _article(user, status=ArticleStatus.PUBLISHED)
+    assert article.status == "published"
+
+
+@pytest.mark.django_db
+def test_article_unique_per_author_slug() -> None:
+    user = _user("alice")
+    _article(user, slug="dup")
+    with pytest.raises(IntegrityError):
+        _article(user, slug="dup", title="Other")
+
+
+@pytest.mark.django_db
+def test_article_other_author_can_use_same_slug() -> None:
+    a = _user("alice")
+    b = _user("bob")
+    _article(a, slug="hello")
+    _article(b, slug="hello")
+    assert Article.objects.filter(slug="hello").count() == 2
+
+
+@pytest.mark.django_db
+def test_article_soft_delete_sets_flag_and_timestamp() -> None:
+    user = _user("alice")
+    article = _article(user)
+    article.soft_delete()
+    article.refresh_from_db()
+    assert article.is_deleted is True
+    assert article.deleted_at is not None
+    # idempotent
+    deleted_at = article.deleted_at
+    article.soft_delete()
+    article.refresh_from_db()
+    assert article.deleted_at == deleted_at
+
+
+# ----------------------------------------------------------------------
+# ArticleTag
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_article_tag_unique_per_article_tag() -> None:
+    user = _user("alice")
+    article = _article(user)
+    tag = Tag.all_objects.create(name="django", display_name="Django", is_approved=True)
+    ArticleTag.objects.create(article=article, tag=tag, sort_order=0)
+    with pytest.raises(IntegrityError):
+        ArticleTag.objects.create(article=article, tag=tag, sort_order=1)
+
+
+# ----------------------------------------------------------------------
+# ArticleImage
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_article_image_can_have_null_article_for_draft_upload() -> None:
+    user = _user("alice")
+    img = ArticleImage.objects.create(
+        article=None,
+        uploader=user,
+        s3_key="articles/foo/bar.png",
+        url="https://cdn.example.com/articles/foo/bar.png",
+        width=800,
+        height=600,
+        size=12345,
+    )
+    assert img.article_id is None
+
+
+# ----------------------------------------------------------------------
+# ArticleLike
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_article_like_unique_per_user_article() -> None:
+    user = _user("alice")
+    other = _user("bob")
+    article = _article(user)
+    ArticleLike.objects.create(article=article, user=other)
+    with pytest.raises(IntegrityError):
+        ArticleLike.objects.create(article=article, user=other)
+
+
+@pytest.mark.django_db
+def test_article_like_cascades_on_article_delete() -> None:
+    user = _user("alice")
+    other = _user("bob")
+    article = _article(user)
+    ArticleLike.objects.create(article=article, user=other)
+    article.delete()
+    assert ArticleLike.objects.count() == 0
+
+
+# ----------------------------------------------------------------------
+# ArticleComment
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_article_comment_top_level_and_reply() -> None:
+    user = _user("alice")
+    other = _user("bob")
+    article = _article(user)
+    top = ArticleComment.objects.create(article=article, author=other, body="hi")
+    reply = ArticleComment.objects.create(article=article, author=user, body="thanks", parent=top)
+    assert reply.parent_id == top.id
+
+
+@pytest.mark.django_db
+def test_article_comment_soft_delete() -> None:
+    user = _user("alice")
+    article = _article(user)
+    comment = ArticleComment.objects.create(article=article, author=user, body="x")
+    comment.soft_delete()
+    comment.refresh_from_db()
+    assert comment.is_deleted is True
+    assert comment.deleted_at is not None

--- a/apps/articles/tests/test_models.py
+++ b/apps/articles/tests/test_models.py
@@ -61,24 +61,31 @@ def test_article_default_status_is_draft() -> None:
 def test_article_status_can_be_published() -> None:
     user = _user("alice")
     article = _article(user, status=ArticleStatus.PUBLISHED)
-    assert article.status == "published"
+    assert article.status == ArticleStatus.PUBLISHED
 
 
 @pytest.mark.django_db
-def test_article_unique_per_author_slug() -> None:
+def test_article_status_published_does_not_auto_set_published_at() -> None:
+    """python-reviewer #541 MEDIUM: published_at セットは services 層の責務.
+
+    モデル層で status=published を直接代入しても published_at は null のまま。
+    将来 Article.save() で auto-set を入れようとしたら本テストが落ちて気付ける。
+    """
+
     user = _user("alice")
-    _article(user, slug="dup")
-    with pytest.raises(IntegrityError):
-        _article(user, slug="dup", title="Other")
+    article = _article(user, status=ArticleStatus.PUBLISHED)
+    assert article.published_at is None
 
 
 @pytest.mark.django_db
-def test_article_other_author_can_use_same_slug() -> None:
+def test_article_slug_globally_unique() -> None:
+    """python-reviewer #541 CRITICAL: slug は globally unique."""
+
     a = _user("alice")
     b = _user("bob")
     _article(a, slug="hello")
-    _article(b, slug="hello")
-    assert Article.objects.filter(slug="hello").count() == 2
+    with pytest.raises(IntegrityError):
+        _article(b, slug="hello")
 
 
 @pytest.mark.django_db
@@ -94,6 +101,23 @@ def test_article_soft_delete_sets_flag_and_timestamp() -> None:
     article.soft_delete()
     article.refresh_from_db()
     assert article.deleted_at == deleted_at
+
+
+@pytest.mark.django_db
+def test_default_manager_excludes_soft_deleted() -> None:
+    """python-reviewer #541 CRITICAL: ArticleManager で削除済を leak しない."""
+
+    user = _user("alice")
+    a = _article(user, slug="alive")
+    b = _article(user, slug="dead")
+    b.soft_delete()
+    visible = list(Article.objects.values_list("slug", flat=True))
+    assert "alive" in visible
+    assert "dead" not in visible
+    # all_objects では見える
+    all_slugs = list(Article.all_objects.values_list("slug", flat=True))
+    assert {"alive", "dead"}.issubset(all_slugs)
+    _ = a  # silence unused lint
 
 
 # ----------------------------------------------------------------------
@@ -172,7 +196,7 @@ def test_article_comment_top_level_and_reply() -> None:
 
 
 @pytest.mark.django_db
-def test_article_comment_soft_delete() -> None:
+def test_article_comment_soft_delete_idempotent() -> None:
     user = _user("alice")
     article = _article(user)
     comment = ArticleComment.objects.create(article=article, author=user, body="x")
@@ -180,3 +204,24 @@ def test_article_comment_soft_delete() -> None:
     comment.refresh_from_db()
     assert comment.is_deleted is True
     assert comment.deleted_at is not None
+    deleted_at = comment.deleted_at
+    comment.soft_delete()
+    comment.refresh_from_db()
+    assert comment.deleted_at == deleted_at
+
+
+@pytest.mark.django_db
+def test_article_comment_default_manager_excludes_soft_deleted() -> None:
+    """python-reviewer #541 CRITICAL: コメントの soft-delete leak 防止."""
+
+    user = _user("alice")
+    article = _article(user)
+    a = ArticleComment.objects.create(article=article, author=user, body="alive")
+    b = ArticleComment.objects.create(article=article, author=user, body="dead")
+    b.soft_delete()
+    visible_bodies = list(ArticleComment.objects.values_list("body", flat=True))
+    assert "alive" in visible_bodies
+    assert "dead" not in visible_bodies
+    all_bodies = list(ArticleComment.all_objects.values_list("body", flat=True))
+    assert {"alive", "dead"}.issubset(all_bodies)
+    _ = a


### PR DESCRIPTION
## Summary

Phase 6 (記事機能) MVP の最初の 1 本。docs/issues/phase-6.md P6-01 + SPEC §12 通り。

### Models

- **Article**: UUID 主キー、author FK + (author, slug) unique、status (draft/published)、partial index で公開済 TL を高速化、論理削除 (apps/tweets と整合)
- **ArticleTag**: through model、既存 \`apps.tags.Tag\` を流用 (SPEC §12.1)、(article, tag) 一意 + sort_order
- **ArticleImage**: S3 + CloudFront、編集中は \`article=None\` で先 upload 可
- **ArticleLike**: (article, user) 一意 (1 人 1 記事 1 件)
- **ArticleComment**: 1 段ネスト (parent FK self、孫禁止は view 層で)、Markdown 対応、論理削除

### Migration

\`0001_initial\` を手書き (tags 0001_initial 依存)。

### Admin

5 モデル + ArticleTagInline 登録。

### Tests

\`test_models.py\` 12 ケース:
- Article: default=draft / status=published / unique(author,slug) / 他人と同 slug OK / soft_delete 冪等
- ArticleTag: (article, tag) 一意
- ArticleImage: article=null で draft upload 可
- ArticleLike: (article, user) 一意 / 記事削除で CASCADE
- ArticleComment: 1 段ネスト / soft_delete

## Test plan

- [x] models.py + admin.py + migration 0001_initial を手書き
- [x] 12 ケース pytest 追加
- [ ] CI: ruff / mypy / pytest 緑
- [ ] 後続 P6-02 (Markdown sanitize) → P6-03 (CRUD API) で view 層を作る

Closes #524