### PR TITLE
[feature][a-direction] /search を A direction に polish (#586 Phase B-1 最終)

### DIFF
--- a/client/e2e/search-a-direction.spec.ts
+++ b/client/e2e/search-a-direction.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * /search A direction polish E2E (#586 Phase B-1-10).
+ *
+ * シナリオ:
+ *   SEARCH-A-1: /search → sticky 「検索」 h1 + 単一 <main>
+ *   SEARCH-A-2: /search?q=test → 「test」 subtitle + 結果 section
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+test.describe("/search A direction polish (#586)", () => {
+	test("SEARCH-A-1: /search (no query) → sticky 「検索」 h1 + 単一 <main>", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/search`);
+
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+
+	test("SEARCH-A-2: /search?q=test → query subtitle + 結果 section が出る", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/search?q=test`);
+
+		// h1 「検索」
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 検索結果 section
+		await expect(page.getByRole("region", { name: "検索結果" })).toBeVisible();
+
+		const mainCount = await page.locator("main").count();
+		expect(mainCount).toBe(1);
+
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/search/page.tsx
+++ b/client/src/app/(template)/search/page.tsx
@@ -39,30 +39,54 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 		: { query: "", results: [], count: 0 };
 
 	return (
-		<main className="mx-auto max-w-3xl px-4 py-6">
-			<header className="mb-6">
-				<h1 className="mb-3 text-xl font-semibold text-foreground">検索</h1>
-				<SearchBox initialValue={query} />
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						検索
+					</h1>
+					{query && (
+						<p
+							className="truncate text-[color:var(--a-text-subtle)]"
+							style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+						>
+							「{query}」 — {data.count} 件
+						</p>
+					)}
+				</div>
 			</header>
 
-			{!query && (
-				<p className="text-sm text-muted-foreground">
-					上のボックスにキーワードを入れて検索してください。
-				</p>
-			)}
+			<div className="px-5 py-5">
+				<div className="mb-6">
+					<SearchBox initialValue={query} />
+				</div>
 
-			{query && (
-				<section aria-label="検索結果" className="space-y-3">
-					<p className="text-sm text-muted-foreground">
-						「{query}」の検索結果: {data.count} 件
+				{!query && (
+					<p className="text-sm text-[color:var(--a-text-muted)]">
+						上のボックスにキーワードを入れて検索してください。
 					</p>
-					<TweetCardList
-						tweets={data.results}
-						ariaLabel={`「${query}」の検索結果`}
-						emptyMessage="一致するツイートはありません。"
-					/>
-				</section>
-			)}
-		</main>
+				)}
+
+				{query && (
+					<section aria-label="検索結果" className="space-y-3">
+						<TweetCardList
+							tweets={data.results}
+							ariaLabel={`「${query}」の検索結果`}
+							emptyMessage="一致するツイートはありません。"
+						/>
+					</section>
+				)}
+			</div>
+		</>
 	);
 }

--- a/docs/specs/search-a-direction-spec.md
+++ b/docs/specs/search-a-direction-spec.md
@@ -1,0 +1,28 @@
+# /search A direction polish (#586 Phase B-1-10 / Phase B-1 最終)
+
+## 背景
+
+#584 (B-1-9) /explore に続き、最後の page。/search を A direction に揃えて Phase B-1 完結。
+
+## 期待動作
+
+- 外側 `<main>` を `<div>` に置換 (nested main 解消)
+- A direction sticky header (「検索」 h1 + query subtitle when set)
+- SearchBox を header 直下の body に置く
+- 検索結果カウントは sticky header の subtitle に集約
+- 「上のボックスにキーワード」 ヒントは muted text
+
+## やらない
+
+- SearchBox 内部 styling — 別 issue
+- TweetCardList 内部 styling — 別 issue
+
+## テスト (E2E)
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+npx playwright test e2e/search-a-direction.spec.ts
+```
+
+- SEARCH-A-1: /search (no query) → sticky 「検索」 h1 + 単一 `<main>`
+- SEARCH-A-2: /search?q=test → query subtitle + 結果 section + 単一 `<main>`


### PR DESCRIPTION
/search に sticky header + nested main 解消。Phase B-1 完結。Closes #586