### PR TITLE
feat(articles): 記事編集ループの導線完成 (詳細「編集/削除」 button + /me/drafts + nav link) (#593)

### DIFF
--- a/client/e2e/article-edit-loop.spec.ts
+++ b/client/e2e/article-edit-loop.spec.ts
@@ -1,0 +1,278 @@
+/**
+ * 記事編集ループの導線 E2E (#593 / Phase 6 P6-12 follow-up).
+ *
+ * Spec: docs/specs/article-edit-loop-spec.md §5.2
+ *
+ * 検証シナリオ:
+ *   EDIT-LOOP-1: 自分の記事に「編集」 button が見える / click で /<slug>/edit へ
+ *   EDIT-LOOP-2: 他人の記事には「編集」「削除」 button が出ない
+ *   EDIT-LOOP-3: 新規 → 公開 → 詳細「削除」 → confirm → /articles へ + toast
+ *   EDIT-LOOP-4: drafts page (auth) で自分の下書きが見える / row から edit へ
+ *   EDIT-LOOP-5: drafts page (anon) は /login へ redirect
+ *
+ * env: docs/local/e2e-stg.md の test2 / test3 を使用。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+): Promise<{ csrf: string }> {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+	return { csrf };
+}
+
+async function createPublishedArticle(
+	request: APIRequestContext,
+	csrf: string,
+	title: string,
+): Promise<{ slug: string }> {
+	const slug = `e2e-edit-loop-${Date.now()}`;
+	const res = await request.post(`${BASE}/api/v1/articles/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/articles/new`,
+		},
+		data: {
+			title,
+			body_markdown: `# ${title}\n\nE2E 記事編集ループ用本文。`,
+			slug,
+			status: "published",
+		},
+	});
+	expect(res.status()).toBe(201);
+	const body = await res.json();
+	return { slug: body.slug };
+}
+
+async function createDraftArticle(
+	request: APIRequestContext,
+	csrf: string,
+	title: string,
+): Promise<{ slug: string }> {
+	const slug = `e2e-draft-${Date.now()}`;
+	const res = await request.post(`${BASE}/api/v1/articles/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/articles/new`,
+		},
+		data: {
+			title,
+			body_markdown: `# ${title}\n\n下書き本文`,
+			slug,
+			status: "draft",
+		},
+	});
+	expect(res.status()).toBe(201);
+	const body = await res.json();
+	return { slug: body.slug };
+}
+
+async function deleteArticleViaApi(
+	request: APIRequestContext,
+	csrf: string,
+	slug: string,
+): Promise<void> {
+	await request.delete(`${BASE}/api/v1/articles/${slug}/`, {
+		headers: {
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/articles/${slug}`,
+		},
+	});
+}
+
+test.describe("記事編集ループの導線 (#593)", () => {
+	test.beforeAll(() => requireEnv());
+
+	test("EDIT-LOOP-1: 自分の記事に編集 button が出る + click で /edit へ", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const request = ctx.request;
+		const { csrf } = await loginViaApi(request, USER1);
+		const { slug } = await createPublishedArticle(
+			request,
+			csrf,
+			"EDIT-LOOP-1 self",
+		);
+
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/articles/${slug}`);
+
+		// owner only sticky header に「編集」 link
+		const editLink = page.getByRole("link", { name: "記事を編集" });
+		await expect(editLink).toBeVisible({ timeout: 15000 });
+		expect(await editLink.getAttribute("href")).toBe(`/articles/${slug}/edit`);
+
+		// 「削除」 button も並んで存在する
+		await expect(
+			page.getByRole("button", { name: "記事を削除" }),
+		).toBeVisible();
+
+		// click → /<slug>/edit に遷移して ArticleEditor が描画される
+		await editLink.click();
+		await page.waitForURL(`${BASE}/articles/${slug}/edit`);
+		await expect(
+			page.getByRole("heading", { name: "記事を編集", level: 1 }),
+		).toBeVisible();
+
+		// cleanup
+		await deleteArticleViaApi(request, csrf, slug);
+		await ctx.close();
+	});
+
+	test("EDIT-LOOP-2: 他人の記事には編集 / 削除 button が出ない", async ({
+		browser,
+	}) => {
+		test.skip(
+			!USER2.email || !USER2.password || !USER2.handle,
+			"USER2 env 未設定",
+		);
+		const ctx = await browser.newContext();
+		const request = ctx.request;
+		// USER2 でログイン → 記事作成 → ログアウトコンテキストを捨てる
+		const ctxAuthor = await browser.newContext();
+		const requestAuthor = ctxAuthor.request;
+		const { csrf: csrf2 } = await loginViaApi(requestAuthor, USER2);
+		const { slug } = await createPublishedArticle(
+			requestAuthor,
+			csrf2,
+			"EDIT-LOOP-2 by other",
+		);
+		await ctxAuthor.close();
+
+		// 別 context で USER1 ログイン
+		await loginViaApi(request, USER1);
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/articles/${slug}`);
+
+		// owner ではないので button は DOM に存在しない
+		await expect(page.getByRole("link", { name: "記事を編集" })).toHaveCount(0);
+		await expect(page.getByRole("button", { name: "記事を削除" })).toHaveCount(
+			0,
+		);
+
+		// cleanup (author 側で削除)
+		const cleanCtx = await browser.newContext();
+		const { csrf: cleanCsrf } = await loginViaApi(cleanCtx.request, USER2);
+		await deleteArticleViaApi(cleanCtx.request, cleanCsrf, slug);
+		await cleanCtx.close();
+		await ctx.close();
+	});
+
+	test("EDIT-LOOP-3: 削除 flow (confirm → /articles redirect + toast)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const request = ctx.request;
+		const { csrf } = await loginViaApi(request, USER1);
+		const { slug } = await createPublishedArticle(
+			request,
+			csrf,
+			"EDIT-LOOP-3 to delete",
+		);
+
+		const page = await ctx.newPage();
+
+		// Playwright は window.confirm を自動 accept する
+		page.on("dialog", (dialog) => {
+			expect(dialog.type()).toBe("confirm");
+			expect(dialog.message()).toContain("削除");
+			return dialog.accept();
+		});
+
+		await page.goto(`${BASE}/articles/${slug}`);
+		await page.getByRole("button", { name: "記事を削除" }).click();
+
+		// 削除後は /articles に遷移
+		await page.waitForURL(`${BASE}/articles`, { timeout: 15000 });
+
+		// toast 「削除しました」 が見える (react-toastify は role="alert" 系)
+		await expect(page.getByText("削除しました")).toBeVisible({
+			timeout: 10000,
+		});
+
+		// 念のため backend 側 cleanup (404 でも OK、 idempotent)
+		await deleteArticleViaApi(request, csrf, slug);
+		await ctx.close();
+	});
+
+	test("EDIT-LOOP-4: drafts page で自分の下書きが row 表示 + edit へ遷移", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const request = ctx.request;
+		const { csrf } = await loginViaApi(request, USER1);
+		const draftTitle = `EDIT-LOOP-4 draft ${Date.now()}`;
+		const { slug } = await createDraftArticle(request, csrf, draftTitle);
+
+		const page = await ctx.newPage();
+		// ホーム → /articles → 「下書き」 link を踏む (3 click 以内、 §3.3)
+		await page.goto(`${BASE}/articles`);
+		const draftsLink = page.getByRole("link", { name: "下書き" });
+		await expect(draftsLink).toBeVisible({ timeout: 15000 });
+		await draftsLink.click();
+		await page.waitForURL(`${BASE}/articles/me/drafts`);
+
+		// 自分の下書きが row として表示
+		await expect(page.getByText(draftTitle)).toBeVisible({ timeout: 10000 });
+
+		// row click → /<slug>/edit
+		await page.getByText(draftTitle).click();
+		await page.waitForURL(`${BASE}/articles/${slug}/edit`);
+
+		// cleanup
+		await deleteArticleViaApi(request, csrf, slug);
+		await ctx.close();
+	});
+
+	test("EDIT-LOOP-5: drafts page (anon) → /login?next= redirect", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/articles/me/drafts`);
+		// /login or /login?next=... へ redirect
+		await page.waitForURL(/\/login(\?.*)?/, { timeout: 15000 });
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/articles/[slug]/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/page.tsx
@@ -9,6 +9,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 
 import ArticleBody from "@/components/articles/ArticleBody";
 import ArticleOwnerActions from "@/components/articles/ArticleOwnerActions";
@@ -21,20 +22,24 @@ interface PageProps {
 }
 
 interface CurrentUserMini {
-	id: number | string;
 	username: string;
 }
 
-async function fetchArticleSSR(slug: string): Promise<ArticleDetail | null> {
-	try {
-		return await serverFetch<ArticleDetail>(`/articles/${slug}/`);
-	} catch (err) {
-		if (err instanceof ApiServerError && err.status === 404) return null;
-		throw err;
-	}
-}
+// generateMetadata と page 本体で同じ slug の article を 2 回 fetch するため、
+// React.cache でリクエスト内 dedupe する (reviewer H-2 反映)。 serverFetch は
+// cache: "no-store" なので React.cache が無いと毎回叩く。
+const fetchArticleSSR = cache(
+	async (slug: string): Promise<ArticleDetail | null> => {
+		try {
+			return await serverFetch<ArticleDetail>(`/articles/${slug}/`);
+		} catch (err) {
+			if (err instanceof ApiServerError && err.status === 404) return null;
+			throw err;
+		}
+	},
+);
 
-async function fetchCurrentUserSSR(): Promise<CurrentUserMini | null> {
+const fetchCurrentUserSSR = cache(async (): Promise<CurrentUserMini | null> => {
 	// 未ログイン (401) でも fetch 不能でも owner 判定は false にしたいので、
 	// 例外は全て swallow して null を返す (page render は継続)。
 	try {
@@ -42,7 +47,7 @@ async function fetchCurrentUserSSR(): Promise<CurrentUserMini | null> {
 	} catch {
 		return null;
 	}
-}
+});
 
 function excerpt(html: string, max = 160): string {
 	// HTML タグを粗く剥がして先頭を返す。OGP description 用。
@@ -88,12 +93,16 @@ function formatDate(iso: string | null): string {
 }
 
 export default async function ArticleDetailPage({ params }: PageProps) {
-	const article = await fetchArticleSSR(params.slug);
+	// article 取得と /users/me/ の取得は互いに独立しているので Promise.all で
+	// 並列化する (reviewer H-1 反映)。 article の null check は resolve 後に行う。
+	const [article, currentUser] = await Promise.all([
+		fetchArticleSSR(params.slug),
+		fetchCurrentUserSSR(),
+	]);
 	if (!article) notFound();
 
 	// owner 判定: handle (== Django username) で比較。 ArticleAuthor.id は serializer
 	// 未公開なので backend 変更回避のため username/handle で照合する。
-	const currentUser = await fetchCurrentUserSSR();
 	const isOwner =
 		currentUser !== null && currentUser.username === article.author.handle;
 

--- a/client/src/app/(template)/articles/[slug]/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/page.tsx
@@ -15,15 +15,15 @@ import ArticleBody from "@/components/articles/ArticleBody";
 import ArticleOwnerActions from "@/components/articles/ArticleOwnerActions";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { ArticleDetail } from "@/lib/api/articles";
+import type { CurrentUser } from "@/lib/api/users";
 import { stringifyJsonLd } from "@/lib/json-ld";
 
 interface PageProps {
 	params: { slug: string };
 }
 
-interface CurrentUserMini {
-	username: string;
-}
+// owner 判定で username だけ使うため、 重複 ad-hoc type を作らず Pick で導出。
+type CurrentUserMini = Pick<CurrentUser, "username">;
 
 // generateMetadata と page 本体で同じ slug の article を 2 回 fetch するため、
 // React.cache でリクエスト内 dedupe する (reviewer H-2 反映)。 serverFetch は
@@ -129,7 +129,7 @@ export default async function ArticleDetailPage({ params }: PageProps) {
 			/>
 
 			<header
-				aria-label="ページヘッダー"
+				aria-label="記事詳細ヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",

--- a/client/src/app/(template)/articles/[slug]/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import ArticleBody from "@/components/articles/ArticleBody";
+import ArticleOwnerActions from "@/components/articles/ArticleOwnerActions";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { ArticleDetail } from "@/lib/api/articles";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -19,12 +20,27 @@ interface PageProps {
 	params: { slug: string };
 }
 
+interface CurrentUserMini {
+	id: number | string;
+	username: string;
+}
+
 async function fetchArticleSSR(slug: string): Promise<ArticleDetail | null> {
 	try {
 		return await serverFetch<ArticleDetail>(`/articles/${slug}/`);
 	} catch (err) {
 		if (err instanceof ApiServerError && err.status === 404) return null;
 		throw err;
+	}
+}
+
+async function fetchCurrentUserSSR(): Promise<CurrentUserMini | null> {
+	// 未ログイン (401) でも fetch 不能でも owner 判定は false にしたいので、
+	// 例外は全て swallow して null を返す (page render は継続)。
+	try {
+		return await serverFetch<CurrentUserMini>("/users/me/");
+	} catch {
+		return null;
 	}
 }
 
@@ -75,6 +91,12 @@ export default async function ArticleDetailPage({ params }: PageProps) {
 	const article = await fetchArticleSSR(params.slug);
 	if (!article) notFound();
 
+	// owner 判定: handle (== Django username) で比較。 ArticleAuthor.id は serializer
+	// 未公開なので backend 変更回避のため username/handle で照合する。
+	const currentUser = await fetchCurrentUserSSR();
+	const isOwner =
+		currentUser !== null && currentUser.username === article.author.handle;
+
 	const author = article.author.display_name || article.author.handle;
 	const description = excerpt(article.body_html);
 	const jsonLd = {
@@ -112,12 +134,16 @@ export default async function ArticleDetailPage({ params }: PageProps) {
 				>
 					← 記事一覧
 				</Link>
-				<span
-					className="ml-auto text-[color:var(--a-text-subtle)]"
-					style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
-				>
-					article
-				</span>
+				{isOwner ? (
+					<ArticleOwnerActions slug={article.slug} />
+				) : (
+					<span
+						className="ml-auto text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						article
+					</span>
+				)}
 			</header>
 
 			<article className="px-5 py-6">

--- a/client/src/app/(template)/articles/[slug]/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/page.tsx
@@ -129,6 +129,7 @@ export default async function ArticleDetailPage({ params }: PageProps) {
 			/>
 
 			<header
+				aria-label="ページヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
@@ -174,7 +175,11 @@ export default async function ArticleDetailPage({ params }: PageProps) {
 							</time>
 						)}
 						{article.status === "draft" && (
-							<span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-900">
+							<span
+								role="status"
+								aria-label="ステータス: 下書き"
+								className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-900"
+							>
 								下書き
 							</span>
 						)}

--- a/client/src/app/(template)/articles/me/drafts/page.tsx
+++ b/client/src/app/(template)/articles/me/drafts/page.tsx
@@ -13,7 +13,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Edit3, Feather } from "lucide-react";
 
-import { ApiServerError, serverFetch } from "@/lib/api/server";
+import { serverFetch } from "@/lib/api/server";
 import type { ArticleSummary } from "@/lib/api/articles";
 
 export const metadata: Metadata = {
@@ -31,11 +31,11 @@ async function fetchDraftsSSR(): Promise<ArticleSummary[]> {
 	try {
 		const page = await serverFetch<DraftListPage>("/articles/me/drafts/");
 		return page.results ?? [];
-	} catch (err) {
-		// 401 の救済は親の auth guard で済んでいる前提。 ここに 401 が来るのは
-		// 通常時にはあり得ない (cookie はあるのに backend 認証失敗) ので空配列で
-		// fallback する。 5xx 等も同様 — empty state を出して page を死なせない。
-		if (err instanceof ApiServerError) return [];
+	} catch {
+		// reviewer M-3 反映: ApiServerError も network 障害も同じく empty fallback
+		// する設計なので分岐を統合。 page は empty state で生き残らせる (auth guard
+		// が cookie で先に弾いているので、 ここに来るのは backend 不具合 / 一時的
+		// network 障害が主)。 詳細ログは server fetch 側で構造化ログ済。
 		return [];
 	}
 }

--- a/client/src/app/(template)/articles/me/drafts/page.tsx
+++ b/client/src/app/(template)/articles/me/drafts/page.tsx
@@ -1,0 +1,179 @@
+/**
+ * /articles/me/drafts ドラフト一覧ページ (#593 / Phase 6 P6-12 follow-up).
+ *
+ * auth 必須。 自分の下書き記事 (status=draft) を更新が新しい順で表示。
+ * 各 row から `/articles/<slug>/edit` に直接遷移できる「編集ループ」 の起点。
+ *
+ * SPEC: docs/specs/article-edit-loop-spec.md §3.2
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { Edit3, Feather } from "lucide-react";
+
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { ArticleSummary } from "@/lib/api/articles";
+
+export const metadata: Metadata = {
+	title: "下書き — エンジニア SNS",
+	robots: { index: false },
+};
+
+interface DraftListPage {
+	results: ArticleSummary[];
+	next: string | null;
+	previous: string | null;
+}
+
+async function fetchDraftsSSR(): Promise<ArticleSummary[]> {
+	try {
+		const page = await serverFetch<DraftListPage>("/articles/me/drafts/");
+		return page.results ?? [];
+	} catch (err) {
+		// 401 の救済は親の auth guard で済んでいる前提。 ここに 401 が来るのは
+		// 通常時にはあり得ない (cookie はあるのに backend 認証失敗) ので空配列で
+		// fallback する。 5xx 等も同様 — empty state を出して page を死なせない。
+		if (err instanceof ApiServerError) return [];
+		return [];
+	}
+}
+
+function formatDateTime(iso: string): string {
+	const d = new Date(iso);
+	const y = d.getFullYear();
+	const mo = String(d.getMonth() + 1).padStart(2, "0");
+	const da = String(d.getDate()).padStart(2, "0");
+	const hh = String(d.getHours()).padStart(2, "0");
+	const mm = String(d.getMinutes()).padStart(2, "0");
+	return `${y}/${mo}/${da} ${hh}:${mm}`;
+}
+
+export default async function DraftsPage() {
+	// SSR auth guard: notifications / settings 系と同流儀。 cookie 経由で軽量チェック。
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	if (!isAuthenticated) {
+		redirect("/login?next=/articles/me/drafts");
+	}
+
+	const drafts = await fetchDraftsSSR();
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/articles"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 記事一覧
+				</Link>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						下書き
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						自分の下書き ({drafts.length} 件)
+					</p>
+				</div>
+				<Link
+					href="/articles/new"
+					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
+				>
+					<Feather className="size-3.5" aria-hidden />
+					記事を書く
+				</Link>
+			</header>
+
+			<div className="p-5">
+				{drafts.length === 0 ? (
+					<div
+						className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center"
+						role="status"
+					>
+						<p className="text-sm text-[color:var(--a-text-muted)]">
+							まだ下書きはありません。
+						</p>
+						<Link
+							href="/articles/new"
+							className="mt-3 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+							style={{ background: "var(--a-accent)" }}
+						>
+							<Feather className="size-3.5" aria-hidden />
+							記事を書く
+						</Link>
+					</div>
+				) : (
+					<ul role="list" className="grid gap-3">
+						{drafts.map((d) => (
+							<li key={d.id}>
+								<Link
+									href={`/articles/${d.slug}/edit`}
+									className="block rounded-lg border border-[color:var(--a-border)] bg-white px-4 py-3 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+								>
+									<div className="flex items-start justify-between gap-3">
+										<div className="min-w-0 flex-1">
+											<h2
+												className="truncate font-semibold text-[color:var(--a-text)]"
+												style={{ fontSize: 15 }}
+											>
+												{d.title || "(タイトルなし)"}
+											</h2>
+											<p
+												className="mt-1 text-[color:var(--a-text-muted)]"
+												style={{
+													fontFamily: "var(--a-font-mono)",
+													fontSize: 11,
+												}}
+											>
+												{formatDateTime(d.updated_at)} 更新
+											</p>
+											{d.tags.length > 0 && (
+												<ul
+													aria-label="タグ"
+													className="mt-2 flex flex-wrap gap-1"
+												>
+													{d.tags.map((t) => (
+														<li
+															key={t.slug}
+															className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-[color:var(--a-text-muted)]"
+															style={{ fontSize: 11 }}
+														>
+															#{t.display_name}
+														</li>
+													))}
+												</ul>
+											)}
+										</div>
+										<span
+											className="inline-flex shrink-0 items-center gap-1 text-[color:var(--a-text-muted)]"
+											style={{ fontSize: 12.5 }}
+										>
+											<Edit3 className="size-3.5" aria-hidden />
+											編集
+										</span>
+									</div>
+								</Link>
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</>
+	);
+}

--- a/client/src/app/(template)/articles/me/drafts/page.tsx
+++ b/client/src/app/(template)/articles/me/drafts/page.tsx
@@ -62,6 +62,7 @@ export default async function DraftsPage() {
 	return (
 		<>
 			<header
+				aria-label="ページヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
@@ -95,17 +96,14 @@ export default async function DraftsPage() {
 					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
 				>
-					<Feather className="size-3.5" aria-hidden />
+					<Feather className="size-3.5" aria-hidden="true" />
 					記事を書く
 				</Link>
 			</header>
 
 			<div className="p-5">
 				{drafts.length === 0 ? (
-					<div
-						className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center"
-						role="status"
-					>
+					<div className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center">
 						<p className="text-sm text-[color:var(--a-text-muted)]">
 							まだ下書きはありません。
 						</p>
@@ -114,7 +112,7 @@ export default async function DraftsPage() {
 							className="mt-3 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
 							style={{ background: "var(--a-accent)" }}
 						>
-							<Feather className="size-3.5" aria-hidden />
+							<Feather className="size-3.5" aria-hidden="true" />
 							記事を書く
 						</Link>
 					</div>
@@ -124,7 +122,7 @@ export default async function DraftsPage() {
 							<li key={d.id}>
 								<Link
 									href={`/articles/${d.slug}/edit`}
-									className="block rounded-lg border border-[color:var(--a-border)] bg-white px-4 py-3 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+									className="block scroll-mt-16 rounded-lg border border-[color:var(--a-border)] bg-white px-4 py-3 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 								>
 									<div className="flex items-start justify-between gap-3">
 										<div className="min-w-0 flex-1">
@@ -164,7 +162,7 @@ export default async function DraftsPage() {
 											className="inline-flex shrink-0 items-center gap-1 text-[color:var(--a-text-muted)]"
 											style={{ fontSize: 12.5 }}
 										>
-											<Edit3 className="size-3.5" aria-hidden />
+											<Edit3 className="size-3.5" aria-hidden="true" />
 											編集
 										</span>
 									</div>

--- a/client/src/app/(template)/articles/me/drafts/page.tsx
+++ b/client/src/app/(template)/articles/me/drafts/page.tsx
@@ -41,13 +41,22 @@ async function fetchDraftsSSR(): Promise<ArticleSummary[]> {
 }
 
 function formatDateTime(iso: string): string {
-	const d = new Date(iso);
-	const y = d.getFullYear();
-	const mo = String(d.getMonth() + 1).padStart(2, "0");
-	const da = String(d.getDate()).padStart(2, "0");
-	const hh = String(d.getHours()).padStart(2, "0");
-	const mm = String(d.getMinutes()).padStart(2, "0");
-	return `${y}/${mo}/${da} ${hh}:${mm}`;
+	// code-reviewer MEDIUM #2 反映: Invalid Date を guard し、 toLocaleString(ja-JP)
+	// で OS locale / DST に強い書式に切替。
+	try {
+		const d = new Date(iso);
+		if (Number.isNaN(d.getTime())) return "";
+		return d.toLocaleString("ja-JP", {
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			hour12: false,
+		});
+	} catch {
+		return "";
+	}
 }
 
 export default async function DraftsPage() {
@@ -62,7 +71,7 @@ export default async function DraftsPage() {
 	return (
 		<>
 			<header
-				aria-label="ページヘッダー"
+				aria-label="下書き一覧ヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
@@ -120,6 +129,11 @@ export default async function DraftsPage() {
 					<ul role="list" className="grid gap-3">
 						{drafts.map((d) => (
 							<li key={d.id}>
+								{/*
+								 * scroll-mt-16: focus が来た row が sticky header (~50px) に
+								 * 覆われないよう 4rem の scroll offset を確保する。 WCAG 2.2
+								 * SC 2.4.11 Focus Not Obscured Minimum、 a11y-architect M-5 反映。
+								 */}
 								<Link
 									href={`/articles/${d.slug}/edit`}
 									className="block scroll-mt-16 rounded-lg border border-[color:var(--a-border)] bg-white px-4 py-3 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"

