### PR TITLE
[feature][a-direction] /notifications に sticky header + polish (#574 Phase B-1-5)

### DIFF
--- a/client/e2e/notifications-a-direction.spec.ts
+++ b/client/e2e/notifications-a-direction.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * /notifications A direction polish E2E (#574 Phase B-1-5).
+ *
+ * Spec: docs/specs/notifications-a-direction-spec.md
+ *
+ * シナリオ:
+ *   NOTIF-A-1: 未ログインで /notifications → /login にリダイレクト
+ *   NOTIF-A-2: ログイン後 /notifications → sticky header の「通知」 h1 + 単一 <main>
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+) {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+test.describe("/notifications A direction polish (#574)", () => {
+	test("NOTIF-A-1: 未ログインで /notifications → /login リダイレクト", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/notifications`);
+		// SSR redirect なので即 /login に着く
+		await page.waitForURL(/\/login(\?|$)/, { timeout: 15000 });
+		expect(page.url()).toContain("/login");
+		await ctx.close();
+	});
+
+	test("NOTIF-A-2: ログイン後 /notifications → sticky header + 単一 <main>", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.goto(`${BASE}/notifications`);
+
+		// h1 「通知」
+		await expect(
+			page.getByRole("heading", { name: "通知", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/notifications/page.tsx
+++ b/client/src/app/(template)/notifications/page.tsx
@@ -1,5 +1,7 @@
 /**
  * /notifications page (#412 / Phase 4A).
+ *
+ * #574 (B-1-5) で A direction sticky header を追加。
  */
 
 import { redirect } from "next/navigation";
@@ -14,8 +16,25 @@ export default function NotificationsPage() {
 		redirect("/login");
 	}
 	return (
-		<div className="mx-auto w-full max-w-2xl">
-			<NotificationsList />
-		</div>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<h1
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					通知
+				</h1>
+			</header>
+			<div className="p-5">
+				<NotificationsList />
+			</div>
+		</>
 	);
 }

--- a/client/src/components/notifications/NotificationsList.tsx
+++ b/client/src/components/notifications/NotificationsList.tsx
@@ -177,7 +177,10 @@ export default function NotificationsList({
 					読み込み中…
 				</div>
 			) : state === "error" ? (
-				<div role="alert" className="text-baby_red p-8 text-center">
+				<div
+					role="alert"
+					className="p-8 text-center text-[color:var(--a-danger)]"
+				>
 					通知の取得に失敗しました
 				</div>
 			) : items.length === 0 ? (

--- a/docs/specs/notifications-a-direction-spec.md
+++ b/docs/specs/notifications-a-direction-spec.md
@@ -1,0 +1,46 @@
+# /notifications A direction polish (#574 Phase B-1-5)
+
+## 背景
+
+#572 (B-1-4) で /messages を polish 済。次は /notifications。現状 `<div className="mx-auto w-full max-w-2xl"><NotificationsList /></div>` のみで sticky header が無く、他 A direction page と統一感に欠ける。NotificationsList 内に `text-baby_red` も残っている。
+
+## 期待動作
+
+- auth 必須 (cookie `logged_in`)、未認証は `/login` に redirect (既存挙動維持、SSR redirect)
+- 最上部に **sticky header**: 「通知」 h1
+- 外側 wrapper は `<div>` (本 PR 前から fragment-level、nested main 問題なし)
+- NotificationsList の error state `text-baby_red` → `text-[color:var(--a-danger)]`
+
+## やらない
+
+- NotificationsList の row item 内部 styling (avatar / actor name / verb / timestamp / unread dot) — 別 issue
+- 通知 kind 別アイコン色 — 別 issue
+- フィルタ / ページネーション機能変更 — 範囲外
+
+## テスト (E2E)
+
+`client/e2e/notifications-a-direction.spec.ts`:
+
+### シナリオ 1: 未ログインは /login にリダイレクト
+
+- **誰が**: 未ログイン
+- **何をする**: `/notifications` を開く
+- **何が見える**: `/login` に redirect (SSR)
+
+### シナリオ 2: ログイン済の構造
+
+- **誰が**: ログイン済 (test2)
+- **何をする**: `/notifications` を開く
+- **何が見える**:
+  - sticky header に 「通知」 h1
+  - 単一 `<main>`
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+npx playwright test e2e/notifications-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-5 (#574)。/notifications に他 A direction page と同じ sticky header を追加し、残っていた baby_* color を清掃。

### 変更

- /notifications wrapper → fragment + sticky header
- 「通知」 h1
- NotificationsList error: text-baby_red → text-[color:var(--a-danger)]
- e2e + spec doc

### やらない

- 通知 row item 内部 styling — 別 issue
- 通知 kind 別アイコン色 — 別 issue

## Test plan

- [x] tsc / lint / build green
- [ ] CI 全緑
- [ ] stg E2E:
\`\`\`bash
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \\
PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \\
PLAYWRIGHT_USER1_PASSWORD=Sirius01 \\
PLAYWRIGHT_USER1_HANDLE=test2 \\
npx playwright test e2e/notifications-a-direction.spec.ts
\`\`\`

## Related

Series: #564 #566 #568 #570 #572 → **#574 (本 PR, B-1-5)**。

Closes #574