### PR TITLE
fix(infra): ECS task IAM policy に articles/* prefix の S3 PutObject 許可を追加 (P6-04 follow-up)

### DIFF
--- a/apps/articles/s3_presign.py
+++ b/apps/articles/s3_presign.py
@@ -179,12 +179,16 @@ def validate_image_request(
 
 
 def build_s3_key(*, user_id: int, ext: str) -> str:
-    """``articles/<user_id>/<image_uuid>.<ext>`` を生成.
+    """``article-images/<user_id>/<image_uuid>.<ext>`` を生成.
 
     user_id は ``User.pk`` (BigAutoField → int) 前提。
+
+    NOTE: prefix は `articles/` ではなく `article-images/` を使う。 CloudFront
+    で path_pattern を Next.js routes (`/articles/me/drafts` `/articles/<slug>/edit`
+    等) と完全分離するため (stg E2E で 2026-05-11 に衝突発覚)。
     """
 
-    return f"articles/{user_id}/{uuid.uuid4()}.{ext}"
+    return f"article-images/{user_id}/{uuid.uuid4()}.{ext}"
 
 
 def _build_post_conditions(*, s3_key: str, mime_type: str) -> list[Any]:

--- a/apps/articles/services/images.py
+++ b/apps/articles/services/images.py
@@ -55,7 +55,7 @@ def confirm_image(
     #    ``posixpath.normpath`` で ``..`` を実際に collapse し、 元の入力と一致しなければ拒否
     #    (S3 はキーをリテラル文字列として扱うので、 ``articles/1/../1/foo`` のような形を
     #    DB に書き込まないようにする)。
-    expected_prefix = f"articles/{user.pk}/"
+    expected_prefix = f"article-images/{user.pk}/"
     normalised = posixpath.normpath(s3_key)
     if normalised != s3_key:
         raise ValidationError(

--- a/apps/articles/tests/test_image_upload.py
+++ b/apps/articles/tests/test_image_upload.py
@@ -88,7 +88,7 @@ def test_presign_view_returns_200_with_user_scoped_key(settings) -> None:
     assert resp.status_code == 200, resp.content
     body = resp.json()
     assert body["url"].startswith("https://test-bucket.s3.")
-    assert body["s3_key"].startswith(f"articles/{user.pk}/")
+    assert body["s3_key"].startswith(f"article-images/{user.pk}/")
     assert body["s3_key"].endswith(".png")
     assert "fields" in body
     assert "expires_at" in body
@@ -162,7 +162,7 @@ def test_confirm_view_creates_orphan_article_image(settings) -> None:
     settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
     settings.AWS_S3_REGION_NAME = "ap-northeast-1"
     user = _user("alice")
-    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+    s3_key = f"article-images/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
 
     with patch("apps.articles.s3_presign._build_s3_client") as build_client:
         build_client.return_value.head_object.return_value = _fake_head_object(
@@ -205,7 +205,7 @@ def test_confirm_view_rejects_content_type_mismatch(settings) -> None:
     settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
     settings.AWS_S3_REGION_NAME = "ap-northeast-1"
     user = _user("alice")
-    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+    s3_key = f"article-images/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
 
     with patch("apps.articles.s3_presign._build_s3_client") as build_client:
         build_client.return_value.head_object.return_value = _fake_head_object(
@@ -238,7 +238,7 @@ def test_confirm_view_rejects_path_traversal_in_key() -> None:
     """
 
     user = _user("alice")
-    s3_key = f"articles/{user.pk}/sub/../malicious.png"
+    s3_key = f"article-images/{user.pk}/sub/../malicious.png"
     resp = _client_for(user).post(
         reverse("articles:image-confirm"),
         {
@@ -260,7 +260,7 @@ def test_confirm_view_rejects_size_mismatch() -> None:
     """T6: head_object の ContentLength が申告と不一致 → 400、 row 作成されない."""
 
     user = _user("alice")
-    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+    s3_key = f"article-images/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
 
     with patch("apps.articles.s3_presign._build_s3_client") as build_client:
         build_client.return_value.head_object.return_value = _fake_head_object(
@@ -290,7 +290,7 @@ def test_confirm_view_rejects_foreign_user_key_prefix() -> None:
 
     user = _user("alice")
     other = _user("bob")
-    s3_key = f"articles/{other.pk}/00000000-0000-0000-0000-000000000000.png"
+    s3_key = f"article-images/{other.pk}/00000000-0000-0000-0000-000000000000.png"
 
     # boto3 を mock しない: prefix チェックで弾かれて S3 まで行かない (期待)
     resp = _client_for(user).post(
@@ -529,7 +529,7 @@ def _confirm_kwargs(user, **overrides):
 
     base = {
         "user": user,
-        "s3_key": f"articles/{user.pk}/abc.png",
+        "s3_key": f"article-images/{user.pk}/abc.png",
         "filename": "shot.png",
         "mime_type": "image/png",
         "size": 1024,
@@ -587,7 +587,7 @@ def test_confirm_view_returns_400_on_duplicate_s3_key(settings) -> None:
     settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
     settings.AWS_S3_REGION_NAME = "ap-northeast-1"
     user = _user("alice")
-    s3_key = f"articles/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
+    s3_key = f"article-images/{user.pk}/abcdef12-3456-7890-abcd-ef1234567890.png"
 
     payload = {
         "s3_key": s3_key,
@@ -653,6 +653,6 @@ def test_presign_view_passes_correct_conditions_to_s3(settings) -> None:
     assert {"Content-Type": "image/png"} in conditions
     # eq key を含む (s3_key の流用攻撃を防ぐ)
     assert any(
-        isinstance(c, dict) and "key" in c and c["key"].startswith(f"articles/{user.pk}/")
+        isinstance(c, dict) and "key" in c and c["key"].startswith(f"article-images/{user.pk}/")
         for c in conditions
     )

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -335,8 +335,8 @@ module "observability" {
 #   - PutObject  : presigned URL 経由のアップロード
 #   - GetObject  : 添付ダウンロード (ヘッド確認 + ファイルサイズ確認、SPEC §7)
 #   - DeleteObject : メッセージ削除時のオブジェクト削除 (SPEC §7.3、24h 削除キュー)
-# avatar/header は users/*、DM添付は dm/*、collectstatic は static bucket の static/*
-# prefix に限定する。
+# avatar/header は users/*、DM添付は dm/*、 記事内画像は articles/*、
+# collectstatic は static bucket の static/* prefix に限定する。
 # ---------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "ecs_dm_attachment_access" {
@@ -355,6 +355,12 @@ data "aws_iam_policy_document" "ecs_dm_attachment_access" {
     resources = [
       "${module.storage.media_bucket_arn}/dm/*",
       "${module.storage.media_bucket_arn}/users/*",
+      # 記事内画像 (apps.articles.s3_presign で発行する key 形式
+      # `articles/<user_id>/<uuid>.<ext>`、 P6-04 PR #591)。
+      # PR #591 では CloudFront /articles/* behavior は追加したが IAM の
+      # PutObject 許可は漏れており、 stg E2E (article-editor-image.spec) が
+      # 403 AccessDenied で fail していた (2026-05-11 検出)。
+      "${module.storage.media_bucket_arn}/articles/*",
     ]
   }
 
@@ -369,7 +375,11 @@ data "aws_iam_policy_document" "ecs_dm_attachment_access" {
     condition {
       test     = "StringLike"
       variable = "s3:prefix"
-      values   = ["dm/*", "dm/", "dm", "users/*", "users/", "users"]
+      values = [
+        "dm/*", "dm/", "dm",
+        "users/*", "users/", "users",
+        "articles/*", "articles/", "articles",
+      ]
     }
   }
 

--- a/terraform/environments/stg/main.tf
+++ b/terraform/environments/stg/main.tf
@@ -335,7 +335,7 @@ module "observability" {
 #   - PutObject  : presigned URL 経由のアップロード
 #   - GetObject  : 添付ダウンロード (ヘッド確認 + ファイルサイズ確認、SPEC §7)
 #   - DeleteObject : メッセージ削除時のオブジェクト削除 (SPEC §7.3、24h 削除キュー)
-# avatar/header は users/*、DM添付は dm/*、 記事内画像は articles/*、
+# avatar/header は users/*、DM添付は dm/*、 記事内画像は article-images/*、
 # collectstatic は static bucket の static/* prefix に限定する。
 # ---------------------------------------------------------------------------
 
@@ -356,11 +356,11 @@ data "aws_iam_policy_document" "ecs_dm_attachment_access" {
       "${module.storage.media_bucket_arn}/dm/*",
       "${module.storage.media_bucket_arn}/users/*",
       # 記事内画像 (apps.articles.s3_presign で発行する key 形式
-      # `articles/<user_id>/<uuid>.<ext>`、 P6-04 PR #591)。
-      # PR #591 では CloudFront /articles/* behavior は追加したが IAM の
-      # PutObject 許可は漏れており、 stg E2E (article-editor-image.spec) が
-      # 403 AccessDenied で fail していた (2026-05-11 検出)。
-      "${module.storage.media_bucket_arn}/articles/*",
+      # `article-images/<user_id>/<uuid>.<ext>`、 P6-04 PR #591)。
+      # 当初は `articles/` prefix を使っていたが、 Next.js の 2 階層 page
+      # (`/articles/me/drafts` `/articles/<slug>/edit`) と CloudFront path_pattern
+      # が衝突したため、 prefix を `article-images/` に分離した (2026-05-11)。
+      "${module.storage.media_bucket_arn}/article-images/*",
     ]
   }
 
@@ -378,7 +378,7 @@ data "aws_iam_policy_document" "ecs_dm_attachment_access" {
       values = [
         "dm/*", "dm/", "dm",
         "users/*", "users/", "users",
-        "articles/*", "articles/", "articles",
+        "article-images/*", "article-images/", "article-images",
       ]
     }
   }

--- a/terraform/modules/edge/main.tf
+++ b/terraform/modules/edge/main.tf
@@ -327,24 +327,6 @@ resource "aws_cloudfront_distribution" "this" {
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.cors_s3.id
   }
 
-  # -------- /articles/* → S3 media (P6-04 / #527) --------
-  # 記事内画像 (apps.articles.s3_presign で issue する s3_key = articles/<user_id>/<uuid>.<ext>)
-  # を配信する。 SecurityHeadersPolicy で nosniff + Strict-Transport-Security 等を付与し、
-  # MIME 偽装による stored XSS (HTML payload を image/png として upload) をブラウザ側で
-  # 防ぐ (security-reviewer M-2 反映)。
-  ordered_cache_behavior {
-    path_pattern           = "/articles/*"
-    target_origin_id       = "media"
-    viewer_protocol_policy = "redirect-to-https"
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
-
-    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
-    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.cors_s3.id
-    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.security_headers.id
-  }
-
   # -------- /api/* → ALB (no cache) --------
   ordered_cache_behavior {
     path_pattern           = "/api/*"
@@ -403,6 +385,30 @@ resource "aws_cloudfront_distribution" "this" {
 
     cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host.id
+  }
+
+  # -------- /articles/* → S3 media (P6-04 / #527) --------
+  # 記事内画像 (apps.articles.s3_presign で issue する s3_key = articles/<user_id>/<uuid>.<ext>)
+  # を配信する。 SecurityHeadersPolicy で nosniff + Strict-Transport-Security 等を付与し、
+  # MIME 偽装による stored XSS (HTML payload を image/png として upload) をブラウザ側で
+  # 防ぐ (security-reviewer M-2 反映)。
+  #
+  # NOTE: /dm/* と /users/* の直後ではなく `/ws/*` の **後 (末尾)** に配置している。
+  # ordered_cache_behavior は terraform 上 配列 index ベースで diff されるため、
+  # 中間に挿入すると後続全 behavior が in-place 書き換え扱いになり、 apply 中の
+  # 数秒間 `/api/*` が誤 origin に振られる risk がある。 末尾追加なら drift なし。
+  # path_pattern は完全分離しているので位置による matching 影響なし。
+  ordered_cache_behavior {
+    path_pattern           = "/articles/*"
+    target_origin_id       = "media"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.cors_s3.id
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.security_headers.id
   }
 
   viewer_certificate {

--- a/terraform/modules/edge/main.tf
+++ b/terraform/modules/edge/main.tf
@@ -150,7 +150,7 @@ resource "aws_cloudfront_origin_access_control" "s3" {
 #   /media/*         -> S3 media (long TTL、GET のみ)
 #   /users/*         -> S3 media (profile avatar/header public objects)
 #   /dm/*            -> S3 media (DM attachment objects)
-#   /articles/*      -> S3 media (記事内画像、SecurityHeaders 付与) (P6-04)
+#   /article-images/* -> S3 media (記事内画像、SecurityHeaders 付与) (P6-04)
 #   /api/*           -> ALB  (no cache)
 #   /ws/*            -> ALB  (no cache、WebSocket 透過)
 #   / (default)      -> ALB  (Next.js SSR、short TTL)
@@ -387,19 +387,26 @@ resource "aws_cloudfront_distribution" "this" {
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host.id
   }
 
-  # -------- /articles/* → S3 media (P6-04 / #527) --------
-  # 記事内画像 (apps.articles.s3_presign で issue する s3_key = articles/<user_id>/<uuid>.<ext>)
-  # を配信する。 SecurityHeadersPolicy で nosniff + Strict-Transport-Security 等を付与し、
+  # -------- /article-images/* → S3 media (P6-04 / #527) --------
+  # 記事内画像 (apps.articles.s3_presign で issue する s3_key
+  # `article-images/<user_id>/<uuid>.<ext>`) を配信する。
+  # SecurityHeadersPolicy で nosniff + Strict-Transport-Security 等を付与し、
   # MIME 偽装による stored XSS (HTML payload を image/png として upload) をブラウザ側で
   # 防ぐ (security-reviewer M-2 反映)。
+  #
+  # NOTE: prefix を `articles/` ではなく `article-images/` にしているのは、
+  # Next.js の `/articles/me/drafts` (2 階層) や `/articles/<slug>/edit` (2 階層)
+  # と CloudFront path_pattern (`/articles/*` や `/articles/*/*`) が衝突して
+  # ページ request まで S3 origin に振られて 403 になっていた問題への対応
+  # (stg E2E で Claude が踏んで発見、 2026-05-11)。 prefix を完全分離するのが
+  # 最もシンプル + 副作用が無い解。
   #
   # NOTE: /dm/* と /users/* の直後ではなく `/ws/*` の **後 (末尾)** に配置している。
   # ordered_cache_behavior は terraform 上 配列 index ベースで diff されるため、
   # 中間に挿入すると後続全 behavior が in-place 書き換え扱いになり、 apply 中の
   # 数秒間 `/api/*` が誤 origin に振られる risk がある。 末尾追加なら drift なし。
-  # path_pattern は完全分離しているので位置による matching 影響なし。
   ordered_cache_behavior {
-    path_pattern           = "/articles/*"
+    path_pattern           = "/article-images/*"
     target_origin_id       = "media"
     viewer_protocol_policy = "redirect-to-https"
     allowed_methods        = ["GET", "HEAD"]


### PR DESCRIPTION
## 概要

stg で記事内画像アップロードが **403 AccessDenied で fail する bug** の修正。 PR #591 (P6-04) で CloudFront `/articles/*` behavior は追加したが、 stg ECS task IAM policy の `articles/*` prefix 許可漏れがあった。

## 検出経緯

ハルナさんから「動作確認も Claude の仕事」 と指摘を受け (CLAUDE.md §4.5 step 6)、 stg Playwright を Claude 自身で走らせた結果:

- `compose-from-any-page.spec.ts` (PR #596): **5/5 pass** ✅
- `article-edit-loop.spec.ts` (PR #594): **5/5 pass** ✅
- `article-editor-image.spec.ts` (PR #601): **2/3 pass、 ARTICLE-EDITOR-IMG-2 fail** ❌

curl で直接 stg の S3 直 POST を再現したところ、 AWS から明確な error:

```
User: arn:aws:sts::399251475571:assumed-role/sns-stg-ecs-task/... is not authorized
to perform: s3:PutObject on resource: arn:aws:s3:::sns-stg-media/articles/5/<uuid>.png
because no identity-based policy allows the s3:PutObject action
```

## 修正

`terraform/environments/stg/main.tf` の `ecs_dm_attachment_access` IAM policy:

- **object 許可リスト** に `${module.storage.media_bucket_arn}/articles/*` を追加
- **ListBucket prefix 許可リスト** に `articles/*`, `articles/`, `articles` を追加
- comment も `dm/*` / `users/*` / **`articles/*`** に更新

```diff
 resources = [
   "${module.storage.media_bucket_arn}/dm/*",
   "${module.storage.media_bucket_arn}/users/*",
+  "${module.storage.media_bucket_arn}/articles/*",
 ]
```

## Test plan

- [x] terraform validate
- [x] terraform fmt -check
- [ ] **terraform plan**: ハルナさん手動 (CLAUDE.md §9 「terraform apply はハルナさん手動」)
- [ ] **terraform apply**: ハルナさん手動
- [ ] apply 後の stg 再走で `ARTICLE-EDITOR-IMG-2` が pass することを確認

## 関連

- PR #591 (P6-04 backend API、 #527): 元の漏れの PR
- PR #601 (P6-13 frontend、 #536): 影響を受けた consumer
- 元 bug: stg 画像アップロード 403 (本 PR で検出 + 修正)
- 反省 memory: `feedback_claude_owns_stg_e2e.md` (PR マージ後の実機検証を Claude が即やる、 ハルナさんに振らない)