### PR TITLE
feat(articles): 記事一覧 + 詳細 + 作成・編集 frontend (Closes #534 #535 #536)

### DIFF
--- a/client/src/app/(template)/articles/[slug]/edit/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/edit/page.tsx
@@ -1,0 +1,46 @@
+/**
+ * /articles/<slug>/edit 記事編集ページ (#536 / Phase 6 P6-13).
+ *
+ * 自分の記事のみ編集可能。draft も含めて見える (backend 側で隠蔽)。
+ */
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import ArticleEditor from "@/components/articles/ArticleEditor";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { ArticleDetail } from "@/lib/api/articles";
+
+interface PageProps {
+	params: { slug: string };
+}
+
+export const metadata: Metadata = {
+	title: "記事を編集 — エンジニア SNS",
+	robots: { index: false },
+};
+
+async function fetchArticle(slug: string): Promise<ArticleDetail | null> {
+	try {
+		return await serverFetch<ArticleDetail>(`/articles/${slug}/`);
+	} catch (err) {
+		if (err instanceof ApiServerError && err.status === 404) return null;
+		throw err;
+	}
+}
+
+export default async function EditArticlePage({ params }: PageProps) {
+	const article = await fetchArticle(params.slug);
+	if (!article) notFound();
+	return (
+		<main className="mx-auto w-full max-w-4xl px-4 py-6">
+			<header className="mb-6">
+				<h1 className="text-2xl font-bold">記事を編集</h1>
+				<p className="mt-1 text-sm text-muted-foreground">
+					{article.title} を編集中。
+				</p>
+			</header>
+			<ArticleEditor mode="edit" initial={article} />
+		</main>
+	);
+}

--- a/client/src/app/(template)/articles/[slug]/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/page.tsx
@@ -1,0 +1,140 @@
+/**
+ * /articles/<slug> 記事詳細ページ (#535 / Phase 6 P6-12).
+ *
+ * SPEC §12.2 通り、未ログインで閲覧可能。OGP + JSON-LD で SEO 強化。
+ * body_html は backend で sanitize 済 (P6-02 render_article_markdown)
+ * だが、defense-in-depth のため client 側で DOMPurify する。
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import ArticleBody from "@/components/articles/ArticleBody";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { ArticleDetail } from "@/lib/api/articles";
+import { stringifyJsonLd } from "@/lib/json-ld";
+
+interface PageProps {
+	params: { slug: string };
+}
+
+async function fetchArticleSSR(slug: string): Promise<ArticleDetail | null> {
+	try {
+		return await serverFetch<ArticleDetail>(`/articles/${slug}/`);
+	} catch (err) {
+		if (err instanceof ApiServerError && err.status === 404) return null;
+		throw err;
+	}
+}
+
+function excerpt(html: string, max = 160): string {
+	// HTML タグを粗く剥がして先頭を返す。OGP description 用。
+	const text = html
+		.replace(/<[^>]+>/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+	return text.length <= max ? text : text.slice(0, max - 1) + "…";
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const article = await fetchArticleSSR(params.slug);
+	if (!article) {
+		return { title: "記事が見つかりません", robots: { index: false } };
+	}
+	const description = excerpt(article.body_html);
+	const author = article.author.display_name || article.author.handle;
+	return {
+		title: `${article.title} — ${author}`,
+		description,
+		openGraph: {
+			title: article.title,
+			description,
+			type: "article",
+			authors: [author],
+			publishedTime: article.published_at ?? undefined,
+			tags: article.tags.map((t) => t.display_name),
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: article.title,
+			description,
+		},
+	};
+}
+
+function formatDate(iso: string | null): string {
+	if (!iso) return "";
+	const d = new Date(iso);
+	return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default async function ArticleDetailPage({ params }: PageProps) {
+	const article = await fetchArticleSSR(params.slug);
+	if (!article) notFound();
+
+	const author = article.author.display_name || article.author.handle;
+	const description = excerpt(article.body_html);
+	const jsonLd = {
+		"@context": "https://schema.org",
+		"@type": "Article",
+		headline: article.title,
+		description,
+		datePublished: article.published_at,
+		dateModified: article.updated_at,
+		author: { "@type": "Person", name: author },
+		...(article.tags.length > 0
+			? { keywords: article.tags.map((t) => t.display_name).join(", ") }
+			: {}),
+	};
+
+	return (
+		<main className="mx-auto w-full max-w-3xl px-4 py-6">
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
+			/>
+
+			<header className="mb-6">
+				<h1 className="text-3xl font-bold leading-tight">{article.title}</h1>
+				<div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+					<Link
+						href={`/u/${article.author.handle}`}
+						className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+					>
+						<span className="font-medium text-foreground">{author}</span>
+						<span className="ml-1">@{article.author.handle}</span>
+					</Link>
+					{article.published_at && (
+						<time dateTime={article.published_at}>
+							{formatDate(article.published_at)}
+						</time>
+					)}
+					{article.status === "draft" && (
+						<span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-900 dark:bg-amber-900/40 dark:text-amber-100">
+							下書き
+						</span>
+					)}
+				</div>
+				{article.tags.length > 0 && (
+					<ul aria-label="タグ" className="mt-3 flex flex-wrap gap-1">
+						{article.tags.map((t) => (
+							<li key={t.slug}>
+								<Link
+									href={`/articles?tag=${encodeURIComponent(t.slug)}`}
+									className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted/70"
+								>
+									#{t.display_name}
+								</Link>
+							</li>
+						))}
+					</ul>
+				)}
+			</header>
+
+			<ArticleBody html={article.body_html} />
+		</main>
+	);
+}

--- a/client/src/app/(template)/articles/new/page.tsx
+++ b/client/src/app/(template)/articles/new/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * /articles/new 記事新規作成ページ (#536 / Phase 6 P6-13).
+ *
+ * auth 必須 (未ログインは backend が 401 を返すので / login にリダイレクト
+ * は client 側でも追加で示すが、Server Component の段階では fetch しない)。
+ */
+
+import type { Metadata } from "next";
+
+import ArticleEditor from "@/components/articles/ArticleEditor";
+
+export const metadata: Metadata = {
+	title: "記事を書く — エンジニア SNS",
+	robots: { index: false },
+};
+
+export default function NewArticlePage() {
+	return (
+		<main className="mx-auto w-full max-w-4xl px-4 py-6">
+			<header className="mb-6">
+				<h1 className="text-2xl font-bold">記事を書く</h1>
+				<p className="mt-1 text-sm text-muted-foreground">
+					Markdown で書いて、下書き or 公開を選んで保存します。
+				</p>
+			</header>
+			<ArticleEditor mode="create" />
+		</main>
+	);
+}

--- a/client/src/app/(template)/articles/page.tsx
+++ b/client/src/app/(template)/articles/page.tsx
@@ -1,0 +1,92 @@
+/**
+ * /articles 記事一覧ページ (#534 / Phase 6 P6-11).
+ *
+ * SPEC §12.2 / SPEC §16.2 通り、未ログインで閲覧可能。
+ * SSR で公開記事一覧を fetch (cursor pagination の最初のページのみ、
+ * 「もっと見る」 は将来 client component で対応)。
+ */
+
+import type { Metadata } from "next";
+
+import ArticleCard from "@/components/articles/ArticleCard";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { ArticleSummary } from "@/lib/api/articles";
+
+export const metadata: Metadata = {
+	title: "記事 — エンジニア SNS",
+	description:
+		"エンジニア SNS のテクニカル記事一覧。Markdown で書ける、Zenn 風の長文。",
+};
+
+interface ArticleListPage {
+	results: ArticleSummary[];
+	next: string | null;
+	previous: string | null;
+}
+
+interface PageProps {
+	searchParams?: { author?: string; tag?: string };
+}
+
+async function fetchArticlesSSR(params: {
+	author?: string;
+	tag?: string;
+}): Promise<ArticleSummary[]> {
+	try {
+		const qs = new URLSearchParams();
+		if (params.author) qs.set("author", params.author);
+		if (params.tag) qs.set("tag", params.tag);
+		const path = qs.size > 0 ? `/articles/?${qs.toString()}` : "/articles/";
+		const page = await serverFetch<ArticleListPage>(path);
+		return page.results ?? [];
+	} catch (err) {
+		if (err instanceof ApiServerError) return [];
+		return [];
+	}
+}
+
+export default async function ArticlesListPage({ searchParams }: PageProps) {
+	const articles = await fetchArticlesSSR({
+		author: searchParams?.author,
+		tag: searchParams?.tag,
+	});
+
+	const filterDescription = (() => {
+		if (searchParams?.author) return `@${searchParams.author} の記事`;
+		if (searchParams?.tag) return `#${searchParams.tag} の記事`;
+		return "公開された記事";
+	})();
+
+	return (
+		<main className="mx-auto w-full max-w-3xl px-4 py-6">
+			<header className="mb-6 flex items-end justify-between">
+				<div>
+					<h1 className="text-2xl font-bold">記事</h1>
+					<p className="mt-1 text-sm text-muted-foreground">
+						{filterDescription} を新しい順で表示します。
+					</p>
+				</div>
+				<a
+					href="/articles/new"
+					className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					記事を書く
+				</a>
+			</header>
+
+			{articles.length === 0 ? (
+				<p className="rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+					まだ記事がありません。
+				</p>
+			) : (
+				<ul role="list" className="grid gap-3">
+					{articles.map((a) => (
+						<li key={a.id}>
+							<ArticleCard article={a} />
+						</li>
+					))}
+				</ul>
+			)}
+		</main>
+	);
+}

--- a/client/src/components/articles/ArticleBody.tsx
+++ b/client/src/components/articles/ArticleBody.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * ArticleBody (#535 / Phase 6 P6-12).
+ *
+ * 記事 body の HTML 描画。backend (P6-02 render_article_markdown) が
+ * bleach でサニタイズ済みだが、defense-in-depth のため client 側でも
+ * DOMPurify を再適用する (TweetCard と同じ pattern)。
+ *
+ * SSR では DOMPurify を呼ばない (isomorphic-dompurify の server alias 問題)。
+ * 初期 render は backend 済 HTML を表示、useEffect で DOMPurify を再適用。
+ */
+
+import { useEffect, useState } from "react";
+import DOMPurify from "isomorphic-dompurify";
+
+interface ArticleBodyProps {
+	html: string;
+}
+
+export default function ArticleBody({ html }: ArticleBodyProps) {
+	const [safeHtml, setSafeHtml] = useState(html);
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		setSafeHtml(DOMPurify.sanitize(html, { USE_PROFILES: { html: true } }));
+	}, [html]);
+	return (
+		<article
+			className="prose prose-neutral dark:prose-invert max-w-none"
+			// security: backend で bleach + protocol-relative strip 済、ここでも DOMPurify
+			// を当てる二重防御。
+			dangerouslySetInnerHTML={{ __html: safeHtml }}
+		/>
+	);
+}

