### PR TITLE
[feature][a-direction] Inline compose 行 + LeftNav「投稿する」 を ComposeTweetDialog に wiring (#555)

### DIFF
--- a/client/src/app/(a)/page.tsx
+++ b/client/src/app/(a)/page.tsx
@@ -12,6 +12,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import AComposeShell from "@/components/layout-a/AComposeShell";
 import HomeFeed from "@/components/timeline/HomeFeed";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { HomeTimelinePage } from "@/lib/api/timeline";
@@ -144,6 +145,7 @@ export default async function HomePage({
 					live
 				</span>
 			</header>
+			<AComposeShell />
 			<HomeFeed
 				initialTab={initialTab}
 				initialTweets={initialTweets}

--- a/client/src/components/layout-a/AComposeShell.tsx
+++ b/client/src/components/layout-a/AComposeShell.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+/**
+ * A direction Compose Shell (#555 Phase B-0-4).
+ *
+ * gan-evaluator Blocker 5 への対応。home-a の inline compose 行を実装し、
+ * ALeftNav の「投稿する」 button からも同じ ComposeTweetDialog を起こす wiring。
+ *
+ * - inline compose 行: avatar + 「いま何を作っていますか？」 prompt + IconBtns +
+ *   char counter (180 limit) + cyan「ツイート」 button
+ * - click で既存 ComposeTweetDialog (root tweet 投稿) を開く
+ * - ALeftNav から `window.dispatchEvent('a-compose-open')` でも開く (左ナビ
+ *   「投稿する」 button を /articles/new に飛ばさず本 shell が掴む)
+ *
+ * 設計: ComposeTweetDialog は元々 dialog の open/close を親が握る方式なので、
+ * 本 shell が open state を保有してそれを渡す。
+ */
+
+import { Code, Hash, Sparkles } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+
+import ComposeTweetDialog from "@/components/tweets/ComposeTweetDialog";
+import { useUserProfile } from "@/hooks/useUseProfile";
+
+const COMPOSE_OPEN_EVENT = "a-compose-open";
+
+/** ALeftNav 等の外部 trigger から呼ぶための window event 名 (export して共有). */
+export function dispatchAComposeOpen(): void {
+	if (typeof window !== "undefined") {
+		window.dispatchEvent(new CustomEvent(COMPOSE_OPEN_EVENT));
+	}
+}
+
+export default function AComposeShell() {
+	const { profile } = useUserProfile();
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		const handler = () => setOpen(true);
+		window.addEventListener(COMPOSE_OPEN_EVENT, handler);
+		return () => window.removeEventListener(COMPOSE_OPEN_EVENT, handler);
+	}, []);
+
+	// 未ログイン時は inline compose を出さない (CTA は landing 側で出している)
+	if (!profile) return null;
+
+	const initials = (profile.display_name || profile.username)
+		.slice(0, 2)
+		.toUpperCase();
+
+	return (
+		<>
+			<button
+				type="button"
+				aria-label="ツイートを投稿する"
+				onClick={() => setOpen(true)}
+				className="flex w-full items-start gap-2.5 border-b px-5 py-3 text-left transition-colors hover:bg-[color:var(--a-bg-subtle)] focus-visible:bg-[color:var(--a-bg-subtle)] focus-visible:outline-none"
+				style={{ borderColor: "var(--a-border)" }}
+			>
+				<div
+					className="grid size-8 shrink-0 place-items-center rounded-full font-semibold text-white"
+					style={{ background: "hsl(200 70% 32%)", fontSize: 12 }}
+					aria-hidden
+				>
+					{initials}
+				</div>
+				<div className="flex-1">
+					<div
+						className="text-[color:var(--a-text-subtle)]"
+						style={{ fontSize: 14, padding: "6px 0 8px" }}
+					>
+						いま何を作っていますか？
+					</div>
+					<div className="mt-1 flex items-center gap-1.5">
+						<IconBtn>
+							<Code className="size-3.5" />
+						</IconBtn>
+						<IconBtn>
+							<Hash className="size-3.5" />
+						</IconBtn>
+						<IconBtn>
+							<Sparkles className="size-3.5" />
+						</IconBtn>
+						<span
+							className="ml-auto text-[color:var(--a-text-subtle)]"
+							style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+						>
+							180
+						</span>
+						<span
+							className="rounded-md px-3 py-1 font-medium text-white"
+							style={{
+								background: "var(--a-accent)",
+								fontSize: 12.5,
+								fontFamily: "inherit",
+							}}
+						>
+							ツイート
+						</span>
+					</div>
+				</div>
+			</button>
+			<ComposeTweetDialog open={open} onOpenChange={setOpen} />
+		</>
+	);
+}
+
+function IconBtn({ children }: { children: ReactNode }) {
+	return (
+		<span
+			aria-hidden
+			className="inline-flex size-7 items-center justify-center rounded-md text-[color:var(--a-text-muted)]"
+		>
+			{children}
+		</span>
+	);
+}

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -32,6 +32,7 @@ import {
 	type LucideIcon,
 } from "lucide-react";
 
+import { dispatchAComposeOpen } from "@/components/layout-a/AComposeShell";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -160,10 +161,11 @@ export default function ALeftNav() {
 			)}
 
 			{isAuthenticated && (
-				<Link
-					href="/articles/new"
-					aria-label="ツイート / 記事を書く"
-					className="mt-3.5 inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-2 font-medium text-white transition-opacity hover:opacity-90"
+				<button
+					type="button"
+					onClick={dispatchAComposeOpen}
+					aria-label="ツイートを投稿する"
+					className="mt-3.5 inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-2 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					style={{
 						background: "var(--a-accent)",
 						fontSize: 13.5,
@@ -172,7 +174,7 @@ export default function ALeftNav() {
 				>
 					<Feather className="size-3.5" />
 					投稿する
-				</Link>
+				</button>
 			)}
 
 			{profile ? (

--- a/client/src/components/layout-a/__tests__/AComposeShell.test.tsx
+++ b/client/src/components/layout-a/__tests__/AComposeShell.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests for AComposeShell (#555 — A direction inline compose + dialog wiring).
+ *
+ * 検証:
+ *  1. 未ログインなら inline compose 行を出さない
+ *  2. ログイン済なら「いま何を作っていますか？」プロンプトを表示する
+ *  3. inline 行 click で ComposeTweetDialog が open する
+ *  4. `dispatchAComposeOpen()` (= window 'a-compose-open' event) で開く
+ *     (ALeftNav 「投稿する」 button からの起動を保証する)
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AComposeShell, {
+	dispatchAComposeOpen,
+} from "@/components/layout-a/AComposeShell";
+
+const { mockUseUserProfile } = vi.hoisted(() => ({
+	mockUseUserProfile: vi.fn(),
+}));
+
+vi.mock("@/hooks/useUseProfile", () => ({
+	useUserProfile: mockUseUserProfile,
+}));
+
+// ComposeTweetDialog は実 dialog として open prop を data-testid で露出させる stub。
+vi.mock("@/components/tweets/ComposeTweetDialog", () => ({
+	default: ({
+		open,
+	}: {
+		open: boolean;
+		onOpenChange: (o: boolean) => void;
+	}) => (
+		<div data-testid="compose-dialog" data-open={open ? "true" : "false"} />
+	),
+}));
+
+describe("AComposeShell", () => {
+	beforeEach(() => {
+		mockUseUserProfile.mockReset();
+	});
+
+	it("未ログイン時は inline compose 行を出さない", () => {
+		mockUseUserProfile.mockReturnValue({
+			profile: undefined,
+			isLoading: false,
+			isError: false,
+		});
+		render(<AComposeShell />);
+		expect(screen.queryByText("いま何を作っていますか？")).toBeNull();
+	});
+
+	it("ログイン済なら inline prompt を表示し、初期 dialog は閉じている", () => {
+		mockUseUserProfile.mockReturnValue({
+			profile: { username: "alice", display_name: "Alice" },
+			isLoading: false,
+			isError: false,
+		});
+		render(<AComposeShell />);
+		expect(screen.getByText("いま何を作っていますか？")).toBeInTheDocument();
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"false",
+		);
+	});
+
+	it("inline 行 click で ComposeTweetDialog が open する", () => {
+		mockUseUserProfile.mockReturnValue({
+			profile: { username: "alice", display_name: "Alice" },
+			isLoading: false,
+			isError: false,
+		});
+		render(<AComposeShell />);
+
+		const trigger = screen.getByRole("button", { name: "ツイートを投稿する" });
+		fireEvent.click(trigger);
+
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"true",
+		);
+	});
+
+	it("dispatchAComposeOpen() (window event) でも dialog が open する", () => {
+		mockUseUserProfile.mockReturnValue({
+			profile: { username: "alice", display_name: "Alice" },
+			isLoading: false,
+			isError: false,
+		});
+		render(<AComposeShell />);
+
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"false",
+		);
+
+		act(() => {
+			dispatchAComposeOpen();
+		});
+
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"true",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Phase 10 A direction Phase B-0-4 (#555)。gan-evaluator Blocker 5 への対応。

- **`AComposeShell`** を新設し、ホーム sticky header と HomeFeed の間に inline compose 行を挿入。avatar + 「いま何を作っていますか？」 placeholder + IconBtns (code / hash / sparkle) + 180 char counter + cyan「ツイート」 button。
- **ALeftNav 「投稿する」 button** を `<Link href=\"/articles/new\">` から `<button onClick={dispatchAComposeOpen}>` に置換。誤って記事 editor に飛ばす導線を廃止し、root tweet 投稿 dialog を起こす。
- どちらの trigger でも **既存 `ComposeTweetDialog`** (Phase 1 で実装済み、TweetComposer をラップ) を開く。dialog state は AComposeShell が hosting し、ALeftNav からは `window.dispatchEvent('a-compose-open')` で通知。
- 未ログイン時は compose 行を出さない (landing に既に CTA があるため重複しない)。

### gan-evaluator の指摘との対応

> Blocker 5: ホーム top に compose 行が無い。LeftNav 「投稿する」 が `/articles/new` に飛ばされ root tweet を投稿できない。

→ inline 行と LeftNav button の 2 経路で **同一の ComposeTweetDialog** が起動するようにした。

### スクリーンショット (期待状態)

- `/` (login済) の sticky header 直下に inline compose 行
- 行 click でモーダル open、textarea にフォーカス、ツイート投稿で TL が refresh
- LeftNav 下部「投稿する」 click でも同 modal が open

## Test plan

- [x] `npx vitest run src/components/layout-a/__tests__/AComposeShell.test.tsx` — 4 ケース pass
  - 未ログイン時は inline compose 行を出さない
  - ログイン済なら prompt 表示 + dialog 初期 closed
  - inline 行 click で dialog open
  - `dispatchAComposeOpen()` (window event) でも open
- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — affected files clean
- [x] `npm run build` — production build green
- [ ] CI 全緑
- [ ] **stg 実機検証 (CLAUDE.md §4.5 step 6)**: merge → CD 反映後、Playwright MCP で
  1. login → `/` を開いて inline compose 行が見える
  2. inline 行 click でモーダルが open する
  3. textarea に入力 → ツイート → TL に新ツイートが現れる
  4. LeftNav 「投稿する」 click で同モーダルが open する
  5. 未ログインで `/` を開いて compose 行が **出ない** ことを確認

## Related

- Epic: #549 (Phase 10 Claude Design A direction)
- gan-evaluator finding: 58/100 (#549 評価)
- Series: #552 #553 #554 (B-0-1〜3, merged) → **#555 (本 PR)** → #556 #557 (B-0-5,6)

Closes #555