### PR TITLE
fix(articles): ナビ導線追加 + E2E spec (Closes #546)

### DIFF
--- a/client/e2e/articles.spec.ts
+++ b/client/e2e/articles.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * 記事 (Zenn ライク) E2E (#534-#536, #545, #546).
+ *
+ * Spec: docs/issues/phase-6.md P6-11/12/13。
+ *
+ * シナリオ:
+ *   ART-1: ログイン → ホーム左ナビ「記事」 → /articles → 「記事を書く」
+ *          → /articles/new → タイトル+本文+published 保存 → /articles/<slug>
+ *          で h1 / 本文 / OGP / JSON-LD を確認
+ *   ART-2: logout → 同じ /articles/<slug> を fetch → 200 (SPEC §12.2 未ログイン閲覧可)
+ *
+ * 必要な env:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me
+ *   PLAYWRIGHT_USER1_EMAIL / PLAYWRIGHT_USER1_PASSWORD / PLAYWRIGHT_USER1_HANDLE
+ *
+ * クリーンアップ:
+ *   - slug を毎回 timestamp で生成 (`stg-art-<unix>`) して衝突回避
+ *   - delete API を呼んで論理削除 (本人 only) — 簡単のため、繰り返し実行で
+ *     残り続けても次回 unique slug で OK
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+) {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+test.describe("記事 MVP E2E (#545 / #546)", () => {
+	test.beforeEach(() => {
+		requireEnv();
+	});
+
+	test("ART-1: ナビから記事画面 → 新規作成 → 公開 → 詳細閲覧", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+
+		// ホーム → 左ナビ「記事」 click で /articles に遷移する (#546 で追加)
+		await page.goto(`${BASE}/`);
+		const articlesNav = page.getByRole("link", { name: "記事" }).first();
+		await expect(articlesNav).toBeVisible({ timeout: 15000 });
+		await articlesNav.click();
+		await expect(page).toHaveURL(/\/articles$/);
+		await expect(
+			page.getByRole("heading", { name: "記事", level: 1 }),
+		).toBeVisible();
+
+		// 「記事を書く」 link で /articles/new
+		await page.getByRole("link", { name: "記事を書く" }).click();
+		await expect(page).toHaveURL(/\/articles\/new$/);
+
+		// フォームを埋めて公開
+		const slug = `stg-art-${Date.now()}`;
+		const title = `stg E2E ${slug}`;
+		await page.getByLabel("タイトル").fill(title);
+		await page.getByLabel(/^slug/).fill(slug);
+		await page
+			.getByLabel(/^本文/)
+			.fill("# h1\n\nbody **bold**\n\n```python\nx = 1\n```");
+		await page.getByLabel("公開").check();
+		// confirm dialog auto-accept
+		page.once("dialog", (d) => d.accept());
+		await page.getByRole("button", { name: /公開する|更新して公開/ }).click();
+
+		// 詳細ページに遷移
+		await expect(page).toHaveURL(new RegExp(`/articles/${slug}$`), {
+			timeout: 15000,
+		});
+
+		// 表示確認
+		await expect(
+			page.getByRole("heading", { name: title, level: 1 }),
+		).toBeVisible();
+		// body_html 描画
+		await expect(
+			page.getByRole("heading", { name: "h1", level: 1 }),
+		).toBeVisible();
+
+		// OGP / JSON-LD
+		const ogTitle = await page
+			.locator('meta[property="og:title"]')
+			.getAttribute("content");
+		expect(ogTitle).toContain(title);
+		const ldText = await page
+			.locator('script[type="application/ld+json"]')
+			.first()
+			.textContent();
+		expect(ldText).toContain('"@type":"Article"');
+
+		await ctx.close();
+	});
+
+	test("ART-2: 未ログインで詳細を閲覧できる (SPEC §12.2)", async ({
+		browser,
+	}) => {
+		// ART-1 が public 記事を作る前提。直近の slug を一覧から取得して使う。
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/articles`);
+		const firstCard = page.getByRole("article").first();
+		await expect(firstCard).toBeVisible({ timeout: 15000 });
+		const link = firstCard.getByRole("link").first();
+		const href = await link.getAttribute("href");
+		expect(href).toBeTruthy();
+
+		// 未ログインのまま詳細 GET
+		const detailResp = await ctx.request.get(`${BASE}${href}`);
+		expect(detailResp.status()).toBe(200);
+
+		await ctx.close();
+	});
+});

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -12,6 +12,7 @@ import {
 	Bell,
 	CircleUser,
 	Compass,
+	FileText,
 	Home,
 	MessageSquare,
 	MessagesSquare,
@@ -35,6 +36,7 @@ const ICON_MAP: Record<
 	User,
 	Bell,
 	MessagesSquare,
+	FileText,
 };
 
 /** isProfile link は self handle を埋めて返す。handle 未取得時は null。 */

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -14,6 +14,7 @@ import { HomeModernIcon } from "@heroicons/react/24/solid";
 import {
 	Bell,
 	Compass,
+	FileText,
 	Home,
 	MessageSquare,
 	MessagesSquare,
@@ -36,6 +37,7 @@ const ICON_MAP: Record<
 	User,
 	Bell,
 	MessagesSquare,
+	FileText,
 };
 
 function resolveLinkPath(

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -46,6 +46,13 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "MessagesSquare",
 	},
 	{
+		// Phase 6 (#546): 記事 (Zenn ライク)。匿名閲覧可。FileText icon は
+		// SPEC §12.4 の「記事マーク 📄」 と同じ Lucide icon。
+		path: "/articles",
+		label: "記事",
+		iconName: "FileText",
+	},
+	{
 		// path は LeftNavbar 側で `/u/<self.handle>` に動的に組み替える
 		path: "",
 		label: "プロフィール",

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -7,7 +7,8 @@ export type LeftNavIconName =
 	| "MessageSquare"
 	| "User"
 	| "Bell"
-	| "MessagesSquare";
+	| "MessagesSquare"
+	| "FileText";
 
 export interface LeftNavLink {
 	/** 静的 path。`isProfile=true` の時は無視され self handle を組み立てる。 */


### PR DESCRIPTION
## Summary

stg 実機検証中にハルナさんから 2 点指摘:

1. **「ホーム画面からどうやったら記事を書く画面に行き着くのかわからない」**
   → 左サイドバー (LeftNavbar / MobileNavbar) に「記事」 link が無く、URL 直叩きでないと到達できなかった。
2. **「E2E テストやった？」**
   → Playwright MCP で stg を踏んだだけで、再現可能な \`client/e2e/articles.spec.ts\` を書いていなかった。

両方修正。

### ナビ導線

- \`leftNavLinks\` に「記事」 entry を掲示板の隣に追加
- Lucide \`FileText\` アイコン (SPEC §12.4 の記事マーク 📄 と同じ)
- \`LeftNavIconName\` に \`"FileText"\` を追加
- LeftNavbar / MobileNavbar の \`ICON_MAP\` に登録

### E2E (\`client/e2e/articles.spec.ts\`)

- **ART-1**: login → ホーム左ナビ「記事」 click → \`/articles\` → 「記事を書く」 → タイトル/本文/published で保存 → \`/articles/<slug>\` で h1 / body_html / OGP / JSON-LD を assert
- **ART-2**: 未ログインで \`/articles/<slug>\` を fetch → 200 (SPEC §12.2)
- env は \`docs/local/e2e-stg.md\` の test2 を使用

## 反省

#499 / #545 で繰り返した「ナビ導線無く動作確認したつもり」 反省を再認識。実装した URL を直叩きで確認しただけでは不十分、ホーム画面から到達できる入口を必ず確認すること。E2E spec ファイルも書くまでが「実機検証」 の一環。

## Test plan

- [x] tsc clean
- [x] LeftNavbar 既存 7 ケース全 pass
- [ ] CI pass
- [ ] stg 反映後、Playwright MCP で「ホーム → 記事ナビ → 一覧 → 新規作成」 を実機踏み

Closes #546
Refs #534 #535 #536 #545