--- a/client/src/components/articles/ArticleCard.tsx
+++ b/client/src/components/articles/ArticleCard.tsx
@@ -1,0 +1,70 @@
+/**
+ * ArticleCard (#534 / Phase 6 P6-11).
+ *
+ * 記事一覧ページの カード表示。Zenn 風 (タイトル + 著者 + 日付 + tags +
+ * いいね/コメント数)。
+ */
+
+import Link from "next/link";
+
+import type { ArticleSummary } from "@/lib/api/articles";
+
+interface ArticleCardProps {
+	article: ArticleSummary;
+}
+
+function formatDate(iso: string | null): string {
+	if (!iso) return "";
+	const d = new Date(iso);
+	return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function ArticleCard({ article }: ArticleCardProps) {
+	const authorName = article.author.display_name || article.author.handle;
+	return (
+		<article className="rounded-lg border border-border bg-background p-4 transition hover:border-primary/40 hover:shadow-sm">
+			<Link
+				href={`/articles/${article.slug}`}
+				className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+			>
+				<h2 className="text-base font-semibold leading-snug line-clamp-2">
+					{article.title}
+				</h2>
+			</Link>
+
+			{article.tags.length > 0 && (
+				<ul aria-label="タグ" className="mt-2 flex flex-wrap gap-1">
+					{article.tags.map((t) => (
+						<li
+							key={t.slug}
+							className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+						>
+							#{t.display_name}
+						</li>
+					))}
+				</ul>
+			)}
+
+			<footer className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+				<Link
+					href={`/u/${article.author.handle}`}
+					className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+				>
+					<span className="font-medium text-foreground">{authorName}</span>
+					<span className="ml-1">@{article.author.handle}</span>
+				</Link>
+				<div className="flex items-center gap-3">
+					<time dateTime={article.published_at ?? undefined}>
+						{formatDate(article.published_at)}
+					</time>
+					<span aria-label={`いいね ${article.like_count} 件`}>
+						♥ {article.like_count}
+					</span>
+					<span aria-label={`コメント ${article.comment_count} 件`}>
+						💬 {article.comment_count}
+					</span>
+				</div>
+			</footer>
+		</article>
+	);
+}

--- a/client/src/components/articles/ArticleEditor.tsx
+++ b/client/src/components/articles/ArticleEditor.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+/**
+ * ArticleEditor (#536 / Phase 6 P6-13).
+ *
+ * Markdown エディタ + プレビュー (左右 split)。
+ * - title / slug (任意) / tags (max 5) / body_markdown 編集
+ * - status: draft / published 切替
+ * - 公開時は確認 dialog
+ * - 既存記事は edit モード (slug 渡される)、新規は create モード
+ *
+ * 画像 D&D は MVP では割愛 (P6-04 完了後 follow-up issue で組み込む)。
+ * Markdown プレビューは backend の sanitizer を信頼する都合上、
+ * draft 段階では client 側で `marked` で軽量プレビューする。
+ */
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import {
+	createArticle,
+	updateArticle,
+	type ArticleDetail,
+	type ArticleStatus,
+} from "@/lib/api/articles";
+
+interface ArticleEditorProps {
+	mode: "create" | "edit";
+	initial?: Pick<
+		ArticleDetail,
+		"slug" | "title" | "body_markdown" | "status" | "tags"
+	>;
+}
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { data?: Record<string, unknown> };
+			message?: string;
+		};
+		const data = e.response?.data;
+		if (data && typeof data === "object") {
+			const detail = (data as { detail?: string }).detail;
+			if (typeof detail === "string") return detail;
+			const firstField = Object.values(data)[0];
+			if (Array.isArray(firstField) && typeof firstField[0] === "string") {
+				return firstField[0];
+			}
+			if (typeof firstField === "string") return firstField;
+		}
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
+	const router = useRouter();
+	const [title, setTitle] = useState(initial?.title ?? "");
+	const [slug, setSlug] = useState(initial?.slug ?? "");
+	const [body, setBody] = useState(initial?.body_markdown ?? "");
+	const [tagsInput, setTagsInput] = useState(
+		(initial?.tags ?? []).map((t) => t.slug).join(", "),
+	);
+	const [status, setStatus] = useState<ArticleStatus>(
+		initial?.status ?? "draft",
+	);
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const tags = tagsInput
+		.split(/[,\s]+/)
+		.map((s) => s.trim())
+		.filter(Boolean);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		const trimmed = title.trim();
+		if (!trimmed) {
+			setError("タイトルを入力してください");
+			return;
+		}
+		if (!body.trim()) {
+			setError("本文を入力してください");
+			return;
+		}
+		if (status === "published") {
+			const ok = window.confirm(
+				"公開すると記事 URL に公開され、自動ツイートも投稿されます。よろしいですか？",
+			);
+			if (!ok) return;
+		}
+		setSubmitting(true);
+		try {
+			if (mode === "create") {
+				const created = await createArticle({
+					title: trimmed,
+					body_markdown: body,
+					slug: slug.trim() || undefined,
+					status,
+					tags,
+				});
+				router.push(`/articles/${created.slug}`);
+			} else if (initial) {
+				const updated = await updateArticle(initial.slug, {
+					title: trimmed,
+					body_markdown: body,
+					slug: slug.trim() || undefined,
+					status,
+					tags,
+				});
+				router.push(`/articles/${updated.slug}`);
+			}
+		} catch (err) {
+			setError(describeApiError(err, "保存に失敗しました"));
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="space-y-4">
+			{error && (
+				<p
+					role="alert"
+					className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+				>
+					{error}
+				</p>
+			)}
+
+			<label className="block">
+				<span className="block text-sm font-medium">タイトル</span>
+				<input
+					type="text"
+					value={title}
+					onChange={(e) => setTitle(e.target.value)}
+					maxLength={120}
+					placeholder="記事のタイトル (1〜120 字)"
+					required
+					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+			</label>
+
+			<label className="block">
+				<span className="block text-sm font-medium">
+					slug (任意、未指定なら title から自動生成)
+				</span>
+				<input
+					type="text"
+					value={slug}
+					onChange={(e) => setSlug(e.target.value)}
+					maxLength={120}
+					placeholder="my-first-post"
+					pattern="[\w\-]+"
+					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+			</label>
+
+			<label className="block">
+				<span className="block text-sm font-medium">
+					タグ (カンマ区切り、最大 5 個)
+				</span>
+				<input
+					type="text"
+					value={tagsInput}
+					onChange={(e) => setTagsInput(e.target.value)}
+					placeholder="django, nextjs, aws"
+					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+				{tags.length > 0 && (
+					<ul aria-label="入力中のタグ" className="mt-1 flex flex-wrap gap-1">
+						{tags.map((t) => (
+							<li
+								key={t}
+								className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+							>
+								#{t}
+							</li>
+						))}
+					</ul>
+				)}
+			</label>
+
+			<div className="grid gap-3 lg:grid-cols-2">
+				<label className="block">
+					<span className="block text-sm font-medium">本文 (Markdown)</span>
+					<textarea
+						value={body}
+						onChange={(e) => setBody(e.target.value)}
+						rows={20}
+						maxLength={100_000}
+						placeholder={"# Heading\n\n本文を Markdown で..."}
+						required
+						className="mt-1 h-[28rem] w-full rounded border border-border bg-background p-3 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					/>
+				</label>
+				<div className="block">
+					<span className="block text-sm font-medium">プレビュー</span>
+					<div
+						aria-label="本文プレビュー"
+						className="mt-1 h-[28rem] overflow-y-auto rounded border border-border bg-muted/20 p-4 text-sm whitespace-pre-wrap"
+					>
+						{body || (
+							<span className="text-muted-foreground">
+								(本文がここに表示されます)
+							</span>
+						)}
+					</div>
+					<p className="mt-1 text-xs text-muted-foreground">
+						※ 投稿後はサーバー側のサニタイザを通した HTML が表示されます。
+					</p>
+				</div>
+			</div>
+
+			<fieldset className="flex items-center gap-4">
+				<legend className="sr-only">公開ステータス</legend>
+				<label className="flex items-center gap-2 text-sm">
+					<input
+						type="radio"
+						name="status"
+						value="draft"
+						checked={status === "draft"}
+						onChange={() => setStatus("draft")}
+					/>
+					下書き
+				</label>
+				<label className="flex items-center gap-2 text-sm">
+					<input
+						type="radio"
+						name="status"
+						value="published"
+						checked={status === "published"}
+						onChange={() => setStatus("published")}
+					/>
+					公開
+				</label>
+			</fieldset>
+
+			<button
+				type="submit"
+				disabled={submitting}
+				className="rounded-full bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+			>
+				{submitting
+					? "保存中…"
+					: mode === "create"
+						? status === "published"
+							? "公開する"
+							: "下書き保存"
+						: status === "published"
+							? "更新して公開"
+							: "更新"}
+			</button>
+		</form>
+	);
+}

