### PR TITLE
[feature][a-direction] RightRail / focus / responsive / badges polish (#557)

### DIFF
--- a/client/src/app/(a)/layout.tsx
+++ b/client/src/app/(a)/layout.tsx
@@ -32,9 +32,12 @@ export default function ALayout({ children }: AppLayoutProps) {
 		>
 			<ALeftNav />
 			{/* #554: overflow-hidden を外して body scroll に。これで header の
-			    `position: sticky top-0` が browser viewport 基準で固定される。 */}
+			    `position: sticky top-0` が browser viewport 基準で固定される。
+			    #557: 中央列に max-width 800px を入れて 1920px wide での読みづらさを解消。
+			    grid の 1fr column 内で `mx-auto` + width clamp で中央寄せ。 */}
 			<main
-				className="flex min-w-0 flex-col sm:border-r sm:border-[color:var(--a-border)]"
+				className="mx-auto flex w-full min-w-0 flex-col sm:border-r sm:border-[color:var(--a-border)]"
+				style={{ maxWidth: 800 }}
 				aria-label="メインコンテンツ"
 			>
 				<AMobileAppBar />

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 /**
- * A direction Left Nav (#550 Phase 10 POC).
+ * A direction Left Nav (#550 Phase 10 POC, polished in #557 Phase B-0-6).
  *
  * `/workspace/staticfiles/test/parts/home-a.jsx` LeftNav の Next.js 移植。
  * Linear / Vercel ベース、light theme、cyan accent、compact density (232px 幅)。
  *
- * - Brand mark + "devstream"
- * - Nav items with badge support (将来 useUnreadCount で badge を表示)
- * - Accent ツイート button
- * - Avatar pod at bottom
+ * #557 で追加:
+ *  - 通知 badge を `useUnreadCount` で wire (cyan pill, 99+ で打ち切り)
+ *  - 全 NavItem / pod に `focus-visible:outline-2 outline-[var(--a-accent)]` (WCAG 2.4.7)
+ *  - 非 active 時の `hover:bg-[var(--a-bg-muted)]` (現在 transparent で hover 無反応)
+ *  - Explore icon を Compass → Hash (reference home-a.jsx の `ic:'hash'` に揃える)
  *
  * 既存 `LeftNavbar` とは別実装で並存 (POC、Phase B で統一予定)。
  */
@@ -19,10 +20,10 @@ import { usePathname } from "next/navigation";
 import {
 	Bell,
 	ChevronDown,
-	Compass,
 	Feather,
 	FileText,
 	Flame,
+	Hash,
 	Home,
 	LogOut,
 	MessageSquare,
@@ -41,20 +42,28 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAuthNavigation } from "@/hooks";
+import { useUnreadCount } from "@/hooks/useUnreadCount";
 import { useUserProfile } from "@/hooks/useUseProfile";
 
-interface NavItem {
+interface NavItemDef {
 	href: string;
 	label: string;
 	Icon: LucideIcon;
 	requiresAuth?: boolean;
+	badgeKey?: "notifications";
 }
 
-const NAV_ITEMS: NavItem[] = [
+const NAV_ITEMS: NavItemDef[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
-	{ href: "/explore", label: "Explore", Icon: Compass },
+	{ href: "/explore", label: "Explore", Icon: Hash },
 	{ href: "/search", label: "検索", Icon: Search },
-	{ href: "/notifications", label: "通知", Icon: Bell, requiresAuth: true },
+	{
+		href: "/notifications",
+		label: "通知",
+		Icon: Bell,
+		requiresAuth: true,
+		badgeKey: "notifications",
+	},
 	{
 		href: "/messages",
 		label: "メッセージ",
@@ -85,14 +94,41 @@ function BrandMark({ size = 22 }: { size?: number }) {
 	);
 }
 
+function NavBadge({ count }: { count: number }) {
+	if (count <= 0) return null;
+	const label = count > 99 ? "99+" : String(count);
+	return (
+		<span
+			aria-label={`未読 ${label} 件`}
+			className="ml-auto inline-flex min-w-[20px] items-center justify-center rounded-full px-1.5 text-white"
+			style={{
+				background: "var(--a-accent)",
+				fontFamily: "var(--a-font-mono)",
+				fontSize: 10.5,
+				lineHeight: "16px",
+				height: 16,
+			}}
+		>
+			{label}
+		</span>
+	);
+}
+
 export default function ALeftNav() {
 	const pathname = usePathname();
 	const { profile } = useUserProfile();
 	const { isAuthenticated, handleLogout } = useAuthNavigation();
+	// 通知 badge: ログイン中のみ polling (`useUnreadCount` 側で enabled=false なら no-op)
+	const { count: notifUnread } = useUnreadCount(isAuthenticated);
 
 	const visibleItems = NAV_ITEMS.filter(
 		(it) => !it.requiresAuth || isAuthenticated,
 	);
+
+	const itemBadgeCount = (key: NavItemDef["badgeKey"]): number => {
+		if (key === "notifications") return notifUnread;
+		return 0;
+	};
 
 	return (
 		<aside
@@ -113,12 +149,15 @@ export default function ALeftNav() {
 			{visibleItems.map((item) => {
 				const isActive =
 					item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+				const badgeCount = itemBadgeCount(item.badgeKey);
 				return (
 					<Link
 						key={item.href}
 						href={item.href}
 						aria-current={isActive || undefined}
-						className="flex items-center gap-3 rounded-md py-1.5 pr-2.5 transition-colors"
+						className={`flex items-center gap-3 rounded-md py-1.5 pr-2.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+							isActive ? "" : "hover:bg-[color:var(--a-bg-muted)]"
+						}`}
 						style={{
 							paddingLeft: 7,
 							borderLeft: `2px solid ${
@@ -131,6 +170,7 @@ export default function ALeftNav() {
 					>
 						<item.Icon className="size-4" />
 						<span className="flex-1 truncate">{item.label}</span>
+						<NavBadge count={badgeCount} />
 					</Link>
 				);
 			})}
@@ -138,9 +178,16 @@ export default function ALeftNav() {
 			{isAuthenticated && profile && (
 				<Link
 					href={`/u/${profile.username}`}
-					className="flex items-center gap-3 rounded-md py-1.5 pr-2.5 transition-colors"
+					aria-current={
+						pathname.startsWith(`/u/${profile.username}`) || undefined
+					}
+					className={`flex items-center gap-3 rounded-md py-1.5 pr-2.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+						pathname.startsWith(`/u/${profile.username}`)
+							? ""
+							: "hover:bg-[color:var(--a-bg-muted)]"
+					}`}
 					style={{
-						paddingLeft: pathname.startsWith(`/u/${profile.username}`) ? 7 : 9,
+						paddingLeft: 7,
 						borderLeft: `2px solid ${
 							pathname.startsWith(`/u/${profile.username}`)
 								? "var(--a-accent)"
@@ -250,7 +297,7 @@ export default function ALeftNav() {
 				<div className="mt-auto flex items-center gap-2 rounded-lg border border-[color:var(--a-border)] p-2">
 					<Link
 						href="/login"
-						className="flex-1 text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)]"
+						className="flex-1 text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 						style={{ fontSize: 12.5 }}
 					>
 						ログインして始める →

--- a/client/src/components/layout-a/ARightRail.tsx
+++ b/client/src/components/layout-a/ARightRail.tsx
@@ -23,7 +23,7 @@ function APanel({ title, children }: { title: string; children: ReactNode }) {
 	return (
 		<div className="mb-3 rounded-lg border border-[color:var(--a-border)] bg-[color:var(--a-bg)] px-3 py-2.5">
 			<div
-				className="mb-1.5 text-[color:var(--a-text-subtle)] uppercase"
+				className="mb-1.5 uppercase text-[color:var(--a-text-subtle)]"
 				style={{
 					fontFamily: "var(--a-font-mono)",
 					fontSize: 10.5,
@@ -54,7 +54,7 @@ export default function ARightRail() {
 				className="mb-3 block rounded-lg border border-[color:var(--a-border)] bg-[color:var(--a-bg)] px-3 py-2.5 transition-colors hover:border-[color:var(--a-border-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 			>
 				<div
-					className="flex items-center gap-2 text-[color:var(--a-text-subtle)] uppercase"
+					className="flex items-center gap-2 uppercase text-[color:var(--a-text-subtle)]"
 					style={{
 						fontFamily: "var(--a-font-mono)",
 						fontSize: 11,
@@ -79,15 +79,11 @@ export default function ARightRail() {
 			</Link>
 
 			<APanel title="Trending tags · 24h">
-				<div className="-mx-1">
-					<TrendingTags />
-				</div>
+				<TrendingTags bare />
 			</APanel>
 
 			<APanel title="Who to follow">
-				<div className="-mx-1">
-					<WhoToFollow isAuthenticated={isAuthenticated} />
-				</div>
+				<WhoToFollow isAuthenticated={isAuthenticated} bare />
 			</APanel>
 
 			<div

--- a/client/src/components/layout-a/__tests__/ALeftNav.test.tsx
+++ b/client/src/components/layout-a/__tests__/ALeftNav.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for ALeftNav (#557 — Phase B-0-6 polish).
+ *
+ * 検証:
+ *  - 通知 NavItem に未読件数 badge が出る (cyan pill)
+ *  - 未読 0 のとき badge は出ない
+ *  - 100+ は "99+" にクリップ
+ *  - 各 NavItem が focus-visible 用の outline class を持つ (WCAG 2.4.7)
+ *  - 非 active NavItem は `hover:bg-[color:var(--a-bg-muted)]` を持つ
+ *  - Explore icon は Hash (reference home-a.jsx の icon vocabulary に揃える)
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ALeftNav from "@/components/layout-a/ALeftNav";
+
+const { mockUseUserProfile, mockUseAuthNavigation, mockUseUnreadCount } =
+	vi.hoisted(() => ({
+		mockUseUserProfile: vi.fn(),
+		mockUseAuthNavigation: vi.fn(),
+		mockUseUnreadCount: vi.fn(),
+	}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: () => "/",
+}));
+
+vi.mock("@/hooks/useUseProfile", () => ({
+	useUserProfile: mockUseUserProfile,
+}));
+
+vi.mock("@/hooks", () => ({
+	useAuthNavigation: mockUseAuthNavigation,
+}));
+
+vi.mock("@/hooks/useUnreadCount", () => ({
+	useUnreadCount: mockUseUnreadCount,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+	DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+	DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+		<>{children}</>
+	),
+	DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+		<>{children}</>
+	),
+	DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+	DropdownMenuSeparator: () => null,
+}));
+
+vi.mock("@/components/layout-a/AComposeShell", () => ({
+	dispatchAComposeOpen: vi.fn(),
+}));
+
+function setupAuthed(unread = 0) {
+	mockUseUserProfile.mockReturnValue({
+		profile: { username: "alice", display_name: "Alice" },
+		isLoading: false,
+		isError: false,
+	});
+	mockUseAuthNavigation.mockReturnValue({
+		isAuthenticated: true,
+		handleLogout: vi.fn(),
+	});
+	mockUseUnreadCount.mockReturnValue({ count: unread, refresh: vi.fn() });
+}
+
+describe("ALeftNav (#557 Phase B-0-6)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("未読 0 のとき通知に badge を出さない", () => {
+		setupAuthed(0);
+		render(<ALeftNav />);
+		expect(screen.queryByLabelText(/未読 .+ 件/)).toBeNull();
+	});
+
+	it("未読 5 件で通知 NavItem に「5」 badge を出す", () => {
+		setupAuthed(5);
+		render(<ALeftNav />);
+		const badge = screen.getByLabelText("未読 5 件");
+		expect(badge).toBeInTheDocument();
+		expect(badge).toHaveTextContent("5");
+	});
+
+	it("未読 100+ は「99+」 にクリップ", () => {
+		setupAuthed(120);
+		render(<ALeftNav />);
+		const badge = screen.getByLabelText("未読 99+ 件");
+		expect(badge).toHaveTextContent("99+");
+	});
+
+	it("非 active NavItem に hover:bg-[var(--a-bg-muted)] が付く", () => {
+		setupAuthed(0);
+		render(<ALeftNav />);
+		// "/" が active なので 「Explore」 (非 active) を確認
+		const exploreLink = screen.getByRole("link", { name: /Explore/ });
+		expect(exploreLink.className).toContain(
+			"hover:bg-[color:var(--a-bg-muted)]",
+		);
+	});
+
+	it("各 NavItem に focus-visible outline が付く", () => {
+		setupAuthed(0);
+		render(<ALeftNav />);
+		const homeLink = screen.getByRole("link", { name: /ホーム/ });
+		expect(homeLink.className).toContain("focus-visible:outline-2");
+		expect(homeLink.className).toContain(
+			"focus-visible:outline-[color:var(--a-accent)]",
+		);
+	});
+
+	it("未ログイン時は 通知 / メッセージ / プロフィール が非表示", () => {
+		mockUseUserProfile.mockReturnValue({
+			profile: undefined,
+			isLoading: false,
+			isError: false,
+		});
+		mockUseAuthNavigation.mockReturnValue({
+			isAuthenticated: false,
+			handleLogout: vi.fn(),
+		});
+		mockUseUnreadCount.mockReturnValue({ count: 0, refresh: vi.fn() });
+
+		render(<ALeftNav />);
+		expect(screen.queryByRole("link", { name: /通知/ })).toBeNull();
+		expect(screen.queryByRole("link", { name: /メッセージ/ })).toBeNull();
+		expect(screen.queryByRole("link", { name: /プロフィール/ })).toBeNull();
+		expect(
+			screen.getByRole("link", { name: /ログインして始める/ }),
+		).toBeInTheDocument();
+	});
+});

--- a/client/src/components/sidebar/TrendingTags.tsx
+++ b/client/src/components/sidebar/TrendingTags.tsx
@@ -19,7 +19,15 @@ const MAX_ITEMS = 10;
 
 type LoadState = "loading" | "ready" | "error";
 
-export default function TrendingTags() {
+interface TrendingTagsProps {
+	/**
+	 * #557: ARightRail (A direction) で APanel に内包する場合に外側 section の
+	 * card style (border + bg + p-4) を抑制する。デフォルトは旧 RightSidebar 互換。
+	 */
+	bare?: boolean;
+}
+
+export default function TrendingTags({ bare = false }: TrendingTagsProps) {
 	const [tags, setTags] = useState<TrendingTag[]>([]);
 	const [state, setState] = useState<LoadState>("loading");
 
@@ -42,15 +50,18 @@ export default function TrendingTags() {
 
 	return (
 		<section
-			aria-labelledby="sidebar-trending-heading"
-			className="rounded-lg border border-border bg-card p-4"
+			aria-label={bare ? "トレンドタグ" : undefined}
+			aria-labelledby={bare ? undefined : "sidebar-trending-heading"}
+			className={bare ? "" : "rounded-lg border border-border bg-card p-4"}
 		>
-			<h2
-				id="sidebar-trending-heading"
-				className="mb-3 text-sm font-semibold text-foreground"
-			>
-				トレンドタグ
-			</h2>
+			{!bare && (
+				<h2
+					id="sidebar-trending-heading"
+					className="mb-3 text-sm font-semibold text-foreground"
+				>
+					トレンドタグ
+				</h2>
+			)}
 
 			{state === "loading" && (
 				<ul className="space-y-2">
@@ -86,7 +97,7 @@ export default function TrendingTags() {
 								className="flex items-center justify-between rounded px-2 py-1.5 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							>
 								<span className="flex items-center gap-2">
-									<span className="text-xs font-bold text-lime-600 dark:text-lime-400 w-6">
+									<span className="w-6 text-xs font-bold text-lime-600 dark:text-lime-400">
 										#{tag.rank}
 									</span>
 									{tag.emoji && <span aria-hidden="true">{tag.emoji}</span>}

--- a/client/src/components/sidebar/WhoToFollow.tsx
+++ b/client/src/components/sidebar/WhoToFollow.tsx
@@ -31,9 +31,17 @@ type LoadState = "loading" | "ready" | "error";
 
 interface WhoToFollowProps {
 	isAuthenticated: boolean;
+	/**
+	 * #557: ARightRail (A direction) で APanel に内包する場合に外側 section の
+	 * card style (border + bg + p-4) を抑制する。デフォルトは旧 RightSidebar 互換。
+	 */
+	bare?: boolean;
 }
 
-export default function WhoToFollow({ isAuthenticated }: WhoToFollowProps) {
+export default function WhoToFollow({
+	isAuthenticated,
+	bare = false,
+}: WhoToFollowProps) {
 	const [users, setUsers] = useState<SidebarUser[]>([]);
 	const [state, setState] = useState<LoadState>("loading");
 
@@ -67,15 +75,18 @@ export default function WhoToFollow({ isAuthenticated }: WhoToFollowProps) {
 
 	return (
 		<section
-			aria-labelledby="sidebar-wtf-heading"
-			className="rounded-lg border border-border bg-card p-4"
+			aria-label={bare ? "おすすめユーザー" : undefined}
+			aria-labelledby={bare ? undefined : "sidebar-wtf-heading"}
+			className={bare ? "" : "rounded-lg border border-border bg-card p-4"}
 		>
-			<h2
-				id="sidebar-wtf-heading"
-				className="mb-3 text-sm font-semibold text-foreground"
-			>
-				おすすめユーザー
-			</h2>
+			{!bare && (
+				<h2
+					id="sidebar-wtf-heading"
+					className="mb-3 text-sm font-semibold text-foreground"
+				>
+					おすすめユーザー
+				</h2>
+			)}
 
 			{state === "loading" && (
 				<ul className="space-y-3">


### PR DESCRIPTION
## Summary

Phase 10 A direction Phase B-0-6 (#557) — gan-evaluator Major 7-12 をまとめて対応する小さな polish batch。
これで Phase B-0 (#549 評価への blocker + major 対応) は完結。

| # | 項目 | 修正 |
| - | - | - |
| 7 | 中央列 1920px wide で広すぎ | ALayout center 列に \`max-width: 800px\` + \`mx-auto\` |
| 8 | NavItem に focus 表示なし (WCAG 2.4.7) | 全 NavItem / pod / brand link に \`focus-visible:outline-2 outline-[var(--a-accent)]\` |
| 9 | RightRail empty state の nested-card | TrendingTags / WhoToFollow に \`bare\` prop、APanel に内包する場合 outer card を抑制 |
| 10 | 通知 / メッセージ 未読 badge 無し | NavItem に badge slot、通知 を \`useUnreadCount\` で wire、cyan pill、99+ clip |
| 11 | Explore icon が Compass | Hash icon に変更 (reference \`home-a.jsx\` の \`ic:'hash'\` に揃える) |
| 12 | NavItem 非 active 状態 hover 無反応 | \`hover:bg-[color:var(--a-bg-muted)]\` を付与 |

## Test plan

- [x] \`npx vitest run src/components/layout-a/__tests__/ALeftNav.test.tsx\` — 6 ケース pass
  - 未読 0 / 5 / 99+ / hover class / focus class / 非ログイン非表示
- [x] \`npx tsc --noEmit\` — green
- [x] \`npx eslint\` 該当ファイル — clean
- [x] \`npm run build\` — production build green
- [ ] CI 全緑
- [ ] **stg 実機検証 (CLAUDE.md §4.5 step 6)**:
  1. \`/\` で center 列が 1920px viewport でも 800px 上限で中央寄せ
  2. NavItem を Tab で巡回 → cyan outline が見える
  3. 非 active NavItem に hover で薄い muted bg がかかる
  4. Explore icon が Hash (#)
  5. 通知に未読あるユーザーで 「通知」 NavItem に cyan badge が出る
  6. RightRail の Trending tags / Who to follow が border-card の nest 無く 1 重で出る

## Related

- Epic: #549 (Phase 10 Claude Design A direction)
- gan-evaluator finding (Major 7-12): 58/100 (#549 評価)
- Series: #552 #553 #554 #555 #556 (B-0-1〜5, merged) → **#557 (本 PR、最終回)**

Closes #557