### PR TITLE
feat(articles): 記事内画像 S3 presigned POST + confirm API (P6-04 / #527)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 562
+        "line_number": 566
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T15:15:08Z"
+  "generated_at": "2026-05-11T07:44:31Z"
 }

--- a/apps/articles/models.py
+++ b/apps/articles/models.py
@@ -164,7 +164,16 @@ class ArticleTag(models.Model):
 
 
 class ArticleImage(models.Model):
-    """記事内に貼られる画像 (S3 + CloudFront 配信)."""
+    """記事内に貼られる画像 (S3 + CloudFront 配信).
+
+    NOTE (database-reviewer M-2 反映): ``Article.soft_delete`` は ``is_deleted=True``
+    の UPDATE しか行わないため、 関連する ``ArticleImage`` は **残存する**
+    (on_delete=CASCADE は hard-delete 時のみ作動)。 これは「記事が論理削除されても
+    本文の画像 URL は失わないようにする / P6-09 GitHub push 連携で再評価する」 と
+    いう設計意図 (docs/specs/article-image-upload-spec.md §1)。 Admin から
+    hard-delete された場合は CASCADE で ArticleImage 行も消えるが、 S3 上の object
+    は残る (orphan S3 object)。 S3 lifecycle (365 日、 follow-up issue) で回収。
+    """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     # 編集中は article=None で先に upload、確定時に article を埋める運用 (P6-04)。

--- a/apps/articles/s3_presign.py
+++ b/apps/articles/s3_presign.py
@@ -1,0 +1,296 @@
+"""記事内画像の S3 直アップロード用 presigned URL ユーティリティ (#527 / Phase 6 P6-04).
+
+設計方針 (docs/specs/article-image-upload-spec.md §1):
+
+- フロントエンド → S3 へ直接 PUT し、 Django は presigned URL 発行 + ``head_object``
+  再検証のみを担う。 サーバ帯域 / CPU を画像で食わない。
+- ``apps.dm.s3_presign`` (DM 添付) と同じ ``generate_presigned_post`` 方式を採用し、
+  ``content-length-range`` / ``eq Content-Type`` / ``eq key`` を S3 側で強制する
+  (security HIGH H-1/H-2/H-3 反映済の流儀をそのまま継承)。
+- 許可 MIME: ``image/jpeg`` / ``image/png`` / ``image/webp`` / ``image/gif`` の 4 種。
+  サイズ上限 5 MiB (``ArticleImage.size`` モデルの想定上限と整合)。
+- ``s3_key`` 形式: ``articles/<user_id>/<image_uuid>.<ext>``。
+  user_id を path に含めることで confirm 側で他人の key を弾ける (IDOR 防止)。
+- boto3 client は関数内で生成 — テストで ``patch("apps.articles.s3_presign._build_s3_client", ...)``
+  しやすく、 ECS task role の credential rotation にも耐える。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Final
+from urllib.parse import quote
+
+import boto3
+from botocore.client import Config as BotoConfig
+from botocore.exceptions import ClientError
+from django.conf import settings
+from django.core.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------------
+# 定数 (spec §3.1)
+# -----------------------------------------------------------------------------
+
+#: 許可する MIME と対応する拡張子。 allowlist 方式で明示。
+ALLOWED_CONTENT_TYPES: Final[dict[str, str]] = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+
+#: アップロード許可サイズ上限 (5 MiB)。 ``ArticleImage.size`` モデルのドキュメント想定値。
+MAX_CONTENT_LENGTH: Final[int] = 5 * 1024 * 1024
+
+#: presigned POST の有効期間 (秒)。 フロント取得 → S3 PUT 完了まで 5 分は十分。
+PRESIGN_EXPIRES_SECONDS: Final[int] = 5 * 60
+
+#: filename の文字長上限。 安全側で 200 文字 (DM 添付と整合)。
+FILENAME_MAX_LENGTH: Final[int] = 200
+
+#: filename の不許可 character pattern。 制御文字 / NUL / sep / parent traversal を排除。
+#  Unicode (日本語ファイル名) は許可するが ``/`` ``\`` ``..`` はブロック。
+_FILENAME_INVALID_PATTERN: Final[re.Pattern[str]] = re.compile(r"[\x00-\x1f\x7f/\\]|\.\.")
+
+
+# -----------------------------------------------------------------------------
+# DTO
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PresignedImageUpload:
+    """presigned POST 発行結果 (immutable DTO).
+
+    ``url``: フロントが POST するエンドポイント (S3 bucket URL)
+    ``fields``: presigned POST の hidden field (key / Content-Type / policy / signature ...)
+    ``s3_key``: 紐付け用に Confirm API へ送る S3 オブジェクトキー
+    ``expires_at``: presign の有効期限 (フロント表示用)
+    """
+
+    url: str
+    fields: dict[str, str]
+    s3_key: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class S3ObjectInfo:
+    """``head_object`` で取得した実 metadata (immutable)."""
+
+    content_length: int
+    content_type: str
+
+
+# -----------------------------------------------------------------------------
+# 検証
+# -----------------------------------------------------------------------------
+
+
+def validate_image_request(
+    *,
+    mime_type: str,
+    size: int,
+    filename: str,
+) -> str:
+    """presign 発行前 / confirm 受け取り時の入力検証.
+
+    Args:
+        mime_type: クライアント申告の MIME。 allowlist と一致する必要がある。
+        size: バイト数。 1 以上 5 MiB 以下。
+        filename: ファイル名。 path traversal / 制御文字 / 拡張子検証.
+
+    Returns:
+        正規化された拡張子 (例 ``"png"``).
+
+    Raises:
+        ValidationError: いずれかの検証に失敗した場合。
+    """
+
+    if mime_type not in ALLOWED_CONTENT_TYPES:
+        raise ValidationError(
+            f"Unsupported mime_type: {mime_type!r}. Allowed: {sorted(ALLOWED_CONTENT_TYPES)}"
+        )
+
+    if size <= 0:
+        raise ValidationError("size must be positive")
+    if size > MAX_CONTENT_LENGTH:
+        raise ValidationError(f"size {size} exceeds maximum {MAX_CONTENT_LENGTH} bytes")
+
+    if not filename or len(filename) > FILENAME_MAX_LENGTH:
+        raise ValidationError(
+            f"filename must be 1..{FILENAME_MAX_LENGTH} chars (got {len(filename)})"
+        )
+    if _FILENAME_INVALID_PATTERN.search(filename):
+        raise ValidationError("filename contains invalid characters (path traversal / control)")
+
+    expected_ext = ALLOWED_CONTENT_TYPES[mime_type]
+    name_lower = filename.lower()
+    dot_idx = name_lower.rfind(".")
+    if dot_idx < 0:
+        raise ValidationError("filename must have an extension matching the mime_type")
+    actual_ext = name_lower[dot_idx + 1 :]
+    accepted_exts = {expected_ext}
+    if expected_ext == "jpg":
+        accepted_exts.add("jpeg")
+    if actual_ext not in accepted_exts:
+        raise ValidationError(
+            f"filename extension '.{actual_ext}' does not match mime_type {mime_type}"
+        )
+
+    return expected_ext
+
+
+# -----------------------------------------------------------------------------
+# 公開 API
+# -----------------------------------------------------------------------------
+
+
+def build_s3_key(*, user_id: Any, ext: str) -> str:
+    """``articles/<user_id>/<image_uuid>.<ext>`` を生成.
+
+    user_id は path-safe な値であること (int / UUID は問題なし)。
+    """
+
+    return f"articles/{user_id}/{uuid.uuid4()}.{ext}"
+
+
+def generate_presigned_image_upload(
+    *,
+    user_id: Any,
+    mime_type: str,
+    size: int,
+    filename: str,
+) -> PresignedImageUpload:
+    """記事内画像の presigned POST URL を発行する.
+
+    Args:
+        user_id: アップロードするユーザーの PK。 s3_key prefix に埋め込む (IDOR 防止)。
+        mime_type: 申告 MIME (allowlist に一致)。
+        size: 申告 bytes。
+        filename: ファイル名 (拡張子検証用)。
+
+    Returns:
+        ``PresignedImageUpload`` (url / fields / s3_key / expires_at)
+
+    Raises:
+        ValidationError: 入力検証失敗。
+    """
+
+    ext = validate_image_request(mime_type=mime_type, size=size, filename=filename)
+    s3_key = build_s3_key(user_id=user_id, ext=ext)
+    bucket = settings.AWS_STORAGE_BUCKET_NAME
+
+    s3_client = _build_s3_client()
+
+    # S3 側で Conditions を強制チェックさせる。
+    #   - content-length-range: 1..MAX_CONTENT_LENGTH (改ざんによる DoS / 巨大 PUT 防止)
+    #   - eq Content-Type: アプリ側申告と完全一致 (MIME 偽装防止)
+    #   - eq key: 別ファイルへの上書き / 別 key への流用攻撃防止
+    try:
+        post_data = s3_client.generate_presigned_post(
+            Bucket=bucket,
+            Key=s3_key,
+            Fields={"Content-Type": mime_type, "key": s3_key},
+            Conditions=[
+                ["content-length-range", 1, MAX_CONTENT_LENGTH],
+                {"Content-Type": mime_type},
+                {"key": s3_key},
+            ],
+            ExpiresIn=PRESIGN_EXPIRES_SECONDS,
+        )
+    except ClientError as exc:  # pragma: no cover - boto3 internal failure
+        logger.error(
+            "articles.image_presign.failed",
+            exc_info=exc,
+            extra={"event": "articles.image_presign.failed"},
+        )
+        raise ValidationError("failed to issue presigned URL") from exc
+
+    expires_at = datetime.now(tz=UTC) + timedelta(seconds=PRESIGN_EXPIRES_SECONDS)
+    return PresignedImageUpload(
+        url=post_data["url"],
+        fields=post_data["fields"],
+        s3_key=s3_key,
+        expires_at=expires_at,
+    )
+
+
+def head_object(*, s3_key: str) -> S3ObjectInfo:
+    """S3 上の object metadata を取得する (Confirm API での再検証用).
+
+    Args:
+        s3_key: 検査対象のオブジェクトキー。
+
+    Returns:
+        :class:`S3ObjectInfo`
+
+    Raises:
+        ValidationError: object が存在しない / アクセス不能。
+    """
+
+    s3_client = _build_s3_client()
+    try:
+        resp = s3_client.head_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=s3_key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            raise ValidationError(f"object not found: {s3_key}") from exc
+        logger.warning(
+            "articles.head_object.unexpected",
+            extra={
+                "event": "articles.head_object.unexpected",
+                "code": code,
+                "key": s3_key,
+            },
+        )
+        raise ValidationError(f"failed to verify object: {s3_key}") from exc
+
+    content_length = int(resp.get("ContentLength", 0))
+    content_type = str(resp.get("ContentType", ""))
+    return S3ObjectInfo(content_length=content_length, content_type=content_type)
+
+
+def public_url_for(*, s3_key: str) -> str:
+    """画像配信用の公開 URL を組み立てる (CloudFront 経由 or 直 S3).
+
+    ``AWS_S3_CUSTOM_DOMAIN`` (CloudFront) があればそれ経由、 なければ S3 virtual host。
+    """
+
+    custom_domain = getattr(settings, "AWS_S3_CUSTOM_DOMAIN", "") or ""
+    if custom_domain:
+        return f"https://{custom_domain}/{quote(s3_key)}"
+    bucket = settings.AWS_STORAGE_BUCKET_NAME
+    region = settings.AWS_S3_REGION_NAME
+    return f"https://{bucket}.s3.{region}.amazonaws.com/{quote(s3_key)}"
+
+
+# -----------------------------------------------------------------------------
+# Internal: boto3 client
+# -----------------------------------------------------------------------------
+
+
+def _build_s3_client() -> Any:
+    """boto3 S3 client を生成する (apps.dm.s3_presign と同方針).
+
+    関数内生成にすることで:
+    - ``patch("apps.articles.s3_presign._build_s3_client", ...)`` でテスト mock 可能
+    - 環境 credential rotation 時にも次回呼び出しから新 credential を拾える
+    """
+
+    return boto3.client(
+        "s3",
+        region_name=settings.AWS_S3_REGION_NAME,
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID or None,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY or None,
+        config=BotoConfig(
+            signature_version=getattr(settings, "AWS_S3_SIGNATURE_VERSION", "s3v4"),
+            s3={"addressing_style": getattr(settings, "AWS_S3_ADDRESSING_STYLE", "virtual")},
+        ),
+    )

--- a/apps/articles/s3_presign.py
+++ b/apps/articles/s3_presign.py
@@ -96,6 +96,57 @@ class S3ObjectInfo:
 # -----------------------------------------------------------------------------
 
 
+def _check_mime(mime_type: str) -> str:
+    """MIME を allowlist でチェックして対応 ext を返す."""
+
+    if mime_type not in ALLOWED_CONTENT_TYPES:
+        raise ValidationError(
+            f"Unsupported mime_type: {mime_type!r}. Allowed: {sorted(ALLOWED_CONTENT_TYPES)}"
+        )
+    return ALLOWED_CONTENT_TYPES[mime_type]
+
+
+def _check_size(size: int) -> None:
+    """size を 1..MAX_CONTENT_LENGTH の範囲でチェック."""
+
+    if size <= 0:
+        raise ValidationError("size must be positive")
+    if size > MAX_CONTENT_LENGTH:
+        raise ValidationError(f"size {size} exceeds maximum {MAX_CONTENT_LENGTH} bytes")
+
+
+def _check_filename(filename: str, expected_ext: str) -> None:
+    """filename の長さ・制御文字・拡張子と MIME の一致をチェック.
+
+    NOTE: ``..`` を含む filename (例 ``photo..backup.png``) は path separator が
+    無い限り 1 つの component で完結するので **拒否しない**。 ``image/jpeg`` は
+    ``.jpg`` と ``.jpeg`` の両方を accept する。
+    ``"..png"`` のように leading dot のみ (本体名なし) は ``rfind(".")`` で拡張子
+    抽出は通るが、 同様に accept される (s3_key は MIME から生成するので filename を
+    storage に使わない — security 上の問題は無く、 spec doc §3.1 で意図的に許容)。
+    """
+
+    if not filename or len(filename) > FILENAME_MAX_LENGTH:
+        raise ValidationError(
+            f"filename must be 1..{FILENAME_MAX_LENGTH} chars (got {len(filename)})"
+        )
+    if _FILENAME_INVALID_PATTERN.search(filename):
+        raise ValidationError("filename contains invalid characters (path traversal / control)")
+
+    name_lower = filename.lower()
+    dot_idx = name_lower.rfind(".")
+    if dot_idx < 0:
+        raise ValidationError("filename must have an extension matching the mime_type")
+    actual_ext = name_lower[dot_idx + 1 :]
+    accepted_exts = {expected_ext}
+    if expected_ext == "jpg":
+        accepted_exts.add("jpeg")
+    if actual_ext not in accepted_exts:
+        raise ValidationError(
+            f"filename extension '.{actual_ext}' does not match mime_type allowlist"
+        )
+
+
 def validate_image_request(
     *,
     mime_type: str,
@@ -116,37 +167,9 @@ def validate_image_request(
         ValidationError: いずれかの検証に失敗した場合。
     """
 
