### PR TITLE
[feature][a-direction] /explore を A direction に polish (#584 B-1-9)

### DIFF
--- a/client/e2e/explore-a-direction.spec.ts
+++ b/client/e2e/explore-a-direction.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * /explore A direction polish E2E (#584 Phase B-1-9).
+ *
+ * Spec: docs/specs/explore-a-direction-spec.md
+ *
+ * シナリオ:
+ *   EXPLORE-A-1: 未ログインで /explore → sticky context bar + HeroBanner h1 + 単一 <main>
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+test.describe("/explore A direction polish (#584)", () => {
+	test("EXPLORE-A-1: 未ログインで /explore → sticky bar + Hero + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/explore`);
+
+		// sticky context bar に「Explore」
+		await expect(page.getByText("Explore").first()).toBeVisible({
+			timeout: 15000,
+		});
+
+		// HeroBanner の h1 が見える (「エンジニアによる」 を含む)
+		await expect(
+			page.getByRole("heading", { name: /エンジニアによる/, level: 1 }),
+		).toBeVisible();
+
+		// 「新規登録する」 + 「ログイン」 CTA
+		await expect(
+			page.getByRole("link", { name: "新規登録する" }),
+		).toBeVisible();
+
+		// 単一 <main>
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/explore/page.tsx
+++ b/client/src/app/(template)/explore/page.tsx
@@ -81,32 +81,52 @@ export default async function ExplorePage() {
 				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(websiteJsonLd) }}
 			/>
 
-			<div className="mx-auto flex max-w-6xl gap-6 px-4">
-				<main className="flex-1 min-w-0">
-					<HeroBanner />
-
-					<section aria-labelledby="explore-feed-heading" className="mt-8">
-						<h2
-							id="explore-feed-heading"
-							className="px-2 mb-4 text-lg font-semibold text-foreground"
-						>
-							トレンドツイート
-						</h2>
-
-						{/* #301: explore も TweetCardList で render。
-						    リアクション / RT は未ログインユーザでも表示はされ、click 時
-						    に 401 → 各 button 内の placeholder 挙動 (ReactionBar
-						    / RepostButton 既存実装) でログイン誘導。 */}
-						<TweetCardList
-							tweets={page.results}
-							ariaLabel="トレンドツイート"
-							emptyMessage="今は表示できるツイートがありません。"
-						/>
-					</section>
-				</main>
-				{/* #316: RightSidebar は (template) layout で全 page 共通 mount。
-				    重複防止のため explore 個別の mount は撤去。 */}
+			{/* #584: page h1 は HeroBanner 側 (「エンジニアによる、エンジニアのための SNS」)
+			    なので、sticky bar は heading 抜きの context bar として置く。 */}
+			<div
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div
+					className="min-w-0 flex-1 truncate font-semibold tracking-tight text-[color:var(--a-text)]"
+					style={{ fontSize: 15, letterSpacing: -0.2 }}
+				>
+					Explore
+				</div>
+				<span
+					className="text-[color:var(--a-text-subtle)]"
+					style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+				>
+					discover
+				</span>
 			</div>
+
+			<article className="min-w-0">
+				<HeroBanner />
+
+				<section aria-labelledby="explore-feed-heading" className="mt-8 px-5">
+					<h2
+						id="explore-feed-heading"
+						className="mb-4 px-2 text-lg font-semibold text-foreground"
+					>
+						トレンドツイート
+					</h2>
+
+					{/* #301: explore も TweetCardList で render。
+					    リアクション / RT は未ログインユーザでも表示はされ、click 時
+					    に 401 → 各 button 内の placeholder 挙動 (ReactionBar
+					    / RepostButton 既存実装) でログイン誘導。 */}
+					<TweetCardList
+						tweets={page.results}
+						ariaLabel="トレンドツイート"
+						emptyMessage="今は表示できるツイートがありません。"
+					/>
+				</section>
+			</article>
 
 			<StickyLoginBanner />
 		</>

--- a/client/src/components/explore/HeroBanner.tsx
+++ b/client/src/components/explore/HeroBanner.tsx
@@ -4,6 +4,8 @@
  * Server-renderable: no client state. Provides the brand headline, tagline,
  * and primary register / login CTAs. Above-the-fold so it ships in the
  * initial paint without layout shift.
+ *
+ * #584 (B-1-9) で lime-500 accent を A direction cyan に置換。
  */
 
 import Link from "next/link";
@@ -13,31 +15,40 @@ const HEADING_ID = "explore-hero-heading";
 export default function HeroBanner() {
 	return (
 		<header aria-labelledby={HEADING_ID} className="px-6 py-16 text-center">
-			<p className="text-xs uppercase tracking-widest text-lime-500 mb-4">
+			<p
+				className="mb-4 uppercase tracking-widest"
+				style={{
+					color: "var(--a-accent)",
+					fontFamily: "var(--a-font-mono)",
+					fontSize: 11,
+					letterSpacing: 1.2,
+				}}
+			>
 				Engineer-Focused SNS
 			</p>
 			<h1
 				id={HEADING_ID}
-				className="text-4xl sm:text-5xl font-bold mb-6 text-foreground"
+				className="mb-6 font-bold text-foreground sm:text-5xl text-4xl"
 			>
 				エンジニアによる、
-				<span className="text-lime-500">エンジニアのための</span> SNS
+				<span style={{ color: "var(--a-accent)" }}>エンジニアのための</span> SNS
 			</h1>
-			<p className="text-lg text-muted-foreground mb-10 mx-auto max-w-2xl leading-relaxed">
+			<p className="mx-auto mb-10 max-w-2xl text-lg leading-relaxed text-muted-foreground">
 				技術タグで興味の近い人を見つけ、Markdown でコードを共有し、 OGP
 				プレビューで議論を深めましょう。
 			</p>
 
-			<div className="flex flex-col sm:flex-row gap-3 justify-center">
+			<div className="flex flex-col justify-center gap-3 sm:flex-row">
 				<Link
 					href="/register"
-					className="inline-flex items-center justify-center px-6 py-3 rounded-md bg-lime-500 text-black font-semibold hover:bg-lime-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					className="inline-flex items-center justify-center rounded-md px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ background: "var(--a-accent)" }}
 				>
 					新規登録する
 				</Link>
 				<Link
 					href="/login"
-					className="inline-flex items-center justify-center px-6 py-3 rounded-md border border-border text-foreground font-semibold hover:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					className="inline-flex items-center justify-center rounded-md border border-[color:var(--a-border)] px-6 py-3 font-semibold text-foreground transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 				>
 					ログイン
 				</Link>

--- a/client/src/components/explore/StickyLoginBanner.tsx
+++ b/client/src/components/explore/StickyLoginBanner.tsx
@@ -55,7 +55,8 @@ export default function StickyLoginBanner() {
 				</p>
 				<Link
 					href="/register"
-					className="rounded-md bg-lime-500 px-4 py-2 text-sm font-semibold text-black hover:bg-lime-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					className="rounded-md px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ background: "var(--a-accent)" }}
 				>
 					新規登録
 				</Link>

--- a/docs/specs/explore-a-direction-spec.md
+++ b/docs/specs/explore-a-direction-spec.md
@@ -1,0 +1,28 @@
+# /explore A direction polish (#584 Phase B-1-9)
+
+## 背景
+
+#581 (B-1-8) で /tag/[name] を polish 済。次は /explore (未ログイン discovery surface)。
+
+## 期待動作
+
+- 外側 `<div mx-auto max-w-6xl>` を撤去して layout の 800px center grid に従わせる
+- 外側 `<main>` を `<article>` に置換 (nested main 解消)
+- sticky context bar (heading 抜き、HeroBanner の h1 が page heading)
+- HeroBanner: `text-lime-500` / `bg-lime-500` → cyan A accent
+- StickyLoginBanner: `bg-lime-500` → cyan A accent
+- ログイン済は `/` にリダイレクト (既存挙動維持)
+
+## やらない
+
+- TweetCardList 内部 styling — 別 issue
+- HeroBanner copy 変更 — 範囲外
+
+## テスト (E2E)
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+npx playwright test e2e/explore-a-direction.spec.ts
+```
+
+シナリオ EXPLORE-A-1: 未ログインで /explore → sticky bar の「Explore」 + HeroBanner の h1「エンジニアによる」 + 「新規登録する」 link + 単一 `<main>`。


### PR DESCRIPTION
/explore (未ログイン surface) を A direction に。lime → cyan accent + nested main 解消 + 800px grid 整合。Closes #584