### PR TITLE
[feature][a-direction] /settings 4 ページを A direction に polish (#577 Phase B-1-6)

### DIFF
--- a/client/e2e/settings-a-direction.spec.ts
+++ b/client/e2e/settings-a-direction.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * /settings A direction polish E2E (#577 Phase B-1-6).
+ *
+ * Spec: docs/specs/settings-a-direction-spec.md
+ *
+ * シナリオ:
+ *   SETTINGS-A-1: /settings/profile → 「プロフィール編集」 h1 + 単一 <main>
+ *   SETTINGS-A-2: /settings/notifications → 「通知の設定」 h1 + 単一 <main>
+ *   SETTINGS-A-3: /settings/blocks → 「ブロック中のユーザー」 h1 + 単一 <main>
+ *   SETTINGS-A-4: /settings/mutes → 「ミュート中のユーザー」 h1 + 単一 <main>
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+) {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+const CASES: Array<{ path: string; heading: string; label: string }> = [
+	{
+		path: "/settings/profile",
+		heading: "プロフィール編集",
+		label: "SETTINGS-A-1",
+	},
+	{
+		path: "/settings/notifications",
+		heading: "通知の設定",
+		label: "SETTINGS-A-2",
+	},
+	{
+		path: "/settings/blocks",
+		heading: "ブロック中のユーザー",
+		label: "SETTINGS-A-3",
+	},
+	{
+		path: "/settings/mutes",
+		heading: "ミュート中のユーザー",
+		label: "SETTINGS-A-4",
+	},
+];
+
+test.describe("/settings A direction polish (#577)", () => {
+	for (const c of CASES) {
+		test(`${c.label}: ${c.path} → 「${c.heading}」 h1 + 単一 <main>`, async ({
+			browser,
+		}) => {
+			requireEnv();
+			const ctx = await browser.newContext();
+			const page = await ctx.newPage();
+			await loginViaApi(ctx.request, USER1);
+			await page.goto(`${BASE}${c.path}`);
+
+			await expect(
+				page.getByRole("heading", { name: c.heading, level: 1 }),
+			).toBeVisible({ timeout: 15000 });
+
+			const mainCount = await page.locator("main").count();
+			expect(mainCount).toBe(1);
+
+			await ctx.close();
+		});
+	}
+});

--- a/client/src/app/(template)/settings/blocks/page.tsx
+++ b/client/src/app/(template)/settings/blocks/page.tsx
@@ -1,5 +1,7 @@
 /**
  * /settings/blocks (Phase 4B / Issue #450).
+ *
+ * #577 (B-1-6) で A direction sticky header を追加。
  */
 
 import { redirect } from "next/navigation";
@@ -12,5 +14,26 @@ export default function BlockedSettingsPage() {
 	if (!isAuthenticated) {
 		redirect("/login");
 	}
-	return <ModerationListClient mode="blocks" />;
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<h1
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					ブロック中のユーザー
+				</h1>
+			</header>
+			<div className="p-5">
+				<ModerationListClient mode="blocks" />
+			</div>
+		</>
+	);
 }

--- a/client/src/app/(template)/settings/mutes/page.tsx
+++ b/client/src/app/(template)/settings/mutes/page.tsx
@@ -1,5 +1,7 @@
 /**
  * /settings/mutes (Phase 4B / Issue #450).
+ *
+ * #577 (B-1-6) で A direction sticky header を追加。
  */
 
 import { redirect } from "next/navigation";
@@ -12,5 +14,26 @@ export default function MutedSettingsPage() {
 	if (!isAuthenticated) {
 		redirect("/login");
 	}
-	return <ModerationListClient mode="mutes" />;
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<h1
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					ミュート中のユーザー
+				</h1>
+			</header>
+			<div className="p-5">
+				<ModerationListClient mode="mutes" />
+			</div>
+		</>
+	);
 }

