### PR TITLE
[feature][a-direction] /messages (DM) を A direction に polish (#572 Phase B-1-4)

### DIFF
--- a/client/e2e/messages-a-direction.spec.ts
+++ b/client/e2e/messages-a-direction.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * /messages (DM) A direction polish E2E (#572 Phase B-1-4).
+ *
+ * Spec: docs/specs/messages-a-direction-spec.md
+ *
+ * シナリオ:
+ *   MESSAGES-A-1: 未ログインで /messages → /login?next=/messages にリダイレクト
+ *   MESSAGES-A-2: ログイン後 /messages → sticky header + 招待 link + 新規グループ
+ *   MESSAGES-A-3: ログイン後 /messages/invitations → 戻る link + 「グループ招待」 h1
+ *
+ * env: docs/local/e2e-stg.md の test2 を使用。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+) {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+test.describe("/messages A direction polish (#572)", () => {
+	test("MESSAGES-A-1: 未ログインで /messages → /login にリダイレクト", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/messages`);
+		// useEffect 側で redirect するので、to /login?next=/messages を待つ
+		await page.waitForURL(/\/login(\?|$)/, { timeout: 15000 });
+		expect(page.url()).toContain("/login");
+		await ctx.close();
+	});
+
+	test("MESSAGES-A-2: ログイン後 /messages → sticky header + 招待 + 新規グループ", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.goto(`${BASE}/messages`);
+
+		// h1 「メッセージ」
+		await expect(
+			page.getByRole("heading", { name: "メッセージ", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 招待 link
+		await expect(page.getByRole("link", { name: /招待/ })).toBeVisible();
+
+		// 新規グループ button
+		await expect(
+			page.getByRole("button", { name: /新規グループ/ }),
+		).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("MESSAGES-A-3: ログイン後 /messages/invitations → 戻る link + h1", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.goto(`${BASE}/messages/invitations`);
+
+		// 「← メッセージ一覧」 戻る link
+		await expect(
+			page.getByRole("link", { name: /メッセージ一覧/ }),
+		).toBeVisible({ timeout: 15000 });
+
+		// h1 「グループ招待」
+		await expect(
+			page.getByRole("heading", { name: "グループ招待", level: 1 }),
+		).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/messages/[id]/page.tsx
+++ b/client/src/app/(template)/messages/[id]/page.tsx
@@ -36,7 +36,7 @@ export default function RoomDetailPage() {
 			<section
 				role="status"
 				aria-live="polite"
-				className="text-baby_grey mx-auto max-w-2xl py-12 text-center"
+				className="mx-auto max-w-2xl py-12 text-center text-[color:var(--a-text-muted)]"
 			>
 				認証情報を確認しています...
 			</section>
@@ -48,7 +48,7 @@ export default function RoomDetailPage() {
 		return (
 			<section
 				role="alert"
-				className="text-baby_red mx-auto max-w-2xl py-12 text-center"
+				className="mx-auto max-w-2xl py-12 text-center text-[color:var(--a-danger)]"
 			>
 				ルーム ID またはプロフィールが不正です。
 			</section>

--- a/client/src/app/(template)/messages/invitations/page.tsx
+++ b/client/src/app/(template)/messages/invitations/page.tsx
@@ -35,7 +35,7 @@ export default function InvitationsPage() {
 			<section
 				role="status"
 				aria-live="polite"
-				className="text-baby_grey mx-auto max-w-2xl py-12 text-center"
+				className="mx-auto max-w-2xl py-12 text-center text-[color:var(--a-text-muted)]"
 			>
 				認証情報を確認しています...
 			</section>
@@ -43,17 +43,32 @@ export default function InvitationsPage() {
 	}
 
 	return (
-		<section className="mx-auto max-w-2xl">
-			<header className="mb-6 flex items-baseline justify-between">
-				<h1 className="text-baby_white text-xl font-bold">グループ招待</h1>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
 				<Link
 					href="/messages"
-					className="text-baby_blue focus-visible:ring-baby_blue focus-visible:ring-offset-baby_veryBlack text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
 				>
-					<span aria-hidden="true">←</span> メッセージ一覧
+					← メッセージ一覧
 				</Link>
+				<h1
+					className="ml-2 min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					グループ招待
+				</h1>
 			</header>
-			<InvitationList />
-		</section>
+			<div className="p-5">
+				<InvitationList />
+			</div>
+		</>
 	);
 }

--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -56,7 +56,7 @@ export default function MessagesPage() {
 			<section
 				role="status"
 				aria-live="polite"
-				className="text-baby_grey mx-auto max-w-2xl py-12 text-center"
+				className="mx-auto max-w-2xl py-12 text-center text-[color:var(--a-text-muted)]"
 			>
 				認証情報を確認しています...
 			</section>
@@ -69,7 +69,7 @@ export default function MessagesPage() {
 		return (
 			<section
 				role="alert"
-				className="text-baby_red mx-auto max-w-2xl py-12 text-center"
+				className="mx-auto max-w-2xl py-12 text-center text-[color:var(--a-danger)]"
 			>
 				プロフィール ID が取得できませんでした。再ログインしてください。
 			</section>
@@ -77,9 +77,21 @@ export default function MessagesPage() {
 	}
 
 	return (
-		<section className="mx-auto max-w-2xl">
-			<header className="mb-6 flex items-baseline justify-between gap-3">
-				<h1 className="text-baby_white text-xl font-bold">メッセージ</h1>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<h1
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					メッセージ
+				</h1>
 				<div className="flex items-center gap-2">
 					{/* #300: 招待リスト導線。pending 0 件でも link は表示 (Phase 3
 					    spec が /messages/invitations 直リンクを使うため)、badge は
@@ -89,13 +101,14 @@ export default function MessagesPage() {
 						aria-label={
 							pendingCount > 0 ? `招待 ${pendingCount} 件` : "招待リストを開く"
 						}
-						className="text-baby_white inline-flex items-center gap-1 rounded-md border border-border px-3 py-1.5 text-sm font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						className="inline-flex items-center gap-1 rounded-md border border-[color:var(--a-border)] px-3 py-1.5 text-sm font-medium text-[color:var(--a-text)] transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					>
 						招待
 						{pendingCount > 0 ? (
 							<span
 								aria-hidden="true"
-								className="bg-baby_red text-baby_white inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1.5 py-0 text-xs font-semibold"
+								className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1.5 py-0 text-xs font-semibold text-white"
+								style={{ background: "var(--a-accent)" }}
 							>
 								{pendingCount}
 							</span>
@@ -108,7 +121,8 @@ export default function MessagesPage() {
 							<button
 								type="button"
 								aria-label="新規グループ作成"
-								className="bg-baby_blue text-baby_white focus-visible:ring-baby_white rounded-md px-3 py-1.5 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2"
+								className="rounded-md px-3 py-1.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+								style={{ background: "var(--a-accent)" }}
 							>
 								＋ 新規グループ
 							</button>
@@ -122,7 +136,9 @@ export default function MessagesPage() {
 					</Dialog>
 				</div>
 			</header>
-			<RoomList currentUserId={profile.pkid} />
-		</section>
+			<div className="p-5">
+				<RoomList currentUserId={profile.pkid} />
+			</div>
+		</>
 	);
 }

--- a/docs/specs/messages-a-direction-spec.md
+++ b/docs/specs/messages-a-direction-spec.md
@@ -1,0 +1,67 @@
+# /messages (DM) A direction polish (#572 Phase B-1-4)
+
+## 背景
+
+#570 (B-1-3) で /boards を polish 済。次は /messages (DM)。レガシーの `baby_white` / `baby_blue` / `baby_red` / `baby_grey` パレットが残っており、A direction の light + cyan と乖離。
+
+## 期待動作
+
+### `/messages` (一覧)
+
+- auth 必須 (cookie `logged_in`)、未認証は `/login?next=/messages` に redirect (既存挙動維持)
+- 最上部に **sticky header**: 「メッセージ」 h1 + 招待 link (+ pending badge cyan) + ＋新規グループ button (cyan)
+- `baby_white` / `baby_blue` / `baby_red` / `baby_grey` を A direction tokens に置換
+- 認証中 / プロフィール不正の loading / error state も A direction palette で表示
+
+### `/messages/invitations`
+
+- 最上部に **sticky header**: 「← メッセージ一覧」 戻る link + 「グループ招待」 h1
+- 同上 palette 置換
+
+### `/messages/[id]`
+
+- 本 PR では outer wrapper + loading/error state のみ調整 (RoomChat 内部は別 issue)
+
+## やらない
+
+- RoomChat / RoomList / RoomListItem / MessageList / MessageBubble / MessageComposer / TypingIndicator / InvitationList の内部 styling — 別 issue (B-1-? DM internals)
+- WebSocket / 既読 / 添付 / push 機能 — 範囲外
+
+## テスト (E2E)
+
+`client/e2e/messages-a-direction.spec.ts` で stg を踏む。
+
+### シナリオ 1: 未ログインは /login にリダイレクト
+
+- **誰が**: 未ログイン
+- **何をする**: `/messages` を開く
+- **何が見える**: `/login?next=/messages` に redirect
+
+### シナリオ 2: ログイン済の /messages 構造
+
+- **誰が**: ログイン済 (test2)
+- **何をする**: `/messages` を開く
+- **何が見える**:
+  - 「メッセージ」 h1
+  - 「招待」 link (`/messages/invitations`)
+  - 「＋ 新規グループ」 button
+  - 単一 `<main>`
+
+### シナリオ 3: ログイン済の /messages/invitations 構造
+
+- **誰が**: ログイン済 (test2)
+- **何をする**: `/messages/invitations` を開く
+- **何が見える**:
+  - 「← メッセージ一覧」 link
+  - 「グループ招待」 h1
+  - 単一 `<main>`
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+npx playwright test e2e/messages-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-4 (#572)。DM のレガシー baby_* パレットを A direction の light + cyan accent に揃える。

### 変更

- /messages: sticky header + 招待 badge cyan + 新規グループ button cyan
- /messages/invitations: sticky header + 「← メッセージ一覧」 戻る link
- /messages/[id]: loading/error state の color のみ調整
- baby_white / baby_blue / baby_red / baby_grey → A direction tokens
- focus-visible outline を cyan accent に統一

### やらない

- RoomChat / RoomList / RoomListItem / MessageList / MessageBubble / MessageComposer / InvitationList 等の内部 styling → 別 issue

## Test plan

- [x] tsc / lint / build 全 green
- [ ] CI 全緑
- [ ] stg E2E:
\`\`\`bash
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \\
PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \\
PLAYWRIGHT_USER1_PASSWORD=Sirius01 \\
PLAYWRIGHT_USER1_HANDLE=test2 \\
npx playwright test e2e/messages-a-direction.spec.ts
\`\`\`

## Related

Epic: #549。Series: #564 #566 #568 #570 → **#572 (本 PR, B-1-4)**。

Closes #572