-    if mime_type not in ALLOWED_CONTENT_TYPES:
-        raise ValidationError(
-            f"Unsupported mime_type: {mime_type!r}. Allowed: {sorted(ALLOWED_CONTENT_TYPES)}"
-        )
-
-    if size <= 0:
-        raise ValidationError("size must be positive")
-    if size > MAX_CONTENT_LENGTH:
-        raise ValidationError(f"size {size} exceeds maximum {MAX_CONTENT_LENGTH} bytes")
-
-    if not filename or len(filename) > FILENAME_MAX_LENGTH:
-        raise ValidationError(
-            f"filename must be 1..{FILENAME_MAX_LENGTH} chars (got {len(filename)})"
-        )
-    if _FILENAME_INVALID_PATTERN.search(filename):
-        raise ValidationError("filename contains invalid characters (path traversal / control)")
-
-    expected_ext = ALLOWED_CONTENT_TYPES[mime_type]
-    name_lower = filename.lower()
-    dot_idx = name_lower.rfind(".")
-    if dot_idx < 0:
-        raise ValidationError("filename must have an extension matching the mime_type")
-    actual_ext = name_lower[dot_idx + 1 :]
-    accepted_exts = {expected_ext}
-    if expected_ext == "jpg":
-        accepted_exts.add("jpeg")
-    if actual_ext not in accepted_exts:
-        raise ValidationError(
-            f"filename extension '.{actual_ext}' does not match mime_type {mime_type}"
-        )
-
+    expected_ext = _check_mime(mime_type)
+    _check_size(size)
+    _check_filename(filename, expected_ext)
     return expected_ext
 
 
@@ -162,6 +185,23 @@ def build_s3_key(*, user_id: int, ext: str) -> str:
     """
 
     return f"articles/{user_id}/{uuid.uuid4()}.{ext}"
+
+
+def _build_post_conditions(*, s3_key: str, mime_type: str) -> list[Any]:
+    """S3 generate_presigned_post の ``Conditions`` を組み立てる.
+
+    S3 側で以下を強制チェックさせる:
+
+    - ``content-length-range`` 1..MAX_CONTENT_LENGTH (改ざんによる DoS / 巨大 PUT 防止)
+    - ``eq Content-Type``: アプリ側申告と完全一致 (MIME 偽装防止)
+    - ``eq key``: 別ファイルへの上書き / 別 key への流用攻撃防止
+    """
+
+    return [
+        ["content-length-range", 1, MAX_CONTENT_LENGTH],
+        {"Content-Type": mime_type},
+        {"key": s3_key},
+    ]
 
 
 def generate_presigned_image_upload(
@@ -189,23 +229,14 @@ def generate_presigned_image_upload(
     ext = validate_image_request(mime_type=mime_type, size=size, filename=filename)
     s3_key = build_s3_key(user_id=user_id, ext=ext)
     bucket = settings.AWS_STORAGE_BUCKET_NAME
-
     s3_client = _build_s3_client()
 
-    # S3 側で Conditions を強制チェックさせる。
-    #   - content-length-range: 1..MAX_CONTENT_LENGTH (改ざんによる DoS / 巨大 PUT 防止)
-    #   - eq Content-Type: アプリ側申告と完全一致 (MIME 偽装防止)
-    #   - eq key: 別ファイルへの上書き / 別 key への流用攻撃防止
     try:
         post_data = s3_client.generate_presigned_post(
             Bucket=bucket,
             Key=s3_key,
             Fields={"Content-Type": mime_type, "key": s3_key},
-            Conditions=[
-                ["content-length-range", 1, MAX_CONTENT_LENGTH],
-                {"Content-Type": mime_type},
-                {"key": s3_key},
-            ],
+            Conditions=_build_post_conditions(s3_key=s3_key, mime_type=mime_type),
             ExpiresIn=PRESIGN_EXPIRES_SECONDS,
         )
     except ClientError as exc:  # pragma: no cover - boto3 internal failure

--- a/apps/articles/s3_presign.py
+++ b/apps/articles/s3_presign.py
@@ -54,9 +54,12 @@ PRESIGN_EXPIRES_SECONDS: Final[int] = 5 * 60
 #: filename の文字長上限。 安全側で 200 文字 (DM 添付と整合)。
 FILENAME_MAX_LENGTH: Final[int] = 200
 
-#: filename の不許可 character pattern。 制御文字 / NUL / sep / parent traversal を排除。
-#  Unicode (日本語ファイル名) は許可するが ``/`` ``\`` ``..`` はブロック。
-_FILENAME_INVALID_PATTERN: Final[re.Pattern[str]] = re.compile(r"[\x00-\x1f\x7f/\\]|\.\.")
+#: filename の不許可 character pattern。 制御文字 / NUL / path separator を排除。
+#  Unicode (日本語ファイル名) と中間の連続ドット (例: ``photo..backup.png``) は許可する。
+#  パストラバーサルは ``/`` ``\`` をブロックすれば防げる (single component の filename 文脈)。
+#  filename が完全一致で ``..`` のみのケースは別途 :func:`validate_image_request` で弾く
+#  (拡張子チェックで rfind 後の actual_ext が空文字になり ValidationError)。
+_FILENAME_INVALID_PATTERN: Final[re.Pattern[str]] = re.compile(r"[\x00-\x1f\x7f/\\]")
 
 
 # -----------------------------------------------------------------------------
@@ -152,10 +155,10 @@ def validate_image_request(
 # -----------------------------------------------------------------------------
 
 
-def build_s3_key(*, user_id: Any, ext: str) -> str:
+def build_s3_key(*, user_id: int, ext: str) -> str:
     """``articles/<user_id>/<image_uuid>.<ext>`` を生成.
 
-    user_id は path-safe な値であること (int / UUID は問題なし)。
+    user_id は ``User.pk`` (BigAutoField → int) 前提。
     """
 
     return f"articles/{user_id}/{uuid.uuid4()}.{ext}"
@@ -163,7 +166,7 @@ def build_s3_key(*, user_id: Any, ext: str) -> str:
 
 def generate_presigned_image_upload(
     *,
-    user_id: Any,
+    user_id: int,
     mime_type: str,
     size: int,
     filename: str,
@@ -244,6 +247,7 @@ def head_object(*, s3_key: str) -> S3ObjectInfo:
             raise ValidationError(f"object not found: {s3_key}") from exc
         logger.warning(
             "articles.head_object.unexpected",
+            exc_info=exc,
             extra={
                 "event": "articles.head_object.unexpected",
                 "code": code,

--- a/apps/articles/serializers.py
+++ b/apps/articles/serializers.py
@@ -164,9 +164,21 @@ class ConfirmImageInputSerializer(serializers.Serializer):
     """`POST /articles/images/confirm/` の入力検証.
 
     width / height は frontend が ``HTMLImageElement.naturalWidth/Height`` から取得する想定。