--- a/client/src/app/(template)/settings/notifications/page.tsx
+++ b/client/src/app/(template)/settings/notifications/page.tsx
@@ -1,5 +1,7 @@
 /**
  * /settings/notifications page (#415).
+ *
+ * #577 (B-1-6) で A direction sticky header を追加。
  */
 
 import { redirect } from "next/navigation";
@@ -13,8 +15,25 @@ export default function NotificationSettingsPage() {
 		redirect("/login");
 	}
 	return (
-		<div className="mx-auto w-full max-w-2xl">
-			<NotificationSettingsForm />
-		</div>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<h1
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					通知の設定
+				</h1>
+			</header>
+			<div className="p-5">
+				<NotificationSettingsForm />
+			</div>
+		</>
 	);
 }

--- a/client/src/app/(template)/settings/profile/page.tsx
+++ b/client/src/app/(template)/settings/profile/page.tsx
@@ -24,14 +24,33 @@ export default async function ProfileSettingsPage() {
 	if (!currentUser) redirect("/login");
 
 	return (
-		<main className="mx-auto max-w-3xl px-4 py-8">
-			<header className="mb-6">
-				<h1 className="text-2xl font-bold">プロフィール編集</h1>
-				<p className="mt-1 text-sm text-muted-foreground">
-					表示名、自己紹介、プロフィール画像、外部リンクを更新できます。
-				</p>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						プロフィール編集
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						表示名 / bio / 画像 / 外部リンク
+					</p>
+				</div>
 			</header>
-			<ProfileEditForm initialUser={currentUser} />
-		</main>
+			<div className="p-5">
+				<ProfileEditForm initialUser={currentUser} />
+			</div>
+		</>
 	);
 }

--- a/client/src/components/moderation/ModerationListClient.tsx
+++ b/client/src/components/moderation/ModerationListClient.tsx
@@ -100,10 +100,14 @@ export default function ModerationListClient({ mode }: Props) {
 	};
 
 	return (
-		<main className="mx-auto w-full max-w-2xl px-4 py-6">
-			<h1 className="mb-4 text-xl font-bold text-gray-900 dark:text-gray-100">
+		<section aria-label={labels.title}>
+			{/* #577: page wrapper の sticky <h1> が page heading なので、
+			    ModerationListClient 内部は <h2> + section に降格 (1 page 1 h1)。
+			    また外側 <main> は (template)/layout の <main> と二重ネストするため
+			    <section> に変更。 */}
+			<h2 className="mb-4 text-xl font-bold text-[color:var(--a-text)]">
 				{labels.title}
-			</h1>
+			</h2>
 			{loading ? (
 				<p className="text-sm text-muted-foreground">読み込み中…</p>
 			) : !rows || rows.length === 0 ? (
@@ -129,10 +133,10 @@ export default function ModerationListClient({ mode }: Props) {
 										width={40}
 										height={40}
 										unoptimized
-										className="h-10 w-10 rounded-full object-cover"
+										className="size-10 rounded-full object-cover"
 									/>
 								) : (
-									<span className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-sm">
+									<span className="flex size-10 items-center justify-center rounded-full bg-muted text-sm">
 										{r.handle.slice(0, 1).toUpperCase()}
 									</span>
 								)}
@@ -156,6 +160,6 @@ export default function ModerationListClient({ mode }: Props) {
 					))}
 				</ul>
 			)}
-		</main>
+		</section>
 	);
 }

