### PR TITLE
[feature][a-direction] /tweet/[id] と /threads/[id] を A direction に polish (#579 Phase B-1-7)

### DIFF
--- a/client/e2e/conversation-a-direction.spec.ts
+++ b/client/e2e/conversation-a-direction.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * /tweet/[id] と /threads/[id] A direction polish E2E (#579 Phase B-1-7).
+ *
+ * Spec: docs/specs/conversation-a-direction-spec.md
+ *
+ * シナリオ:
+ *   CONV-A-1: 未ログインで /tweet/<id> → sticky 「ツイート」 h1 + 単一 <main>
+ *   CONV-A-2: 未ログインで /threads/<id> → sticky 戻る link + thread title h1 + 単一 <main>
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+test.describe("conversation A direction polish (#579)", () => {
+	test("CONV-A-1: 未ログインで /tweet/<id> → sticky 「ツイート」 h1 + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		// Find a tweet id via /explore (lists public tweets)
+		await page.goto(`${BASE}/explore`);
+		const tweetLink = page.locator('a[href^="/tweet/"]').first();
+		const count = await tweetLink.count();
+		if (count === 0) {
+			test.skip(true, "No public tweets on stg, skip /tweet/<id> test");
+			return;
+		}
+		const href = await tweetLink.getAttribute("href");
+		await page.goto(`${BASE}${href}`);
+
+		await expect(
+			page.getByRole("heading", { name: "ツイート", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("CONV-A-2: 未ログインで /threads/<id> → sticky 戻る link + h1 + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/boards`);
+		const boardLink = page.locator('a[href^="/boards/"]').first();
+		const boardCount = await boardLink.count();
+		if (boardCount === 0) {
+			test.skip(true, "No boards on stg, skip /threads/<id> test");
+			return;
+		}
+		const boardHref = await boardLink.getAttribute("href");
+		await page.goto(`${BASE}${boardHref}`);
+
+		const threadLink = page.locator('a[href^="/threads/"]').first();
+		const threadCount = await threadLink.count();
+		if (threadCount === 0) {
+			test.skip(true, "No threads on first board, skip");
+			return;
+		}
+		const threadHref = await threadLink.getAttribute("href");
+		await page.goto(`${BASE}${threadHref}`);
+
+		// sticky header: back link (← <board>)
+		await expect(page.locator("header a").first()).toBeVisible({
+			timeout: 15000,
+		});
+
+		// thread title h1 が見える
+		await expect(page.locator("h1").first()).toBeVisible();
+
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -131,12 +131,29 @@ export async function generateMetadata({
 
 function Tombstoned({ deletedAt }: { deletedAt: string }) {
 	return (
-		<main className="mx-auto max-w-xl px-6 py-16 text-center">
-			<h1 className="mb-4 text-2xl font-bold">このツイートは削除されました</h1>
-			<p className="text-sm text-muted-foreground">
-				削除日時: {new Date(deletedAt).toLocaleString("ja-JP")}
-			</p>
-		</main>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<h1
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					ツイート
+				</h1>
+			</header>
+			<div className="mx-auto max-w-xl px-6 py-16 text-center">
+				<p className="mb-4 text-2xl font-bold">このツイートは削除されました</p>
+				<p className="text-sm text-[color:var(--a-text-muted)]">
+					削除日時: {new Date(deletedAt).toLocaleString("ja-JP")}
+				</p>
+			</div>
+		</>
 	);
 }
 
@@ -171,33 +188,57 @@ export default async function TweetDetailPage({ params }: PageProps) {
 	};
 
 	return (
-		<main className="mx-auto max-w-2xl px-6 py-10">
-			<script
-				type="application/ld+json"
-				// security-reviewer Phase 1 CRITICAL: tweet.body はユーザー生成コンテンツで
-				// `</script>` が含まれうるため stringifyJsonLd で </ をエスケープする。
-				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
-			/>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<h1
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					ツイート
+				</h1>
+				<span
+					className="truncate text-[color:var(--a-text-subtle)]"
+					style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+				>
+					@{tweet.author_handle}
+				</span>
+			</header>
 
-			{/* #326: ancestor chain (上から古い順) → focal (強調) → replies の縦スレ.
-			    focal は border-l 強調で視覚的に区別する (Twitter conversation view)。 */}
-			{ancestors.length > 0 ? (
-				<section aria-label="親ツイート" className="mb-2">
-					<TweetCardList
-						tweets={ancestors}
-						ariaLabel="親ツイート"
-						currentUserHandle={currentUser?.username}
-					/>
-				</section>
-			) : null}
+			<article className="mx-auto max-w-2xl p-6">
+				<script
+					type="application/ld+json"
+					// security-reviewer Phase 1 CRITICAL: tweet.body はユーザー生成コンテンツで
+					// `</script>` が含まれうるため stringifyJsonLd で </ をエスケープする。
+					dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
+				/>
 
-			{/* #337: focal + replies を client component に切り出して、reply 投稿時
-			    に即時 append できるようにする (リロード不要)。 */}
-			<ConversationReplies
-				focal={tweet}
-				initialReplies={replies}
-				currentUserHandle={currentUser?.username}
-			/>
-		</main>
+				{/* #326: ancestor chain (上から古い順) → focal (強調) → replies の縦スレ.
+				    focal は border-l 強調で視覚的に区別する (Twitter conversation view)。 */}
+				{ancestors.length > 0 ? (
+					<section aria-label="親ツイート" className="mb-2">
+						<TweetCardList
+							tweets={ancestors}
+							ariaLabel="親ツイート"
+							currentUserHandle={currentUser?.username}
+						/>
+					</section>
+				) : null}
+
+				{/* #337: focal + replies を client component に切り出して、reply 投稿時
+				    に即時 append できるようにする (リロード不要)。 */}
+				<ConversationReplies
+					focal={tweet}
+					initialReplies={replies}
+					currentUserHandle={currentUser?.username}
+				/>
+			</article>
+		</>
 	);
 }

--- a/client/src/components/boards/ThreadView.tsx
+++ b/client/src/components/boards/ThreadView.tsx
@@ -57,112 +57,133 @@ export default function ThreadView({
 	}, []);
 
 	return (
-		<main className="mx-auto w-full max-w-3xl px-4 py-6">
-			<header className="mb-4">
-				<p className="text-xs text-gray-500 dark:text-gray-400">
-					<Link href={`/boards/${thread.board}`} className="hover:underline">
-						← {thread.board} 板
-					</Link>
-				</p>
-				<h1 className="mt-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
-					{thread.title}
-					{thread.locked && (
-						<span
-							className="ml-2 rounded bg-gray-200 px-2 py-0.5 text-sm text-gray-700 dark:bg-gray-700 dark:text-gray-300"
-							aria-label="ロック済"
-						>
-							🔒 ロック済
-						</span>
-					)}
-				</h1>
-				<p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-					{threadState.post_count} / 1000 レス
-				</p>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href={`/boards/${thread.board}`}
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← {thread.board}
+				</Link>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						{thread.title}
+						{thread.locked && (
+							<span
+								className="ml-2 inline-block rounded bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
+								aria-label="ロック済"
+							>
+								🔒
+							</span>
+						)}
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{threadState.post_count} / 1000 レス
+					</p>
+				</div>
 			</header>
 
-			{threadState.locked && (
-				<div
-					role="alert"
-					className="mb-4 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
-				>
-					このスレはレス上限 (1000)
-					に達しました。新しいスレッドを立ててください。
-				</div>
-			)}
-			{!threadState.locked && threadState.approaching_limit && (
-				<div
-					role="status"
-					className="mb-4 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
-				>
-					残りわずかです (現在 {threadState.post_count}{" "}
-					レス)。新スレッドの作成を検討してください。
-				</div>
-			)}
-
-			<section aria-labelledby="post-list-heading">
-				<h2 id="post-list-heading" className="sr-only">
-					レス一覧
-				</h2>
-				{posts.length === 0 ? (
-					<p className="text-sm text-gray-500 dark:text-gray-400">
-						まだレスがありません。
-					</p>
-				) : (
-					<ol
-						role="list"
-						className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+			<div className="p-5">
+				{threadState.locked && (
+					<div
+						role="alert"
+						className="mb-4 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
 					>
-						{posts.map((p) => (
-							<ThreadPostItem
-								key={p.id}
-								post={p}
-								currentUserHandle={currentUserHandle}
-								isAdmin={isAdmin}
-								onDelete={handleDeleted}
-							/>
-						))}
-					</ol>
+						このスレはレス上限 (1000)
+						に達しました。新しいスレッドを立ててください。
+					</div>
+				)}
+				{!threadState.locked && threadState.approaching_limit && (
+					<div
+						role="status"
+						className="mb-4 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
+					>
+						残りわずかです (現在 {threadState.post_count}{" "}
+						レス)。新スレッドの作成を検討してください。
+					</div>
 				)}
 
-				<nav
-					aria-label="ページネーション"
-					className="mt-4 flex items-center justify-between text-sm"
-				>
-					{initialPosts.previous ? (
-						<a
-							href={`/threads/${thread.id}?p=${page - 1}`}
-							className="text-blue-600 hover:underline dark:text-blue-400"
-						>
-							← 前のページ
-						</a>
+				<section aria-labelledby="post-list-heading">
+					<h2 id="post-list-heading" className="sr-only">
+						レス一覧
+					</h2>
+					{posts.length === 0 ? (
+						<p className="text-sm text-[color:var(--a-text-muted)]">
+							まだレスがありません。
+						</p>
 					) : (
-						<span />
-					)}
-					<span className="text-gray-500 dark:text-gray-400">
-						全 {initialPosts.count} レス
-					</span>
-					{initialPosts.next ? (
-						<a
-							href={`/threads/${thread.id}?p=${page + 1}`}
-							className="text-blue-600 hover:underline dark:text-blue-400"
+						<ol
+							role="list"
+							className="rounded-lg border border-[color:var(--a-border)] bg-[color:var(--a-bg)]"
 						>
-							次のページ →
-						</a>
-					) : (
-						<span />
+							{posts.map((p) => (
+								<ThreadPostItem
+									key={p.id}
+									post={p}
+									currentUserHandle={currentUserHandle}
+									isAdmin={isAdmin}
+									onDelete={handleDeleted}
+								/>
+							))}
+						</ol>
 					)}
-				</nav>
-			</section>
 
-			<section className="mt-6">
-				<PostComposer
-					threadId={thread.id}
-					isAuthenticated={isAuthenticated}
-					threadState={threadState}
-					boardSlug={thread.board}
-					onPosted={handlePosted}
-				/>
-			</section>
-		</main>
+					<nav
+						aria-label="ページネーション"
+						className="mt-4 flex items-center justify-between text-sm"
+					>
+						{initialPosts.previous ? (
+							<a
+								href={`/threads/${thread.id}?p=${page - 1}`}
+								className="rounded hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+								style={{ color: "var(--a-accent)" }}
+							>
+								← 前のページ
+							</a>
+						) : (
+							<span />
+						)}
+						<span className="text-[color:var(--a-text-muted)]">
+							全 {initialPosts.count} レス
+						</span>
+						{initialPosts.next ? (
+							<a
+								href={`/threads/${thread.id}?p=${page + 1}`}
+								className="rounded hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+								style={{ color: "var(--a-accent)" }}
+							>
+								次のページ →
+							</a>
+						) : (
+							<span />
+						)}
+					</nav>
+				</section>
+
+				<section className="mt-6">
+					<PostComposer
+						threadId={thread.id}
+						isAuthenticated={isAuthenticated}
+						threadState={threadState}
+						boardSlug={thread.board}
+						onPosted={handlePosted}
+					/>
+				</section>
+			</div>
+		</>
 	);
 }

--- a/docs/specs/conversation-a-direction-spec.md
+++ b/docs/specs/conversation-a-direction-spec.md
@@ -1,0 +1,53 @@
+# /tweet/[id] と /threads/[id] A direction polish (#579 Phase B-1-7)
+
+## 背景
+
+#577 (B-1-6) で /settings を polish 済。次は個別 conversation ページ (/tweet/[id], /threads/[id])。両方とも nested main + dark gray palette が残っている。
+
+## 期待動作
+
+### `/tweet/[id]` (個別ツイート)
+
+- 外側 `<main>` を `<article>` に置換 (nested main 解消)
+- A direction sticky header: 「ツイート」 + @author_handle (右側 muted)
+- Tombstone variant も同じ sticky header shell に統一
+- 既存 JSON-LD / ConversationReplies / TweetCardList は無変更
+
+### `/threads/[id]` (掲示板スレ)
+
+- ThreadView 内の外側 `<main>` を `<div>` に置換
+- A direction sticky header: 「← <board>」 戻る link + スレタイトル h1 + post_count subtitle
+- 内部の `text-gray-*` / `dark:bg-gray-*` / `border-gray-*` / `text-blue-600 dark:text-blue-400` を A direction tokens に置換
+- pagination link を cyan accent に
+- amber-\* warning banner はそのまま (locked / approaching_limit)
+
+## やらない
+
+- ConversationReplies / TweetCardList / TweetCard 内部 styling — 別 issue
+- ThreadPostItem / PostComposer 内部 styling — 別 issue
+
+## テスト (E2E)
+
+`client/e2e/conversation-a-direction.spec.ts`:
+
+### シナリオ 1: /tweet/<id>
+
+- **誰が**: 未ログイン
+- **何をする**: /tweet/<existing_id> を開く (stg /explore から最初の tweet link を辿る)
+- **何が見える**: sticky header の「ツイート」 h1 + 単一 `<main>`
+
+### シナリオ 2: /threads/<id>
+
+- **誰が**: 未ログイン
+- **何をする**: /boards → 最初の board → 最初の thread を開く
+- **何が見える**: sticky header に「← <board>」 戻る link + スレタイトル h1 + 単一 `<main>`
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+npx playwright test e2e/conversation-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-7 (#579)。個別 conversation ページ (/tweet/[id], /threads/[id]) を sticky header + A direction tokens に揃える。

### 変更

- /tweet/[id]: outer \`<main>\` → \`<article>\` + sticky header (「ツイート」 + @handle)
- Tombstone variant も同じ sticky shell
- ThreadView (/threads/[id]): outer \`<main>\` → \`<div>\` + sticky header (戻る link + h1 + post_count)
- text-gray-_ / dark:bg-gray-_ / text-blue-600 系を A direction tokens に
- pagination link を cyan accent に

### やらない

- ConversationReplies / TweetCardList / TweetCard 内部 styling — 別 issue
- ThreadPostItem / PostComposer 内部 styling — 別 issue

## Test plan

- [x] tsc / lint / build green
- [ ] CI 全緑
- [ ] stg E2E:
\`\`\`bash
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/conversation-a-direction.spec.ts
\`\`\`

Series: #564 #566 #568 #570 #572 #574 #576 #577 → **#579 (本 PR, B-1-7)**

Closes #579