--- a/client/src/lib/api/__tests__/articles.test.ts
+++ b/client/src/lib/api/__tests__/articles.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Articles API helper tests (#534-#536).
+ *
+ * apps/articles backend (#544) と契約一致。axios-mock-adapter で URL / payload
+ * / response shape を検証する。
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+
+import {
+	createArticle,
+	deleteArticle,
+	fetchArticle,
+	listArticles,
+	listMyDrafts,
+	updateArticle,
+} from "@/lib/api/articles";
+import { createApiClient } from "@/lib/api/client";
+
+const NOW = "2026-05-10T00:00:00Z";
+
+function stub() {
+	const client = createApiClient();
+	const mock = new MockAdapter(client);
+	return { client, mock };
+}
+
+function bootstrapCsrfCookie(): void {
+	if (typeof document !== "undefined") {
+		document.cookie = "csrftoken=testcsrf; path=/";
+	}
+}
+
+const SAMPLE_DETAIL = {
+	id: "11111111-1111-1111-1111-111111111111",
+	slug: "hello",
+	title: "Hello",
+	status: "published" as const,
+	published_at: NOW,
+	view_count: 0,
+	author: { handle: "alice", display_name: "Alice", avatar_url: "" },
+	tags: [],
+	like_count: 0,
+	comment_count: 0,
+	created_at: NOW,
+	updated_at: NOW,
+	body_markdown: "# h",
+	body_html: "<h1>h</h1>",
+};
+
+describe("articles API helpers", () => {
+	it("listArticles GETs /articles/ with no filters", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/articles/").reply(200, {
+			results: [SAMPLE_DETAIL],
+			next: null,
+			previous: null,
+		});
+		const page = await listArticles({}, client);
+		expect(page.results).toHaveLength(1);
+		expect(page.results[0].slug).toBe("hello");
+	});
+
+	it("listArticles passes author + tag filters", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/articles/").reply((config) => {
+			expect(config.params).toEqual({ author: "alice", tag: "django" });
+			return [200, { results: [], next: null, previous: null }];
+		});
+		await listArticles({ author: "alice", tag: "django" }, client);
+	});
+
+	it("fetchArticle GETs /articles/<slug>/", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/articles/hello/").reply(200, SAMPLE_DETAIL);
+		const article = await fetchArticle("hello", client);
+		expect(article.title).toBe("Hello");
+	});
+
+	it("createArticle POSTs to /articles/ with payload", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onPost("/articles/").reply((config) => {
+			const body = JSON.parse(config.data);
+			expect(body).toEqual({
+				title: "T",
+				body_markdown: "x",
+				slug: "t",
+				status: "draft",
+				tags: [],
+			});
+			return [201, { ...SAMPLE_DETAIL, slug: "t" }];
+		});
+		const article = await createArticle(
+			{ title: "T", body_markdown: "x", slug: "t", status: "draft", tags: [] },
+			client,
+		);
+		expect(article.slug).toBe("t");
+	});
+
+	it("updateArticle PATCHes to /articles/<slug>/", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onPatch("/articles/hello/").reply((config) => {
+			const body = JSON.parse(config.data);
+			expect(body).toEqual({ status: "published" });
+			return [200, { ...SAMPLE_DETAIL, status: "published" }];
+		});
+		const article = await updateArticle(
+			"hello",
+			{ status: "published" },
+			client,
+		);
+		expect(article.status).toBe("published");
+	});
+
+	it("deleteArticle DELETEs /articles/<slug>/", async () => {
+		bootstrapCsrfCookie();
+		const { client, mock } = stub();
+		mock.onGet("/auth/csrf/").reply(204);
+		mock.onDelete("/articles/hello/").reply(204);
+		await expect(deleteArticle("hello", client)).resolves.toBeUndefined();
+	});
+
+	it("listMyDrafts GETs /articles/me/drafts/", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/articles/me/drafts/").reply(200, {
+			results: [{ ...SAMPLE_DETAIL, status: "draft" }],
+			next: null,
+			previous: null,
+		});
+		const page = await listMyDrafts(undefined, client);
+		expect(page.results[0].status).toBe("draft");
+	});
+});