--- a/client/src/components/notifications/NotificationSettingsForm.tsx
+++ b/client/src/components/notifications/NotificationSettingsForm.tsx
@@ -121,7 +121,10 @@ export default function NotificationSettingsForm() {
 	}
 	if (state === "error") {
 		return (
-			<div role="alert" className="text-baby_red p-8 text-center">
+			<div
+				role="alert"
+				className="p-8 text-center text-[color:var(--a-danger)]"
+			>
 				通知設定の取得に失敗しました
 			</div>
 		);
@@ -135,12 +138,14 @@ export default function NotificationSettingsForm() {
 			className="rounded-lg border border-border bg-card"
 		>
 			<header className="border-b border-border p-4">
-				<h1
+				{/* #577: page wrapper の sticky <h1>「通知の設定」 が page heading なので、
+				    NotificationSettingsForm 内部は <h2> に降格 (1 page 1 h1)。 */}
+				<h2
 					id="notif-settings-heading"
 					className="text-lg font-bold text-foreground"
 				>
 					通知の設定
-				</h1>
+				</h2>
 				<p className="mt-1 text-xs text-muted-foreground">
 					種別ごとに通知の受け取りを ON/OFF できます。OFF
 					にすると、その種別の通知は作成されません。

--- a/docs/specs/settings-a-direction-spec.md
+++ b/docs/specs/settings-a-direction-spec.md
@@ -1,0 +1,58 @@
+# /settings A direction polish (#577 Phase B-1-6)
+
+## 背景
+
+#574 (B-1-5) で /notifications を polish 済。次は **/settings 4 ページ** (profile, notifications, blocks, mutes)。各 page が独自 wrapper で sticky header が無い。ModerationListClient は内部に `<main>` を持っており (template)/layout の `<main>` と nested。
+
+## 期待動作
+
+### `/settings/profile`
+
+- 外側 wrapper を `<div>` に置換 + sticky header (「プロフィール編集」 h1 + 「表示名 / bio / 画像 / 外部リンク」 subtitle)
+- ProfileEditForm は無変更
+
+### `/settings/notifications`
+
+- bare `<div>` を sticky header + `<div>` に
+- NotificationSettingsForm の内部 `<h1>` を `<h2>` に降格 + `text-baby_red` を `text-[color:var(--a-danger)]` に
+
+### `/settings/blocks`, `/settings/mutes`
+
+- bare コンポーネント render を sticky header + `<div>` でラップ
+- ModerationListClient の外側 `<main>` を `<section>` に置換 (nested main 解消) + 内部 `<h1>` を `<h2>` に降格
+- `text-gray-900 dark:text-gray-100` を `text-[color:var(--a-text)]` に
+
+## やらない
+
+- ProfileEditForm 内部 styling — 別 issue
+- 通知 toggle / mute / block の機能変更 — 範囲外
+
+## テスト (E2E)
+
+`client/e2e/settings-a-direction.spec.ts`:
+
+### シナリオ 1: /settings/profile
+
+- ログイン済 (test2) で `/settings/profile` を開く → sticky header の「プロフィール編集」 h1 + 単一 `<main>`
+
+### シナリオ 2: /settings/notifications
+
+- ログイン済で `/settings/notifications` を開く → 「通知の設定」 h1 + 単一 `<main>`
+
+### シナリオ 3: /settings/blocks
+
+- ログイン済で `/settings/blocks` を開く → 「ブロック中のユーザー」 h1 + 単一 `<main>`
+
+### シナリオ 4: /settings/mutes
+
+- ログイン済で `/settings/mutes` を開く → 「ミュート中のユーザー」 h1 + 単一 `<main>`
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+npx playwright test e2e/settings-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-6 (#577)。/settings 4 ページ (profile, notifications, blocks, mutes) を A direction に揃える + ModerationListClient の nested main を解消。

### 変更

- 4 ページ全てに sticky header + h1
- ModerationListClient: outer \`<main>\` → \`<section>\` + 内部 \`<h1>\` → \`<h2>\` + text-gray-* → A tokens
- NotificationSettingsForm: 内部 \`<h1>\` → \`<h2>\` + text-baby_red → text-[color:var(--a-danger)]
- e2e/settings-a-direction.spec.ts (4 シナリオ)

### やらない

- ProfileEditForm 内部 styling — 別 issue
- 通知 toggle / mute / block の機能変更 — 範囲外

## Test plan

- [x] tsc / lint / build / vitest (71/599) green
- [ ] CI 全緑
- [ ] stg E2E

## Related

Series: #564 #566 #568 #570 #572 #574 #576 → **#577 (本 PR, B-1-6)**

Closes #577