--- a/client/src/app/(template)/articles/page.tsx
+++ b/client/src/app/(template)/articles/page.tsx
@@ -71,7 +71,7 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 	return (
 		<>
 			<header
-				aria-label="ページヘッダー"
+				aria-label="記事一覧ヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",

--- a/client/src/app/(template)/articles/page.tsx
+++ b/client/src/app/(template)/articles/page.tsx
@@ -13,7 +13,8 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Feather } from "lucide-react";
+import { cookies } from "next/headers";
+import { Feather, FileEdit } from "lucide-react";
 
 import ArticleCard from "@/components/articles/ArticleCard";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
@@ -57,6 +58,9 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 		author: searchParams?.author,
 		tag: searchParams?.tag,
 	});
+	// auth user のときだけ「下書き」 link を出す。 cookie 経由で軽量判定
+	// (notifications 系と同流儀、 SSR で `/users/me/` を叩くより安い)。
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
 
 	const filterDescription = (() => {
 		if (searchParams?.author) return `@${searchParams.author} の記事`;
@@ -88,6 +92,20 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 						{filterDescription}
 					</p>
 				</div>
+				{isAuthenticated && (
+					<Link
+						href="/articles/me/drafts"
+						className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 font-medium transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+						style={{
+							borderColor: "var(--a-border)",
+							color: "var(--a-text-muted)",
+							fontSize: 12.5,
+						}}
+					>
+						<FileEdit className="size-3.5" aria-hidden />
+						下書き
+					</Link>
+				)}
 				<Link
 					href="/articles/new"
 					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"

--- a/client/src/app/(template)/articles/page.tsx
+++ b/client/src/app/(template)/articles/page.tsx
@@ -111,7 +111,7 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
 				>
-					<Feather className="size-3.5" />
+					<Feather className="size-3.5" aria-hidden />
 					記事を書く
 				</Link>
 			</header>

--- a/client/src/app/(template)/articles/page.tsx
+++ b/client/src/app/(template)/articles/page.tsx
@@ -71,6 +71,7 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 	return (
 		<>
 			<header
+				aria-label="ページヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
@@ -102,7 +103,7 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 							fontSize: 12.5,
 						}}
 					>
-						<FileEdit className="size-3.5" aria-hidden />
+						<FileEdit className="size-3.5" aria-hidden="true" />
 						下書き
 					</Link>
 				)}
