### PR TITLE
[feature][a-direction] /tag/[name] を A direction に polish (#581 Phase B-1-8)

### DIFF
--- a/client/e2e/tag-a-direction.spec.ts
+++ b/client/e2e/tag-a-direction.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * /tag/[name] A direction polish E2E (#581 Phase B-1-8).
+ *
+ * Spec: docs/specs/tag-a-direction-spec.md
+ *
+ * シナリオ:
+ *   TAG-A-1: 未ログインで /tag/<name> → sticky 「#name」 h1 + 単一 <main>
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+test.describe("/tag/[name] A direction polish (#581)", () => {
+	test("TAG-A-1: 未ログインで /tag/<name> → sticky h1 + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		// Find a tag via /explore (or fall back to a known stg tag like 「python」)
+		await page.goto(`${BASE}/explore`);
+		const tagLink = page.locator('a[href^="/tag/"]').first();
+		const count = await tagLink.count();
+		let href: string | null = null;
+		if (count > 0) {
+			href = await tagLink.getAttribute("href");
+		} else {
+			// fallback: hit a known plausible tag
+			href = "/tag/python";
+		}
+		await page.goto(`${BASE}${href}`);
+
+		// h1 starting with `#`
+		await expect(
+			page.locator("h1").filter({ hasText: /^#/ }).first(),
+		).toBeVisible({ timeout: 15000 });
+
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/tag/[name]/page.tsx
+++ b/client/src/app/(template)/tag/[name]/page.tsx
@@ -68,54 +68,74 @@ export default async function TagPage({ params }: PageProps) {
 	const tweets = await loadTweets(tag.name);
 
 	return (
-		<main className="mx-auto max-w-3xl px-4 pb-10 pt-6">
-			<header className="mb-6">
-				<h1 className="text-2xl font-bold">#{tag.display_name}</h1>
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						#{tag.display_name}
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{tag.usage_count} 件のツイート
+					</p>
+				</div>
+			</header>
+
+			<div className="px-5 py-5">
 				{tag.description && (
-					<p className="mt-2 text-sm text-muted-foreground">
+					<p className="mb-5 text-sm text-[color:var(--a-text-muted)]">
 						{tag.description}
 					</p>
 				)}
-				<p className="mt-3 text-xs text-muted-foreground">
-					{tag.usage_count} 件のツイート
-				</p>
-			</header>
 
-			{tag.related && tag.related.length > 0 && (
-				<section className="mb-8" aria-labelledby="related-heading">
-					<h2
-						id="related-heading"
-						className="mb-2 text-sm font-semibold text-muted-foreground"
-					>
-						関連タグ
+				{tag.related && tag.related.length > 0 && (
+					<section className="mb-8" aria-labelledby="related-heading">
+						<h2
+							id="related-heading"
+							className="mb-2 text-sm font-semibold text-[color:var(--a-text-muted)]"
+						>
+							関連タグ
+						</h2>
+						<ul className="flex flex-wrap gap-2">
+							{tag.related.map((r) => (
+								<li key={r.name}>
+									<a
+										href={`/tag/${r.name}`}
+										className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-sm text-[color:var(--a-text-muted)] transition-colors hover:bg-[color:var(--a-bg-subtle)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+									>
+										#{r.display_name}
+									</a>
+								</li>
+							))}
+						</ul>
+					</section>
+				)}
+
+				<section aria-labelledby="tweets-heading">
+					<h2 id="tweets-heading" className="mb-3 text-lg font-semibold">
+						このタグのツイート
 					</h2>
-					<ul className="flex flex-wrap gap-2">
-						{tag.related.map((r) => (
-							<li key={r.name}>
-								<a
-									href={`/tag/${r.name}`}
-									className="rounded-full bg-muted px-2 py-0.5 text-sm hover:bg-accent"
-								>
-									#{r.display_name}
-								</a>
-							</li>
-						))}
-					</ul>
+					{/* #301: 旧 inline link 列挙を TweetCardList に置換。リアクション
+					    / RT / 「もっと見る」展開が動作する。 */}
+					<TweetCardList
+						tweets={tweets}
+						ariaLabel={`${tag.display_name} タグのツイート`}
+						emptyMessage="まだこのタグのツイートはありません。"
+					/>
 				</section>
-			)}
-
-			<section aria-labelledby="tweets-heading">
-				<h2 id="tweets-heading" className="mb-3 text-lg font-semibold">
-					このタグのツイート
-				</h2>
-				{/* #301: 旧 inline link 列挙を TweetCardList に置換。リアクション
-				    / RT / 「もっと見る」展開が動作する。 */}
-				<TweetCardList
-					tweets={tweets}
-					ariaLabel={`${tag.display_name} タグのツイート`}
-					emptyMessage="まだこのタグのツイートはありません。"
-				/>
-			</section>
-		</main>
+			</div>
+		</>
 	);
 }

--- a/docs/specs/tag-a-direction-spec.md
+++ b/docs/specs/tag-a-direction-spec.md
@@ -1,0 +1,35 @@
+# /tag/[name] A direction polish (#581 Phase B-1-8)
+
+## 背景
+
+#579 (B-1-7) で /tweet/[id], /threads/[id] を polish 済。次は /tag/[name]。outer `<main>` (nested) + sticky header 無し。
+
+## 期待動作
+
+- 外側 `<main>` を `<div>` に置換 (nested main 解消)
+- A direction sticky header: 「#display_name」 h1 + 「N 件のツイート」 subtitle
+- description は body 領域に muted text で表示
+- 関連タグ pill を A direction tokens に (`var(--a-bg-muted)` + `var(--a-text-muted)`)
+- focus-visible cyan outline 追加
+
+## やらない
+
+- TweetCardList 内部 styling — 別 issue
+- Backend / API 変更
+
+## テスト (E2E)
+
+`client/e2e/tag-a-direction.spec.ts`:
+
+### シナリオ 1
+
+- **誰が**: 未ログイン
+- **何をする**: /explore から最初の `/tag/...` link を辿る (なければ `/tag/python` を直叩き)
+- **何が見える**: h1 が「#」 始まり + 単一 `<main>`
+
+## Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+npx playwright test e2e/tag-a-direction.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase B-1-8 (#581)。/tag/[name] を sticky header + A direction tokens に揃える。

### 変更

- outer \`<main>\` → \`<div>\` (nested main 解消)
- sticky header 「#name」 h1 + 「N 件のツイート」 subtitle
- 関連タグ pill を A direction tokens + cyan focus
- e2e + spec doc

## Test plan

- [x] tsc / build green
- [ ] CI 全緑
- [ ] stg E2E

Series: #564 #566 #568 #570 #572 #574 #576 #577 #579 → **#581 (本 PR, B-1-8)**

Closes #581