+
+    NOTE (security-reviewer M-1 反映): ``s3_key`` は ``RegexField`` で
+    ``[a-zA-Z0-9._/-]`` のみを accept する。 ``posixpath.normpath`` は path
+    separator ベースの正規化しかしないため、 制御文字 (`\\t`、`\\n`、`\\r`、
+    `\\x00`、`\\x7f` 等) が valid prefix の後に紛れ込むと normpath = 元 で
+    通過してしまい boto3 内部まで到達する defense-in-depth gap が DM 添付には
+    存在した (DM 側にも同じ穴があり別 issue で起票予定)。 本 PR では allowlist
+    に絞ることで制御文字を入力段階で 400 にする。
     """
 
-    s3_key = serializers.CharField(min_length=1, max_length=512)
+    s3_key = serializers.RegexField(
+        regex=r"^[a-zA-Z0-9._/-]+$",
+        min_length=1,
+        max_length=512,
+    )
     filename = serializers.CharField(min_length=1, max_length=200)
     mime_type = serializers.ChoiceField(choices=sorted(ALLOWED_CONTENT_TYPES))
     size = serializers.IntegerField(min_value=1, max_value=MAX_CONTENT_LENGTH)

--- a/apps/articles/serializers.py
+++ b/apps/articles/serializers.py
@@ -14,7 +14,8 @@ from typing import Any
 from django.utils.text import slugify
 from rest_framework import serializers
 
-from apps.articles.models import Article, ArticleStatus
+from apps.articles.models import Article, ArticleImage, ArticleStatus
+from apps.articles.s3_presign import ALLOWED_CONTENT_TYPES, MAX_CONTENT_LENGTH
 from apps.tags.models import Tag
 
 
@@ -140,3 +141,51 @@ class ArticleUpdateInputSerializer(serializers.Serializer):
         required=False,
         max_length=5,
     )
+
+
+# --------------------------------------------------------------------------
+# 画像アップロード (P6-04 / docs/specs/article-image-upload-spec.md)
+# --------------------------------------------------------------------------
+
+
+class PresignImageInputSerializer(serializers.Serializer):
+    """`POST /articles/images/presign/` の入力検証.
+
+    値そのものの allowlist / size 上限は :func:`apps.articles.s3_presign.validate_image_request`
+    で最終確認するが、 ここでも UX のために早期 400 を返す。
+    """
+
+    filename = serializers.CharField(min_length=1, max_length=200)
+    mime_type = serializers.ChoiceField(choices=sorted(ALLOWED_CONTENT_TYPES))
+    size = serializers.IntegerField(min_value=1, max_value=MAX_CONTENT_LENGTH)
+
+
+class ConfirmImageInputSerializer(serializers.Serializer):
+    """`POST /articles/images/confirm/` の入力検証.
+
+    width / height は frontend が ``HTMLImageElement.naturalWidth/Height`` から取得する想定。
+    """
+
+    s3_key = serializers.CharField(min_length=1, max_length=512)
+    filename = serializers.CharField(min_length=1, max_length=200)
+    mime_type = serializers.ChoiceField(choices=sorted(ALLOWED_CONTENT_TYPES))
+    size = serializers.IntegerField(min_value=1, max_value=MAX_CONTENT_LENGTH)
+    width = serializers.IntegerField(min_value=1, max_value=10000)
+    height = serializers.IntegerField(min_value=1, max_value=10000)
+
+
+class ArticleImageOutputSerializer(serializers.ModelSerializer):
+    """`/articles/images/confirm/` の 201 response。 frontend が Markdown に挿入する ``url`` を含む."""
+
+    class Meta:
+        model = ArticleImage
+        fields = (
+            "id",
+            "s3_key",
+            "url",
+            "width",
+            "height",
+            "size",
+            "created_at",
+        )
+        read_only_fields = fields

--- a/apps/articles/services/images.py
+++ b/apps/articles/services/images.py
@@ -1,8 +1,8 @@
 """Article image confirm サービス (#527 / Phase 6 P6-04).
 
-presigned PUT 完了後、 S3 上の実物を ``head_object`` で再検証してから
-``ArticleImage`` の orphan (article=None) を作成する。 frontend は本 service の
-返却 ``ArticleImage`` の ``url`` を Markdown 本文に ``![](url)`` として埋め込む想定。
+presigned POST で S3 へのアップロード完了後、 実物を ``head_object`` で再検証してから
+``ArticleImage`` の orphan (article=None) を作成する。 frontend は本 service の返却
+``ArticleImage`` の ``url`` を Markdown 本文に ``![](url)`` として埋め込む想定。
 
 責務分離:
 - 入力検証 / S3 確認 / ORM 作成 をこの module に集約する。 view 層は HTTP 変換のみ。
@@ -12,7 +12,6 @@ presigned PUT 完了後、 S3 上の実物を ``head_object`` で再検証して
 from __future__ import annotations
 
 import posixpath
-from typing import Any
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.core.exceptions import ValidationError
@@ -31,7 +30,7 @@ def confirm_image(
     width: int,
     height: int,
 ) -> ArticleImage:
-    """presigned PUT 完了後の画像を確定し、 orphan ``ArticleImage`` を作成する.
+    """presigned POST 完了後の画像を確定し、 orphan ``ArticleImage`` を作成する.
 
     Args:
         user: アップロード実行者 (presign 時の user と一致前提、 view 層で検証済み)。
@@ -46,15 +45,21 @@ def confirm_image(
         作成された orphan ``ArticleImage`` (``article=None``)。
 
     Raises:
-        ValidationError: prefix mismatch / S3 上に実物なし / metadata 不一致 /
-            入力検証失敗。
+        ValidationError: prefix mismatch / s3_key 内に traversal 表記 / S3 上に実物なし /
+            metadata 不一致 / 入力検証失敗。
     """
 
     # 1. s3_key prefix を再検証する。 presign 経由で生成した key だが、 独立コード経由で
     #    confirm 呼びされた場合 / フロントの key 改ざんに対する保険。
-    #    ``posixpath.normpath`` で ``..`` を実際に collapse する (DM HIGH H-1 と同パターン)。
+    #    ``posixpath.normpath`` で ``..`` を実際に collapse し、 元の入力と一致しなければ拒否
+    #    (S3 はキーをリテラル文字列として扱うので、 ``articles/1/../1/foo`` のような形を
+    #    DB に書き込まないようにする)。
     expected_prefix = f"articles/{user.pk}/"
     normalised = posixpath.normpath(s3_key)
+    if normalised != s3_key:
+        raise ValidationError(
+            f"s3_key contains path traversal or non-canonical sequences: {s3_key!r}"
+        )
     if not normalised.startswith(expected_prefix):
         raise ValidationError(f"s3_key must start with '{expected_prefix}': got {s3_key!r}")
 
@@ -89,9 +94,16 @@ def confirm_image(
     )
 
 
-def _validate_dimensions(*, width: Any, height: Any) -> None:
-    """width / height の境界検証 (1..10000 の正整数)."""
+def _validate_dimensions(*, width: int, height: int) -> None:
+    """width / height の境界検証 (1..10000 の正整数).
+
+    serializer 側で同等の検証を行うが、 service が他経路から直接呼ばれた場合の保険。
+    ``isinstance(value, bool)`` を先に弾く: Python は ``bool`` を ``int`` のサブクラスに
+    しているため ``True`` / ``False`` が通過しないように明示する。
+    """
 
     for label, value in (("width", width), ("height", height)):
-        if not isinstance(value, int) or value < 1 or value > 10000:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValidationError(f"{label} must be int (got {type(value).__name__})")
+        if value < 1 or value > 10000:
             raise ValidationError(f"{label} must be 1..10000 (got {value!r})")

--- a/apps/articles/services/images.py
+++ b/apps/articles/services/images.py
@@ -1,0 +1,97 @@
+"""Article image confirm サービス (#527 / Phase 6 P6-04).
+
+presigned PUT 完了後、 S3 上の実物を ``head_object`` で再検証してから
+``ArticleImage`` の orphan (article=None) を作成する。 frontend は本 service の
+返却 ``ArticleImage`` の ``url`` を Markdown 本文に ``![](url)`` として埋め込む想定。
+
+責務分離:
+- 入力検証 / S3 確認 / ORM 作成 をこの module に集約する。 view 層は HTTP 変換のみ。
+- DM (``apps.dm.services.confirm_attachment``) と同型の責務境界。
+"""
+
+from __future__ import annotations
+
+import posixpath
+from typing import Any
+
+from django.contrib.auth.models import AbstractBaseUser
+from django.core.exceptions import ValidationError
+
+from apps.articles import s3_presign as _presign
+from apps.articles.models import ArticleImage
+
+
+def confirm_image(
+    *,
+    user: AbstractBaseUser,
+    s3_key: str,
+    filename: str,
+    mime_type: str,
+    size: int,
+    width: int,
+    height: int,
+) -> ArticleImage:
+    """presigned PUT 完了後の画像を確定し、 orphan ``ArticleImage`` を作成する.
+
+    Args:
+        user: アップロード実行者 (presign 時の user と一致前提、 view 層で検証済み)。
+        s3_key: presign 発行時に返した key (改ざん検出のため Conditions で eq 強制済み)。
+        filename: 申告ファイル名 (DB 保存はしないが拡張子検証に使う)。
+        mime_type: 申告 MIME (``head_object`` の ContentType と完全一致を要求)。
+        size: 申告 bytes (``head_object`` の ContentLength と完全一致を要求)。
+        width: 画像の幅 (frontend が ``naturalWidth`` から取得)。
+        height: 画像の高さ。
+
+    Returns:
+        作成された orphan ``ArticleImage`` (``article=None``)。
+
+    Raises:
+        ValidationError: prefix mismatch / S3 上に実物なし / metadata 不一致 /
+            入力検証失敗。
+    """
+
+    # 1. s3_key prefix を再検証する。 presign 経由で生成した key だが、 独立コード経由で
+    #    confirm 呼びされた場合 / フロントの key 改ざんに対する保険。
+    #    ``posixpath.normpath`` で ``..`` を実際に collapse する (DM HIGH H-1 と同パターン)。
+    expected_prefix = f"articles/{user.pk}/"
+    normalised = posixpath.normpath(s3_key)
+    if not normalised.startswith(expected_prefix):
+        raise ValidationError(f"s3_key must start with '{expected_prefix}': got {s3_key!r}")
+
+    # 2. 入力検証 (presign 経路を経ない呼びへの保険)。
+    _presign.validate_image_request(mime_type=mime_type, size=size, filename=filename)
+
+    # 3. width / height の境界。 過大値で DB / フロントが事故らないよう view 層と二重ガード。
+    _validate_dimensions(width=width, height=height)
+
+    # 4. S3 で実物を再検証。 frontend の申告は信用しない (security CRITICAL)。
+    info = _presign.head_object(s3_key=s3_key)
+    if info.content_length != size:
+        raise ValidationError(
+            f"S3 上のサイズ ({info.content_length}) が申告 ({size}) と一致しません"
+        )
+    # 空文字 fallback も「不一致」 として明示的に弾く (DM HIGH H-2 と同方針)。
+    if info.content_type != mime_type:
+        raise ValidationError(
+            f"S3 上の Content-Type ({info.content_type!r}) が申告 ({mime_type!r}) と一致しません"
+        )
+
+    # 5. orphan ArticleImage を作成。 後で article 保存時に本文 URL から binding する。
+    url = _presign.public_url_for(s3_key=s3_key)
+    return ArticleImage.objects.create(
+        article=None,
+        uploader=user,
+        s3_key=s3_key,
+        url=url,
+        width=width,
+        height=height,
+        size=size,
+    )
+
+
+def _validate_dimensions(*, width: Any, height: Any) -> None:
+    """width / height の境界検証 (1..10000 の正整数)."""
+
+    for label, value in (("width", width), ("height", height)):
+        if not isinstance(value, int) or value < 1 or value > 10000:
+            raise ValidationError(f"{label} must be 1..10000 (got {value!r})")

--- a/apps/articles/services/images.py
+++ b/apps/articles/services/images.py
@@ -15,6 +15,7 @@ import posixpath
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.core.exceptions import ValidationError
+from django.db import transaction
 
 from apps.articles import s3_presign as _presign
 from apps.articles.models import ArticleImage
@@ -70,6 +71,14 @@ def confirm_image(
     _validate_dimensions(width=width, height=height)
 
     # 4. S3 で実物を再検証。 frontend の申告は信用しない (security CRITICAL)。
+    #
+    # NOTE (database-reviewer L-1): head_object (外部 I/O) と ArticleImage.create
+    # は ``transaction.atomic`` で包んでいない。 head_object 完了後に DB insert が
+    # 失敗した場合、 S3 上に object が残るが DB row が無い「孤立 S3 object」 になる。
+    # これは presign 発行 → S3 PUT 成功 → confirm 失敗 (size mismatch 等) と同じ
+    # 結果で、 S3 lifecycle rule (365 日、 follow-up issue) で最終的に回収される。
+    # atomic で包むと head_object の I/O 待ちの間 DB connection を保持してしまう
+    # ため意図的に外している。
     info = _presign.head_object(s3_key=s3_key)
     if info.content_length != size:
         raise ValidationError(
@@ -82,16 +91,21 @@ def confirm_image(
         )
 
     # 5. orphan ArticleImage を作成。 後で article 保存時に本文 URL から binding する。
+    # database-reviewer H-1: unique(s3_key) で同一 key 二重 confirm 時 IntegrityError
+    # が走るが、 outer の implicit transaction を broken state にしないため
+    # transaction.atomic で savepoint を切る (caller は IntegrityError を catch して
+    # 400 に変換できる)。
     url = _presign.public_url_for(s3_key=s3_key)
-    return ArticleImage.objects.create(
-        article=None,
-        uploader=user,
-        s3_key=s3_key,
-        url=url,
-        width=width,
-        height=height,
-        size=size,
-    )
+    with transaction.atomic():
+        return ArticleImage.objects.create(
+            article=None,
+            uploader=user,
+            s3_key=s3_key,
+            url=url,
+            width=width,
+            height=height,
+            size=size,
+        )
 
 
 def _validate_dimensions(*, width: int, height: int) -> None:

--- a/apps/articles/tests/test_image_upload.py
+++ b/apps/articles/tests/test_image_upload.py
@@ -190,6 +190,64 @@ def test_confirm_view_creates_orphan_article_image(settings) -> None:
 
 
 @pytest.mark.django_db
+def test_confirm_view_rejects_content_type_mismatch(settings) -> None:
+    """T5b (spec §5 T6 同等の Content-Type 版): head_object の ContentType が申告と
+    不一致 → 400、 row 作成されない (MIME 偽装防止)."""
+
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    settings.AWS_S3_REGION_NAME = "ap-northeast-1"
+    user = _user("alice")
+    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.head_object.return_value = _fake_head_object(
+            content_length=1024,
+            content_type="image/jpeg",  # 申告は image/png → 不一致
+        )
+        resp = _client_for(user).post(
+            reverse("articles:image-confirm"),
+            {
+                "s3_key": s3_key,
+                "filename": "shot.png",
+                "mime_type": "image/png",
+                "size": 1024,
+                "width": 800,
+                "height": 600,
+            },
+            format="json",
+        )
+
+    assert resp.status_code == 400
+    assert ArticleImage.objects.filter(s3_key=s3_key).count() == 0
+
+
+@pytest.mark.django_db
+def test_confirm_view_rejects_path_traversal_in_key() -> None:
+    """T7b: s3_key に ``..`` を含むと posixpath.normpath で正規化後と元が一致せず 400.
+
+    `articles/<user>/../<user>/foo.png` のような形は、 正規化後は self-prefix に
+    一致してしまうが、 元の文字列に traversal 表記があるので DB 行を作らない。
+    """
+
+    user = _user("alice")
+    s3_key = f"articles/{user.pk}/sub/../malicious.png"
+    resp = _client_for(user).post(
+        reverse("articles:image-confirm"),
+        {
+            "s3_key": s3_key,
+            "filename": "shot.png",
+            "mime_type": "image/png",
+            "size": 1024,
+            "width": 800,
+            "height": 600,
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert ArticleImage.objects.filter(s3_key=s3_key).count() == 0
+
+
+@pytest.mark.django_db
 def test_confirm_view_rejects_size_mismatch() -> None:
     """T6: head_object の ContentLength が申告と不一致 → 400、 row 作成されない."""
 

--- a/apps/articles/tests/test_image_upload.py
+++ b/apps/articles/tests/test_image_upload.py
@@ -572,6 +572,50 @@ def test_confirm_image_rejects_bool_as_dimension() -> None:
 
 
 # ---------------------------------------------------------------------------
+# IntegrityError → 400 (database-reviewer HIGH H-1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_confirm_view_returns_400_on_duplicate_s3_key(settings) -> None:
+    """H-1: 同一 s3_key で confirm が二重呼び出しされたら 500 ではなく 400 に変換.
+
+    network retry / 二重 submit が起きたケースを想定。 unique constraint で
+    IntegrityError が走るが、 view 層で DRFValidationError に変換する。
+    """
+
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    settings.AWS_S3_REGION_NAME = "ap-northeast-1"
+    user = _user("alice")
+    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+
+    payload = {
+        "s3_key": s3_key,
+        "filename": "shot.png",
+        "mime_type": "image/png",
+        "size": 1024,
+        "width": 800,
+        "height": 600,
+    }
+
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.head_object.return_value = _fake_head_object(
+            content_length=1024,
+            content_type="image/png",
+        )
+        # 1 回目: 201 で確定する
+        resp1 = _client_for(user).post(reverse("articles:image-confirm"), payload, format="json")
+        assert resp1.status_code == 201
+
+        # 2 回目: 既に確定済の s3_key なので 400 (500 にはならない)
+        resp2 = _client_for(user).post(reverse("articles:image-confirm"), payload, format="json")
+
+    assert resp2.status_code == 400
+    # 重複しても DB には 1 行だけ残る
+    assert ArticleImage.objects.filter(s3_key=s3_key).count() == 1
+
+
+# ---------------------------------------------------------------------------
 # Conditions assertion (review MEDIUM-3)
 # ---------------------------------------------------------------------------
 

--- a/apps/articles/tests/test_image_upload.py
+++ b/apps/articles/tests/test_image_upload.py
@@ -452,6 +452,74 @@ def test_public_url_for_falls_back_to_virtual_host(settings) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Security: s3_key control chars (security-reviewer M-1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        "articles/1/abc.png\nINJECT",
+        "articles/1/abc.png\x00null",
+        "articles/1/abc\x7fdel.png",
+        "articles/1/abc\rcr.png",
+        "articles/1/abc\ttab.png",
+        "articles/1/中文.png",  # non-ASCII not in allowlist
+        "articles/1/space inside.png",
+    ],
+)
+@pytest.mark.django_db
+def test_confirm_view_rejects_s3_key_with_control_chars(bad_key: str) -> None:
+    """M-1: s3_key の RegexField allowlist で制御文字 / 非 ASCII / space は 400 になる.
+
+    serializer 層で弾くため head_object に到達せず、 boto3 内部にも非正規文字を渡さない
+    (defense-in-depth)。 ``posixpath.normpath`` は path-separator 系しか正規化しないため
+    制御文字を含む key が ``normalised == s3_key`` を通過してしまう穴を塞ぐ。
+    """
+
+    user = _user("alice")
+    resp = _client_for(user).post(
+        reverse("articles:image-confirm"),
+        {
+            "s3_key": bad_key,
+            "filename": "shot.png",
+            "mime_type": "image/png",
+            "size": 1024,
+            "width": 800,
+            "height": 600,
+        },
+        format="json",
+    )
+    # serializer 段階で 400、 head_object / DB に到達しない。 NUL を含む key は
+    # PostgreSQL の COUNT も呼べないので、 ここでは status だけ確認する (件数 0 は
+    # 「未到達」 とほぼ等価)。
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Security: Bearer token must not authenticate (security-reviewer M-3)
+# ---------------------------------------------------------------------------
+
+
+def test_image_views_use_explicit_cookie_authentication() -> None:
+    """M-3: ``authentication_classes = [CookieAuthentication]`` が明示されていることを
+    確認する.
+
+    本プロジェクトの ``CookieAuthentication`` は ``JWTAuthentication`` を継承していて
+    Bearer header も accept する (cookie_auth.py:75-79 参照、 意図的)。 重要なのは
+    DRF default の auth 順序 (JWTAuthentication → CookieAuthentication) を素通しに
+    せず、 CSRF enforce が必要な cookie 経路を統一クラスに寄せている点。 tweet view と
+    同じ class 構成にする (reviewer M-3 反映)。
+    """
+
+    from apps.articles.views import ConfirmArticleImageView, PresignArticleImageView
+    from apps.common.cookie_auth import CookieAuthentication
+
+    assert PresignArticleImageView.authentication_classes == [CookieAuthentication]
+    assert ConfirmArticleImageView.authentication_classes == [CookieAuthentication]
+
+
+# ---------------------------------------------------------------------------
 # Dimension boundary tests (review MEDIUM-2)
 # ---------------------------------------------------------------------------
 

--- a/apps/articles/tests/test_image_upload.py
+++ b/apps/articles/tests/test_image_upload.py
@@ -1,0 +1,405 @@
+"""Tests for article image presign + confirm API (#527 / Phase 6 P6-04).
+
+docs/specs/article-image-upload-spec.md の T1-T8。 DM 添付 (apps/dm/tests/
+test_views_attachments.py) と同じく boto3 client を patch して S3 を呼ばない
+状態でロジックを検証する。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.articles.models import ArticleImage
+
+User = get_user_model()
+
+
+def _user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+def _client_for(user) -> APIClient:
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+def _fake_post_response(bucket: str, key: str, mime_type: str) -> dict:
+    """boto3 ``generate_presigned_post`` の正常 response を模倣する."""
+
+    return {
+        "url": f"https://{bucket}.s3.ap-northeast-1.amazonaws.com/",
+        "fields": {
+            "key": key,
+            "Content-Type": mime_type,
+            "policy": "fake-policy-base64",
+            "x-amz-signature": "fake-signature",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Presign view (T1-T4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_presign_view_returns_200_with_user_scoped_key(settings) -> None:
+    """T1: 認証ユーザーが valid payload で叩くと 200 + s3_key が user 単位."""
+
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    settings.AWS_S3_REGION_NAME = "ap-northeast-1"
+    user = _user("alice")
+
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.generate_presigned_post.side_effect = (
+            lambda **kw: _fake_post_response(kw["Bucket"], kw["Key"], "image/png")
+        )
+        resp = _client_for(user).post(
+            reverse("articles:image-presign"),
+            {
+                "filename": "shot.png",
+                "mime_type": "image/png",
+                "size": 1024,
+            },
+            format="json",
+        )
+
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["url"].startswith("https://test-bucket.s3.")
+    assert body["s3_key"].startswith(f"articles/{user.pk}/")
+    assert body["s3_key"].endswith(".png")
+    assert "fields" in body
+    assert "expires_at" in body
+
+
+@pytest.mark.django_db
+def test_presign_view_rejects_oversize() -> None:
+    """T2: size=5MB+1 → 400 (presigned URL は発行されない)."""
+
+    user = _user("alice")
+    resp = _client_for(user).post(
+        reverse("articles:image-presign"),
+        {
+            "filename": "huge.jpg",
+            "mime_type": "image/jpeg",
+            "size": 5 * 1024 * 1024 + 1,
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_presign_view_rejects_unsupported_mime() -> None:
+    """T3: MIME が allowlist に無い → 400."""
+
+    user = _user("alice")
+    resp = _client_for(user).post(
+        reverse("articles:image-presign"),
+        {
+            "filename": "doc.pdf",
+            "mime_type": "application/pdf",
+            "size": 1024,
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_presign_view_requires_auth() -> None:
+    """T4: 匿名 → 401 (presigned URL を発行しない)."""
+
+    resp = APIClient().post(
+        reverse("articles:image-presign"),
+        {
+            "filename": "shot.png",
+            "mime_type": "image/png",
+            "size": 1024,
+        },
+        format="json",
+    )
+    assert resp.status_code in {401, 403}  # IsAuthenticated default
+
+
+# ---------------------------------------------------------------------------
+# Confirm view (T5-T8)
+# ---------------------------------------------------------------------------
+
+
+def _fake_head_object(content_length: int, content_type: str):
+    """``head_object`` が返す DTO 相当の dict を作る。"""
+
+    return {"ContentLength": content_length, "ContentType": content_type}
+
+
+@pytest.mark.django_db
+def test_confirm_view_creates_orphan_article_image(settings) -> None:
+    """T5: head_object と申告 metadata が一致 → 201 + ArticleImage orphan 作成."""
+
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    settings.AWS_S3_REGION_NAME = "ap-northeast-1"
+    user = _user("alice")
+    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.head_object.return_value = _fake_head_object(
+            content_length=1024,
+            content_type="image/png",
+        )
+        resp = _client_for(user).post(
+            reverse("articles:image-confirm"),
+            {
+                "s3_key": s3_key,
+                "filename": "shot.png",
+                "mime_type": "image/png",
+                "size": 1024,
+                "width": 800,
+                "height": 600,
+            },
+            format="json",
+        )
+
+    assert resp.status_code == 201, resp.content
+    body = resp.json()
+    assert body["s3_key"] == s3_key
+    assert body["width"] == 800
+    assert body["height"] == 600
+    assert body["size"] == 1024
+    assert body["url"].endswith(s3_key)
+
+    # DB に orphan ArticleImage が作られている (article=None, uploader=user)
+    image = ArticleImage.objects.get(s3_key=s3_key)
+    assert image.article_id is None
+    assert image.uploader_id == user.pk
+    assert image.size == 1024
+
+
+@pytest.mark.django_db
+def test_confirm_view_rejects_size_mismatch() -> None:
+    """T6: head_object の ContentLength が申告と不一致 → 400、 row 作成されない."""
+
+    user = _user("alice")
+    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.head_object.return_value = _fake_head_object(
+            content_length=999,  # 申告は 1024 → 不一致
+            content_type="image/png",
+        )
+        resp = _client_for(user).post(
+            reverse("articles:image-confirm"),
+            {
+                "s3_key": s3_key,
+                "filename": "shot.png",
+                "mime_type": "image/png",
+                "size": 1024,
+                "width": 800,
+                "height": 600,
+            },
+            format="json",
+        )
+
+    assert resp.status_code == 400
+    assert ArticleImage.objects.filter(s3_key=s3_key).count() == 0
+
+
+@pytest.mark.django_db
+def test_confirm_view_rejects_foreign_user_key_prefix() -> None:
+    """T7: 他ユーザーの uuid から始まる s3_key を confirm しようとしても 400 (row 作成されない)."""
+
+    user = _user("alice")
+    other = _user("bob")
+    s3_key = f"articles/{other.pk}/00000000-0000-0000-0000-000000000000.png"
+
+    # boto3 を mock しない: prefix チェックで弾かれて S3 まで行かない (期待)
+    resp = _client_for(user).post(
+        reverse("articles:image-confirm"),
+        {
+            "s3_key": s3_key,
+            "filename": "shot.png",
+            "mime_type": "image/png",
+            "size": 1024,
+            "width": 800,
+            "height": 600,
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert ArticleImage.objects.filter(s3_key=s3_key).count() == 0
+
+
+@pytest.mark.django_db
+def test_confirm_view_requires_auth() -> None:
+    """T8: 匿名 → 401 (head_object も呼ばれない、 row 作成されない)."""
+
+    s3_key = "articles/00000000/00000000-0000-0000-0000-000000000000.png"
+    resp = APIClient().post(
+        reverse("articles:image-confirm"),
+        {
+            "s3_key": s3_key,
+            "filename": "shot.png",
+            "mime_type": "image/png",
+            "size": 1024,
+            "width": 800,
+            "height": 600,
+        },
+        format="json",
+    )
+    assert resp.status_code in {401, 403}
+    assert ArticleImage.objects.filter(s3_key=s3_key).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit-level checks for the validator (defense-in-depth for non-view callers)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_image_request_rejects_path_traversal() -> None:
+    """filename に `..` を含むと ValidationError (path traversal 対策)."""
+
+    from apps.articles.s3_presign import validate_image_request
+
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(mime_type="image/png", size=1024, filename="../evil.png")
+
+
+def test_validate_image_request_rejects_extension_mismatch() -> None:
+    """filename の拡張子が mime_type と一致しなければ ValidationError."""
+
+    from apps.articles.s3_presign import validate_image_request
+
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(mime_type="image/png", size=1024, filename="shot.jpg")
+
+
+def test_validate_image_request_accepts_jpeg_with_jpg_extension() -> None:
+    """``image/jpeg`` は `.jpg` と `.jpeg` の両方を受容する."""
+
+    from apps.articles.s3_presign import validate_image_request
+
+    # raises 無し
+    validate_image_request(mime_type="image/jpeg", size=1024, filename="shot.jpg")
+    validate_image_request(mime_type="image/jpeg", size=1024, filename="shot.jpeg")
+
+
+def test_validate_image_request_rejects_unsupported_mime_direct() -> None:
+    """validate_image_request 直叩きで unsupported MIME → ValidationError.
+
+    view 層は ChoiceField で先に弾くが、 ``confirm_image`` など他経路から呼ばれた場合の
+    fail-fast を担保する (defense-in-depth)。
+    """
+
+    from apps.articles.s3_presign import validate_image_request
+
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(mime_type="application/pdf", size=1024, filename="doc.pdf")
+
+
+def test_validate_image_request_rejects_non_positive_size() -> None:
+    """size <= 0 は ValidationError."""
+
+    from apps.articles.s3_presign import validate_image_request
+
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(mime_type="image/png", size=0, filename="shot.png")
+
+
+def test_validate_image_request_rejects_oversize_direct() -> None:
+    """size > MAX_CONTENT_LENGTH は ValidationError."""
+
+    from apps.articles.s3_presign import (
+        MAX_CONTENT_LENGTH,
+        validate_image_request,
+    )
+
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(
+            mime_type="image/png", size=MAX_CONTENT_LENGTH + 1, filename="shot.png"
+        )
+
+
+def test_validate_image_request_rejects_empty_filename() -> None:
+    """filename が空 / 過大は ValidationError."""
+
+    from apps.articles.s3_presign import validate_image_request
+
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(mime_type="image/png", size=1024, filename="")
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(mime_type="image/png", size=1024, filename="a" * 201 + ".png")
+
+
+def test_validate_image_request_rejects_filename_without_extension() -> None:
+    """拡張子の無い filename は ValidationError."""
+
+    from apps.articles.s3_presign import validate_image_request
+
+    with pytest.raises(DjangoValidationError):
+        validate_image_request(mime_type="image/png", size=1024, filename="no_dot_name")
+
+
+def test_head_object_translates_not_found_to_validation_error() -> None:
+    """S3 が NoSuchKey を返したら ValidationError("object not found")."""
+
+    from botocore.exceptions import ClientError
+
+    from apps.articles.s3_presign import head_object
+
+    err = ClientError({"Error": {"Code": "NoSuchKey", "Message": "missing"}}, "HeadObject")
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.head_object.side_effect = err
+        with pytest.raises(DjangoValidationError) as exc_info:
+            head_object(s3_key="articles/1/abc.png")
+    assert "not found" in str(exc_info.value)
+
+
+def test_head_object_translates_other_errors_to_validation_error() -> None:
+    """403 等 NoSuchKey 以外のエラーも ValidationError("failed to verify") に変換される."""
+
+    from botocore.exceptions import ClientError
+
+    from apps.articles.s3_presign import head_object
+
+    err = ClientError({"Error": {"Code": "403", "Message": "AccessDenied"}}, "HeadObject")
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.head_object.side_effect = err
+        with pytest.raises(DjangoValidationError) as exc_info:
+            head_object(s3_key="articles/1/abc.png")
+    assert "failed to verify" in str(exc_info.value)
+
+
+def test_public_url_for_uses_custom_domain_when_set(settings) -> None:
+    """``AWS_S3_CUSTOM_DOMAIN`` が設定されていれば CloudFront URL を返す."""
+
+    from apps.articles.s3_presign import public_url_for
+
+    settings.AWS_S3_CUSTOM_DOMAIN = "cdn.example.com"
+    url = public_url_for(s3_key="articles/1/abc.png")
+    assert url == "https://cdn.example.com/articles/1/abc.png"
+
+
+def test_public_url_for_falls_back_to_virtual_host(settings) -> None:
+    """``AWS_S3_CUSTOM_DOMAIN`` が空なら S3 virtual host URL に fallback."""
+
+    from apps.articles.s3_presign import public_url_for
+
+    settings.AWS_S3_CUSTOM_DOMAIN = ""
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    settings.AWS_S3_REGION_NAME = "ap-northeast-1"
+    url = public_url_for(s3_key="articles/1/abc.png")
+    assert url == ("https://test-bucket.s3.ap-northeast-1.amazonaws.com/articles/1/abc.png")

--- a/apps/articles/tests/test_image_upload.py
+++ b/apps/articles/tests/test_image_upload.py
@@ -10,12 +10,20 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.articles.models import ArticleImage
+from apps.articles.s3_presign import (
+    MAX_CONTENT_LENGTH,
+    head_object,
+    public_url_for,
+    validate_image_request,
+)
+from apps.articles.services.images import confirm_image
 
 User = get_user_model()
 
@@ -328,9 +336,7 @@ def test_confirm_view_requires_auth() -> None:
 
 
 def test_validate_image_request_rejects_path_traversal() -> None:
-    """filename に `..` を含むと ValidationError (path traversal 対策)."""
-
-    from apps.articles.s3_presign import validate_image_request
+    """filename に `../` を含むと ValidationError (path traversal 対策)."""
 
     with pytest.raises(DjangoValidationError):
         validate_image_request(mime_type="image/png", size=1024, filename="../evil.png")
@@ -339,8 +345,6 @@ def test_validate_image_request_rejects_path_traversal() -> None:
 def test_validate_image_request_rejects_extension_mismatch() -> None:
     """filename の拡張子が mime_type と一致しなければ ValidationError."""
 
-    from apps.articles.s3_presign import validate_image_request
-
     with pytest.raises(DjangoValidationError):
         validate_image_request(mime_type="image/png", size=1024, filename="shot.jpg")
 
@@ -348,11 +352,20 @@ def test_validate_image_request_rejects_extension_mismatch() -> None:
 def test_validate_image_request_accepts_jpeg_with_jpg_extension() -> None:
     """``image/jpeg`` は `.jpg` と `.jpeg` の両方を受容する."""
 
-    from apps.articles.s3_presign import validate_image_request
-
     # raises 無し
     validate_image_request(mime_type="image/jpeg", size=1024, filename="shot.jpg")
     validate_image_request(mime_type="image/jpeg", size=1024, filename="shot.jpeg")
+
+
+def test_validate_image_request_accepts_double_dot_in_middle() -> None:
+    """``photo..backup.png`` のような中間連続ドットは accept する.
+
+    docs/specs/article-image-upload-spec.md §3.1 で意図的に許容している (path separator が
+    無ければ traversal にならない)。 DM の filename pattern とは挙動が異なる。
+    """
+
+    # raises 無し
+    validate_image_request(mime_type="image/png", size=1024, filename="photo..backup.png")
 
 
 def test_validate_image_request_rejects_unsupported_mime_direct() -> None:
@@ -362,8 +375,6 @@ def test_validate_image_request_rejects_unsupported_mime_direct() -> None:
     fail-fast を担保する (defense-in-depth)。
     """
 
-    from apps.articles.s3_presign import validate_image_request
-
     with pytest.raises(DjangoValidationError):
         validate_image_request(mime_type="application/pdf", size=1024, filename="doc.pdf")
 
@@ -371,19 +382,12 @@ def test_validate_image_request_rejects_unsupported_mime_direct() -> None:
 def test_validate_image_request_rejects_non_positive_size() -> None:
     """size <= 0 は ValidationError."""
 
-    from apps.articles.s3_presign import validate_image_request
-
     with pytest.raises(DjangoValidationError):
         validate_image_request(mime_type="image/png", size=0, filename="shot.png")
 
 
 def test_validate_image_request_rejects_oversize_direct() -> None:
     """size > MAX_CONTENT_LENGTH は ValidationError."""
-
-    from apps.articles.s3_presign import (
-        MAX_CONTENT_LENGTH,
-        validate_image_request,
-    )
 
     with pytest.raises(DjangoValidationError):
         validate_image_request(
@@ -394,8 +398,6 @@ def test_validate_image_request_rejects_oversize_direct() -> None:
 def test_validate_image_request_rejects_empty_filename() -> None:
     """filename が空 / 過大は ValidationError."""
 
-    from apps.articles.s3_presign import validate_image_request
-
     with pytest.raises(DjangoValidationError):
         validate_image_request(mime_type="image/png", size=1024, filename="")
     with pytest.raises(DjangoValidationError):
@@ -405,18 +407,12 @@ def test_validate_image_request_rejects_empty_filename() -> None:
 def test_validate_image_request_rejects_filename_without_extension() -> None:
     """拡張子の無い filename は ValidationError."""
 
-    from apps.articles.s3_presign import validate_image_request
-
     with pytest.raises(DjangoValidationError):
         validate_image_request(mime_type="image/png", size=1024, filename="no_dot_name")
 
 
 def test_head_object_translates_not_found_to_validation_error() -> None:
     """S3 が NoSuchKey を返したら ValidationError("object not found")."""
-
-    from botocore.exceptions import ClientError
-
-    from apps.articles.s3_presign import head_object
 
     err = ClientError({"Error": {"Code": "NoSuchKey", "Message": "missing"}}, "HeadObject")
     with patch("apps.articles.s3_presign._build_s3_client") as build_client:
@@ -429,10 +425,6 @@ def test_head_object_translates_not_found_to_validation_error() -> None:
 def test_head_object_translates_other_errors_to_validation_error() -> None:
     """403 等 NoSuchKey 以外のエラーも ValidationError("failed to verify") に変換される."""
 
-    from botocore.exceptions import ClientError
-
-    from apps.articles.s3_presign import head_object
-
     err = ClientError({"Error": {"Code": "403", "Message": "AccessDenied"}}, "HeadObject")
     with patch("apps.articles.s3_presign._build_s3_client") as build_client:
         build_client.return_value.head_object.side_effect = err
@@ -444,8 +436,6 @@ def test_head_object_translates_other_errors_to_validation_error() -> None:
 def test_public_url_for_uses_custom_domain_when_set(settings) -> None:
     """``AWS_S3_CUSTOM_DOMAIN`` が設定されていれば CloudFront URL を返す."""
 
-    from apps.articles.s3_presign import public_url_for
-
     settings.AWS_S3_CUSTOM_DOMAIN = "cdn.example.com"
     url = public_url_for(s3_key="articles/1/abc.png")
     assert url == "https://cdn.example.com/articles/1/abc.png"
@@ -454,10 +444,103 @@ def test_public_url_for_uses_custom_domain_when_set(settings) -> None:
 def test_public_url_for_falls_back_to_virtual_host(settings) -> None:
     """``AWS_S3_CUSTOM_DOMAIN`` が空なら S3 virtual host URL に fallback."""
 
-    from apps.articles.s3_presign import public_url_for
-
     settings.AWS_S3_CUSTOM_DOMAIN = ""
     settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
     settings.AWS_S3_REGION_NAME = "ap-northeast-1"
     url = public_url_for(s3_key="articles/1/abc.png")
     assert url == ("https://test-bucket.s3.ap-northeast-1.amazonaws.com/articles/1/abc.png")
+
+
+# ---------------------------------------------------------------------------
+# Dimension boundary tests (review MEDIUM-2)
+# ---------------------------------------------------------------------------
+
+
+def _confirm_kwargs(user, **overrides):
+    """``confirm_image`` の典型 kwargs を組む helper (boundary テスト用)."""
+
+    base = {
+        "user": user,
+        "s3_key": f"articles/{user.pk}/abc.png",
+        "filename": "shot.png",
+        "mime_type": "image/png",
+        "size": 1024,
+        "width": 800,
+        "height": 600,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.django_db
+def test_confirm_image_rejects_width_zero() -> None:
+    """width=0 は service レベルで ValidationError (serializer bypass 経路の保険)."""
+
+    user = _user("alice")
+    with pytest.raises(DjangoValidationError):
+        confirm_image(**_confirm_kwargs(user, width=0))
+
+
+@pytest.mark.django_db
+def test_confirm_image_rejects_height_over_max() -> None:
+    """height=10001 (10000 + 1) は service レベルで ValidationError."""
+
+    user = _user("alice")
+    with pytest.raises(DjangoValidationError):
+        confirm_image(**_confirm_kwargs(user, height=10001))
+
+
+@pytest.mark.django_db
+def test_confirm_image_rejects_bool_as_dimension() -> None:
+    """Python の ``True`` / ``False`` は ``int`` のサブクラスだが service は弾く.
+
+    serializer の ``IntegerField`` も bool を許さないが、 service が独立呼びされる
+    場合の保険として明示的にチェックしている。
+    """
+
+    user = _user("alice")
+    with pytest.raises(DjangoValidationError):
+        confirm_image(**_confirm_kwargs(user, width=True))
+
+
+# ---------------------------------------------------------------------------
+# Conditions assertion (review MEDIUM-3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_presign_view_passes_correct_conditions_to_s3(settings) -> None:
+    """presign 発行時に S3 へ渡る ``Conditions`` が spec 通りであることを確認.
+
+    Conditions は S3 側で content-length-range / eq Content-Type / eq key を強制する
+    primary な security mechanism。 regression で削除 / 弱体化されないようテストで保護する。
+    """
+
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    settings.AWS_S3_REGION_NAME = "ap-northeast-1"
+    user = _user("alice")
+
+    with patch("apps.articles.s3_presign._build_s3_client") as build_client:
+        build_client.return_value.generate_presigned_post.side_effect = (
+            lambda **kw: _fake_post_response(kw["Bucket"], kw["Key"], "image/png")
+        )
+        _client_for(user).post(
+            reverse("articles:image-presign"),
+            {"filename": "shot.png", "mime_type": "image/png", "size": 1024},
+            format="json",
+        )
+
+        # generate_presigned_post の呼び出し引数を確認
+        assert build_client.return_value.generate_presigned_post.call_count == 1
+        kwargs = build_client.return_value.generate_presigned_post.call_args.kwargs
+        conditions = kwargs["Conditions"]
+
+    # content-length-range を含む
+    assert ["content-length-range", 1, MAX_CONTENT_LENGTH] in conditions
+    # eq Content-Type を含む (申告 MIME と完全一致)
+    assert {"Content-Type": "image/png"} in conditions
+    # eq key を含む (s3_key の流用攻撃を防ぐ)
+    assert any(
+        isinstance(c, dict) and "key" in c and c["key"].startswith(f"articles/{user.pk}/")
+        for c in conditions
+    )

--- a/apps/articles/urls.py
+++ b/apps/articles/urls.py
@@ -10,7 +10,9 @@ from django.urls import path
 from apps.articles.views import (
     ArticleDetailView,
     ArticleListCreateView,
+    ConfirmArticleImageView,
     MyDraftListView,
+    PresignArticleImageView,
 )
 
 app_name = "articles"
@@ -18,5 +20,9 @@ app_name = "articles"
 urlpatterns = [
     path("", ArticleListCreateView.as_view(), name="list-create"),
     path("me/drafts/", MyDraftListView.as_view(), name="my-drafts"),
+    # 画像アップロード (P6-04). detail (slug) より前に置いて
+    # "images" が slug として吸い取られるのを防ぐ。
+    path("images/presign/", PresignArticleImageView.as_view(), name="image-presign"),
+    path("images/confirm/", ConfirmArticleImageView.as_view(), name="image-confirm"),
     path("<slug:slug>/", ArticleDetailView.as_view(), name="detail"),
 ]

--- a/apps/articles/views.py
+++ b/apps/articles/views.py
@@ -24,28 +24,47 @@ docs/issues/phase-6.md P6-03 + SPEC §12 を実装。
 
 from __future__ import annotations
 
+import logging
+
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError
 from django.db.models import F
 from django.utils import timezone
 from rest_framework import generics, permissions, status, throttling
 from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.articles import s3_presign as _presign
 from apps.articles.models import Article, ArticleStatus, ArticleTag
 from apps.articles.serializers import (
     ArticleCreateInputSerializer,
     ArticleDetailSerializer,
+    ArticleImageOutputSerializer,
     ArticleSummarySerializer,
     ArticleUpdateInputSerializer,
+    ConfirmImageInputSerializer,
+    PresignImageInputSerializer,
 )
+from apps.articles.services.images import confirm_image
+
+logger = logging.getLogger(__name__)
 
 
 class _ArticleWriteThrottle(throttling.UserRateThrottle):
     scope = "article_write"
+
+
+class _ArticleImagePresignThrottle(throttling.ScopedRateThrottle):
+    scope = "article_image_presign"
+
+
+class _ArticleImageConfirmThrottle(throttling.ScopedRateThrottle):
+    scope = "article_image_confirm"
 
 
 class _ArticleListPagination(CursorPagination):
@@ -231,4 +250,108 @@ class MyDraftListView(generics.ListAPIView):
             Article.objects.filter(author=self.request.user, status=ArticleStatus.DRAFT)
             .select_related("author")
             .prefetch_related("article_tags__tag")
+        )
+
+
+# ---------------------------------------------------------------------------
+# 画像アップロード (P6-04 / docs/specs/article-image-upload-spec.md)
+# ---------------------------------------------------------------------------
+
+
+class PresignArticleImageView(APIView):
+    """``POST /api/v1/articles/images/presign/``: 記事内画像の presigned POST URL を発行する.
+
+    body: ``{"filename": str, "mime_type": str, "size": int}``
+    response (200): ``{"url", "fields", "s3_key", "expires_at"}``
+
+    認可:
+    - 認証必須 (``IsAuthenticated``)
+    - throttle ``article_image_presign`` 30/hour (stg 300/hour) で濫用抑制
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+    throttle_classes = [_ArticleImagePresignThrottle]
+
+    def post(self, request: Request) -> Response:
+        serializer = PresignImageInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        try:
+            result = _presign.generate_presigned_image_upload(
+                user_id=request.user.pk,
+                mime_type=data["mime_type"],
+                size=data["size"],
+                filename=data["filename"],
+            )
+        except DjangoValidationError as exc:
+            raise DRFValidationError(detail=exc.messages) from exc
+
+        # 監査用: 署名済 URL 本体 (credentials を含む) は残さず object_key のみ記録。
+        logger.info(
+            "articles.image_presign.issued",
+            extra={
+                "event": "articles.image_presign.issued",
+                "user_id": request.user.pk,
+                "s3_key": result.s3_key,
+            },
+        )
+
+        return Response(
+            {
+                "url": result.url,
+                "fields": result.fields,
+                "s3_key": result.s3_key,
+                "expires_at": result.expires_at.isoformat(),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class ConfirmArticleImageView(APIView):
+    """``POST /api/v1/articles/images/confirm/``: presign で PUT 完了した画像を確定する.
+
+    body: ``{"s3_key", "filename", "mime_type", "size", "width", "height"}``
+    response (201): ``ArticleImageOutputSerializer`` 全フィールド (id, s3_key, url, width, height, size, created_at)
+
+    フロー (services.images.confirm_image を参照):
+    1. s3_key prefix が ``articles/<request.user.pk>/`` で始まることを再検証 (IDOR 防止)
+    2. ``head_object`` で S3 上の実物 metadata と申告を再検証 (改ざん防止)
+    3. orphan ``ArticleImage`` (article=None) を作成
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+    throttle_classes = [_ArticleImageConfirmThrottle]
+
+    def post(self, request: Request) -> Response:
+        serializer = ConfirmImageInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        try:
+            image = confirm_image(
+                user=request.user,
+                s3_key=data["s3_key"],
+                filename=data["filename"],
+                mime_type=data["mime_type"],
+                size=data["size"],
+                width=data["width"],
+                height=data["height"],
+            )
+        except DjangoValidationError as exc:
+            raise DRFValidationError(detail=exc.messages) from exc
+
+        logger.info(
+            "articles.image_confirm.created",
+            extra={
+                "event": "articles.image_confirm.created",
+                "user_id": request.user.pk,
+                "image_id": str(image.id),
+                "s3_key": image.s3_key,
+            },
+        )
+
+        return Response(
+            ArticleImageOutputSerializer(image).data,
+            status=status.HTTP_201_CREATED,
         )

--- a/apps/articles/views.py
+++ b/apps/articles/views.py
@@ -51,6 +51,7 @@ from apps.articles.serializers import (
     PresignImageInputSerializer,
 )
 from apps.articles.services.images import confirm_image
+from apps.common.cookie_auth import CookieAuthentication
 
 logger = logging.getLogger(__name__)
 
@@ -276,8 +277,15 @@ class PresignArticleImageView(APIView):
     認可:
     - 認証必須 (``IsAuthenticated``)
     - throttle ``article_image_presign`` 30/hour (stg 300/hour) で濫用抑制
+    - ``authentication_classes`` を ``CookieAuthentication`` のみに明示
+      (security-reviewer M-3 反映): tweet view と同じ class 構成に揃える。
+      なお ``CookieAuthentication`` は ``JWTAuthentication`` を継承していて Bearer
+      header も accept する (cookie_auth.py:75-79、 意図的)。 重要なのは DRF default の
+      auth chain (JWTAuthentication 先、 CookieAuthentication 後) を素通しせず、
+      CSRF enforce 経路を統一クラスに寄せている点。
     """
 
+    authentication_classes = [CookieAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     throttle_classes = [_ArticleImagePresignThrottle]
 
@@ -327,8 +335,12 @@ class ConfirmArticleImageView(APIView):
     1. s3_key prefix が ``articles/<request.user.pk>/`` で始まることを再検証 (IDOR 防止)
     2. ``head_object`` で S3 上の実物 metadata と申告を再検証 (改ざん防止)
     3. orphan ``ArticleImage`` (article=None) を作成
+
+    認可: presign view と同じく ``CookieAuthentication`` のみ
+    (security-reviewer M-3 反映、 Bearer token を意図せず受け入れない)。
     """
 
+    authentication_classes = [CookieAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     throttle_classes = [_ArticleImageConfirmThrottle]
 

--- a/apps/articles/views.py
+++ b/apps/articles/views.py
@@ -59,11 +59,20 @@ class _ArticleWriteThrottle(throttling.UserRateThrottle):
     scope = "article_write"
 
 
-class _ArticleImagePresignThrottle(throttling.ScopedRateThrottle):
+class _ArticleImagePresignThrottle(throttling.UserRateThrottle):
+    """画像 presign URL 発行 throttle (article_image_presign scope).
+
+    NOTE: ``ScopedRateThrottle`` は view 側に ``throttle_scope`` 属性が必要で、
+    クラス属性 ``scope`` だけでは no-op になる。 ``_ArticleWriteThrottle`` と同様に
+    ``UserRateThrottle`` 継承 + クラス属性 ``scope`` で適用される。
+    """
+
     scope = "article_image_presign"
 
 
-class _ArticleImageConfirmThrottle(throttling.ScopedRateThrottle):
+class _ArticleImageConfirmThrottle(throttling.UserRateThrottle):
+    """画像 confirm throttle (article_image_confirm scope).  see notes 上記."""
+
     scope = "article_image_confirm"
 
 
@@ -309,7 +318,7 @@ class PresignArticleImageView(APIView):
 
 
 class ConfirmArticleImageView(APIView):
-    """``POST /api/v1/articles/images/confirm/``: presign で PUT 完了した画像を確定する.
+    """``POST /api/v1/articles/images/confirm/``: presigned POST で完了した画像を確定する.
 
     body: ``{"s3_key", "filename", "mime_type", "size", "width", "height"}``
     response (201): ``ArticleImageOutputSerializer`` 全フィールド (id, s3_key, url, width, height, size, created_at)

--- a/apps/articles/views.py
+++ b/apps/articles/views.py
@@ -361,6 +361,12 @@ class ConfirmArticleImageView(APIView):
             )
         except DjangoValidationError as exc:
             raise DRFValidationError(detail=exc.messages) from exc
+        except IntegrityError as exc:
+            # database-reviewer HIGH H-1: 同一 s3_key で confirm が二重呼び出しされた
+            # 場合 (network retry / 二重 submit) は unique constraint が走り
+            # IntegrityError になる。 そのまま 500 にせず 400 に変換して
+            # 「既に確定済み」 と明示する。 既存 Article CRUD の slug 衝突と同じ流儀。
+            raise DRFValidationError(detail=["この s3_key は既に確定済みです"]) from exc
 
         logger.info(
             "articles.image_confirm.created",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -472,6 +472,10 @@ _THROTTLE_RATES_BASE = {
     # Phase 6 articles (P6-03):
     # 30/hour = 2 分に 1 本ペース。長文記事の保存頻度を考えると十分余裕あり。
     "article_write": "30/hour" if not _IS_STG else "300/hour",
+    # Phase 6 articles 画像アップロード (P6-04 / docs/specs/article-image-upload-spec.md):
+    # 30/hour は記事 1 本に画像 10 枚貼っても 3 本/時 = 通常運用十分。
+    "article_image_presign": "30/hour" if not _IS_STG else "300/hour",
+    "article_image_confirm": "30/hour" if not _IS_STG else "300/hour",
 }
 
 REST_FRAMEWORK = {

--- a/docs/specs/article-image-upload-spec.md
+++ b/docs/specs/article-image-upload-spec.md
@@ -1,0 +1,242 @@
+# 記事内画像アップロード spec (P6-04 / Issue #527)
+
+> Phase 6 P6-04 backend のみ。 frontend D&D 連携は別 PR (P6-13 follow-up)。
+>
+> 関連:
+>
+> - [docs/issues/phase-6.md](../issues/phase-6.md) P6-04
+> - [docs/SPEC.md](../SPEC.md) §12 (記事)、§7.3 (DM attachment、 流用元)
+> - [apps/dm/s3_presign.py](../../apps/dm/s3_presign.py) (presigned POST + head_object 再検証パターン、 そのまま踏襲)
+> - [apps/dm/services.py](../../apps/dm/services.py) `confirm_attachment` (確定フローの参考)
+> - chatapp 参考: `app/posts/views.py` の `media` action は **multipart 直アップロード方式** で本リポジトリの方針と異なるため API 形式は流用しない (流儀のみ参考にした)。
+
+## 1. 背景・目的
+
+`ArticleImage` モデル ([apps/articles/models.py:166-202](../../apps/articles/models.py)) は P6-01 で既に作成済 (`article=null` 可、 `s3_key` unique、 width/height/size 必須)。 しかし「画像を S3 にアップロードするための endpoint」 が無いため、 記事本文に画像を貼ることができない。
+
+P6-04 では DM 添付と同じ **presigned POST + confirm 二段階方式** で `ArticleImage` を作成する 2 つの API を追加する。 frontend の D&D 実装 (P6-13 follow-up) はこの API を消費する。
+
+### なぜ presigned POST + confirm の二段階か
+
+| 方式                                                    | 長所                                                                                                                              | 短所                                                                        |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| multipart 直アップロード (chatapp / Django デフォルト)  | シンプル、 1 リクエスト                                                                                                           | サーバ帯域・CPU を画像で食う、 ECS task の memory pressure、 大量並列で死ぬ |
+| presigned PUT + 単発                                    | サーバ非経由、 中庸                                                                                                               | クライアントが任意の Content-Type で PUT 可能 (MIME 偽装余地)               |
+| **presigned POST + Conditions + confirm 再検証** (採用) | サーバ非経由、 S3 側で `content-length-range` / `eq Content-Type` / `eq key` を強制、 confirm で `head_object` 再検証で改ざん検出 | 2 リクエスト必要 (frontend は state machine 増える)                         |
+
+DM 添付で security-reviewer の指摘 (HIGH H-1/H-2/H-3) を反映して採用した形式と同じ。 新しい流儀を導入せず、 既存パターンを使う。
+
+## 2. やる / やらない
+
+### やる (PR A スコープ)
+
+- `apps/articles/s3_presign.py` 新設: `validate_image_request` / `build_s3_key` / `generate_presigned_image_upload` / `head_object` / `public_url_for` を `apps/dm/s3_presign.py` から **必要分のみ port**。
+- `POST /api/v1/articles/images/presign/` endpoint 追加 (auth、 throttle、 serializer 入力検証)。
+- `POST /api/v1/articles/images/confirm/` endpoint 追加 (auth、 throttle、 head_object 再検証、 `ArticleImage` orphan 作成、 serializer 出力)。
+- `apps/articles/services/images.py` 新設: `confirm_image` 関数で「`head_object` 再検証 → `ArticleImage.objects.create(article=None, uploader=user, ...)` → DTO 返却」 を担う。
+- throttle scope 追加 (`article_image_presign: 30/hour` + `article_image_confirm: 30/hour`、 stg は 300/hour)。
+- pytest: 8 ケース (presign 成功 / size 超過 / MIME 不許可 / 認証必須 + confirm 成功 / size 不一致 / Content-Type 不一致 / object 不在 / 認証必須)。
+- カバレッジ 80%+ を `apps/articles/s3_presign.py` と `apps/articles/services/images.py` で達成。
+- admin に `ArticleImage` を登録 (orphan 監査用)。 既に登録済みなら no-op。
+
+### やらない (このスコープ外、 別 PR / 別 Issue へ)
+
+- frontend ArticleEditor の D&D / paste 連携 (PR C / P6-13 follow-up)。
+- 画像と `Article` の自動 binding (本文 markdown 内の URL を scan して `ArticleImage.article` を埋める)。 P6-09 (GitHub push) と連動するため別 Issue で再検討。
+- orphan `ArticleImage` (article=NULL のまま 24 時間以上) の GC Celery beat。 S3 lifecycle rule (既存 365 日自動削除) で当面しのぐ。 別 Issue で起票。
+- 動画 (video/\*) や任意 file 形式の添付。 SPEC §12 は image のみ。
+
+## 3. API 仕様
+
+### 3.1 `POST /api/v1/articles/images/presign/`
+
+S3 presigned POST URL を発行する。
+
+#### 認可
+
+- `IsAuthenticated` 必須 (匿名は 401)。
+- throttle `article_image_presign: 30/hour` (stg `300/hour`)。 30/hour は記事 1 本に画像 10 枚貼っても 3 本/時 = 通常運用十分。
+
+#### Request body
+
+```json
+{
+	"filename": "screenshot.png",
+	"mime_type": "image/png",
+	"size": 245678
+}
+```
+
+| field       | 型     | 制約                                                                                                                             |
+| ----------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `filename`  | string | 1〜200 文字、 制御文字 / NUL / `/` / `\` / `..` を含まない、 拡張子が `mime_type` と一致 (`image/jpeg` は `jpg` `jpeg` 両方許容) |
+| `mime_type` | string | `image/jpeg` / `image/png` / `image/webp` / `image/gif` の 4 種のみ                                                              |
+| `size`      | int    | 1〜5_242_880 (5 MiB)                                                                                                             |
+
+#### Response (200)
+
+```json
+{
+  "url": "https://<bucket>.s3.<region>.amazonaws.com/",
+  "fields": {
+    "key": "articles/<user_uuid>/<image_uuid>.png",
+    "Content-Type": "image/png",
+    "policy": "...",
+    "x-amz-signature": "...",
+    ...
+  },
+  "s3_key": "articles/<user_uuid>/<image_uuid>.png",
+  "expires_at": "2026-05-11T12:34:56+00:00"
+}
+```
+
+- `s3_key` は `articles/<user_uuid>/<image_uuid>.<ext>` 形式。
+  - `<user_uuid>` は `request.user.id` を 16 進そのまま (path-traversal 安全)。
+  - `<image_uuid>` は `uuid4()` を新規発行 (collision 確率は実質ゼロ)。
+  - 拡張子は MIME map から決定 (`image/jpeg` → `jpg` 固定)。
+- `expires_at` は ISO8601 UTC、 5 分後。
+
+#### Response (400)
+
+`{"detail": "..."}` または `{"field_name": ["..."]}` で標準的な DRF エラー形式。
+
+#### S3 側強制 (Conditions)
+
+`generate_presigned_post` の `Conditions` で:
+
+```python
+[
+  ["content-length-range", 1, 5_242_880],
+  {"Content-Type": "image/png"},   # 申告と完全一致
+  {"key": "articles/<user_uuid>/<image_uuid>.png"},  # 別 key への流用禁止
+]
+```
+
+→ frontend が PUT 時にサイズや MIME を書き換えても S3 側で 403 で reject。
+
+### 3.2 `POST /api/v1/articles/images/confirm/`
+
+S3 への PUT 完了後、 `ArticleImage` orphan を作成する。
+
+#### 認可
+
+- `IsAuthenticated` 必須。
+- throttle `article_image_confirm: 30/hour` (stg `300/hour`)。
+- s3_key の prefix `articles/<request.user.id>/` を強制 (他ユーザーの key を confirm されないように)。
+
+#### Request body
+
+```json
+{
+	"s3_key": "articles/<user_uuid>/<image_uuid>.png",
+	"filename": "screenshot.png",
+	"mime_type": "image/png",
+	"size": 245678,
+	"width": 1024,
+	"height": 768
+}
+```
+
+| field       | 型     | 制約                                                                                            |
+| ----------- | ------ | ----------------------------------------------------------------------------------------------- |
+| `s3_key`    | string | `articles/<request.user.id>/` で始まる、 `posixpath.normpath` で `..` collapse 後も prefix 一致 |
+| `filename`  | string | 3.1 と同条件                                                                                    |
+| `mime_type` | string | 3.1 と同条件                                                                                    |
+| `size`      | int    | 3.1 と同条件、 かつ `head_object` の `ContentLength` と完全一致                                 |
+| `width`     | int    | 1〜10000 (frontend は `naturalWidth` から取得)                                                  |
+| `height`    | int    | 1〜10000                                                                                        |
+
+#### Response (201)
+
+```json
+{
+	"id": "<image_uuid>",
+	"s3_key": "articles/<user_uuid>/<image_uuid>.png",
+	"url": "https://cdn.example.com/articles/<user_uuid>/<image_uuid>.png",
+	"width": 1024,
+	"height": 768,
+	"size": 245678,
+	"created_at": "2026-05-11T12:34:56+00:00"
+}
+```
+
+`url` は `AWS_S3_CUSTOM_DOMAIN` (CloudFront) があればそれ経由、 なければ S3 virtual host (`https://<bucket>.s3.<region>.amazonaws.com/<key>`)。 既存 `apps.dm.s3_presign.public_url_for` と同方針。
+
+#### Response (400)
+
+| エラー                                               | trigger                                  |
+| ---------------------------------------------------- | ---------------------------------------- |
+| `s3_key must start with 'articles/<your_uuid>/'`     | 他ユーザーの key を confirm しようとした |
+| `S3 上のサイズ (X) が申告 (Y) と一致しません`        | 改ざんで PUT した                        |
+| `S3 上の Content-Type (X) が申告 (Y) と一致しません` | MIME 偽装                                |
+| `object not found: <s3_key>`                         | PUT が未完了、 または key 流用           |
+| `width / height は 1..10000`                         | 範囲外                                   |
+
+## 4. データ層
+
+### 4.1 既存 `ArticleImage` モデル (no change)
+
+[apps/articles/models.py:166](../../apps/articles/models.py) で既に定義済:
+
+- `article: FK Article, null=True, blank=True` ← orphan 許容
+- `uploader: FK User, on_delete=CASCADE`
+- `s3_key: CharField(unique=True, max=512)`
+- `url: URLField(max=1024)`
+- `width / height / size: PositiveIntegerField`
+- `created_at: DateTimeField(auto_now_add)`
+
+migration 追加は不要 (既に 0001_initial に含まれている)。
+
+### 4.2 admin
+
+[apps/articles/admin.py](../../apps/articles/admin.py) で既に登録済かを確認。 未登録なら `@admin.register(ArticleImage)` を追加。 list_display は `id` `uploader` `article` `s3_key` `size` `created_at` 程度で十分。
+
+## 5. テスト (TDD)
+
+`apps/articles/tests/test_image_upload.py` に pytest を 8 ケース書く (Red 確認 → 実装で Green)。
+
+| #   | テスト名                                  | 検証内容                                                                                                          |
+| --- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| T1  | `test_presign_success`                    | auth user が valid request → 200 + url/fields/s3_key/expires_at が返る、 s3_key が `articles/<user_id>/` で始まる |
+| T2  | `test_presign_rejects_oversized`          | size=5MB+1 → 400                                                                                                  |
+| T3  | `test_presign_rejects_unsupported_mime`   | mime_type=`application/pdf` → 400                                                                                 |
+| T4  | `test_presign_requires_auth`              | 匿名 → 401                                                                                                        |
+| T5  | `test_confirm_success`                    | `head_object` mock で metadata 一致 → 201 + ArticleImage row 作成 (article=None、 uploader=user)                  |
+| T6  | `test_confirm_rejects_size_mismatch`      | head_object の ContentLength が申告と不一致 → 400、 row 作成されない                                              |
+| T7  | `test_confirm_rejects_foreign_key_prefix` | 他ユーザーの uuid から始まる s3_key → 400、 row 作成されない                                                      |
+| T8  | `test_confirm_requires_auth`              | 匿名 → 401                                                                                                        |
+
+`boto3.client` は `apps.articles.s3_presign.boto3.client` を `unittest.mock.patch` する (DM テストと同パターン)。 `head_object` は MagicMock の返り値で `ContentLength` / `ContentType` を制御。
+
+カバレッジ目標:
+
+- `apps/articles/s3_presign.py`: 90%+ (例外パスも touch)
+- `apps/articles/services/images.py`: 85%+
+
+## 6. ファイル変更まとめ
+
+```
+apps/articles/
+  s3_presign.py          [新規 ~150 行]  DM の s3_presign.py から image 用に port
+  services/
+    images.py            [新規 ~80 行]   confirm_image() で head_object + create
+  serializers.py         [既存 +40 行]   PresignImageInput / ConfirmImageInput / ImageConfirmResponse
+  views.py               [既存 +60 行]   PresignArticleImageView + ConfirmArticleImageView
+  urls.py                [既存 +2 行]    images/presign/ + images/confirm/
+  admin.py               [既存 +10 行]   ArticleImage 登録 (未登録なら)
+  tests/
+    test_image_upload.py [新規 ~250 行] T1-T8
+
+config/settings/base.py  [既存 +4 行]    article_image_presign / article_image_confirm scope
+
+docs/specs/
+  article-image-upload-spec.md  [新規、 本ファイル]
+```
+
+合計概算 ≈ 600 行 (テスト除いて ≈ 350 行)。 small PR ルール (500 行以下) を 1 PR 内で守れる。
+
+## 7. 後続 PR への申し送り
+
+- **PR B (P6-12 follow-up)**: 詳細ページに「編集」 button + `/articles/me/drafts` 画面。 API は既存 `listMyDrafts`。
+- **PR C (P6-13 follow-up)**: ArticleEditor の live Markdown preview (`marked` + 既存 `isomorphic-dompurify`) + 画像 D&D。 本 spec の API (`/articles/images/presign/` + `/confirm/`) を消費し、 success 時に `![](url)` を caret 位置に挿入。 `gan-evaluator` agent を呼んで実機 UX を採点。
+- **後追い Issue**: orphan `ArticleImage` (article=NULL かつ 24h 経過) の GC Celery beat。 S3 lifecycle (365 日) で当面回避。

--- a/terraform/modules/edge/main.tf
+++ b/terraform/modules/edge/main.tf
@@ -150,6 +150,7 @@ resource "aws_cloudfront_origin_access_control" "s3" {
 #   /media/*         -> S3 media (long TTL、GET のみ)
 #   /users/*         -> S3 media (profile avatar/header public objects)
 #   /dm/*            -> S3 media (DM attachment objects)
+#   /articles/*      -> S3 media (記事内画像、SecurityHeaders 付与) (P6-04)
 #   /api/*           -> ALB  (no cache)
 #   /ws/*            -> ALB  (no cache、WebSocket 透過)
 #   / (default)      -> ALB  (Next.js SSR、short TTL)
@@ -181,6 +182,21 @@ data "aws_cloudfront_origin_request_policy" "all_viewer_except_host" {
 
 data "aws_cloudfront_origin_request_policy" "cors_s3" {
   name = "Managed-CORS-S3Origin"
+}
+
+# AWS Managed Response Headers Policy: `SecurityHeadersPolicy`
+# 提供する header (security-reviewer M-2 反映、 P6-04 / #527):
+#   - X-Content-Type-Options: nosniff  (MIME sniffing 防止、 stored XSS 緩和)
+#   - Strict-Transport-Security: max-age=31536000; includeSubDomains
+#   - X-Frame-Options: SAMEORIGIN
+#   - Referrer-Policy: strict-origin-when-cross-origin
+#   - X-XSS-Protection: 1; mode=block
+# /articles/* に attach することで、 MIME 偽装で stored XSS を試みる
+# 攻撃 (HTML payload を image/png として upload) をブラウザ側で防ぐ。
+# /dm/* と /users/* にも同じ policy を retrofit すべきだが、 本 PR
+# スコープは /articles/* のみ (follow-up issue で対応)。
+data "aws_cloudfront_response_headers_policy" "security_headers" {
+  name = "Managed-SecurityHeadersPolicy"
 }
 
 resource "aws_cloudfront_distribution" "this" {
@@ -309,6 +325,24 @@ resource "aws_cloudfront_distribution" "this" {
 
     cache_policy_id          = data.aws_cloudfront_cache_policy.caching_optimized.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.cors_s3.id
+  }
+
+  # -------- /articles/* → S3 media (P6-04 / #527) --------
+  # 記事内画像 (apps.articles.s3_presign で issue する s3_key = articles/<user_id>/<uuid>.<ext>)
+  # を配信する。 SecurityHeadersPolicy で nosniff + Strict-Transport-Security 等を付与し、
+  # MIME 偽装による stored XSS (HTML payload を image/png として upload) をブラウザ側で
+  # 防ぐ (security-reviewer M-2 反映)。
+  ordered_cache_behavior {
+    path_pattern           = "/articles/*"
+    target_origin_id       = "media"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.cors_s3.id
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.security_headers.id
   }
 
   # -------- /api/* → ALB (no cache) --------


### PR DESCRIPTION
## 概要

Phase 6 P6-04 backend。 記事編集中に画像を貼るための upload 機構を追加。 frontend D&D 連携 (P6-13 follow-up) はこの API を消費する想定。

Closes #527

### 実装した API

- `POST /api/v1/articles/images/presign/` → S3 presigned POST URL を発行
  - `filename` / `mime_type` / `size` を入力検証
  - `s3_key = articles/<user_id>/<uuid>.<ext>` で IDOR 防止
  - 30/hour throttle (stg 300/hour)
- `POST /api/v1/articles/images/confirm/` → `head_object` で実物を再検証 → orphan `ArticleImage` (article=None) を作成 → CloudFront URL を返す
  - 二重 confirm 時は 400 (`IntegrityError` 捕捉、 H-1)
  - 30/hour throttle (stg 300/hour)

### 既存パターンとの整合

DM 添付 (`apps/dm/s3_presign.py` + `apps/dm/services.py`) の presigned POST + `head_object` 再検証パターンを **そのまま流儀として踏襲**。 security-reviewer の HIGH H-1/H-2/H-3 (DM 修正時に反映済) を継承。

- presigned POST + `Conditions` で S3 側強制: `content-length-range` / `eq Content-Type` / `eq key`
- 許可 MIME: image/jpeg / png / webp / gif、 サイズ上限 5 MiB
- `posixpath.normpath` で `..` を collapse + 正規化前後の一致確認で path traversal 防止
- `s3_key` を RegexField allowlist で制御文字を入力段階で 400 (security-reviewer M-1 反映)
- `authentication_classes = [CookieAuthentication]` 明示で tweet view と一貫

### CloudFront

`terraform/modules/edge/main.tf` に `/articles/*` ordered_cache_behavior 追加 + AWS managed `SecurityHeadersPolicy` (X-Content-Type-Options: nosniff 等) を attach (security-reviewer H-1 + M-2)。 plan / apply はハルナさん手動 (CLAUDE.md §9)。

### 仕様書

[docs/specs/article-image-upload-spec.md](./docs/specs/article-image-upload-spec.md) に詳細。

---

## レビュー履歴 (4 reviewer 直列起動、 CLAUDE.md §4.2 マトリクス + §4.5 並列禁止)

| Reviewer | 判定 | 反映 commit |
|----------|------|-------------|
| python-reviewer | WARNING (no blockers) | de8f001 |
| code-reviewer | WARNING (no blockers) | 9c4de53 |
| security-reviewer | **Block on H-1 + M-1** | 63e9b20 |
| database-reviewer | HIGH H-1 即対応推奨 | a8dbb4f |

全 HIGH (5 件) + 大半の MEDIUM を本 PR で反映済み。 PR 外とした 3 項目は follow-up issue 起票済 (#588 #589 #590)。

---

## テスト

- 36 ケース全 pass: presign / confirm の view-level + s3_presign / services の unit + 制御文字 7 種 parametrize + dimension boundary + Conditions assert + 二重 confirm + Bearer token explicit auth class 確認
- coverage `apps/articles/s3_presign.py` **99%** / `apps/articles/services/images.py` **100%**
- ruff / terraform fmt / terraform validate 緑

## Test plan

- [x] presign view 200 + s3_key prefix が user 単位
- [x] presign view 5MB+1 / unsupported MIME / 匿名 → 400 / 401
- [x] confirm view 201 + orphan ArticleImage 作成
- [x] confirm view size mismatch / Content-Type mismatch / 他人の key prefix / 制御文字 / 匿名 → 400 / 401
- [x] confirm view 二重呼び出し → 400 (500 にならない)
- [x] presigned_post の Conditions に content-length-range / eq Content-Type / eq key が入っている
- [x] dimension boundary: width=0 / height=10001 / width=True 拒否
- [x] CookieAuthentication が両 view に明示 attach されている
- [x] terraform validate / fmt 緑
- [ ] **stg apply 後の動作確認**: ハルナさん手動 (terraform apply)
- [ ] **stg E2E**: P6-13 frontend (画像 D&D 編集 UI) と組み合わせて確認、 別 PR で実施

## Follow-up

- #588 (refactor): apps/{articles,dm,boards}/s3_presign を `apps/common/s3.py` に集約検討
- #589 (feature): orphan ArticleImage GC (Celery beat + S3 lifecycle + partial index)
- #590 (infra): SecurityHeadersPolicy を /dm/* と /users/* にも retrofit + DM head_object に exc_info 追加