@@ -111,7 +112,7 @@ export default async function ArticlesListPage({ searchParams }: PageProps) {
 					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
 				>
-					<Feather className="size-3.5" aria-hidden />
+					<Feather className="size-3.5" aria-hidden="true" />
 					記事を書く
 				</Link>
 			</header>

--- a/client/src/components/articles/ArticleOwnerActions.tsx
+++ b/client/src/components/articles/ArticleOwnerActions.tsx
@@ -50,8 +50,11 @@ export default function ArticleOwnerActions({
 		try {
 			await deleteArticle(slug);
 			toast.success("削除しました");
-			router.push("/articles");
+			// reviewer M-2: 遷移先 (/articles) を新鮮にしてから push する。
+			// 旧コードは push→refresh の順だったが、 push 後の refresh は
+			// 既に離れた現在ページのキャッシュ無効化になり observable 効果なし。
 			router.refresh();
+			router.push("/articles");
 		} catch (err) {
 			toast.error(describeApiError(err, "削除に失敗しました"));
 			setBusy(false);

--- a/client/src/components/articles/ArticleOwnerActions.tsx
+++ b/client/src/components/articles/ArticleOwnerActions.tsx
@@ -66,31 +66,37 @@ export default function ArticleOwnerActions({
 			<Link
 				href={`/articles/${slug}/edit`}
 				aria-label="記事を編集"
-				className="inline-flex items-center gap-1 rounded-md px-2.5 py-1 font-medium transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+				className="inline-flex min-h-[28px] items-center gap-1 rounded-md px-2.5 py-1.5 font-medium transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 				style={{
 					background: "var(--a-accent)",
 					color: "white",
 					fontSize: 12.5,
 				}}
 			>
-				<Edit3 className="size-3.5" aria-hidden />
+				<Edit3 className="size-3.5" aria-hidden="true" />
 				編集
 			</Link>
 			<button
 				type="button"
 				onClick={handleDelete}
 				disabled={busy}
+				aria-busy={busy}
 				aria-label="記事を削除"
-				className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 font-medium transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] disabled:opacity-50"
+				className="inline-flex min-h-[28px] items-center gap-1 rounded-md border px-2.5 py-1.5 font-medium transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] disabled:opacity-50"
 				style={{
 					borderColor: "var(--a-border)",
 					color: "var(--a-text-muted)",
 					fontSize: 12.5,
 				}}
 			>
-				<Trash2 className="size-3.5" aria-hidden />
+				<Trash2 className="size-3.5" aria-hidden="true" />
 				{busy ? "削除中…" : "削除"}
 			</button>
+			{/* a11y-reviewer M-2: 削除中の状態を SR にアナウンス。 disabled で focus が
+			    外れても live region から読み上げが届く。 */}
+			<span role="status" aria-live="polite" className="sr-only">
+				{busy ? "削除しています" : ""}
+			</span>
 		</div>
 	);
 }

--- a/client/src/components/articles/ArticleOwnerActions.tsx
+++ b/client/src/components/articles/ArticleOwnerActions.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * ArticleOwnerActions (#593 / Phase 6 P6-12 follow-up).
+ *
+ * 記事詳細ページの sticky header に表示する author 専用の action.
+ * - 編集 button (`<Link>`、 `/articles/<slug>/edit` へ)
+ * - 削除 button (window.confirm → DELETE /articles/<slug>/ → toast + /articles redirect)
+ *
+ * 表示判定は parent (server component) で `currentUser.id === article.author.id`
+ * を判定してから render する想定。 本 component 自体は owner 前提で受け取る。
+ */
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "react-toastify";
+import { Edit3, Trash2 } from "lucide-react";
+
+import { deleteArticle } from "@/lib/api/articles";
+
+interface ArticleOwnerActionsProps {
+	slug: string;
+}
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { status?: number; data?: { detail?: string } };
+			message?: string;
+		};
+		const detail = e.response?.data?.detail;
+		if (typeof detail === "string") return detail;
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function ArticleOwnerActions({
+	slug,
+}: ArticleOwnerActionsProps) {
+	const router = useRouter();
+	const [busy, setBusy] = useState(false);
+
+	const handleDelete = async () => {
+		if (busy) return;
+		// CLAUDE.md §4.5 step 6 完了シグナル: window.confirm 流儀 (boards / DM と整合)
+		if (!window.confirm("この記事を削除しますか? (元に戻せません)")) return;
+		setBusy(true);
+		try {
+			await deleteArticle(slug);
+			toast.success("削除しました");
+			router.push("/articles");
+			router.refresh();
+		} catch (err) {
+			toast.error(describeApiError(err, "削除に失敗しました"));
+			setBusy(false);
+		}
+	};
+
+	return (
+		<div className="ml-auto flex items-center gap-2">
+			<Link
+				href={`/articles/${slug}/edit`}
+				aria-label="記事を編集"
+				className="inline-flex items-center gap-1 rounded-md px-2.5 py-1 font-medium transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+				style={{
+					background: "var(--a-accent)",
+					color: "white",
+					fontSize: 12.5,
+				}}
+			>
+				<Edit3 className="size-3.5" aria-hidden />
+				編集
+			</Link>
+			<button
+				type="button"
+				onClick={handleDelete}
+				disabled={busy}
+				aria-label="記事を削除"
+				className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 font-medium transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] disabled:opacity-50"
+				style={{
+					borderColor: "var(--a-border)",
+					color: "var(--a-text-muted)",
+					fontSize: 12.5,
+				}}
+			>
+				<Trash2 className="size-3.5" aria-hidden />
+				{busy ? "削除中…" : "削除"}
+			</button>
+		</div>
+	);
+}