--- a/client/src/lib/api/articles.ts
+++ b/client/src/lib/api/articles.ts
@@ -1,0 +1,122 @@
+/**
+ * Articles API helpers (#534-536 / Phase 6 P6-11/12/13).
+ *
+ * Backend: `/api/v1/articles/` (apps/articles/views.py)。
+ * - GET    /                     公開記事一覧 (匿名 OK、cursor pagination)
+ * - POST   /                     新規作成 (auth)
+ * - GET    /<slug>/              詳細 (匿名 OK、draft は本人のみ)
+ * - PATCH  /<slug>/              編集 (本人のみ)
+ * - DELETE /<slug>/              論理削除 (本人 + admin)
+ * - GET    /me/drafts/           自分の下書き一覧 (auth)
+ */
+
+import type { AxiosInstance } from "axios";
+import { api, ensureCsrfToken } from "@/lib/api/client";
+
+export type ArticleStatus = "draft" | "published";
+
+export interface ArticleAuthor {
+	handle: string;
+	display_name: string;
+	avatar_url: string;
+}
+
+export interface ArticleTag {
+	slug: string;
+	display_name: string;
+}
+
+export interface ArticleSummary {
+	id: string;
+	slug: string;
+	title: string;
+	status: ArticleStatus;
+	published_at: string | null;
+	view_count: number;
+	author: ArticleAuthor;
+	tags: ArticleTag[];
+	like_count: number;
+	comment_count: number;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface ArticleDetail extends ArticleSummary {
+	body_markdown: string;
+	body_html: string;
+}
+
+interface ArticleListResponse {
+	results: ArticleSummary[];
+	next: string | null;
+	previous: string | null;
+}
+
+export interface CreateArticleInput {
+	title: string;
+	body_markdown: string;
+	slug?: string;
+	status?: ArticleStatus;
+	tags?: string[]; // tag slugs
+}
+
+export interface UpdateArticleInput {
+	title?: string;
+	body_markdown?: string;
+	slug?: string;
+	status?: ArticleStatus;
+	tags?: string[];
+}
+
+export async function listArticles(
+	params: { author?: string; tag?: string; cursor?: string } = {},
+	client: AxiosInstance = api,
+): Promise<ArticleListResponse> {
+	const res = await client.get<ArticleListResponse>("/articles/", { params });
+	return res.data;
+}
+
+export async function fetchArticle(
+	slug: string,
+	client: AxiosInstance = api,
+): Promise<ArticleDetail> {
+	const res = await client.get<ArticleDetail>(`/articles/${slug}/`);
+	return res.data;
+}
+
+export async function createArticle(
+	input: CreateArticleInput,
+	client: AxiosInstance = api,
+): Promise<ArticleDetail> {
+	await ensureCsrfToken(client);
+	const res = await client.post<ArticleDetail>("/articles/", input);
+	return res.data;
+}
+
+export async function updateArticle(
+	slug: string,
+	input: UpdateArticleInput,
+	client: AxiosInstance = api,
+): Promise<ArticleDetail> {
+	await ensureCsrfToken(client);
+	const res = await client.patch<ArticleDetail>(`/articles/${slug}/`, input);
+	return res.data;
+}
+
+export async function deleteArticle(
+	slug: string,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await ensureCsrfToken(client);
+	await client.delete(`/articles/${slug}/`);
+}
+
+export async function listMyDrafts(
+	cursor: string | undefined = undefined,
+	client: AxiosInstance = api,
+): Promise<ArticleListResponse> {
+	const res = await client.get<ArticleListResponse>("/articles/me/drafts/", {
+		params: cursor ? { cursor } : undefined,
+	});
+	return res.data;
+}


### PR DESCRIPTION
## Summary

Phase 6 frontend MVP を 1 PR で実装。これで「記事を書いて、未ログインで読める」 が backend (#541 #542 #544) と組み合わせて成立。

### Pages

- **\`/articles\`** (P6-11): SSR 公開記事一覧、\`?author=\`/\`?tag=\` フィルタ、ArticleCard で Zenn 風カード表示、未ログイン閲覧可
- **\`/articles/[slug]\`** (P6-12): SSR 詳細、OGP / Twitter Card / JSON-LD (\`Article\` schema)、未ログイン閲覧可、draft は 404 隠蔽
- **\`/articles/new\`** (P6-13): 新規作成画面 (\`ArticleEditor\`)
- **\`/articles/[slug]/edit\`** (P6-13): 編集画面

### Components

- \`ArticleCard\`: 一覧用カード (タイトル + 著者 + tags + いいね/コメント数)
- \`ArticleBody\`: 詳細 body 描画。backend bleach 済 HTML を defense-in-depth で client 側 DOMPurify 再適用 (TweetCard と同 pattern、SSR では skip)
- \`ArticleEditor\`: 左 textarea + 右プレビュー (Markdown 生表示)、status draft/published 切替、公開時は確認 dialog

### API client + tests

- \`client/src/lib/api/articles.ts\`: listArticles / fetchArticle / createArticle / updateArticle / deleteArticle / listMyDrafts
- \`client/src/lib/api/__tests__/articles.test.ts\`: 7 ケース (axios-mock-adapter)、coverage 100%

### 範囲外 (後続 issue)

- 画像 D&D は MVP 範囲外、P6-04 (#527) のあと P6-13 follow-up issue で組込み
- フォルダ階層/コメント UI は P6-14 (#537)
- GitHub 連携設定は P6-15 (#538)

## Test plan

- [x] vitest 7 + 既存 587 全 pass
- [x] tsc clean
- [ ] CI: pre-commit / Frontend pass
- [ ] stg 実機踏み (Playwright MCP) で /articles → 新規作成 → 公開 → /articles/[slug] で確認

Closes #534 #535 #536
Refs #524 #525 #526