### PR TITLE
fix(layout-a): ALeftNav「投稿する」 button が home 以外でも動くよう dialog host を layout に上げる (#595)

### DIFF
--- a/client/e2e/compose-from-any-page.spec.ts
+++ b/client/e2e/compose-from-any-page.spec.ts
@@ -73,12 +73,13 @@ test.describe("ALeftNav 「投稿する」 button が全ページで動く (#595
 			const page = await ctx.newPage();
 			await page.goto(`${BASE}${path}`);
 
-			// ALeftNav の cyan「投稿する」 button (aria-label="ツイートを投稿する")
-			// は inline compose 行と aria-label が同じなので、 home では複数 hit する。
-			// LeftNav 側を狙うため、 全部 first() で取って click する。
+			// ALeftNav の cyan「投稿する」 button は home の inline compose 行と
+			// aria-label が同じ ("ツイートを投稿する")。 LeftNav 側に scope を絞るため
+			// ALeftNav root の <aside aria-label="メインナビゲーション"> を起点に取る。
+			// home でも他ページでも一意に決まる (typescript-reviewer MEDIUM 反映)。
 			const trigger = page
-				.getByRole("button", { name: "ツイートを投稿する" })
-				.first();
+				.locator('aside[aria-label="メインナビゲーション"]')
+				.getByRole("button", { name: "ツイートを投稿する" });
 			await expect(trigger).toBeVisible({ timeout: 15000 });
 			await trigger.click();
 

--- a/client/e2e/compose-from-any-page.spec.ts
+++ b/client/e2e/compose-from-any-page.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * ALeftNav 「投稿する」 button が全 (template) 配下ページで動くことを検証する E2E (#595).
+ *
+ * Spec: docs/specs/compose-from-any-page-spec.md
+ *
+ * 検証シナリオ:
+ *   COMPOSE-ANY-1 home (/) で button → dialog open
+ *   COMPOSE-ANY-2 /articles で button → dialog open
+ *   COMPOSE-ANY-3 /explore で button → dialog open
+ *   COMPOSE-ANY-4 /u/<handle> で button → dialog open
+ *   COMPOSE-ANY-5 /notifications で button → dialog open
+ *
+ * env: docs/local/e2e-stg.md の test2 を使用。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+): Promise<void> {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+const PAGES_TO_TEST: Array<{ id: string; path: string }> = [
+	{ id: "COMPOSE-ANY-1", path: "/" },
+	{ id: "COMPOSE-ANY-2", path: "/articles" },
+	{ id: "COMPOSE-ANY-3", path: "/explore" },
+	{ id: "COMPOSE-ANY-4", path: `/u/${USER1.handle}` },
+	{ id: "COMPOSE-ANY-5", path: "/notifications" },
+];
+
+test.describe("ALeftNav 「投稿する」 button が全ページで動く (#595)", () => {
+	test.beforeAll(() => requireEnv());
+
+	for (const { id, path } of PAGES_TO_TEST) {
+		test(`${id}: ${path} で 投稿する button → dialog open`, async ({
+			browser,
+		}) => {
+			const ctx = await browser.newContext();
+			await loginViaApi(ctx.request, USER1);
+			const page = await ctx.newPage();
+			await page.goto(`${BASE}${path}`);
+
+			// ALeftNav の cyan「投稿する」 button (aria-label="ツイートを投稿する")
+			// は inline compose 行と aria-label が同じなので、 home では複数 hit する。
+			// LeftNav 側を狙うため、 全部 first() で取って click する。
+			const trigger = page
+				.getByRole("button", { name: "ツイートを投稿する" })
+				.first();
+			await expect(trigger).toBeVisible({ timeout: 15000 });
+			await trigger.click();
+
+			// dialog が開いたことを role=dialog で確認 (DialogTitle "投稿する" sr-only)
+			await expect(page.getByRole("dialog", { name: /投稿する/ })).toBeVisible({
+				timeout: 10000,
+			});
+
+			await ctx.close();
+		});
+	}
+});

--- a/client/src/app/(template)/layout.tsx
+++ b/client/src/app/(template)/layout.tsx
@@ -18,6 +18,7 @@
 
 import type { ReactNode } from "react";
 
+import AComposeDialogHost from "@/components/layout-a/AComposeDialogHost";
 import ALeftNav from "@/components/layout-a/ALeftNav";
 import AMobileAppBar from "@/components/layout-a/AMobileShell";
 import ARightRail from "@/components/layout-a/ARightRail";
@@ -47,6 +48,13 @@ export default function TemplateLayout({ children }: LayoutProps) {
 				{children}
 			</main>
 			<ARightRail />
+			{/*
+			 * #595: ALeftNav 「投稿する」 button / AComposeShell の inline 行から
+			 * dispatch される `a-compose-open` window event を listen して
+			 * ComposeTweetDialog を開く。 (template) 配下の全ページで 1 つだけ存在
+			 * すれば良いので layout レベルに置く。 home 以外でも投稿 button が動く。
+			 */}
+			<AComposeDialogHost />
 		</div>
 	);
 }

--- a/client/src/components/layout-a/AComposeDialogHost.tsx
+++ b/client/src/components/layout-a/AComposeDialogHost.tsx
@@ -14,7 +14,7 @@
  * `dispatchAComposeOpen()` を呼ぶだけになり、 dialog state は持たない。
  */
 
-import { useEffect, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 
 import ComposeTweetDialog from "@/components/tweets/ComposeTweetDialog";
 
@@ -27,7 +27,7 @@ export function dispatchAComposeOpen(): void {
 	}
 }
 
-export default function AComposeDialogHost() {
+export default function AComposeDialogHost(): ReactElement {
 	const [open, setOpen] = useState(false);
 
 	useEffect(() => {

--- a/client/src/components/layout-a/AComposeDialogHost.tsx
+++ b/client/src/components/layout-a/AComposeDialogHost.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/**
+ * AComposeDialogHost — ComposeTweetDialog の wiring host (#595).
+ *
+ * 以前 AComposeShell が抱えていた:
+ *   - `useState(open)` + `useEffect` で `a-compose-open` window event を listen
+ *   - `<ComposeTweetDialog>` の render
+ * を本 component に切り出した。 (template)/layout.tsx に **1 つだけ** 埋めることで、
+ * home 以外のページからも ALeftNav 「投稿する」 button が dispatch するイベントを
+ * 拾えるようにする (bug #595)。
+ *
+ * AComposeShell (home 専用 inline compose UI) は本 host に残った
+ * `dispatchAComposeOpen()` を呼ぶだけになり、 dialog state は持たない。
+ */
+
+import { useEffect, useState } from "react";
+
+import ComposeTweetDialog from "@/components/tweets/ComposeTweetDialog";
+
+const COMPOSE_OPEN_EVENT = "a-compose-open";
+
+/** ALeftNav / AComposeShell 等の trigger から呼ぶための window event 発火関数. */
+export function dispatchAComposeOpen(): void {
+	if (typeof window !== "undefined") {
+		window.dispatchEvent(new CustomEvent(COMPOSE_OPEN_EVENT));
+	}
+}
+
+export default function AComposeDialogHost() {
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		const handler = () => setOpen(true);
+		window.addEventListener(COMPOSE_OPEN_EVENT, handler);
+		return () => window.removeEventListener(COMPOSE_OPEN_EVENT, handler);
+	}, []);
+
+	return <ComposeTweetDialog open={open} onOpenChange={setOpen} />;
+}

--- a/client/src/components/layout-a/AComposeShell.tsx
+++ b/client/src/components/layout-a/AComposeShell.tsx
@@ -34,7 +34,7 @@ export default function AComposeShell() {
 		<button
 			type="button"
 			aria-label="ツイートを投稿する"
-			onClick={() => dispatchAComposeOpen()}
+			onClick={dispatchAComposeOpen}
 			className="flex w-full items-start gap-2.5 border-b px-5 py-3 text-left transition-colors hover:bg-[color:var(--a-bg-subtle)] focus-visible:bg-[color:var(--a-bg-subtle)] focus-visible:outline-none"
 			style={{ borderColor: "var(--a-border)" }}
 		>

--- a/client/src/components/layout-a/AComposeShell.tsx
+++ b/client/src/components/layout-a/AComposeShell.tsx
@@ -1,45 +1,27 @@
 "use client";
 
 /**
- * A direction Compose Shell (#555 Phase B-0-4).
+ * A direction Compose Shell (#555 Phase B-0-4, refactor #595).
  *
- * gan-evaluator Blocker 5 への対応。home-a の inline compose 行を実装し、
- * ALeftNav の「投稿する」 button からも同じ ComposeTweetDialog を起こす wiring。
+ * home (`/`) でだけ表示する **inline compose 行**:
+ *   avatar + 「いま何を作っていますか？」 prompt + IconBtns + char counter (180) +
+ *   cyan「ツイート」 button
  *
- * - inline compose 行: avatar + 「いま何を作っていますか？」 prompt + IconBtns +
- *   char counter (180 limit) + cyan「ツイート」 button
- * - click で既存 ComposeTweetDialog (root tweet 投稿) を開く
- * - ALeftNav から `window.dispatchEvent('a-compose-open')` でも開く (左ナビ
- *   「投稿する」 button を /articles/new に飛ばさず本 shell が掴む)
- *
- * 設計: ComposeTweetDialog は元々 dialog の open/close を親が握る方式なので、
- * 本 shell が open state を保有してそれを渡す。
+ * click で `dispatchAComposeOpen()` を呼んで `AComposeDialogHost` 経由で
+ * `ComposeTweetDialog` を開く。 dialog state / listener / dialog 本体は本
+ * component には居ない (#595 で AComposeDialogHost に切り出した — home 以外でも
+ * ALeftNav の「投稿する」 button が動くようにするため、 (template)/layout.tsx 側に
+ * host を 1 つ埋めた)。
  */
 
 import { Code, Hash, Sparkles } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 
-import ComposeTweetDialog from "@/components/tweets/ComposeTweetDialog";
+import { dispatchAComposeOpen } from "@/components/layout-a/AComposeDialogHost";
 import { useUserProfile } from "@/hooks/useUseProfile";
-
-const COMPOSE_OPEN_EVENT = "a-compose-open";
-
-/** ALeftNav 等の外部 trigger から呼ぶための window event 名 (export して共有). */
-export function dispatchAComposeOpen(): void {
-	if (typeof window !== "undefined") {
-		window.dispatchEvent(new CustomEvent(COMPOSE_OPEN_EVENT));
-	}
-}
 
 export default function AComposeShell() {
 	const { profile } = useUserProfile();
-	const [open, setOpen] = useState(false);
-
-	useEffect(() => {
-		const handler = () => setOpen(true);
-		window.addEventListener(COMPOSE_OPEN_EVENT, handler);
-		return () => window.removeEventListener(COMPOSE_OPEN_EVENT, handler);
-	}, []);
 
 	// 未ログイン時は inline compose を出さない (CTA は landing 側で出している)
 	if (!profile) return null;
@@ -49,59 +31,56 @@ export default function AComposeShell() {
 		.toUpperCase();
 
 	return (
-		<>
-			<button
-				type="button"
-				aria-label="ツイートを投稿する"
-				onClick={() => setOpen(true)}
-				className="flex w-full items-start gap-2.5 border-b px-5 py-3 text-left transition-colors hover:bg-[color:var(--a-bg-subtle)] focus-visible:bg-[color:var(--a-bg-subtle)] focus-visible:outline-none"
-				style={{ borderColor: "var(--a-border)" }}
+		<button
+			type="button"
+			aria-label="ツイートを投稿する"
+			onClick={() => dispatchAComposeOpen()}
+			className="flex w-full items-start gap-2.5 border-b px-5 py-3 text-left transition-colors hover:bg-[color:var(--a-bg-subtle)] focus-visible:bg-[color:var(--a-bg-subtle)] focus-visible:outline-none"
+			style={{ borderColor: "var(--a-border)" }}
+		>
+			<div
+				className="grid size-8 shrink-0 place-items-center rounded-full font-semibold text-white"
+				style={{ background: "hsl(200 70% 32%)", fontSize: 12 }}
+				aria-hidden
 			>
+				{initials}
+			</div>
+			<div className="flex-1">
 				<div
-					className="grid size-8 shrink-0 place-items-center rounded-full font-semibold text-white"
-					style={{ background: "hsl(200 70% 32%)", fontSize: 12 }}
-					aria-hidden
+					className="text-[color:var(--a-text-subtle)]"
+					style={{ fontSize: 14, padding: "6px 0 8px" }}
 				>
-					{initials}
+					いま何を作っていますか？
 				</div>
-				<div className="flex-1">
-					<div
-						className="text-[color:var(--a-text-subtle)]"
-						style={{ fontSize: 14, padding: "6px 0 8px" }}
+				<div className="mt-1 flex items-center gap-1.5">
+					<IconBtn>
+						<Code className="size-3.5" />
+					</IconBtn>
+					<IconBtn>
+						<Hash className="size-3.5" />
+					</IconBtn>
+					<IconBtn>
+						<Sparkles className="size-3.5" />
+					</IconBtn>
+					<span
+						className="ml-auto text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
 					>
-						いま何を作っていますか？
-					</div>
-					<div className="mt-1 flex items-center gap-1.5">
-						<IconBtn>
-							<Code className="size-3.5" />
-						</IconBtn>
-						<IconBtn>
-							<Hash className="size-3.5" />
-						</IconBtn>
-						<IconBtn>
-							<Sparkles className="size-3.5" />
-						</IconBtn>
-						<span
-							className="ml-auto text-[color:var(--a-text-subtle)]"
-							style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
-						>
-							180
-						</span>
-						<span
-							className="rounded-md px-3 py-1 font-medium text-white"
-							style={{
-								background: "var(--a-accent)",
-								fontSize: 12.5,
-								fontFamily: "inherit",
-							}}
-						>
-							ツイート
-						</span>
-					</div>
+						180
+					</span>
+					<span
+						className="rounded-md px-3 py-1 font-medium text-white"
+						style={{
+							background: "var(--a-accent)",
+							fontSize: 12.5,
+							fontFamily: "inherit",
+						}}
+					>
+						ツイート
+					</span>
 				</div>
-			</button>
-			<ComposeTweetDialog open={open} onOpenChange={setOpen} />
-		</>
+			</div>
+		</button>
 	);
 }
 

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -33,7 +33,7 @@ import {
 	type LucideIcon,
 } from "lucide-react";
 
-import { dispatchAComposeOpen } from "@/components/layout-a/AComposeShell";
+import { dispatchAComposeOpen } from "@/components/layout-a/AComposeDialogHost";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/client/src/components/layout-a/__tests__/AComposeDialogHost.test.tsx
+++ b/client/src/components/layout-a/__tests__/AComposeDialogHost.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for AComposeDialogHost (#595).
+ *
+ * 検証:
+ *  T-HOST-1 default で dialog closed
+ *  T-HOST-2 `dispatchAComposeOpen()` (= window 'a-compose-open' event) で open に切り替わる
+ *  T-HOST-3 dialog の onOpenChange(false) (= 閉じる動作) で再び closed
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import AComposeDialogHost, {
+	dispatchAComposeOpen,
+} from "@/components/layout-a/AComposeDialogHost";
+
+// ComposeTweetDialog は実 dialog 描画を避けて open prop を data-testid で露出
+// させる stub。 onOpenChange は dialog 内 close ボタンの代わりに data-close から
+// 呼べるようにする。
+vi.mock("@/components/tweets/ComposeTweetDialog", () => ({
+	default: ({
+		open,
+		onOpenChange,
+	}: {
+		open: boolean;
+		onOpenChange: (o: boolean) => void;
+	}) => (
+		<div
+			data-testid="compose-dialog"
+			data-open={open ? "true" : "false"}
+			role="dialog"
+		>
+			<button
+				type="button"
+				data-testid="compose-dialog-close"
+				onClick={() => onOpenChange(false)}
+			>
+				close
+			</button>
+		</div>
+	),
+}));
+
+describe("AComposeDialogHost", () => {
+	it("T-HOST-1 default で dialog は closed", () => {
+		render(<AComposeDialogHost />);
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"false",
+		);
+	});
+
+	it("T-HOST-2 dispatchAComposeOpen() で dialog が open になる", () => {
+		render(<AComposeDialogHost />);
+
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"false",
+		);
+
+		act(() => {
+			dispatchAComposeOpen();
+		});
+
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"true",
+		);
+	});
+
+	it("T-HOST-3 dialog の onOpenChange(false) で再び closed", () => {
+		render(<AComposeDialogHost />);
+
+		act(() => {
+			dispatchAComposeOpen();
+		});
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"true",
+		);
+
+		act(() => {
+			screen.getByTestId("compose-dialog-close").click();
+		});
+		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
+			"data-open",
+			"false",
+		);
+	});
+});

--- a/client/src/components/layout-a/__tests__/AComposeShell.test.tsx
+++ b/client/src/components/layout-a/__tests__/AComposeShell.test.tsx
@@ -1,44 +1,38 @@
 /**
- * Tests for AComposeShell (#555 — A direction inline compose + dialog wiring).
+ * Tests for AComposeShell (#555 — A direction inline compose、 refactor #595).
  *
  * 検証:
  *  1. 未ログインなら inline compose 行を出さない
  *  2. ログイン済なら「いま何を作っていますか？」プロンプトを表示する
- *  3. inline 行 click で ComposeTweetDialog が open する
- *  4. `dispatchAComposeOpen()` (= window 'a-compose-open' event) で開く
- *     (ALeftNav 「投稿する」 button からの起動を保証する)
+ *  3. inline 行 click で `dispatchAComposeOpen()` を呼ぶ (= window event 発火)
+ *
+ * NOTE: dialog state / listener / `<ComposeTweetDialog>` は `AComposeDialogHost` に
+ * 切り出された (#595 修正)。 dialog の open 動作は `AComposeDialogHost.test.tsx`
+ * で検証する。
  */
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import AComposeShell, {
-	dispatchAComposeOpen,
-} from "@/components/layout-a/AComposeShell";
+import AComposeShell from "@/components/layout-a/AComposeShell";
 
-const { mockUseUserProfile } = vi.hoisted(() => ({
+const { mockUseUserProfile, dispatchSpy } = vi.hoisted(() => ({
 	mockUseUserProfile: vi.fn(),
+	dispatchSpy: vi.fn(),
 }));
 
 vi.mock("@/hooks/useUseProfile", () => ({
 	useUserProfile: mockUseUserProfile,
 }));
 
-// ComposeTweetDialog は実 dialog として open prop を data-testid で露出させる stub。
-vi.mock("@/components/tweets/ComposeTweetDialog", () => ({
-	default: ({
-		open,
-	}: {
-		open: boolean;
-		onOpenChange: (o: boolean) => void;
-	}) => (
-		<div data-testid="compose-dialog" data-open={open ? "true" : "false"} />
-	),
+vi.mock("@/components/layout-a/AComposeDialogHost", () => ({
+	dispatchAComposeOpen: dispatchSpy,
 }));
 
 describe("AComposeShell", () => {
 	beforeEach(() => {
 		mockUseUserProfile.mockReset();
+		dispatchSpy.mockReset();
 	});
 
 	it("未ログイン時は inline compose 行を出さない", () => {
@@ -51,7 +45,7 @@ describe("AComposeShell", () => {
 		expect(screen.queryByText("いま何を作っていますか？")).toBeNull();
 	});
 
-	it("ログイン済なら inline prompt を表示し、初期 dialog は閉じている", () => {
+	it("ログイン済なら inline prompt を表示する", () => {
 		mockUseUserProfile.mockReturnValue({
 			profile: { username: "alice", display_name: "Alice" },
 			isLoading: false,
@@ -59,13 +53,9 @@ describe("AComposeShell", () => {
 		});
 		render(<AComposeShell />);
 		expect(screen.getByText("いま何を作っていますか？")).toBeInTheDocument();
-		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
-			"data-open",
-			"false",
-		);
 	});
 
-	it("inline 行 click で ComposeTweetDialog が open する", () => {
+	it("inline 行 click で dispatchAComposeOpen() を呼ぶ (= dialog host が dialog を開く)", () => {
 		mockUseUserProfile.mockReturnValue({
 			profile: { username: "alice", display_name: "Alice" },
 			isLoading: false,
@@ -76,32 +66,6 @@ describe("AComposeShell", () => {
 		const trigger = screen.getByRole("button", { name: "ツイートを投稿する" });
 		fireEvent.click(trigger);
 
-		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
-			"data-open",
-			"true",
-		);
-	});
-
-	it("dispatchAComposeOpen() (window event) でも dialog が open する", () => {
-		mockUseUserProfile.mockReturnValue({
-			profile: { username: "alice", display_name: "Alice" },
-			isLoading: false,
-			isError: false,
-		});
-		render(<AComposeShell />);
-
-		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
-			"data-open",
-			"false",
-		);
-
-		act(() => {
-			dispatchAComposeOpen();
-		});
-
-		expect(screen.getByTestId("compose-dialog")).toHaveAttribute(
-			"data-open",
-			"true",
-		);
+		expect(dispatchSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/client/src/components/layout-a/__tests__/ALeftNav.test.tsx
+++ b/client/src/components/layout-a/__tests__/ALeftNav.test.tsx
@@ -51,7 +51,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 	DropdownMenuSeparator: () => null,
 }));
 
-vi.mock("@/components/layout-a/AComposeShell", () => ({
+vi.mock("@/components/layout-a/AComposeDialogHost", () => ({
 	dispatchAComposeOpen: vi.fn(),
 }));
 

--- a/docs/specs/compose-from-any-page-spec.md
+++ b/docs/specs/compose-from-any-page-spec.md
@@ -1,0 +1,138 @@
+# ALeftNav「投稿する」 button が home 以外で反応しない bug 修正 spec (#595)
+
+> Phase 6 ループ完成作業中に発見した bug 修正。 frontend のみ、 backend 変更なし。
+>
+> 関連: [#595 (本 bug issue)](https://github.com/haruna0712/claude-code/issues/595)
+> 既存 PR: [#594](https://github.com/haruna0712/claude-code/pull/594) (記事編集ループ、 本修正とは独立)
+
+## 1. 再現手順 / 期待動作 / 実際の動作
+
+| 項目           | 内容                                                                                                                                                                                                           |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **再現手順**   | stg にログイン → home (`/`) 以外のページ (例: `/articles`) に移動 → ALeftNav の cyan 「投稿する」 button を click                                                                                              |
+| **期待動作**   | `ComposeTweetDialog` が開く (home と同じ)                                                                                                                                                                      |
+| **実際の動作** | button click しても何も起きない (dialog が開かない)                                                                                                                                                            |
+| **影響範囲**   | home (`/`) 以外の **全 auth 必要ページ** (`/articles` / `/explore` / `/u/<handle>` / `/notifications` / `/messages` / `/boards` / `/search` / `/settings/*` / `/tag/<name>` / `/tweet/<id>` / `/threads/<id>`) |
+
+## 2. 原因
+
+[`AComposeShell.tsx`](../../client/src/components/layout-a/AComposeShell.tsx) が `ComposeTweetDialog` の `open` state を保有し、 `window.dispatchEvent('a-compose-open')` を listen して dialog を開く設計。 [`ALeftNav.tsx:213`](../../client/src/components/layout-a/ALeftNav.tsx#L213) の「投稿する」 button は `dispatchAComposeOpen()` を呼ぶだけ。
+
+`<AComposeShell />` は [`(template)/page.tsx:145`](<../../client/src/app/(template)/page.tsx#L145>) で **home (`/`) のみ** render されているため、 他のページでは listener が存在せず chain が切れる:
+
+```
+[button click] → dispatchAComposeOpen()
+              → window.dispatchEvent('a-compose-open')
+              → 🔴 listener (= AComposeShell) が居ない (home 以外のページ)
+              → 何も起きない
+```
+
+## 3. 修正方針
+
+dialog wiring を **`(template)/layout.tsx` に上げる**。 `AComposeShell` (inline compose UI) は home でのみ表示するが、 dialog 本体は全 (template) 配下で共通利用できるようにする:
+
+```
+(template)/layout.tsx
+├── <AComposeDialogHost />   ← 新規。 listener + state + ComposeTweetDialog
+├── <ALeftNav />              ← 既存。 button onClick = dispatchAComposeOpen()
+├── {children}
+│     └── /page.tsx          ← home でだけ
+│         └── <AComposeShell />  ← 既存。 inline compose UI のみ、 dialog state 削除
+```
+
+## 4. やる / やらない
+
+### やる
+
+1. **`AComposeDialogHost.tsx`** 新規 (`client/src/components/layout-a/`):
+   - `"use client"`
+   - `useState(open)` + `useEffect` で `a-compose-open` window event を listen
+   - `<ComposeTweetDialog open={open} onOpenChange={setOpen} />` のみ render
+   - inline UI は持たない (純粋な dialog host)
+2. **`(template)/layout.tsx`** に `<AComposeDialogHost />` を 1 つ追加 (全ページ共通)
+3. **`AComposeShell.tsx`** を inline compose UI 専用にスリム化:
+   - `useState(open)` / `useEffect listener` / `<ComposeTweetDialog>` を削除
+   - inline compose button の `onClick` を `setOpen(true)` から `dispatchAComposeOpen` に変更
+   - home でだけ表示する inline compose UI (avatar + prompt + IconBtns + cyan ツイート button) は維持
+4. **vitest** `AComposeShell.test.tsx` を更新:
+   - 既存 4 つの test の「dialog が open する」 assert を「`dispatchAComposeOpen` が呼ばれる」 / 「`a-compose-open` event が dispatch される」 形に変える
+   - 新規 `AComposeDialogHost.test.tsx`: `a-compose-open` event を dispatch → dialog open / close を verify
+5. **Playwright** `client/e2e/compose-from-any-page.spec.ts` 新規:
+   - 各ページ (home + articles + explore + u/handle + notifications) で「投稿する」 button → dialog open
+
+### やらない
+
+- ALeftNav 自身の変更 (button onClick は今のまま `dispatchAComposeOpen`)
+- `ComposeTweetDialog` の内部実装 (TweetComposer など)
+- inline compose UI のデザイン変更
+- 別 layout 系の compose UI 追加 (mobile nav 等は別 issue)
+
+## 5. テスト
+
+### 5.1 Vitest
+
+新規 `AComposeDialogHost.test.tsx`:
+
+- T-HOST-1 default で dialog closed
+- T-HOST-2 `dispatchAComposeOpen()` → dialog が open
+- T-HOST-3 dialog 閉じる動作で `open=false` に戻る
+
+更新 `AComposeShell.test.tsx`:
+
+- inline compose button click → `dispatchAComposeOpen` が呼ばれる (window event を spy)
+- 既存「dialog が open する」 assert は host 側に移管
+
+### 5.2 Playwright E2E `client/e2e/compose-from-any-page.spec.ts`
+
+各シナリオで auth user として:
+
+| ID            | ページ           | 手順                  | 期待        |
+| ------------- | ---------------- | --------------------- | ----------- |
+| COMPOSE-ANY-1 | `/`              | ALeftNav button click | dialog open |
+| COMPOSE-ANY-2 | `/articles`      | 同上                  | dialog open |
+| COMPOSE-ANY-3 | `/explore`       | 同上                  | dialog open |
+| COMPOSE-ANY-4 | `/u/<handle>`    | 同上                  | dialog open |
+| COMPOSE-ANY-5 | `/notifications` | 同上                  | dialog open |
+
+dialog の open は `getByRole('dialog', { name: /投稿する/ })` で判定。
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+  npx playwright test client/e2e/compose-from-any-page.spec.ts
+```
+
+## 6. ファイル変更まとめ
+
+```
+client/src/components/layout-a/
+  AComposeDialogHost.tsx              [新規 ~40 行]   listener + state + dialog
+  __tests__/
+    AComposeDialogHost.test.tsx       [新規 ~80 行]   T-HOST-1..3
+  AComposeShell.tsx                   [既存 -30 行]   dialog 部分を削除、 inline UI のみ
+  __tests__/
+    AComposeShell.test.tsx            [既存 修正]    dialog assert を dispatch spy に変更
+
+client/src/app/(template)/
+  layout.tsx                          [既存 +2 行]    <AComposeDialogHost /> を埋める
+
+client/e2e/
+  compose-from-any-page.spec.ts       [新規 ~100 行]  COMPOSE-ANY-1..5
+
+docs/specs/
+  compose-from-any-page-spec.md       [新規、 本ファイル]
+```
+
+合計概算 ≈ 250 行 (test + spec 除いて ≈ 70 行)。 small PR ルール余裕。
+
+## 7. CLAUDE.md §4.5 step 6 完了チェックリスト
+
+- [ ] Playwright spec ファイル新設、 5 ページで投稿 button が動くことをコード化
+- [ ] テストシナリオを spec doc §5.2 に書いた
+- [ ] ホーム 3 click 以内 (button 自体が全ページに既存なので 1 click)
+- [ ] 未ログインで壊れない (button が出ない、 dialog host は profile 不要なので display:none 制御不要)
+- [ ] 「完了シグナル」 = dialog open 自体が visible cue。 既存の投稿後 `toast.success("投稿しました")` は維持
+- [ ] stg Playwright 第一選択
+- [ ] `gan-evaluator` agent: bug 修正 (新ルート無し / UI 大変更無し) なので必須ではないが、 念のため呼ぶ (home 以外で実際に動くか目視で第三者確認)


### PR DESCRIPTION
## 概要

bug 修正 PR。 stg でハルナさんが発見した「home (`/`) 以外のページで ALeftNav の cyan「投稿する」 button を押しても dialog が開かない」 問題を解消する。

Closes #595

### 原因

`AComposeShell` が `useState(open)` + `useEffect listener` + `<ComposeTweetDialog>` 本体を所有していたが、 home の `(template)/page.tsx` でしか render されていなかったため、 ALeftNav が dispatch する `a-compose-open` window event を home 以外では誰も listen しておらず chain が切れていた。

```
[button click] → dispatchAComposeOpen()
              → window.dispatchEvent('a-compose-open')
              → 🔴 listener (= AComposeShell) が居ない (home 以外)
              → 何も起きない
```

### 修正

| ファイル | 変更 |
|----------|------|
| `AComposeDialogHost.tsx` (新) | dialog state + listener + `<ComposeTweetDialog>` の wiring のみ。 inline UI は持たない pure host。 `dispatchAComposeOpen` も本ファイルから export する canonical 配置に。 |
| `(template)/layout.tsx` | `<AComposeDialogHost />` を 1 つ埋めて全ページ共通の listener にする。 |
| `AComposeShell.tsx` | dialog state / listener / dialog 本体を削除して inline compose UI だけに純化。 button click は `dispatchAComposeOpen()` を呼ぶだけ。 |
| `ALeftNav.tsx` | `dispatchAComposeOpen` の import path を AComposeShell → AComposeDialogHost に変更。 |

修正後:

```
[button click] → dispatchAComposeOpen()
              → window.dispatchEvent('a-compose-open')
              → AComposeDialogHost listener (template/layout で常に居る)
              → setOpen(true)
              → <ComposeTweetDialog> open
```

### テスト

- **vitest** (14/14 pass):
  - 新規 `AComposeDialogHost.test.tsx` (3): default closed / dispatch で open / onOpenChange(false) で再 close
  - 修正 `AComposeShell.test.tsx` (3): 未ログイン非表示 / inline prompt 表示 / button click で `dispatchAComposeOpen` が呼ばれる (dialog 開閉 assert は host 側に移管)
  - 既存 `ALeftNav.test.tsx` (6): mock path 追従、 regression なし
- **Playwright** `client/e2e/compose-from-any-page.spec.ts` 新規 (5 シナリオ):
  - COMPOSE-ANY-1 `/` / COMPOSE-ANY-2 `/articles` / COMPOSE-ANY-3 `/explore` / COMPOSE-ANY-4 `/u/<handle>` / COMPOSE-ANY-5 `/notifications` で「投稿する」 button → dialog open
- tsc / eslint 緑

仕様: [docs/specs/compose-from-any-page-spec.md](./docs/specs/compose-from-any-page-spec.md)

## Test plan

- [x] vitest 14/14 pass
- [x] tsc / eslint 緑
- [ ] CI 緑
- [ ] stg 反映後に Playwright E2E `compose-from-any-page.spec.ts`
- [ ] stg 反映後にハルナさんが実画面で確認 (報告された再現手順を再度踏む)

## CLAUDE.md §4.5 完了チェックリスト

- [x] Playwright spec ファイル新設、 5 ページで投稿 button が動くことをコード化
- [x] テストシナリオを spec doc §5.2 に書いた
- [x] ホーム 3 click 以内 (button 自体は全ページに既存なので 1 click)
- [x] 未ログインで壊れない (button は auth 時のみ render、 host は profile 不要だが listener だけなので副作用無し)
- [x] 完了シグナル (dialog open 自体が visible cue、 投稿成功後の toast は維持)
- [ ] stg Playwright 実行: マージ → CD 後にハルナさん側で踏む
- [ ] `gan-evaluator` agent stg 反映後 (任意、 bug 修正なので必須ではないが念のため)

## 関連

- bug 報告元: ハルナさん stg 触り (2026-05-11 朝)
- 影響度: HIGH (auth ユーザーが home 以外で書こうとして詰まる UX 重大)
- 同時進行 PR: #594 (記事編集ループ、 本 PR とは独立)