### PR TITLE
feat(design): A shell — Sticky header + tabs underline (Closes #554)

### DIFF
--- a/client/src/app/(a)/layout.tsx
+++ b/client/src/app/(a)/layout.tsx
@@ -31,8 +31,10 @@ export default function ALayout({ children }: AppLayoutProps) {
 			}}
 		>
 			<ALeftNav />
+			{/* #554: overflow-hidden を外して body scroll に。これで header の
+			    `position: sticky top-0` が browser viewport 基準で固定される。 */}
 			<main
-				className="flex min-w-0 flex-col overflow-hidden sm:border-r sm:border-[color:var(--a-border)]"
+				className="flex min-w-0 flex-col sm:border-r sm:border-[color:var(--a-border)]"
 				aria-label="メインコンテンツ"
 			>
 				<AMobileAppBar />

--- a/client/src/app/(a)/page.tsx
+++ b/client/src/app/(a)/page.tsx
@@ -113,8 +113,10 @@ export default async function HomePage({
 
 	return (
 		<>
+			{/* #554: sticky top-0 で scroll しても header が固定。backdrop blur が
+			    こうして初めて機能する (Phase A POC で position:sticky 抜けていた)。 */}
 			<header
-				className="flex items-center gap-4 px-5 py-3"
+				className="sticky top-0 z-10 flex items-center gap-4 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
 					background: "rgba(255,255,255,0.85)",

--- a/client/src/components/timeline/TimelineTabs.tsx
+++ b/client/src/components/timeline/TimelineTabs.tsx
@@ -4,6 +4,10 @@
  * TimelineTabs — tab switcher for "おすすめ" and "フォロー中" timelines.
  * URL state: ?tab=recommended / ?tab=following persisted via next/navigation.
  * (P2-13 / Issue #186)
+ *
+ * #554 (Phase B-0-3): cosmetic を A direction の border-bottom underline 方式に
+ * 上書き。shadcn primitive (rounded pill chip + shadow) は触らず、TimelineTabs
+ * 側で className override で実現する (tailwind-merge が後勝ち)。
  */
 
 import { useRouter } from "next/navigation";
@@ -32,11 +36,26 @@ export default function TimelineTabs({
 
 	return (
 		<Tabs value={activeTab} onValueChange={handleTabChange}>
-			<TabsList aria-label="タイムラインタブ" className="w-full">
-				<TabsTrigger value="recommended" className="flex-1">
+			<TabsList
+				aria-label="タイムラインタブ"
+				// A direction: pill chip / bg / p / h を打ち消して、border-bottom
+				// 1px のシンプル bar に。tailwind-merge が後勝ちで bg-muted / p-1 /
+				// rounded-lg / h-9 を上書きする。
+				className="h-auto w-full justify-start rounded-none border-b border-[color:var(--a-border)] bg-transparent p-0"
+			>
+				<TabsTrigger
+					value="recommended"
+					// A direction trigger:
+					// - rounded-md / shadow / data-[state=active]:bg-background を打ち消す
+					// - 代わりに data-[state=active]:border-b-2 + accent cyan
+					className="flex-1 rounded-none border-b-2 border-transparent bg-transparent px-3 py-2.5 text-sm shadow-none data-[state=active]:border-[color:var(--a-accent)] data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+				>
 					おすすめ
 				</TabsTrigger>
-				<TabsTrigger value="following" className="flex-1">
+				<TabsTrigger
+					value="following"
+					className="flex-1 rounded-none border-b-2 border-transparent bg-transparent px-3 py-2.5 text-sm shadow-none data-[state=active]:border-[color:var(--a-accent)] data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+				>
 					フォロー中
 				</TabsTrigger>
 			</TabsList>


### PR DESCRIPTION
Phase B-0-3。gan-evaluator Blocker 3+4。(a)/page.tsx header に sticky top-0 z-10 追加 / (a)/layout.tsx main の overflow-hidden を除去 / TimelineTabs を A direction の border-bottom underline cosmetic に上書き。Closes #554. Refs #551.