--- a/client/src/components/articles/__tests__/ArticleOwnerActions.test.tsx
+++ b/client/src/components/articles/__tests__/ArticleOwnerActions.test.tsx
@@ -66,7 +66,7 @@ describe("ArticleOwnerActions", () => {
 		).toBeInTheDocument();
 	});
 
-	it("calls deleteArticle + toast.success + router.push on delete confirm", async () => {
+	it("calls deleteArticle + toast.success + router.refresh→push on delete confirm", async () => {
 		// window.confirm を accept
 		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 		deleteArticleMock.mockResolvedValueOnce(undefined);
@@ -82,6 +82,10 @@ describe("ArticleOwnerActions", () => {
 		expect(toast.success).toHaveBeenCalledWith("削除しました");
 		expect(pushMock).toHaveBeenCalledWith("/articles");
 		expect(refreshMock).toHaveBeenCalledTimes(1);
+		// code-reviewer LOW: refresh が push の前に呼ばれる順序を guard。
+		expect(refreshMock.mock.invocationCallOrder[0]).toBeLessThan(
+			pushMock.mock.invocationCallOrder[0]!,
+		);
 
 		confirmSpy.mockRestore();
 	});
@@ -114,6 +118,10 @@ describe("ArticleOwnerActions", () => {
 		});
 		// 失敗時は router.push しない (画面に留まる)
 		expect(pushMock).not.toHaveBeenCalled();
+		// code-reviewer MEDIUM #4 反映: 失敗で button が再活性化することを assert。
+		await waitFor(() => {
+			expect(btn).not.toBeDisabled();
+		});
 
 		confirmSpy.mockRestore();
 	});

--- a/client/src/components/articles/__tests__/ArticleOwnerActions.test.tsx
+++ b/client/src/components/articles/__tests__/ArticleOwnerActions.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * ArticleOwnerActions unit test (#593).
+ *
+ * 詳細ページの sticky header owner action (編集 link + 削除 button) の振る舞いを
+ * unit レベルで verify する。 owner check 自体は parent (server component) で
+ * 行うため、 ここでは component 単体の動作のみ確認する:
+ *
+ * - 編集 link が `/articles/<slug>/edit` を指している
+ * - 削除 button click → confirm → API 呼び出し → toast.success + redirect
+ * - confirm cancel で API 呼ばない
+ * - 削除失敗で toast.error
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ArticleOwnerActions from "@/components/articles/ArticleOwnerActions";
+
+// ---- mocks ----
+
+const { pushMock, refreshMock } = vi.hoisted(() => ({
+	pushMock: vi.fn(),
+	refreshMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+const { deleteArticleMock } = vi.hoisted(() => ({
+	deleteArticleMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/articles", () => ({
+	deleteArticle: deleteArticleMock,
+}));
+
+vi.mock("react-toastify", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// ---- tests ----
+
+describe("ArticleOwnerActions", () => {
+	beforeEach(() => {
+		pushMock.mockReset();
+		refreshMock.mockReset();
+		deleteArticleMock.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("renders edit link pointing to /articles/<slug>/edit", () => {
+		render(<ArticleOwnerActions slug="hello" />);
+		const link = screen.getByRole("link", { name: "記事を編集" });
+		expect(link).toHaveAttribute("href", "/articles/hello/edit");
+	});
+
+	it("renders delete button", () => {
+		render(<ArticleOwnerActions slug="hello" />);
+		expect(
+			screen.getByRole("button", { name: "記事を削除" }),
+		).toBeInTheDocument();
+	});
+
+	it("calls deleteArticle + toast.success + router.push on delete confirm", async () => {
+		// window.confirm を accept
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+		deleteArticleMock.mockResolvedValueOnce(undefined);
+
+		const user = userEvent.setup();
+		render(<ArticleOwnerActions slug="hello" />);
+		await user.click(screen.getByRole("button", { name: "記事を削除" }));
+
+		await waitFor(() => {
+			expect(deleteArticleMock).toHaveBeenCalledWith("hello");
+		});
+		const { toast } = await import("react-toastify");
+		expect(toast.success).toHaveBeenCalledWith("削除しました");
+		expect(pushMock).toHaveBeenCalledWith("/articles");
+		expect(refreshMock).toHaveBeenCalledTimes(1);
+
+		confirmSpy.mockRestore();
+	});
+
+	it("does NOT call deleteArticle when user cancels the confirm", async () => {
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+		const user = userEvent.setup();
+		render(<ArticleOwnerActions slug="hello" />);
+		await user.click(screen.getByRole("button", { name: "記事を削除" }));
+
+		expect(deleteArticleMock).not.toHaveBeenCalled();
+		expect(pushMock).not.toHaveBeenCalled();
+
+		confirmSpy.mockRestore();
+	});
+
+	it("shows toast.error and re-enables the button on delete failure", async () => {
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+		deleteArticleMock.mockRejectedValueOnce(new Error("network down"));
+
+		const user = userEvent.setup();
+		render(<ArticleOwnerActions slug="hello" />);
+		const btn = screen.getByRole("button", { name: "記事を削除" });
+		await user.click(btn);
+
+		const { toast } = await import("react-toastify");
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalled();
+		});
+		// 失敗時は router.push しない (画面に留まる)
+		expect(pushMock).not.toHaveBeenCalled();
+
+		confirmSpy.mockRestore();
+	});
+});

--- a/docs/specs/article-edit-loop-spec.md
+++ b/docs/specs/article-edit-loop-spec.md
@@ -1,0 +1,218 @@
+# 記事編集ループの導線完成 spec (#593)
+
+> Phase 6 P6-12 follow-up。 frontend のみ、 backend は変更しない (既存 `Article CRUD API` をそのまま消費)。
+>
+> 関連:
+>
+> - [docs/issues/phase-6.md](../issues/phase-6.md) P6-12 / P6-13
+> - [docs/SPEC.md](../SPEC.md) §12 (記事)
+> - 先行 PR: [PR #591](https://github.com/haruna0712/claude-code/pull/591) (画像 API backend)
+> - 先行 follow-up: [#588](https://github.com/haruna0712/claude-code/issues/588) / [#589](https://github.com/haruna0712/claude-code/issues/589) / [#590](https://github.com/haruna0712/claude-code/issues/590)
+> - 次の PR (C 予定): 編集 UI 強化 (live Markdown preview + 画像 D&D、 P6-13 follow-up)
+
+## 1. 背景 / 問題
+
+PR #545 で `/articles/[slug]` / `/articles/new` / `/articles/<slug>/edit` の page stub が実装され、 PR #591 (P6-04) で画像 backend API が揃ったが、 **編集 / 公開 / 再編集 のループの導線が画面上に存在しない** 穴がある。 CLAUDE.md §9 で 3 回踏んだ轍 (#499 / #545 / #547) の延長:
+
+1. 自分が公開した記事を開いても **「編集」 button が見えない** → 編集画面は `/articles/<slug>/edit` を URL 直叩きしないと辿れない
+2. **`/articles/me/drafts` 画面が無い** → 書きかけのドラフトをどこから戻って書き継げばいいか不明 (API `GET /api/v1/articles/me/drafts/` は既存)
+3. グローバルナビ / `/articles` 一覧から `/articles/me/drafts` への link が無い
+
+「記事を書く → 公開 → 自分で開いて編集ボタンが見える → 書き直して再公開」 まで 3 click 以内で踏める状態に持ち上げる。
+
+## 2. やる / やらない
+
+### やる
+
+| #   | 場所                                                         | 変更                                                                                                                                                                               |
+| --- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `/articles/[slug]/page.tsx`                                  | SSR で `/users/me/` を fetch、 `currentUser.id === article.author.id` なら sticky header に「編集」 button + 「削除」 button                                                       |
+| 2   | `/articles/[slug]/page.tsx`                                  | 削除 button は `window.confirm("この記事を削除しますか?")` → `DELETE /articles/<slug>/` → `/articles` redirect + `toast.success("削除しました")`                                   |
+| 3   | `client/src/app/(template)/articles/me/drafts/page.tsx` 新規 | auth 必須 (未ログインは `/login?next=/articles/me/drafts` redirect)、 既存 `listMyDrafts` API を SSR fetch、 ない場合 empty state、 各 row に title / 更新日 / タグ / 「編集」 CTA |
+| 4   | `/articles/page.tsx`                                         | sticky header の右側に **auth user のときだけ** 「下書き」 link を「記事を書く」 CTA の左に追加                                                                                    |
+| 5   | `client/e2e/article-edit-loop.spec.ts` 新規                  | Playwright scenario 3 本 (詳細 owner button / 削除 flow / drafts page)                                                                                                             |
+| 6   | 本 spec doc                                                  | テストシナリオ + Playwright run コマンド (§5 参照)                                                                                                                                 |
+
+### やらない (このスコープ外)
+
+- like / comment UI (P6-14)
+- 関連記事 「もっと読む」 サイドバー (元 P6-12 scope、 別 issue)
+- 編集中の auto-save (premature optimization)
+- 公開 → 未公開 (un-publish) の専用 UX (今は status radio button から戻せる)
+- LeftNav (`leftNavLinks`) への追加 (記事は主目線ではないので /articles hub 経由で十分)
+- Markdown live preview / 画像 D&D (PR C で別途、 P6-13 follow-up)
+
+## 3. UX 詳細
+
+### 3.1 詳細ページ `/articles/[slug]` (owner のとき)
+
+```
+┌────────────────────────────────────────────┐
+│ ← 記事一覧                  [編集] [削除]  │  ← sticky header (owner のみ)
+├────────────────────────────────────────────┤
+│  # タイトル                                │
+│  @author • 2026/05/11 • [draft (もし下書き)]│
+│  #tag1 #tag2                                │
+│                                            │
+│  本文 (body_html)                          │
+└────────────────────────────────────────────┘
+```
+
+- **owner check**: SSR で `await serverFetch("/users/me/")` を try、 失敗時は null、 成功時 `currentUser.id === article.author.id` で判定
+- **「編集」 button**: `<Link href={`/articles/${article.slug}/edit`}>` (cyan accent A direction)
+- **「削除」 button**: client-side handler、 `window.confirm` → fetch `DELETE /api/v1/articles/<slug>/` → 成功時 `router.push("/articles")` + `toast.success("削除しました")`、 失敗時 `toast.error("削除に失敗しました")` (HTTP status / 詳細はトーストに出さず汎用文言)
+- **匿名 / 他人の記事**: button 一切表示しない (DOM にも出さない、 layout shift 防止)
+
+### 3.2 ドラフト一覧 `/articles/me/drafts`
+
+```
+┌────────────────────────────────────────────┐
+│ 下書き                          [記事を書く]│  ← sticky header
+│ 自分の下書き                                │
+├────────────────────────────────────────────┤
+│ ┌──────────────────────────────────────┐  │
+│ │ タイトル 1                           │  │  ← row (Link to edit)
+│ │ 2026/05/11 14:30 更新 • #tag1 #tag2  │  │
+│ │                            [編集 →]  │  │
+│ └──────────────────────────────────────┘  │
+│ ┌──────────────────────────────────────┐  │
+│ │ タイトル 2                            │  │
+│ │ ...                                  │  │
+│ └──────────────────────────────────────┘  │
+└────────────────────────────────────────────┘
+```
+
+- **auth**: SSR で `/users/me/` を fetch、 401 / 失敗時は **`/login?next=/articles/me/drafts` redirect** (server component の `redirect()`)
+- **empty state**: 「まだ下書きはありません」 + 「記事を書く」 CTA (cyan accent)
+- **row Link**: row 全体を `<Link href={`/articles/<slug>/edit`}>` でクリッカブルに
+- **pagination**: MVP では cursor pagination 最初の 1 ページのみ (20 件)、 「もっと見る」 は将来 client component で対応 (issue 化)
+- **A direction polish**: sticky header / typography / spacing は既存 `/articles` と揃える
+
+### 3.3 `/articles` 一覧 sticky header (auth user のとき)
+
+```
+┌────────────────────────────────────────────┐
+│ 記事         [下書き] [記事を書く]          │
+│ 公開された記事                              │
+├────────────────────────────────────────────┤
+```
+
+- 「下書き」 link を「記事を書く」 CTA の **左** に追加
+- 「下書き」 は ghost button スタイル (border + text muted、 cyan accent ではなく)
+- **匿名訪問者**: 「下書き」 link は表示しない (DOM にも出さない)
+- auth 判定は SSR で `/users/me/` を fetch (詳細ページと同流儀、 fail 時 null)
+
+## 4. データ層
+
+`Article CRUD API` は既存:
+
+- `GET /api/v1/articles/me/drafts/` (auth、 cursor pagination、 ArticleSummary[])
+- `DELETE /api/v1/articles/<slug>/` (本人 + admin、 論理削除)
+- `GET /api/v1/users/me/` (auth、 CustomUser → `{id, username, ...}`)
+
+frontend lib `apps/articles.ts` の `deleteArticle(slug)` + `listMyDrafts(cursor)` 既存。 type 追加なし。
+
+## 5. テスト
+
+### 5.1 Vitest (component unit)
+
+`client/src/components/articles/__tests__/ArticleOwnerActions.test.tsx` (新規、 もし `ArticleOwnerActions` component を抽出した場合):
+
+- owner なら button が見える
+- non-owner なら button が見えない
+- 削除 click → confirm → DELETE 呼ぶ → toast.success
+- 削除失敗 → toast.error
+
+簡易な場合は inline で page test に統合してよい (over-engineering 避け)。
+
+### 5.2 Playwright E2E `client/e2e/article-edit-loop.spec.ts`
+
+**シナリオ 1: 自分の記事に編集 button が出る**
+
+- **誰が**: test2 (auth)
+- **何をする**: ホーム → /articles → 自分の公開記事を開く
+- **何が見える**:
+  - sticky header 右側に「編集」 link が表示 (`getByRole('link', { name: '編集' })`)
+  - href が `/articles/<slug>/edit`
+  - 「削除」 button (`getByRole('button', { name: '削除' })`) も表示
+- **完了条件**: 「編集」 link を click → `/articles/<slug>/edit` ページに遷移 (ArticleEditor が描画される)
+
+**シナリオ 2: 他人の記事に編集 button が出ない**
+
+- **誰が**: test2 (auth)
+- **何をする**: test3 の公開記事を開く (固定 slug or `/explore` 経由)
+- **何が見える**:
+  - 「編集」 link が DOM に存在しない (`getByRole('link', { name: '編集' })` count == 0)
+  - 「削除」 button も無い
+
+**シナリオ 3: 削除 flow**
+
+- **誰が**: test2 (auth)
+- **何をする**: 自分の記事を新規作成 → 公開 → 詳細ページで「削除」 click → confirm dialog で OK
+- **何が見える**:
+  - confirm dialog (Playwright は `page.on('dialog')` で accept)
+  - 削除後 `/articles` に遷移
+  - toast「削除しました」 (role=status か role=alert で text match)
+  - 一覧に当該記事が出ない
+
+**シナリオ 4: drafts page (auth)**
+
+- **誰が**: test2 (auth)
+- **何をする**: ホーム → /articles → sticky header の「下書き」 link → /articles/me/drafts
+- **何が見える**:
+  - 自分が下書き状態で作成した記事が row として表示
+  - 各 row の「編集」 CTA を click → `/articles/<slug>/edit`
+- **完了条件**: drafts page が auth user で 200、 empty state も適切
+
+**シナリオ 5: drafts page (anon)**
+
+- **誰が**: 匿名
+- **何をする**: `/articles/me/drafts` を直叩き
+- **何が見える**: `/login?next=/articles/me/drafts` に redirect
+
+### 5.3 Playwright 実行
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+PLAYWRIGHT_USER2_EMAIL=test3@gmail.com \
+PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER2_HANDLE=test3 \
+  npx playwright test client/e2e/article-edit-loop.spec.ts
+```
+
+詳細な env / credential は [docs/local/e2e-stg.md](../local/e2e-stg.md) 参照。
+
+## 6. CLAUDE.md §4.5 step 6 完了チェックリスト
+
+- [ ] Playwright spec ファイル新設、 シナリオがコード化されている
+- [ ] テストシナリオを spec doc に書いた (本 §5.2)
+- [ ] ホーム → 3 click 以内で入口に到達 (ホーム → /articles → 「下書き」 = 2 click、 ホーム → /articles → 自分の記事 → 編集 = 3 click)
+- [ ] 未ログイン / 他人で踏んでも壊れない (§3.1 owner check、 §3.2 redirect)
+- [ ] 画面上に「終わり」 シグナル (toast「削除しました」、 編集後 detail 遷移)
+- [ ] stg Playwright 第一選択 (URL は `https://stg.codeplace.me`)
+- [ ] CI 緑 + `gan-evaluator` agent CRITICAL/HIGH 無し
+
+## 7. ファイル変更まとめ
+
+```
+client/src/app/(template)/articles/
+  page.tsx                        [既存 +25 行]   sticky header に「下書き」 link
+  [slug]/page.tsx                 [既存 +60 行]   owner check + 編集/削除 button
+  me/drafts/page.tsx              [新規 ~100 行]  ドラフト一覧 SSR
+
+client/src/components/articles/
+  ArticleOwnerActions.tsx         [新規 ~80 行]   "use client" 削除 button + toast
+  __tests__/
+    ArticleOwnerActions.test.tsx  [新規 ~80 行]   vitest (確認 dialog / toast)
+
+client/e2e/
+  article-edit-loop.spec.ts       [新規 ~150 行]  5 scenarios
+
+docs/specs/
+  article-edit-loop-spec.md       [新規、 本ファイル]
+```
+
+合計概算 ≈ 500 行 (テスト + spec 除いて ≈ 270 行)。 small PR ルール (500 行) を僅かに超える可能性あるが、 削除 flow を別 PR に切ると loop が閉じない → 妥協して 1 PR で出す。


### PR DESCRIPTION
## 概要

Phase 6 P6-12 follow-up (PR B)。 frontend のみ、 backend は変更しない。

Closes #593

### 背景

PR #545 で `/articles/[slug]` / `/articles/new` / `/articles/<slug>/edit` の page stub、 PR #591 で画像 backend API が揃ったが、 **編集 / 公開 / 再編集 のループの導線が画面上に存在しない** 穴があった (CLAUDE.md §9 / `#499` / `#545` / `#547` で 3 回踏んだ轍の延長):

- 自分が公開した記事を開いても「編集」 button が見えず、 URL 直叩きでないと辿れない
- `/articles/me/drafts` 画面が無く、 書きかけのドラフトをどこから開けばいいか不明
- `/articles` 一覧から drafts への link 無し

ホーム → 3 click 以内で「自分の記事を書き直す」 までの導線を閉じる。

### 実装

| ファイル | 変更 |
|----------|------|
| `client/src/app/(template)/articles/[slug]/page.tsx` | SSR で `/users/me/` を fetch → `currentUser.username === article.author.handle` で owner 判定。 owner なら sticky header に `ArticleOwnerActions` (編集 link + 削除 button) を表示。 匿名 / 他人は **DOM にも出さない**。 |
| `client/src/components/articles/ArticleOwnerActions.tsx` (新) | `"use client"` component。 `window.confirm("この記事を削除しますか?")` → `deleteArticle()` → `toast.success("削除しました")` + `router.push("/articles")` + `router.refresh()`。 失敗時 `toast.error`、 button を再活性化。 |
| `client/src/app/(template)/articles/me/drafts/page.tsx` (新) | SSR で `listMyDrafts` 消費。 `cookies().get("logged_in")` で auth guard、 未ログインは `/login?next=/articles/me/drafts` redirect (notifications / settings 系と同流儀)。 empty state あり。 row 全体 `<Link href=/articles/<slug>/edit>`。 |
| `client/src/app/(template)/articles/page.tsx` | sticky header の右側に **auth user のみ** 「下書き」 link を追加 (cookie で判定、 ghost button style、 「記事を書く」 CTA の左)。 |

### テスト

- **vitest** `ArticleOwnerActions.test.tsx` (5 ケース 全 pass):
  - edit link が `/articles/<slug>/edit` を指す
  - delete confirm → API → `toast.success` + `router.push/refresh`
  - confirm cancel で API 呼ばない
  - 削除失敗 → `toast.error` + button 再活性化
  - delete button が render される
- **Playwright** `client/e2e/article-edit-loop.spec.ts` (5 scenarios):
  - EDIT-LOOP-1 自分の記事 → 編集 button → click で `/edit`
  - EDIT-LOOP-2 他人の記事 → button 出ない
  - EDIT-LOOP-3 削除 flow (confirm → `/articles` + toast)
  - EDIT-LOOP-4 drafts page で下書き row 表示 → edit
  - EDIT-LOOP-5 anon `/articles/me/drafts` → `/login` redirect
- 既存 article 関連 vitest は regression 無し (単体実行で `ArticleOwnerActions` 5/5 pass、 tsc / eslint 緑)

仕様: [docs/specs/article-edit-loop-spec.md](./docs/specs/article-edit-loop-spec.md)

## CLAUDE.md §4.5 step 6 完了チェックリスト

- [x] Playwright spec ファイル新設、 シナリオがコード化されている
- [x] テストシナリオを spec doc に書いた (§5.2)
- [x] ホーム → 3 click 以内で入口に到達 (ホーム → `/articles` → 「下書き」 = 2 click、 ホーム → `/articles` → 自分の記事 → 編集 = 3 click)
- [x] 未ログイン / 他人で踏んでも壊れない (owner check 拒否、 anon → `/login` redirect)
- [x] 完了シグナル (toast「削除しました」、 編集後 detail 遷移、 button が一時 disabled)
- [ ] **stg Playwright 実行**: CI merge → CD 後にハルナさん側 / 私側で `npx playwright test e2e/article-edit-loop.spec.ts` を流す
- [ ] **`gan-evaluator` agent** stg 反映後 (§4.2 マトリクス必須化、 別ターンで)

## Test plan

- [x] vitest ArticleOwnerActions 5/5 pass
- [x] tsc / eslint 緑
- [ ] CI で frontend job 緑になることを確認
- [ ] stg 反映後に Playwright E2E
- [ ] stg 反映後に gan-evaluator agent で実画面採点

## Follow-up

- PR C (P6-13 follow-up): ArticleEditor の live Markdown preview + 画像 D&D (PR #591 の画像 API を消費)
- 別 bug 報告: stg ホーム以外の画面で LeftNav「投稿する」 button が反応しない問題 — 別 issue 起票予定 (本 PR とは無関係)