### PR TITLE
fix(a11y): NotificationsList の h1 を h2 に降格 (#574 follow-up)

### DIFF
--- a/client/src/components/notifications/NotificationsList.tsx
+++ b/client/src/components/notifications/NotificationsList.tsx
@@ -131,13 +131,15 @@ export default function NotificationsList({
 			className="rounded-lg border border-border bg-card"
 		>
 			<header className="flex items-center justify-between border-b border-border p-4">
-				<h1
+				{/* #574 後続: page wrapper の sticky <h1>「通知」 が page heading なので、
+				    NotificationsList の内部見出しは <h2> に降格 (1 page 1 h1)。 */}
+				<h2
 					id="notifications-heading"
 					className="flex items-center gap-2 text-lg font-bold text-foreground"
 				>
 					<Bell className="size-5" aria-hidden="true" />
 					{groupedTitle}
-				</h1>
+				</h2>
 				{/* a11y MED: tablist + tab は tabpanel ペアが必要なので、ここは
 				    通常の toggle button + aria-pressed にする (X 慣習)。 */}
 				<div role="group" aria-label="フィルタ" className="flex gap-2 text-sm">


### PR DESCRIPTION
## Summary

#574 (B-1-5) follow-up。/notifications page wrapper に sticky \`<h1>\`「通知」 を追加した結果、NotificationsList 内部の \`<h1>\` と二重 h1 が共存。WCAG / 慣習的に 1 page 1 h1 が望ましいため、内部見出しを \`<h2>\` に降格。

stg E2E (\`e2e/notifications-a-direction.spec.ts\`) の NOTIF-A-2 で「strict mode violation: 2 elements」 として検出された。

### 変更

- NotificationsList の \`<h1 id="notifications-heading">\` → \`<h2 id="notifications-heading">\`
- aria-labelledby の参照先 id は維持

## Test plan

- [x] tsc / build green
- [ ] CI 全緑
- [ ] stg E2E: NOTIF-A-2 が pass

Refs #574