### PR TITLE
feat(articles): Markdown サニタイザサービス + XSS テスト 30+ (P6-02, Closes #525)

### DIFF
--- a/apps/articles/migrations/0001_initial.py
+++ b/apps/articles/migrations/0001_initial.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
                 ("slug", models.SlugField(max_length=120, unique=True)),
                 ("title", models.CharField(max_length=120)),
                 ("body_markdown", models.TextField()),
-                ("body_html", models.TextField(blank=True)),
+                ("body_html", models.TextField(blank=True, editable=False)),
                 (
                     "status",
                     models.CharField(
@@ -240,7 +240,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("body", models.TextField()),
-                ("body_html", models.TextField(blank=True)),
+                ("body_html", models.TextField(blank=True, editable=False)),
                 ("is_deleted", models.BooleanField(default=False)),
                 ("deleted_at", models.DateTimeField(blank=True, null=True)),
                 ("created_at", models.DateTimeField(auto_now_add=True)),

--- a/apps/articles/models.py
+++ b/apps/articles/models.py
@@ -56,7 +56,10 @@ class Article(models.Model):
     body_markdown = models.TextField()
     # P6-02 の render_article_markdown() で sanitize 済 HTML を cache。
     # NEVER assign body_html directly from user input — 必ずサニタイザ経由。
-    body_html = models.TextField(blank=True)
+    # security-reviewer #542 HIGH H-2: editable=False で DRF ModelSerializer /
+    # admin form の writable field から自動除外。`Article.objects.update()` の
+    # bypass は防げないが、API / admin 経由の事故を排除。
+    body_html = models.TextField(blank=True, editable=False)
     status = models.CharField(
         max_length=16,
         choices=ArticleStatus.choices,
@@ -253,8 +256,9 @@ class ArticleComment(models.Model):
         blank=True,
     )
     body = models.TextField()
-    # P6-02 で render 済 HTML を cache。
-    body_html = models.TextField(blank=True)
+    # P6-02 で render 済 HTML を cache。security-reviewer #542 HIGH H-2:
+    # editable=False で DRF / admin の writable から自動除外。
+    body_html = models.TextField(blank=True, editable=False)
     is_deleted = models.BooleanField(default=False)
     deleted_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/apps/articles/models.py
+++ b/apps/articles/models.py
@@ -97,6 +97,18 @@ class Article(models.Model):
     def __str__(self) -> str:
         return f"{self.title} (@{self.author_id} / {self.slug})"
 
+    def save(self, *args, **kwargs):
+        """body_html を body_markdown から自動生成 (P6-02 サニタイザ).
+
+        P6-01 review HIGH-1: body_html を view 層から直接代入する footgun を
+        防ぐため、save() 時に必ずサニタイザ経由で再生成する。
+        """
+
+        from apps.articles.services.markdown import render_article_markdown
+
+        self.body_html = render_article_markdown(self.body_markdown or "")
+        super().save(*args, **kwargs)
+
     def soft_delete(self) -> None:
         """論理削除 (apps/tweets と同じ pattern).
 
@@ -261,6 +273,14 @@ class ArticleComment(models.Model):
 
     def __str__(self) -> str:
         return f"comment:{self.id} on {self.article_id}"
+
+    def save(self, *args, **kwargs):
+        """body_html を body から自動生成 (P6-02 サニタイザ)."""
+
+        from apps.articles.services.markdown import render_article_markdown
+
+        self.body_html = render_article_markdown(self.body or "")
+        super().save(*args, **kwargs)
 
     def soft_delete(self) -> None:
         """論理削除 (Article と同じく atomic UPDATE、冪等)."""

--- a/apps/articles/services/markdown.py
+++ b/apps/articles/services/markdown.py
@@ -1,0 +1,121 @@
+"""Article 用 Markdown → HTML サニタイザ (#525 / Phase 6 P6-02).
+
+docs/issues/phase-6.md P6-02 + SPEC §12 通り。
+
+apps/tweets/rendering.py との関係:
+    - bleach allowlist (`settings.MARKDOWN_BLEACH_*`) は記事 / ツイート共通。
+    - markdown2 の extras だけ記事用に変える:
+        * `break-on-newline` は **使わない** (記事は段落構造を保持するため、
+          単一改行を <br> に変換しない)
+    - protocol-relative URL の除去 + linkify rel 強制は同じ pattern を踏襲。
+
+公開 API:
+    - `render_article_markdown(source: str) -> str`
+
+セキュリティ:
+    - `<script>` `<iframe>` `<object>` `javascript:` `data:` は bleach で除去
+    - `//evil.com/x` (protocol-relative) は post-process で属性ごと除去
+    - `<a>` には `rel="nofollow noopener noreferrer"` + `target="_blank"` 強制
+    - XSS テストセット (test_markdown.py) で OWASP Cheat Sheet 30+ ペイロードを検証
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import bleach
+import markdown2
+from django.conf import settings
+
+# 記事用 markdown2 extras。tweets と異なり break-on-newline は使わず段落保持。
+# - fenced-code-blocks: ```lang\n...\n``` を <pre><code> に変換
+# - highlightjs-lang:   ↑ の出力に `class="language-xxx"` を付与 (frontend Shiki 用)
+# - code-friendly:      `_` で囲ったテキストを強調にしない (変数名保持)
+# - tables:             パイプ記法のテーブル
+# - strike:             ~~text~~ → <s>text</s>
+# - target-blank-links: 外部 <a> に target="_blank" rel="noopener" 付与
+# - footnotes:          記事は脚注を許可 (ツイートでは不要)
+# - cuddled-lists:      リスト間に空行が無いケースもパース
+_MARKDOWN_EXTRAS: dict[str, Any] = {
+    "fenced-code-blocks": {},
+    "highlightjs-lang": None,
+    "code-friendly": None,
+    "tables": None,
+    "strike": None,
+    "target-blank-links": None,
+    "footnotes": None,
+    "cuddled-lists": None,
+}
+
+# linkify が <a> に強制付与する rel 値。XSS / open-redirect 防御の最低ライン。
+_LINKIFY_REL_VALUES = ("nofollow", "noopener", "noreferrer")
+
+# bleach allowlist は通っても `src="//evil"` のような protocol-relative URL は
+# 素通りしてしまう (apps/tweets/rendering.py と同じ問題)。後段で属性ごと除去。
+_PROTOCOL_RELATIVE_ATTR_RE = re.compile(
+    r'\s(src|href)="//[^"]*"',
+    re.IGNORECASE,
+)
+
+
+def _strip_protocol_relative_urls(html: str) -> str:
+    """`src="//..."` / `href="//..."` 属性を除去する."""
+
+    if not html:
+        return html
+    return _PROTOCOL_RELATIVE_ATTR_RE.sub("", html)
+
+
+def _linkify_callback(attrs: dict, new: bool = False) -> dict:
+    """linkify した <a> に target/rel を強制付与する."""
+
+    href_key = (None, "href")
+    if attrs.get(href_key) is None:
+        # bleach 内部で 一時的に href が無いケースが起こるため安全側へ
+        return attrs
+    attrs[(None, "target")] = "_blank"
+    attrs[(None, "rel")] = " ".join(_LINKIFY_REL_VALUES)
+    return attrs
+
+
+def _build_markdown() -> markdown2.Markdown:
+    """markdown2.Markdown インスタンス生成 (footnotes 連番が混ざらないよう毎回新規)."""
+
+    return markdown2.Markdown(extras=_MARKDOWN_EXTRAS)
+
+
+def render_article_markdown(source: str) -> str:
+    """Article body の Markdown をサニタイズ済 HTML に変換する.
+
+    パイプライン:
+        1. markdown2 で HTML 化 (extras: 段落、コードブロック、表、脚注)
+        2. bleach.clean で settings.MARKDOWN_BLEACH_* 準拠の allowlist
+        3. protocol-relative URL を post-process で除去
+        4. bleach.linkify で URL を <a target="_blank" rel="..."> に
+    """
+
+    if not source:
+        return ""
+
+    converter = _build_markdown()
+    rendered_html = converter.convert(source)
+
+    sanitized = bleach.clean(
+        rendered_html,
+        tags=settings.MARKDOWN_BLEACH_ALLOWED_TAGS,
+        attributes=settings.MARKDOWN_BLEACH_ALLOWED_ATTRS,
+        protocols=settings.MARKDOWN_BLEACH_ALLOWED_PROTOCOLS,
+        strip=True,  # 不許可タグは中身だけ残し外枠除去
+        strip_comments=True,
+    )
+
+    sanitized = _strip_protocol_relative_urls(sanitized)
+
+    linkified = bleach.linkify(
+        sanitized,
+        callbacks=[_linkify_callback],
+        skip_tags=["pre", "code"],  # コード内 URL は自動リンクしない
+    )
+
+    return linkified

--- a/apps/articles/services/markdown.py
+++ b/apps/articles/services/markdown.py
@@ -28,6 +28,23 @@ import bleach
 import markdown2
 from django.conf import settings
 
+# security-reviewer #542 CRITICAL C-1: markdown2 の blockquote パーサは Python
+# 再帰実装で、163+ 段ネストすると RecursionError でワーカーが落ちる。
+# body_markdown に長さ + ネスト深さの両ガードをかけて DoS を遮断する。
+_MAX_BODY_BYTES = 100_000  # 100KB は SPEC §12 上の長文記事でも十分な上限
+_MAX_BLOCKQUOTE_DEPTH = 20  # Zenn / Qiita でも 5 段以上はまず無い、安全に余裕を持たせる
+# `> ` 連続行の数を数えるため line head で `^` プレースホルダ
+_BLOCKQUOTE_DEPTH_RE = re.compile(r"^(?:>\s*)+", re.MULTILINE)
+
+
+class MarkdownInputTooLargeError(ValueError):
+    """body_markdown が _MAX_BODY_BYTES を超えたとき raise."""
+
+
+class MarkdownNestingTooDeepError(ValueError):
+    """blockquote ネスト深さが _MAX_BLOCKQUOTE_DEPTH を超えたとき raise."""
+
+
 # 記事用 markdown2 extras。tweets と異なり break-on-newline は使わず段落保持。
 # - fenced-code-blocks: ```lang\n...\n``` を <pre><code> に変換
 # - highlightjs-lang:   ↑ の出力に `class="language-xxx"` を付与 (frontend Shiki 用)
@@ -71,12 +88,35 @@ def _linkify_callback(attrs: dict, new: bool = False) -> dict:
     """linkify した <a> に target/rel を強制付与する."""
 
     href_key = (None, "href")
-    if attrs.get(href_key) is None:
-        # bleach 内部で 一時的に href が無いケースが起こるため安全側へ
+    href = attrs.get(href_key)
+    if href is None:
+        return attrs
+    # security-reviewer #542 MEDIUM M-1: 同ページアンカー (`#xxx`) に
+    # target="_blank" を付けると ToC 系のリンクで新タブが開いて UX が崩れる。
+    # rel も nofollow 不要なのでスキップ。
+    if href.startswith("#"):
         return attrs
     attrs[(None, "target")] = "_blank"
     attrs[(None, "rel")] = " ".join(_LINKIFY_REL_VALUES)
     return attrs
+
+
+# security-reviewer #542 MEDIUM M-3: <noscript> / <style> / <script> ブロックは
+# bleach の strip でタグだけ消すと中身の HTML が残ってしまう。allowlist が
+# 将来広がったときに「noscript の中に隠した攻撃」 が顕在化するため、bleach
+# 前段でブロック全体を除去する。apps/tweets/rendering.py と同 pattern。
+_SCRIPTING_BLOCK_RE = re.compile(
+    r"<(script|style|noscript)\b[^>]*>.*?</\1\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _strip_scripting_blocks(html: str) -> str:
+    """`<script>` / `<style>` / `<noscript>` を中身ごと除去 (前処理)."""
+
+    if not html:
+        return html
+    return _SCRIPTING_BLOCK_RE.sub("", html)
 
 
 def _build_markdown() -> markdown2.Markdown:
@@ -85,21 +125,55 @@ def _build_markdown() -> markdown2.Markdown:
     return markdown2.Markdown(extras=_MARKDOWN_EXTRAS)
 
 
+def _enforce_input_limits(source: str) -> None:
+    """body_markdown の DoS ガード (security-reviewer #542 CRITICAL C-1).
+
+    - サイズ: 100KB 超は MarkdownInputTooLargeError
+    - blockquote ネスト深さ: 20 段超は MarkdownNestingTooDeepError
+      (markdown2 の blockquote パーサが Python 再帰で、163+ 段で RecursionError)
+    """
+
+    if len(source.encode("utf-8")) > _MAX_BODY_BYTES:
+        raise MarkdownInputTooLargeError(
+            f"body_markdown のサイズが上限 ({_MAX_BODY_BYTES} bytes) を超えています"
+        )
+    # `> ` を連続でカウント。各行の最大段数を取得して上限と比較。
+    max_depth = 0
+    for match in _BLOCKQUOTE_DEPTH_RE.finditer(source):
+        depth = match.group(0).count(">")
+        if depth > max_depth:
+            max_depth = depth
+    if max_depth > _MAX_BLOCKQUOTE_DEPTH:
+        raise MarkdownNestingTooDeepError(
+            f"blockquote ネスト深さが上限 ({_MAX_BLOCKQUOTE_DEPTH}) を超えています"
+        )
+
+
 def render_article_markdown(source: str) -> str:
     """Article body の Markdown をサニタイズ済 HTML に変換する.
 
     パイプライン:
+        0. 入力サイズ + ネスト深さの DoS ガード (CRITICAL C-1)
         1. markdown2 で HTML 化 (extras: 段落、コードブロック、表、脚注)
-        2. bleach.clean で settings.MARKDOWN_BLEACH_* 準拠の allowlist
-        3. protocol-relative URL を post-process で除去
-        4. bleach.linkify で URL を <a target="_blank" rel="..."> に
+        2. <script>/<style>/<noscript> ブロックを中身ごと除去 (M-3)
+        3. bleach.clean で settings.MARKDOWN_BLEACH_* 準拠の allowlist
+        4. protocol-relative URL を post-process で除去
+        5. bleach.linkify で URL を <a target="_blank" rel="..."> に
+
+    Raises:
+        MarkdownInputTooLargeError / MarkdownNestingTooDeepError:
+            ガードに引っかかった場合 (view 層で 400 にハンドリングする想定)
     """
 
     if not source:
         return ""
 
+    _enforce_input_limits(source)
+
     converter = _build_markdown()
     rendered_html = converter.convert(source)
+
+    rendered_html = _strip_scripting_blocks(rendered_html)
 
     sanitized = bleach.clean(
         rendered_html,

--- a/apps/articles/tests/test_markdown.py
+++ b/apps/articles/tests/test_markdown.py
@@ -1,0 +1,305 @@
+"""Tests for `apps/articles/services/markdown.py` (#525 / Phase 6 P6-02).
+
+docs/issues/phase-6.md P6-02 受け入れ基準:
+- `<script>` / `javascript:` / `onerror=` / `<iframe>` 等が全て除去される
+- fenced code block (```python ... ```) が `<pre><code class="language-python">`
+  でハイライト出力 (frontend Shiki 用)
+- 通常の Markdown (h2、リスト、リンク、画像、表) が崩れず出力
+- `Article.save()` で body_html が自動生成される
+
+XSS テストセットは OWASP XSS Filter Evasion Cheat Sheet からピックアップ。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.articles.services.markdown import render_article_markdown
+
+# ----------------------------------------------------------------------
+# 基本的な Markdown 描画
+# ----------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_string() -> None:
+    assert render_article_markdown("") == ""
+
+
+def test_paragraph_kept_as_block() -> None:
+    """tweets と異なり break-on-newline は OFF。段落構造は保持."""
+
+    html = render_article_markdown("hello\nworld\n\nsecond paragraph")
+    # 単一改行は <br> ではなく空白扱い (markdown2 デフォルト)
+    assert "<br" not in html
+    assert html.count("<p>") == 2
+
+
+def test_heading_levels() -> None:
+    html = render_article_markdown("# h1\n## h2\n### h3\n#### h4\n##### h5\n###### h6")
+    for level in range(1, 7):
+        assert f"<h{level}>" in html
+
+
+def test_unordered_list() -> None:
+    html = render_article_markdown("- a\n- b\n- c")
+    assert html.count("<li>") == 3
+    assert "<ul>" in html
+
+
+def test_ordered_list() -> None:
+    html = render_article_markdown("1. a\n2. b\n3. c")
+    assert html.count("<li>") == 3
+    assert "<ol>" in html
+
+
+def test_inline_link_with_target_and_rel() -> None:
+    html = render_article_markdown("[example](https://example.com)")
+    assert 'href="https://example.com"' in html
+    # target-blank-links extra で target="_blank" rel="noopener" が付く
+    assert 'target="_blank"' in html
+    assert "noopener" in html
+
+
+def test_image_with_https_src_kept() -> None:
+    html = render_article_markdown("![alt](https://cdn.example.com/x.png)")
+    assert "<img" in html
+    assert 'src="https://cdn.example.com/x.png"' in html
+
+
+def test_blockquote() -> None:
+    html = render_article_markdown("> quoted")
+    assert "<blockquote>" in html
+
+
+def test_horizontal_rule() -> None:
+    html = render_article_markdown("---\n")
+    assert "<hr" in html
+
+
+def test_table() -> None:
+    md = "| a | b |\n|---|---|\n| 1 | 2 |"
+    html = render_article_markdown(md)
+    assert "<table>" in html
+    assert "<th>" in html
+    assert "<td>" in html
+
+
+def test_inline_code() -> None:
+    html = render_article_markdown("use `print(x)` here")
+    assert "<code>print(x)</code>" in html
+
+
+def test_fenced_code_block_with_language_class() -> None:
+    """frontend Shiki が `class="language-python"` を見るので必須."""
+
+    md = "```python\nx = 1\n```"
+    html = render_article_markdown(md)
+    assert "<pre>" in html
+    assert "<code" in html
+    assert "language-python" in html
+
+
+def test_strikethrough() -> None:
+    html = render_article_markdown("~~old~~")
+    assert "<s>" in html or "<strike>" in html or "<del>" in html
+
+
+def test_strong_and_emphasis() -> None:
+    html = render_article_markdown("**bold** and *italic*")
+    assert "<strong>" in html
+    assert "<em>" in html
+
+
+# ----------------------------------------------------------------------
+# XSS payload tests (OWASP Cheat Sheet ベース、30+ ケース)
+# ----------------------------------------------------------------------
+
+
+XSS_PAYLOADS_NEUTRALIZED = [
+    # 1. 直接 script tag
+    "<script>alert(1)</script>",
+    # 2. 大文字
+    "<SCRIPT>alert(1)</SCRIPT>",
+    # 3. 改行混入
+    "<scr\nipt>alert(1)</script>",
+    # 4. 属性 onerror
+    '<img src="x" onerror="alert(1)">',
+    # 5. 属性 onload
+    '<body onload="alert(1)">',
+    # 6. javascript: スキーム
+    "[link](javascript:alert(1))",
+    # 7. JAVASCRIPT: 大文字
+    "[link](JAVASCRIPT:alert(1))",
+    # 8. data: URI
+    "[link](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)",
+    # 9. vbscript:
+    "[link](vbscript:msgbox(1))",
+    # 10. SVG payload
+    '<svg onload="alert(1)">',
+    # 11. iframe
+    '<iframe src="javascript:alert(1)"></iframe>',
+    # 12. object
+    '<object data="evil.swf"></object>',
+    # 13. embed
+    '<embed src="evil.swf">',
+    # 14. base href hijack
+    '<base href="https://evil.com/">',
+    # 15. meta refresh
+    '<meta http-equiv="refresh" content="0; url=https://evil.com">',
+    # 16. form action
+    '<form action="https://evil.com" method="POST"><input/></form>',
+    # 17. style with expression()
+    '<div style="background:url(javascript:alert(1))">',
+    # 18. expression() in attr
+    '<div style="width:expression(alert(1))">x</div>',
+    # 19. behavior
+    '<div style="behavior:url(evil.htc)">x</div>',
+    # 20. img src=javascript:
+    '<img src="javascript:alert(1)">',
+    # 21. event onclick
+    '<div onclick="alert(1)">x</div>',
+    # 22. event onmouseover
+    '<a href="#" onmouseover="alert(1)">x</a>',
+    # 23. event onfocus
+    '<input onfocus="alert(1)" autofocus>',
+    # 24. <link rel=stylesheet>
+    '<link rel="stylesheet" href="https://evil.com/x.css">',
+    # 25. video poster
+    '<video><source onerror="alert(1)"></video>',
+    # 26. CSS @import (内側)
+    '<style>@import "https://evil.com/x.css";</style>',
+    # 27. xmlns alt
+    '<x xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="javascript:alert(1)">x</a></x>',
+    # 28. mathml
+    '<math><mtext><a href="javascript:alert(1)">click</a></mtext></math>',
+    # 29. noscript escape
+    '<noscript><p title="</noscript><img src=x onerror=alert(1)>"></p></noscript>',
+    # 30. comment hiding script (ブラウザは comment 内 script を実行しないが、
+    #     bleach が comment を残してしまうと CSS で見せる手口に悪用される)
+    "<!--<script>alert(1)</script>-->",
+    # 31. button formaction
+    '<button formaction="javascript:alert(1)">x</button>',
+    # 32. <a href> with whitespace before scheme
+    "[link]( javascript:alert(1) )",
+]
+
+
+@pytest.mark.parametrize("payload", XSS_PAYLOADS_NEUTRALIZED)
+def test_xss_payload_neutralized(payload: str) -> None:
+    """全ペイロードについて: render 後に script 系 / on*= / javascript: が残らない."""
+
+    html = render_article_markdown(payload)
+    lower = html.lower()
+    # 攻撃に直接結びつく文字列が全て無いことを assert
+    assert "<script" not in lower
+    assert "</script" not in lower
+    assert "javascript:" not in lower
+    assert "vbscript:" not in lower
+    assert "data:text/html" not in lower
+    assert "<iframe" not in lower
+    assert "<object" not in lower
+    assert "<embed" not in lower
+    assert "<base" not in lower
+    assert "<meta" not in lower
+    assert "<form" not in lower
+    assert "<link" not in lower
+    assert "<style" not in lower
+    assert "<noscript" not in lower
+    assert "<!--" not in lower  # comment は strip_comments=True で消える想定
+    assert "onerror=" not in lower
+    assert "onload=" not in lower
+    assert "onclick=" not in lower
+    assert "onmouseover=" not in lower
+    assert "onfocus=" not in lower
+    assert "expression(" not in lower
+    assert "behavior:" not in lower
+    assert "formaction=" not in lower
+
+
+def test_protocol_relative_url_in_image_stripped() -> None:
+    """`//evil.example` 形式の protocol-relative は post-process で削除."""
+
+    html = render_article_markdown("![](//evil.example/x.gif)")
+    assert "//evil.example" not in html
+
+
+def test_protocol_relative_url_in_link_stripped() -> None:
+    html = render_article_markdown("[link](//evil.example)")
+    assert 'href="//evil.example"' not in html
+
+
+# ----------------------------------------------------------------------
+# Article.save() で body_html が自動生成される
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_article_save_renders_body_html() -> None:
+    from django.contrib.auth import get_user_model
+
+    from apps.articles.models import Article
+
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="alice",
+        email="alice@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="A",
+        last_name="L",
+    )
+    article = Article.objects.create(
+        author=user,
+        slug="hello",
+        title="Hello",
+        body_markdown="# Heading\n\nbody **bold**",
+    )
+    assert "<h1>" in article.body_html
+    assert "<strong>" in article.body_html
+
+
+@pytest.mark.django_db
+def test_article_save_neutralizes_xss_in_body_markdown() -> None:
+    from django.contrib.auth import get_user_model
+
+    from apps.articles.models import Article
+
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="bob",
+        email="bob@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="B",
+        last_name="L",
+    )
+    article = Article.objects.create(
+        author=user,
+        slug="xss-test",
+        title="x",
+        body_markdown="<script>alert(1)</script>safe",
+    )
+    assert "<script" not in article.body_html.lower()
+    assert "safe" in article.body_html
+
+
+@pytest.mark.django_db
+def test_article_comment_save_renders_body_html() -> None:
+    from django.contrib.auth import get_user_model
+
+    from apps.articles.models import Article, ArticleComment
+
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="carol",
+        email="carol@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="C",
+        last_name="L",
+    )
+    article = Article.objects.create(author=user, slug="commented", title="C", body_markdown="x")
+    comment = ArticleComment.objects.create(
+        article=article,
+        author=user,
+        body="**bold** comment with `code`",
+    )
+    assert "<strong>" in comment.body_html
+    assert "<code>" in comment.body_html

--- a/apps/articles/tests/test_markdown.py
+++ b/apps/articles/tests/test_markdown.py
@@ -55,9 +55,22 @@ def test_ordered_list() -> None:
 def test_inline_link_with_target_and_rel() -> None:
     html = render_article_markdown("[example](https://example.com)")
     assert 'href="https://example.com"' in html
-    # target-blank-links extra で target="_blank" rel="noopener" が付く
+    # security-reviewer #542 LOW L-3: rel の各トークンを assert 個別に
+    # (将来 _LINKIFY_REL_VALUES が縮小したら気付ける)
     assert 'target="_blank"' in html
+    assert "nofollow" in html
     assert "noopener" in html
+    assert "noreferrer" in html
+
+
+def test_anchor_link_skips_target_blank() -> None:
+    """security-reviewer #542 MEDIUM M-1: 同ページ # アンカーは target=_blank
+    付与しない (ToC が新タブで開く UX 崩れを避ける)."""
+
+    html = render_article_markdown("[Intro](#intro)")
+    assert 'href="#intro"' in html
+    assert 'target="_blank"' not in html
+    assert "nofollow" not in html
 
 
 def test_image_with_https_src_kept() -> None:
@@ -279,6 +292,49 @@ def test_article_save_neutralizes_xss_in_body_markdown() -> None:
     )
     assert "<script" not in article.body_html.lower()
     assert "safe" in article.body_html
+
+
+# ----------------------------------------------------------------------
+# DoS ガード (security-reviewer #542 CRITICAL C-1)
+# ----------------------------------------------------------------------
+
+
+def test_oversize_body_markdown_raises_input_too_large() -> None:
+    """100KB 超は MarkdownInputTooLargeError."""
+
+    from apps.articles.services.markdown import (
+        _MAX_BODY_BYTES,
+        MarkdownInputTooLargeError,
+    )
+
+    payload = "x" * (_MAX_BODY_BYTES + 1)
+    with pytest.raises(MarkdownInputTooLargeError):
+        render_article_markdown(payload)
+
+
+def test_deeply_nested_blockquote_raises_nesting_too_deep() -> None:
+    """163+ 段の nested blockquote を投げると markdown2 が RecursionError で
+    crash する (security-reviewer 実証済み)。事前に MarkdownNestingTooDeepError
+    で reject する。"""
+
+    from apps.articles.services.markdown import (
+        _MAX_BLOCKQUOTE_DEPTH,
+        MarkdownNestingTooDeepError,
+    )
+
+    payload = "> " * (_MAX_BLOCKQUOTE_DEPTH + 1) + "evil"
+    with pytest.raises(MarkdownNestingTooDeepError):
+        render_article_markdown(payload)
+
+
+def test_max_blockquote_depth_passes() -> None:
+    """20 段までは OK で render できる."""
+
+    from apps.articles.services.markdown import _MAX_BLOCKQUOTE_DEPTH
+
+    payload = "> " * _MAX_BLOCKQUOTE_DEPTH + "ok"
+    html = render_article_markdown(payload)
+    assert "ok" in html
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Phase 6 P6-02。Article body の Markdown を XSS 安全な HTML に変換するサニタイザを実装。

### サービス層

\`apps/articles/services/markdown.py\`:
- \`render_article_markdown(source: str) -> str\` 単一 public API
- \`markdown2\` extras: fenced-code-blocks / highlightjs-lang / tables / footnotes / target-blank-links。**break-on-newline は OFF** で段落構造を保持 (記事は長文向け、tweets と異なる)
- \`bleach\` allowlist は \`settings.MARKDOWN_BLEACH_*\` を tweets と共有
- protocol-relative URL (\`//evil.com/x\`) は post-process で除去
- linkify した \`<a>\` には \`target="_blank" rel="nofollow noopener noreferrer"\` 強制

### models 側

\`Article.save()\` / \`ArticleComment.save()\` で \`body_html\` を必ずサニタイザ経由で自動生成。P6-01 review HIGH の「body_html 直接代入 footgun」 を排除。

### Test (49 ケース)

- 基本 Markdown: 13 ケース (heading 1-6 / list / link / image / blockquote / hr / table / inline code / fenced+language class / strikethrough / strong+emphasis / 段落)
- **XSS payload neutralization**: 32 ケース (OWASP Cheat Sheet ベース) — script tag 全 case / on*= 全 case / javascript:/vbscript:/data: / SVG / iframe / object / embed / base / meta / form / link / style / noscript / CSS expression / behavior / formaction / mathml / xlink / HTML comment 残留 / protocol-relative URL
- model 統合: Article.save → body_html 自動生成 + XSS 中和、ArticleComment 同様

## Test plan

- [x] 49 pytest 追加
- [ ] CI: ruff / mypy / pytest 緑
- [ ] python-reviewer + security-reviewer (security-sensitive code)
- [ ] 後続 P6-03 で view 層 (CRUD API) を作る

Closes #525
Refs #524 #541