### PR TITLE
[feature][a-direction] /articles に sticky header + A accent CTA + nested main 修正 (#566 Phase B-1-1)

### DIFF
--- a/client/e2e/articles-a-direction.spec.ts
+++ b/client/e2e/articles-a-direction.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * /articles A direction polish E2E (#566 Phase B-1-1).
+ *
+ * Spec: docs/specs/articles-a-direction-spec.md
+ *
+ * シナリオ:
+ *   ARTICLES-A-1: 未ログインで /articles を開く → A direction sticky header +
+ *                 「記事を書く」 link + 一覧 or empty。<main> が 1 件のみ。
+ *   ARTICLES-A-2: 未ログインで /articles/<slug> を開く → 詳細表示。
+ *                 sticky header に 「← 記事一覧」 link。<main> が 1 件のみ。
+ *   ARTICLES-A-3: ログイン後 /articles/new を開く → sticky header
+ *                 「記事を書く」。ArticleEditor が見える。<main> が 1 件のみ。
+ *
+ * env: docs/local/e2e-stg.md の test2 を使用。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+) {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+test.describe("/articles A direction polish (#566)", () => {
+	test("ARTICLES-A-1: 未ログインで /articles → sticky header + 一覧 + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/articles`);
+
+		// sticky header: 「記事」 heading
+		await expect(
+			page.getByRole("heading", { name: "記事", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 「記事を書く」 link が見える
+		await expect(page.getByRole("link", { name: /記事を書く/ })).toBeVisible();
+
+		// <main> は layout の 1 件だけ (page 側は <div>)
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("ARTICLES-A-2: 未ログインで /articles/<slug> → sticky header に 「← 記事一覧」 link", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+
+		// Try to find a published article slug via the list page first
+		await page.goto(`${BASE}/articles`);
+		const firstArticleLink = page
+			.locator('a[href^="/articles/"]')
+			.filter({ hasNotText: /記事を書く/ })
+			.first();
+		const count = await firstArticleLink.count();
+		if (count === 0) {
+			test.skip(true, "No published articles on stg, skip detail test");
+			return;
+		}
+		const href = await firstArticleLink.getAttribute("href");
+		await page.goto(`${BASE}${href}`);
+
+		// sticky header: 「← 記事一覧」 link
+		await expect(page.getByRole("link", { name: /記事一覧/ })).toBeVisible({
+			timeout: 15000,
+		});
+
+		// h1 has article title (any text)
+		await expect(page.locator("article h1").first()).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("ARTICLES-A-3: ログイン後 /articles/new → sticky header + editor + 単一 <main>", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.goto(`${BASE}/articles/new`);
+
+		// sticky header に 「記事を書く」
+		await expect(
+			page.getByRole("heading", { name: "記事を書く", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 「← 記事一覧」 link
+		await expect(page.getByRole("link", { name: /記事一覧/ })).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/articles/[slug]/edit/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/edit/page.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import ArticleEditor from "@/components/articles/ArticleEditor";
@@ -33,14 +34,40 @@ export default async function EditArticlePage({ params }: PageProps) {
 	const article = await fetchArticle(params.slug);
 	if (!article) notFound();
 	return (
-		<main className="mx-auto w-full max-w-4xl px-4 py-6">
-			<header className="mb-6">
-				<h1 className="text-2xl font-bold">記事を編集</h1>
-				<p className="mt-1 text-sm text-muted-foreground">
-					{article.title} を編集中。
-				</p>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href={`/articles/${article.slug}`}
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 記事に戻る
+				</Link>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						記事を編集
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{article.title}
+					</p>
+				</div>
 			</header>
-			<ArticleEditor mode="edit" initial={article} />
-		</main>
+			<div className="p-5">
+				<ArticleEditor mode="edit" initial={article} />
+			</div>
+		</>
 	);
 }

--- a/client/src/app/(template)/articles/[slug]/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/page.tsx
@@ -91,50 +91,77 @@ export default async function ArticleDetailPage({ params }: PageProps) {
 	};
 
 	return (
-		<main className="mx-auto w-full max-w-3xl px-4 py-6">
+		<>
 			<script
 				type="application/ld+json"
 				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
 			/>
 
-			<header className="mb-6">
-				<h1 className="text-3xl font-bold leading-tight">{article.title}</h1>
-				<div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-					<Link
-						href={`/u/${article.author.handle}`}
-						className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-					>
-						<span className="font-medium text-foreground">{author}</span>
-						<span className="ml-1">@{article.author.handle}</span>
-					</Link>
-					{article.published_at && (
-						<time dateTime={article.published_at}>
-							{formatDate(article.published_at)}
-						</time>
-					)}
-					{article.status === "draft" && (
-						<span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-900 dark:bg-amber-900/40 dark:text-amber-100">
-							下書き
-						</span>
-					)}
-				</div>
-				{article.tags.length > 0 && (
-					<ul aria-label="タグ" className="mt-3 flex flex-wrap gap-1">
-						{article.tags.map((t) => (
-							<li key={t.slug}>
-								<Link
-									href={`/articles?tag=${encodeURIComponent(t.slug)}`}
-									className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted/70"
-								>
-									#{t.display_name}
-								</Link>
-							</li>
-						))}
-					</ul>
-				)}
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/articles"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 記事一覧
+				</Link>
+				<span
+					className="ml-auto text-[color:var(--a-text-subtle)]"
+					style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+				>
+					article
+				</span>
 			</header>
 
-			<ArticleBody html={article.body_html} />
-		</main>
+			<article className="px-5 py-6">
+				<header className="mb-6">
+					<h1 className="text-3xl font-bold leading-tight">{article.title}</h1>
+					<div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-[color:var(--a-text-muted)]">
+						<Link
+							href={`/u/${article.author.handle}`}
+							className="rounded hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+						>
+							<span className="font-medium text-[color:var(--a-text)]">
+								{author}
+							</span>
+							<span className="ml-1">@{article.author.handle}</span>
+						</Link>
+						{article.published_at && (
+							<time dateTime={article.published_at}>
+								{formatDate(article.published_at)}
+							</time>
+						)}
+						{article.status === "draft" && (
+							<span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-900">
+								下書き
+							</span>
+						)}
+					</div>
+					{article.tags.length > 0 && (
+						<ul aria-label="タグ" className="mt-3 flex flex-wrap gap-1">
+							{article.tags.map((t) => (
+								<li key={t.slug}>
+									<Link
+										href={`/articles?tag=${encodeURIComponent(t.slug)}`}
+										className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)] hover:bg-[color:var(--a-bg-subtle)]"
+									>
+										#{t.display_name}
+									</Link>
+								</li>
+							))}
+						</ul>
+					)}
+				</header>
+
+				<ArticleBody html={article.body_html} />
+			</article>
+		</>
 	);
 }

--- a/client/src/app/(template)/articles/new/page.tsx
+++ b/client/src/app/(template)/articles/new/page.tsx
@@ -1,11 +1,14 @@
 /**
  * /articles/new 記事新規作成ページ (#536 / Phase 6 P6-13).
  *
- * auth 必須 (未ログインは backend が 401 を返すので / login にリダイレクト
+ * auth 必須 (未ログインは backend が 401 を返すので /login にリダイレクト
  * は client 側でも追加で示すが、Server Component の段階では fetch しない)。
+ *
+ * #566 (B-1-1) で外側 <main> を <div> に変更 + sticky header 追加。
  */
 
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import ArticleEditor from "@/components/articles/ArticleEditor";
 
@@ -16,14 +19,40 @@ export const metadata: Metadata = {
 
 export default function NewArticlePage() {
 	return (
-		<main className="mx-auto w-full max-w-4xl px-4 py-6">
-			<header className="mb-6">
-				<h1 className="text-2xl font-bold">記事を書く</h1>
-				<p className="mt-1 text-sm text-muted-foreground">
-					Markdown で書いて、下書き or 公開を選んで保存します。
-				</p>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/articles"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 記事一覧
+				</Link>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						記事を書く
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						Markdown で書いて、下書き or 公開を選んで保存
+					</p>
+				</div>
 			</header>
-			<ArticleEditor mode="create" />
-		</main>
+			<div className="p-5">
+				<ArticleEditor mode="create" />
+			</div>
+		</>
 	);
 }

--- a/client/src/app/(template)/articles/page.tsx
+++ b/client/src/app/(template)/articles/page.tsx
@@ -4,9 +4,16 @@
  * SPEC §12.2 / SPEC §16.2 通り、未ログインで閲覧可能。
  * SSR で公開記事一覧を fetch (cursor pagination の最初のページのみ、
  * 「もっと見る」 は将来 client component で対応)。
+ *
+ * #566 (B-1-1) で A direction polish:
+ *  - 外側 <main> を <div> に変更 ((template)/layout の <main> と二重ネスト解消)
+ *  - sticky header 追加 (他 A direction page と統一)
+ *  - 「記事を書く」 CTA を cyan A accent に変更
  */
 
 import type { Metadata } from "next";
+import Link from "next/link";
+import { Feather } from "lucide-react";
 
 import ArticleCard from "@/components/articles/ArticleCard";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
@@ -58,35 +65,54 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 	})();
 
 	return (
-		<main className="mx-auto w-full max-w-3xl px-4 py-6">
-			<header className="mb-6 flex items-end justify-between">
-				<div>
-					<h1 className="text-2xl font-bold">記事</h1>
-					<p className="mt-1 text-sm text-muted-foreground">
-						{filterDescription} を新しい順で表示します。
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						記事
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{filterDescription}
 					</p>
 				</div>
-				<a
+				<Link
 					href="/articles/new"
-					className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
 				>
+					<Feather className="size-3.5" />
 					記事を書く
-				</a>
+				</Link>
 			</header>
 
-			{articles.length === 0 ? (
-				<p className="rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
-					まだ記事がありません。
-				</p>
-			) : (
-				<ul role="list" className="grid gap-3">
-					{articles.map((a) => (
-						<li key={a.id}>
-							<ArticleCard article={a} />
-						</li>
-					))}
-				</ul>
-			)}
-		</main>
+			<div className="p-5">
+				{articles.length === 0 ? (
+					<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
+						まだ記事がありません。
+					</p>
+				) : (
+					<ul role="list" className="grid gap-3">
+						{articles.map((a) => (
+							<li key={a.id}>
+								<ArticleCard article={a} />
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</>
 	);
 }

--- a/client/src/components/articles/ArticleCard.tsx
+++ b/client/src/components/articles/ArticleCard.tsx
@@ -22,12 +22,12 @@ function formatDate(iso: string | null): string {
 export default function ArticleCard({ article }: ArticleCardProps) {
 	const authorName = article.author.display_name || article.author.handle;
 	return (
-		<article className="rounded-lg border border-border bg-background p-4 transition hover:border-primary/40 hover:shadow-sm">
+		<article className="rounded-lg border border-[color:var(--a-border)] bg-[color:var(--a-bg)] p-4 transition-colors hover:border-[color:var(--a-border-strong)]">
 			<Link
 				href={`/articles/${article.slug}`}
-				className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+				className="block rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 			>
-				<h2 className="text-base font-semibold leading-snug line-clamp-2">
+				<h2 className="line-clamp-2 text-base font-semibold leading-snug">
 					{article.title}
 				</h2>
 			</Link>
@@ -48,7 +48,7 @@ export default function ArticleCard({ article }: ArticleCardProps) {
 			<footer className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
 				<Link
 					href={`/u/${article.author.handle}`}
-					className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+					className="rounded hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 				>
 					<span className="font-medium text-foreground">{authorName}</span>
 					<span className="ml-1">@{article.author.handle}</span>

--- a/client/src/components/articles/ArticleEditor.tsx
+++ b/client/src/components/articles/ArticleEditor.tsx
@@ -198,7 +198,7 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 					<span className="block text-sm font-medium">プレビュー</span>
 					<div
 						aria-label="本文プレビュー"
-						className="mt-1 h-[28rem] overflow-y-auto rounded border border-border bg-muted/20 p-4 text-sm whitespace-pre-wrap"
+						className="mt-1 h-[28rem] overflow-y-auto whitespace-pre-wrap rounded border border-border bg-muted/20 p-4 text-sm"
 					>
 						{body || (
 							<span className="text-muted-foreground">

--- a/docs/specs/articles-a-direction-spec.md
+++ b/docs/specs/articles-a-direction-spec.md
@@ -1,0 +1,82 @@
+# /articles A direction polish (#566 Phase B-1-1)
+
+## 背景
+
+#564 (B-1-0) で `(template)/layout.tsx` を A direction shell に統一した結果、
+`/articles` 配下も A 直格子に乗ったが、本文側にいくつかの残骸:
+
+- 外側 `<main>` が (template)/layout の `<main>` と **二重ネスト** (invalid HTML)
+- 「記事を書く」 CTA が shadcn `bg-primary` で A accent (cyan) と色が衝突
+- 他 A direction page (`/`) と違って sticky header が無く一貫性に欠ける
+
+## 期待動作
+
+### `/articles` (一覧)
+
+- 最上部に **sticky header**: 「記事」 タイトル + filter 説明 + 右に「記事を書く」 cyan pill button
+- header 直下に記事カード一覧 (`ArticleCard` を使った Zenn 風)
+- 外側 wrapper は `<div>` (layout 側の `<main>` と二重ネストしない)
+- 記事ゼロのとき empty state パネル
+
+### `/articles/<slug>` (詳細)
+
+- 最上部に **sticky header**: 「記事」 + 戻る link (`/articles`)
+- 本文は `<article>` で囲み (HTML semantic)、外側 `<main>` を撤廃
+- 既存の OGP / JSON-LD は維持
+
+### `/articles/new` (新規作成)
+
+- 最上部に **sticky header**: 「記事を書く」 + 戻る link (`/articles`)
+- 外側 wrapper は `<div>`、ArticleEditor をそのまま埋め込み
+
+### `/articles/<slug>/edit` (編集)
+
+- 最上部に **sticky header**: 「記事を編集」 + 戻る link (`/articles/<slug>`)
+- 外側 wrapper は `<div>`、ArticleEditor を edit mode で埋め込み
+
+## やらない
+
+- ArticleEditor (Markdown editor) 内部の styling 変更
+- ArticleBody (prose) の dark:prose-invert 削除 (light でも問題なし)
+- Backend API / model 変更
+
+## テスト (E2E)
+
+`client/e2e/articles-a-direction.spec.ts` で stg を踏む。
+
+### シナリオ 1: 一覧の構造
+
+- **誰が**: 未ログイン訪問者
+- **何をする**: `/articles` を開く
+- **何が見える**:
+  - `getByRole('main')` が **1 件のみ** (layout 側の main、page 側は div)
+  - `getByText('記事')` heading が見える
+  - 「記事を書く」 link/button が見える、href=/articles/new
+  - sticky header が viewport top にいる (CSS が適用済)
+
+### シナリオ 2: 詳細の構造
+
+- **誰が**: 未ログイン訪問者
+- **何をする**: `/articles/<existing-slug>` を開く (stg に既存の公開記事を 1 つ用意)
+- **何が見える**:
+  - `getByRole('main')` が 1 件のみ
+  - 記事 title が h1 で表示
+  - 「記事一覧へ戻る」 link が sticky header にある
+
+### シナリオ 3: 新規作成の構造
+
+- **誰が**: ログイン済ユーザー (test2)
+- **何をする**: `/articles/new` を開く
+- **何が見える**:
+  - sticky header に「記事を書く」
+  - 編集 form が見える (`ArticleEditor`)
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+npx playwright test e2e/articles-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-1 (#566)。#564 (B-1-0) で全 (template) page が A direction shell に乗った後、本文側を順次 polish する流れの最初。

### 変更

- 外側 `<main>` 二重ネスト解消: /articles, /articles/[slug], /articles/new, /articles/[slug]/edit
- 各 page に A direction の **sticky header + backdrop blur** を追加
- 「記事を書く」 CTA を shadcn `bg-primary` から **cyan `var(--a-accent)`** に
- 詳細 / 編集ページに「← 記事一覧」 戻る link を sticky header に
- ArticleCard の hover を `border-[color:var(--a-border-strong)]` に揃える
- **e2e: `client/e2e/articles-a-direction.spec.ts`** を新設 (3 シナリオ)
- **spec doc: `docs/specs/articles-a-direction-spec.md`** を新設

### やらない

- ArticleEditor 内部 styling (Markdown editor) — 別 issue
- ArticleBody (`prose`) の dark:prose-invert 変更 — light でも問題なし

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npx eslint --fix` — clean
- [x] `npm run build` — production build green
- [ ] CI 全緑
- [ ] **stg E2E (CLAUDE.md §4.5 step 6 第一選択)** — merge → CD 反映後:
  ```bash
  PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
  PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
  PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
  PLAYWRIGHT_USER1_HANDLE=test2 \
  npx playwright test e2e/articles-a-direction.spec.ts
  ```

## Related

- Epic: #549 (Phase 10 Claude Design A direction)
- Previous: #564 (B-1-0, shell unify) → **#566 (本 PR, /articles polish)**

Closes #566