### PR TITLE
[feature][a-direction] /u/[handle] プロフィールに sticky header + A accent tab underline (#568 Phase B-1-2)

### DIFF
--- a/client/e2e/profile-a-direction.spec.ts
+++ b/client/e2e/profile-a-direction.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * /u/[handle] A direction polish E2E (#568 Phase B-1-2).
+ *
+ * Spec: docs/specs/profile-a-direction-spec.md
+ *
+ * シナリオ:
+ *   PROFILE-A-1: 未ログインで /u/test2 → sticky header + 単一 <main> + tabs
+ *   PROFILE-A-2: 未ログインで /u/test2/followers → 戻る link + 「フォロワー」 + 単一 <main>
+ *   PROFILE-A-3: 未ログインで /u/test2/following → 戻る link + 「フォロー中」 + 単一 <main>
+ *
+ * env: docs/local/e2e-stg.md の test2 を使用。
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+const HANDLE = process.env.PLAYWRIGHT_USER1_HANDLE ?? "test2";
+
+test.describe("/u/[handle] A direction polish (#568)", () => {
+	test("PROFILE-A-1: 未ログインで /u/<handle> → sticky header + 単一 <main> + tabs", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/u/${HANDLE}`);
+
+		// sticky header: display_name or username が h1
+		await expect(page.locator("h1").first()).toBeVisible({ timeout: 15000 });
+
+		// @handle がどこかに見える (sticky header または stats)
+		await expect(page.getByText(`@${HANDLE}`).first()).toBeVisible();
+
+		// tabs (ポスト / いいね)
+		await expect(page.getByRole("link", { name: "ポスト" })).toBeVisible();
+		await expect(page.getByRole("link", { name: "いいね" })).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("PROFILE-A-2: 未ログインで /u/<handle>/followers → 戻る link + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/u/${HANDLE}/followers`);
+
+		// 戻る link
+		await expect(
+			page.getByRole("link", { name: new RegExp(`@${HANDLE}`) }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 「フォロワー」 heading
+		await expect(
+			page.getByRole("heading", { name: "フォロワー", level: 1 }),
+		).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("PROFILE-A-3: 未ログインで /u/<handle>/following → 戻る link + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/u/${HANDLE}/following`);
+
+		// 戻る link
+		await expect(
+			page.getByRole("link", { name: new RegExp(`@${HANDLE}`) }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 「フォロー中」 heading
+		await expect(
+			page.getByRole("heading", { name: "フォロー中", level: 1 }),
+		).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/u/[handle]/followers/page.tsx
+++ b/client/src/app/(template)/u/[handle]/followers/page.tsx
@@ -31,23 +31,43 @@ export default async function FollowersPage({ params }: PageProps) {
 	if (!profile) notFound();
 
 	return (
-		<main className="mx-auto max-w-3xl pb-10">
-			<header className="border-b border-border px-4 py-3">
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
 				<Link
 					href={`/u/${profile.username}`}
-					className="text-xs text-muted-foreground hover:underline"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
 				>
-					← {profile.display_name || profile.username} さんのプロフィールへ戻る
+					← @{profile.username}
 				</Link>
-				<h1 className="mt-1 text-lg font-bold">
-					{profile.display_name || profile.username} のフォロワー
-				</h1>
-				<p className="text-xs text-muted-foreground">@{profile.username}</p>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						フォロワー
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{profile.display_name || profile.username}
+					</p>
+				</div>
 			</header>
-			<UserList
-				endpoint={`/users/${profile.username}/followers/`}
-				emptyMessage="フォロワーはまだいません。"
-			/>
-		</main>
+			<div className="pb-10">
+				<UserList
+					endpoint={`/users/${profile.username}/followers/`}
+					emptyMessage="フォロワーはまだいません。"
+				/>
+			</div>
+		</>
 	);
 }

--- a/client/src/app/(template)/u/[handle]/following/page.tsx
+++ b/client/src/app/(template)/u/[handle]/following/page.tsx
@@ -31,23 +31,43 @@ export default async function FollowingPage({ params }: PageProps) {
 	if (!profile) notFound();
 
 	return (
-		<main className="mx-auto max-w-3xl pb-10">
-			<header className="border-b border-border px-4 py-3">
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
 				<Link
 					href={`/u/${profile.username}`}
-					className="text-xs text-muted-foreground hover:underline"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
 				>
-					← {profile.display_name || profile.username} さんのプロフィールへ戻る
+					← @{profile.username}
 				</Link>
-				<h1 className="mt-1 text-lg font-bold">
-					{profile.display_name || profile.username} がフォロー中
-				</h1>
-				<p className="text-xs text-muted-foreground">@{profile.username}</p>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						フォロー中
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{profile.display_name || profile.username}
+					</p>
+				</div>
 			</header>
-			<UserList
-				endpoint={`/users/${profile.username}/following/`}
-				emptyMessage="まだ誰もフォローしていません。"
-			/>
-		</main>
+			<div className="pb-10">
+				<UserList
+					endpoint={`/users/${profile.username}/following/`}
+					emptyMessage="まだ誰もフォローしていません。"
+				/>
+			</div>
+		</>
 	);
 }

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -155,7 +155,7 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 	};
 
 	return (
-		<main className="mx-auto max-w-3xl px-4 pb-10">
+		<>
 			<script
 				type="application/ld+json"
 				// security-reviewer Phase 1 CRITICAL: profile.bio / display_name は
@@ -164,202 +164,231 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
 			/>
 
-			{profile.header_url && (
-				// eslint-disable-next-line @next/next/no-img-element
-				<img
-					src={profile.header_url}
-					alt=""
-					className="aspect-[3/1] w-full rounded-lg object-cover"
-				/>
-			)}
-
-			<header className="-mt-10 flex flex-col gap-3 px-4 sm:flex-row sm:items-end sm:gap-6">
-				{profile.avatar_url ? (
-					// eslint-disable-next-line @next/next/no-img-element
-					<img
-						src={profile.avatar_url}
-						alt=""
-						className="size-24 rounded-full border-4 border-background bg-muted"
-					/>
-				) : (
+			{/* #568: sticky context bar — body の <h1> と重複させないため heading
+			    にはしない。本文 header の "プロフィール" を sticky に summary 表示。 */}
+			<div
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
 					<div
-						className="size-24 rounded-full border-4 border-background bg-muted"
-						aria-hidden
-					/>
-				)}
-				<div className="flex-1 pb-2">
-					<h1 className="text-xl font-bold sm:text-2xl">
+						className="truncate font-semibold tracking-tight text-[color:var(--a-text)]"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
 						{profile.display_name || profile.username}
-					</h1>
-					<div className="text-sm text-muted-foreground">
+					</div>
+					<div
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
 						@{profile.username}
 					</div>
 				</div>
-				{/* #296 + #299: profile header の右端に Follow / DM 入口を並べる。
-				    self / 未ログイン判定は各 component 内で行うので親は条件分岐不要。 */}
-				<div className="flex items-center gap-2 pb-2">
-					{isOwnProfile ? (
-						<a
-							href="/settings/profile"
-							className="rounded-full border border-border px-4 py-2 text-sm font-semibold transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-						>
-							プロフィールを編集
-						</a>
-					) : (
-						<>
-							<FollowButton
-								targetHandle={profile.username}
-								initialIsFollowing={profile.is_following}
-							/>
-							<StartDMButton targetHandle={profile.username} />
-							{/* Phase 4B (#448): X 風 kebab → ミュート / ブロック / 通報 */}
-							<ProfileKebab
-								target_handle={profile.username}
-								target_user_id={profile.user_id}
-								initial_is_blocking={profile.is_blocking}
-								initial_is_muting={profile.is_muting}
-							/>
-						</>
-					)}
-				</div>
-			</header>
-
-			{profile.bio && (
-				<p className="mt-4 whitespace-pre-wrap px-4 text-sm">{profile.bio}</p>
-			)}
-
-			<ul className="mt-3 flex flex-wrap gap-3 px-4 text-sm">
-				{SNS_LINKS.filter(({ key }) => profile[key]).map(({ key, label }) => (
-					<li key={key}>
-						<a
-							href={profile[key] as string}
-							rel="noopener noreferrer"
-							target="_blank"
-							className="underline hover:text-indigo-500 dark:hover:text-lime-400"
-						>
-							{label}
-						</a>
-					</li>
-				))}
-			</ul>
-
-			{/* #421: フォロー数 / フォロワー数 (X 風)。click で一覧ページへ。 */}
-			<div className="mt-3 flex flex-wrap gap-5 px-4 text-sm">
-				<Link
-					href={`/u/${profile.username}/following`}
-					className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-				>
-					<span className="font-semibold text-foreground">
-						{profile.following_count.toLocaleString()}
-					</span>
-					<span className="ml-1 text-muted-foreground">フォロー中</span>
-				</Link>
-				<Link
-					href={`/u/${profile.username}/followers`}
-					className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-				>
-					<span className="font-semibold text-foreground">
-						{profile.followers_count.toLocaleString()}
-					</span>
-					<span className="ml-1 text-muted-foreground">フォロワー</span>
-				</Link>
 			</div>
 
-			{/* #421: ポスト / いいね タブ (X 風)。?tab=likes で切替。
-			    #499: 自分のプロフィールのみ「お気に入り」 タブを追加。 */}
-			<nav
-				aria-label="プロフィール タブ"
-				className="mt-6 flex border-b border-border px-4"
-			>
-				{(
-					(isOwnProfile
-						? [
-								{
-									key: "tweets",
-									label: "ポスト",
-									href: `/u/${profile.username}`,
-								},
-								{
-									key: "likes",
-									label: "いいね",
-									href: `/u/${profile.username}?tab=likes`,
-								},
-								{
-									key: "favorites",
-									label: "お気に入り",
-									href: `/u/${profile.username}?tab=favorites`,
-								},
-							]
-						: [
-								{
-									key: "tweets",
-									label: "ポスト",
-									href: `/u/${profile.username}`,
-								},
-								{
-									key: "likes",
-									label: "いいね",
-									href: `/u/${profile.username}?tab=likes`,
-								},
-							]) as ReadonlyArray<{
-						key: ProfileTab;
-						label: string;
-						href: string;
-					}>
-				).map((t) => (
-					<Link
-						key={t.key}
-						href={t.href}
-						aria-current={tab === t.key ? "page" : undefined}
-						className={`relative px-4 py-3 text-sm font-medium transition ${
-							tab === t.key
-								? "text-foreground"
-								: "text-muted-foreground hover:bg-muted/40"
-						}`}
-					>
-						{t.label}
-						{tab === t.key ? (
-							<span
-								aria-hidden="true"
-								className="absolute inset-x-2 bottom-0 h-1 rounded-full bg-primary"
-							/>
-						) : null}
-					</Link>
-				))}
-			</nav>
-
-			<section className="mt-4 px-4" aria-labelledby="tweets-heading">
-				<h2 id="tweets-heading" className="sr-only">
-					{tab === "likes"
-						? "いいねした投稿"
-						: tab === "favorites"
-							? "お気に入り"
-							: "ツイート"}
-				</h2>
-				{tab === "favorites" && isOwnProfile ? (
-					/* #499: 自分のお気に入り (Google ブックマーク風 folder ツリー)。
-					    他人プロフィールでは tab 自体非表示にしているが、
-					    URL 直叩きで来たケースに備えて isOwnProfile gate を二重化。 */
-					<FavoritesTab currentUserHandle={profile.username} />
-				) : tab === "likes" ? (
-					<TweetCardList
-						tweets={likedTweets}
-						ariaLabel={`@${profile.username} がいいねした投稿`}
-						emptyMessage="いいねした投稿がありません。"
-						currentUserHandle={currentUser?.username}
-					/>
-				) : (
-					/* #298: 旧 plain link 列挙を TweetCard ベースに置換。
-					    リアクション (P2-14) / RT (P2-15) / 「もっと見る」展開 (P2-18)
-					    が本配線される。HomeFeed と同 ARIA feed pattern。 */
-					<TweetCardList
-						tweets={tweets}
-						ariaLabel={`@${profile.username} のツイート`}
-						emptyMessage="まだツイートがありません。"
-						currentUserHandle={currentUser?.username}
+			<div className="px-4 pb-10">
+				{profile.header_url && (
+					// eslint-disable-next-line @next/next/no-img-element
+					<img
+						src={profile.header_url}
+						alt=""
+						className="aspect-[3/1] w-full rounded-lg object-cover"
 					/>
 				)}
-			</section>
-		</main>
+
+				<header className="-mt-10 flex flex-col gap-3 px-4 sm:flex-row sm:items-end sm:gap-6">
+					{profile.avatar_url ? (
+						// eslint-disable-next-line @next/next/no-img-element
+						<img
+							src={profile.avatar_url}
+							alt=""
+							className="size-24 rounded-full border-4 border-background bg-muted"
+						/>
+					) : (
+						<div
+							className="size-24 rounded-full border-4 border-background bg-muted"
+							aria-hidden
+						/>
+					)}
+					<div className="flex-1 pb-2">
+						<h1 className="text-xl font-bold sm:text-2xl">
+							{profile.display_name || profile.username}
+						</h1>
+						<div className="text-sm text-muted-foreground">
+							@{profile.username}
+						</div>
+					</div>
+					{/* #296 + #299: profile header の右端に Follow / DM 入口を並べる。
+				    self / 未ログイン判定は各 component 内で行うので親は条件分岐不要。 */}
+					<div className="flex items-center gap-2 pb-2">
+						{isOwnProfile ? (
+							<a
+								href="/settings/profile"
+								className="rounded-full border border-border px-4 py-2 text-sm font-semibold transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							>
+								プロフィールを編集
+							</a>
+						) : (
+							<>
+								<FollowButton
+									targetHandle={profile.username}
+									initialIsFollowing={profile.is_following}
+								/>
+								<StartDMButton targetHandle={profile.username} />
+								{/* Phase 4B (#448): X 風 kebab → ミュート / ブロック / 通報 */}
+								<ProfileKebab
+									target_handle={profile.username}
+									target_user_id={profile.user_id}
+									initial_is_blocking={profile.is_blocking}
+									initial_is_muting={profile.is_muting}
+								/>
+							</>
+						)}
+					</div>
+				</header>
+
+				{profile.bio && (
+					<p className="mt-4 whitespace-pre-wrap px-4 text-sm">{profile.bio}</p>
+				)}
+
+				<ul className="mt-3 flex flex-wrap gap-3 px-4 text-sm">
+					{SNS_LINKS.filter(({ key }) => profile[key]).map(({ key, label }) => (
+						<li key={key}>
+							<a
+								href={profile[key] as string}
+								rel="noopener noreferrer"
+								target="_blank"
+								className="underline hover:text-[color:var(--a-accent)]"
+							>
+								{label}
+							</a>
+						</li>
+					))}
+				</ul>
+
+				{/* #421: フォロー数 / フォロワー数 (X 風)。click で一覧ページへ。 */}
+				<div className="mt-3 flex flex-wrap gap-5 px-4 text-sm">
+					<Link
+						href={`/u/${profile.username}/following`}
+						className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					>
+						<span className="font-semibold text-foreground">
+							{profile.following_count.toLocaleString()}
+						</span>
+						<span className="ml-1 text-muted-foreground">フォロー中</span>
+					</Link>
+					<Link
+						href={`/u/${profile.username}/followers`}
+						className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					>
+						<span className="font-semibold text-foreground">
+							{profile.followers_count.toLocaleString()}
+						</span>
+						<span className="ml-1 text-muted-foreground">フォロワー</span>
+					</Link>
+				</div>
+
+				{/* #421: ポスト / いいね タブ (X 風)。?tab=likes で切替。
+			    #499: 自分のプロフィールのみ「お気に入り」 タブを追加。 */}
+				<nav
+					aria-label="プロフィール タブ"
+					className="mt-6 flex border-b border-border px-4"
+				>
+					{(
+						(isOwnProfile
+							? [
+									{
+										key: "tweets",
+										label: "ポスト",
+										href: `/u/${profile.username}`,
+									},
+									{
+										key: "likes",
+										label: "いいね",
+										href: `/u/${profile.username}?tab=likes`,
+									},
+									{
+										key: "favorites",
+										label: "お気に入り",
+										href: `/u/${profile.username}?tab=favorites`,
+									},
+								]
+							: [
+									{
+										key: "tweets",
+										label: "ポスト",
+										href: `/u/${profile.username}`,
+									},
+									{
+										key: "likes",
+										label: "いいね",
+										href: `/u/${profile.username}?tab=likes`,
+									},
+								]) as ReadonlyArray<{
+							key: ProfileTab;
+							label: string;
+							href: string;
+						}>
+					).map((t) => (
+						<Link
+							key={t.key}
+							href={t.href}
+							aria-current={tab === t.key ? "page" : undefined}
+							className={`relative px-4 py-3 text-sm font-medium transition ${
+								tab === t.key
+									? "text-foreground"
+									: "text-muted-foreground hover:bg-muted/40"
+							}`}
+						>
+							{t.label}
+							{tab === t.key ? (
+								<span
+									aria-hidden="true"
+									className="absolute inset-x-2 bottom-0 h-1 rounded-full"
+									style={{ background: "var(--a-accent)" }}
+								/>
+							) : null}
+						</Link>
+					))}
+				</nav>
+
+				<section className="mt-4 px-4" aria-labelledby="tweets-heading">
+					<h2 id="tweets-heading" className="sr-only">
+						{tab === "likes"
+							? "いいねした投稿"
+							: tab === "favorites"
+								? "お気に入り"
+								: "ツイート"}
+					</h2>
+					{tab === "favorites" && isOwnProfile ? (
+						/* #499: 自分のお気に入り (Google ブックマーク風 folder ツリー)。
+					    他人プロフィールでは tab 自体非表示にしているが、
+					    URL 直叩きで来たケースに備えて isOwnProfile gate を二重化。 */
+						<FavoritesTab currentUserHandle={profile.username} />
+					) : tab === "likes" ? (
+						<TweetCardList
+							tweets={likedTweets}
+							ariaLabel={`@${profile.username} がいいねした投稿`}
+							emptyMessage="いいねした投稿がありません。"
+							currentUserHandle={currentUser?.username}
+						/>
+					) : (
+						/* #298: 旧 plain link 列挙を TweetCard ベースに置換。
+					    リアクション (P2-14) / RT (P2-15) / 「もっと見る」展開 (P2-18)
+					    が本配線される。HomeFeed と同 ARIA feed pattern。 */
+						<TweetCardList
+							tweets={tweets}
+							ariaLabel={`@${profile.username} のツイート`}
+							emptyMessage="まだツイートがありません。"
+							currentUserHandle={currentUser?.username}
+						/>
+					)}
+				</section>
+			</div>
+		</>
 	);
 }

--- a/docs/specs/profile-a-direction-spec.md
+++ b/docs/specs/profile-a-direction-spec.md
@@ -1,0 +1,71 @@
+# /u/[handle] A direction polish (#568 Phase B-1-2)
+
+## 背景
+
+#564 (B-1-0) で全 page A direction shell に統一、#566 (B-1-1) で /articles を polish。次にプロフィール (`/u/[handle]`) を A direction に整合させる。
+
+## 期待動作
+
+### `/u/[handle]` (プロフィール本体)
+
+- 最上部に **sticky header**: 表示名 + @handle (固定で見える状態)
+- 外側 wrapper を `<div>` に変更 ((template)/layout の `<main>` と二重ネスト解消)
+- タブ active underline を `bg-primary` から **cyan `var(--a-accent)`** に
+- SNS link (GitHub / X / Zenn 等) の hover を `hover:text-indigo-500 dark:hover:text-lime-400` から **`hover:text-[color:var(--a-accent)]`** に
+- 既存 component (Header image / Avatar / FollowButton / StartDMButton / ProfileKebab / TweetCardList) は無変更
+
+### `/u/[handle]/followers`
+
+- 最上部に **sticky header**: 「← @handle」 戻る link + 「フォロワー」 タイトル + 表示名
+- 外側 wrapper を `<div>` に変更
+
+### `/u/[handle]/following`
+
+- 同様に sticky header + `<div>` wrapper
+
+## やらない
+
+- TweetCard / TweetCardList の dark theme 残骸 — 別 issue
+- FavoritesTab の light theme 化 — 別 issue
+- ProfileEditForm (settings) — Phase B-1-? settings 系
+- Avatar / header image の `next/image` 化 — 別 issue
+- ProfileKebab / FollowButton / StartDMButton の styling — 別 issue
+
+## テスト (E2E)
+
+`client/e2e/profile-a-direction.spec.ts` で stg を踏む。
+
+### シナリオ 1: プロフィール構造
+
+- **誰が**: 未ログイン訪問者
+- **何をする**: `/u/test2` を開く
+- **何が見える**:
+  - `getByRole('main')` が **1 件のみ** (layout 側)
+  - sticky header に表示名 + @test2 が見える
+  - 「ポスト」 「いいね」 タブが見える
+
+### シナリオ 2: フォロワー一覧の構造
+
+- **誰が**: 未ログイン訪問者
+- **何をする**: `/u/test2/followers` を開く
+- **何が見える**:
+  - `getByRole('main')` が 1 件のみ
+  - sticky header に 「← @test2」 戻る link + 「フォロワー」 heading
+
+### シナリオ 3: フォロー中一覧の構造
+
+- **誰が**: 未ログイン訪問者
+- **何をする**: `/u/test2/following` を開く
+- **何が見える**:
+  - `getByRole('main')` が 1 件のみ
+  - sticky header に 「← @test2」 戻る link + 「フォロー中」 heading
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+npx playwright test e2e/profile-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-2 (#568)。#566 (B-1-1, /articles) に続いて、利用頻度の高いプロフィール 3 ページを A direction に polish。

### 変更

- /u/[handle], /u/[handle]/followers, /u/[handle]/following で:
  - 外側 \`<main>\` → \`<div>\` (nested main 解消)
  - A direction sticky context bar + backdrop blur
- profile tab active underline を shadcn \`bg-primary\` から **cyan \`var(--a-accent)\`** に
- SNS link hover を \`hover:text-indigo-500 dark:hover:text-lime-400\` から \`var(--a-accent)\` に
- followers / following の戻る link を sticky header に集約

### a11y

- /u/[handle] は body header に既存の \`<h1>\` があるため、sticky bar は \`<div>\` で実装 (h1 重複回避)
- followers / following は sticky bar 内の \`<h1>\` がページ唯一の見出し

### やらない

- TweetCard / FavoritesTab の light theme 化 — 別 issue
- Avatar / header_url の next/image 化 — 別 issue
- ProfileEditForm (settings) — 別 issue

## Test plan

- [x] tsc / eslint / build 全 green
- [ ] CI 全緑
- [ ] stg E2E (CLAUDE.md §4.5):
\`\`\`bash
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \\
PLAYWRIGHT_USER1_HANDLE=test2 \\
npx playwright test e2e/profile-a-direction.spec.ts
\`\`\`

## Related

- Epic: #549
- Previous: #564 (B-1-0 shell unify) → #566 (B-1-1 /articles) → **#568 (本 PR, B-1-2 /profile)**

Closes #568