### PR TITLE
[feature][a-direction] /boards を A direction に polish (#570 Phase B-1-3)

### DIFF
--- a/client/e2e/boards-a-direction.spec.ts
+++ b/client/e2e/boards-a-direction.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * /boards A direction polish E2E (#570 Phase B-1-3).
+ *
+ * Spec: docs/specs/boards-a-direction-spec.md
+ *
+ * シナリオ:
+ *   BOARDS-A-1: 未ログインで /boards → sticky header + 単一 <main>
+ *   BOARDS-A-2: 未ログインで /boards/<slug> → 戻る link + 単一 <main>
+ *
+ * env: docs/local/e2e-stg.md
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+test.describe("/boards A direction polish (#570)", () => {
+	test("BOARDS-A-1: 未ログインで /boards → sticky header + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/boards`);
+
+		// h1 「掲示板」
+		await expect(
+			page.getByRole("heading", { name: "掲示板", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("BOARDS-A-2: 未ログインで /boards/<slug> → 戻る link + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+
+		// Find a board slug via the list page
+		await page.goto(`${BASE}/boards`);
+		const firstBoardLink = page.locator('a[href^="/boards/"]').first();
+		const count = await firstBoardLink.count();
+		if (count === 0) {
+			test.skip(true, "No boards on stg, skip detail test");
+			return;
+		}
+		const href = await firstBoardLink.getAttribute("href");
+		await page.goto(`${BASE}${href}`);
+
+		// 「← 掲示板」 戻る link
+		await expect(
+			page.getByRole("link", { name: /掲示板/ }).first(),
+		).toBeVisible({ timeout: 15000 });
+
+		// 板名 h1 が見える (どんな名前でも level=1 の heading が 1 つ以上)
+		await expect(page.locator("h1").first()).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/boards/[slug]/page.tsx
+++ b/client/src/app/(template)/boards/[slug]/page.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cookies } from "next/headers";
 
@@ -66,80 +67,104 @@ export default async function BoardDetailPage({
 	const isAuthenticated = cookies().get("logged_in")?.value === "true";
 
 	return (
-		<main className="mx-auto w-full max-w-3xl px-4 py-6">
-			<header className="mb-6 flex items-start gap-3">
-				<div
-					className="mt-2 h-2 w-2 shrink-0 rounded-full"
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/boards"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 掲示板
+				</Link>
+				<span
+					className="size-2 shrink-0 rounded-full"
 					style={{ backgroundColor: board.color }}
 					aria-hidden="true"
 				/>
-				<div>
-					<h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
 						{board.name}
 					</h1>
 					{board.description && (
-						<p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+						<p
+							className="truncate text-[color:var(--a-text-subtle)]"
+							style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+						>
 							{board.description}
 						</p>
 					)}
 				</div>
 			</header>
 
-			<section className="mb-6">
-				<ThreadComposer
-					boardSlug={board.slug}
-					isAuthenticated={isAuthenticated}
-				/>
-			</section>
+			<div className="p-5">
+				<section className="mb-6">
+					<ThreadComposer
+						boardSlug={board.slug}
+						isAuthenticated={isAuthenticated}
+					/>
+				</section>
 
-			<section aria-labelledby="thread-list-heading">
-				<h2 id="thread-list-heading" className="sr-only">
-					スレッド一覧
-				</h2>
-				{threads.count === 0 ? (
-					<p className="text-sm text-gray-500 dark:text-gray-400">
-						まだスレッドがありません。
-					</p>
-				) : (
-					<ul
-						role="list"
-						className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+				<section aria-labelledby="thread-list-heading">
+					<h2 id="thread-list-heading" className="sr-only">
+						スレッド一覧
+					</h2>
+					{threads.count === 0 ? (
+						<p className="text-sm text-[color:var(--a-text-muted)]">
+							まだスレッドがありません。
+						</p>
+					) : (
+						<ul
+							role="list"
+							className="rounded-lg border border-[color:var(--a-border)] bg-[color:var(--a-bg)]"
+						>
+							{threads.results.map((t) => (
+								<ThreadRow key={t.id} thread={t} />
+							))}
+						</ul>
+					)}
+
+					<nav
+						aria-label="ページネーション"
+						className="mt-4 flex items-center justify-between text-sm"
 					>
-						{threads.results.map((t) => (
-							<ThreadRow key={t.id} thread={t} />
-						))}
-					</ul>
-				)}
-
-				<nav
-					aria-label="ページネーション"
-					className="mt-4 flex items-center justify-between text-sm"
-				>
-					{threads.previous ? (
-						<a
-							href={`/boards/${board.slug}?page=${page - 1}`}
-							className="text-blue-600 hover:underline dark:text-blue-400"
-						>
-							← 前のページ
-						</a>
-					) : (
-						<span />
-					)}
-					<span className="text-gray-500 dark:text-gray-400">
-						全 {threads.count} 件
-					</span>
-					{threads.next ? (
-						<a
-							href={`/boards/${board.slug}?page=${page + 1}`}
-							className="text-blue-600 hover:underline dark:text-blue-400"
-						>
-							次のページ →
-						</a>
-					) : (
-						<span />
-					)}
-				</nav>
-			</section>
-		</main>
+						{threads.previous ? (
+							<Link
+								href={`/boards/${board.slug}?page=${page - 1}`}
+								className="rounded hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+								style={{ color: "var(--a-accent)" }}
+							>
+								← 前のページ
+							</Link>
+						) : (
+							<span />
+						)}
+						<span className="text-[color:var(--a-text-muted)]">
+							全 {threads.count} 件
+						</span>
+						{threads.next ? (
+							<Link
+								href={`/boards/${board.slug}?page=${page + 1}`}
+								className="rounded hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+								style={{ color: "var(--a-accent)" }}
+							>
+								次のページ →
+							</Link>
+						) : (
+							<span />
+						)}
+					</nav>
+				</section>
+			</div>
+		</>
 	);
 }

--- a/client/src/app/(template)/boards/page.tsx
+++ b/client/src/app/(template)/boards/page.tsx
@@ -30,29 +30,46 @@ export default async function BoardsListPage() {
 	const boards = await fetchBoardsSSR();
 
 	return (
-		<main className="mx-auto w-full max-w-3xl px-4 py-6">
-			<header className="mb-6">
-				<h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-					掲示板
-				</h1>
-				<p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-					技術トピックごとに議論する場所です。誰でも閲覧でき、ログインすればスレッドやレスを投稿できます。
-				</p>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						掲示板
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						技術トピックごとに議論する場所
+					</p>
+				</div>
 			</header>
 
-			{boards.length === 0 ? (
-				<p className="text-sm text-gray-500 dark:text-gray-400">
-					まだ板がありません。
-				</p>
-			) : (
-				<ul role="list" className="grid gap-3 sm:grid-cols-2">
-					{boards.map((b) => (
-						<li key={b.slug}>
-							<BoardCard board={b} />
-						</li>
-					))}
-				</ul>
-			)}
-		</main>
+			<div className="p-5">
+				{boards.length === 0 ? (
+					<p className="text-sm text-[color:var(--a-text-muted)]">
+						まだ板がありません。
+					</p>
+				) : (
+					<ul role="list" className="grid gap-3 sm:grid-cols-2">
+						{boards.map((b) => (
+							<li key={b.slug}>
+								<BoardCard board={b} />
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</>
 	);
 }

--- a/client/src/components/boards/BoardCard.tsx
+++ b/client/src/components/boards/BoardCard.tsx
@@ -17,7 +17,7 @@ export default function BoardCard({ board }: BoardCardProps) {
 	return (
 		<Link
 			href={`/boards/${board.slug}`}
-			className="group flex flex-col rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-700 dark:bg-gray-900"
+			className="group flex flex-col rounded-lg border border-[color:var(--a-border)] bg-[color:var(--a-bg)] p-4 transition-colors hover:border-[color:var(--a-border-strong)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 			aria-label={`${board.name} 板`}
 		>
 			<div
@@ -25,11 +25,11 @@ export default function BoardCard({ board }: BoardCardProps) {
 				style={{ backgroundColor: board.color }}
 				aria-hidden="true"
 			/>
-			<h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 group-hover:underline">
+			<h2 className="text-lg font-semibold text-[color:var(--a-text)] group-hover:underline">
 				{board.name}
 			</h2>
 			{board.description && (
-				<p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+				<p className="mt-1 text-sm text-[color:var(--a-text-muted)]">
 					{board.description}
 				</p>
 			)}

--- a/client/src/components/boards/ThreadRow.tsx
+++ b/client/src/components/boards/ThreadRow.tsx
@@ -33,29 +33,29 @@ export default function ThreadRow({ thread }: ThreadRowProps) {
 		thread.author?.handle ||
 		"削除されたユーザー";
 	return (
-		<li className="border-b border-gray-200 dark:border-gray-700">
+		<li className="border-b border-[color:var(--a-border)] last:border-b-0">
 			<Link
 				href={`/threads/${thread.id}`}
-				className="block px-4 py-3 transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800"
+				className="block px-4 py-3 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 				aria-label={`${thread.title} (${thread.post_count} レス)`}
 			>
 				<div className="flex items-center justify-between gap-3">
-					<h3 className="flex-1 truncate text-base font-medium text-gray-900 dark:text-gray-100">
+					<h3 className="flex-1 truncate text-base font-medium text-[color:var(--a-text)]">
 						{thread.title}
 						{thread.locked && (
 							<span
-								className="ml-2 inline-block rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+								className="ml-2 inline-block rounded bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
 								aria-label="ロック済"
 							>
 								🔒
 							</span>
 						)}
 					</h3>
-					<span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+					<span className="shrink-0 text-sm text-[color:var(--a-text-muted)]">
 						{thread.post_count} レス
 					</span>
 				</div>
-				<div className="mt-1 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+				<div className="mt-1 flex items-center justify-between text-xs text-[color:var(--a-text-muted)]">
 					<span>{authorLabel}</span>
 					<time dateTime={thread.last_post_at}>
 						{formatDateTime(thread.last_post_at)}

--- a/docs/specs/boards-a-direction-spec.md
+++ b/docs/specs/boards-a-direction-spec.md
@@ -1,0 +1,59 @@
+# /boards A direction polish (#570 Phase B-1-3)
+
+## 背景
+
+#568 (B-1-2) で /u/[handle] を polish 済。次は **/boards** (掲示板)。5ch 風で dark theme 色 (`text-gray-900`, `dark:bg-gray-900`, `text-blue-600`) が多用されており、A direction の light + cyan accent と乖離。
+
+## 期待動作
+
+### `/boards` (一覧)
+
+- 最上部に **sticky header**: 「掲示板」 + 「技術トピックごとに議論する場所」 subtitle
+- 外側 wrapper を `<div>` に変更
+- `BoardCard` 内の `text-gray-*` / `border-gray-*` / `bg-gray-*` / `dark:*` を A direction tokens に置換
+- focus-visible outline を cyan accent に
+
+### `/boards/[slug]` (詳細・スレ一覧)
+
+- 最上部に **sticky header**: 「← 掲示板」 戻る link + 板 color dot + 板名 + 説明
+- 外側 wrapper を `<div>` に変更
+- `ThreadRow` 内の `text-gray-*` / `border-gray-*` / `bg-gray-*` / `dark:*` を A direction tokens に置換
+- pagination link の `text-blue-600` を cyan `var(--a-accent)` に
+- threads list の outer container を `border-[color:var(--a-border)] bg-[color:var(--a-bg)]` に
+
+## やらない
+
+- ThreadView (`/threads/[id]`) — 別 issue (B-1-? thread)
+- ThreadComposer / PostComposer 本文 styling — 別 issue
+- Backend / API 変更
+
+## テスト (E2E)
+
+`client/e2e/boards-a-direction.spec.ts` で stg を踏む。
+
+### シナリオ 1: 板一覧の構造
+
+- **誰が**: 未ログイン訪問者
+- **何をする**: `/boards` を開く
+- **何が見える**:
+  - `getByRole('main')` が **1 件のみ**
+  - sticky header に「掲示板」 が h1 で見える
+  - 板が ≥1 件あれば BoardCard が見える (なければ empty state)
+
+### シナリオ 2: 板詳細の構造
+
+- **誰が**: 未ログイン訪問者
+- **何をする**: `/boards` から最初の板 link を踏む → `/boards/<slug>` を開く
+- **何が見える**:
+  - `getByRole('main')` が 1 件のみ
+  - sticky header に「← 掲示板」 戻る link + 板名 h1
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+npx playwright test e2e/boards-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-3 (#570)。/boards (掲示板) を 5ch 風の dark gray + blue accent から A direction の light + cyan accent に揃える。

### 変更

- /boards, /boards/[slug] の外側 \`<main>\` → \`<div>\` (nested main 解消)
- A direction sticky header + backdrop blur 追加 (戻る link 付き)
- BoardCard: gray-* / dark:* / blue-500 outline → A direction tokens + cyan focus
- ThreadRow: 同上 + hover:bg-[var(--a-bg-muted)]
- pagination link を cyan accent に
- e2e/boards-a-direction.spec.ts (2 シナリオ)

### やらない

- ThreadView (\`/threads/[id]\`) — 別 issue
- ThreadComposer / PostComposer 本文 styling — 別 issue

## Test plan

- [x] tsc / lint / build / vitest (71 files / 599 tests) 全 green
- [ ] CI 全緑
- [ ] stg E2E:
\`\`\`bash
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \\
npx playwright test e2e/boards-a-direction.spec.ts
\`\`\`

## Related

Epic: #549。Series: #564 #566 #568 → **#570 (本 PR, B-1-3 /boards)**。

Closes #570