### PR TITLE
fix(articles): /new と /<slug>/edit に SSR auth + owner gate を追加 (#606)

### DIFF
--- a/client/e2e/article-edit-loop.spec.ts
+++ b/client/e2e/article-edit-loop.spec.ts
@@ -9,6 +9,9 @@
  *   EDIT-LOOP-3: 新規 → 公開 → 詳細「削除」 → confirm → /articles へ + toast
  *   EDIT-LOOP-4: drafts page (auth) で自分の下書きが見える / row から edit へ
  *   EDIT-LOOP-5: drafts page (anon) は /login へ redirect
+ *   EDIT-LOOP-6: /articles/new (anon) → /login?next=/articles/new redirect (#606)
+ *   EDIT-LOOP-7: /articles/<slug>/edit (anon) → /login?next=... redirect (#606)
+ *   EDIT-LOOP-8: 他人の /articles/<slug>/edit → 404 (#606 / gan-evaluator H2)
  *
  * env: docs/local/e2e-stg.md の test2 / test3 を使用。
  */
@@ -274,5 +277,77 @@ test.describe("記事編集ループの導線 (#593)", () => {
 		// /login or /login?next=... へ redirect
 		await page.waitForURL(/\/login(\?.*)?/, { timeout: 15000 });
 		await ctx.close();
+	});
+
+	test("EDIT-LOOP-6: /articles/new (anon) → /login?next= redirect (#606)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/articles/new`);
+		await page.waitForURL(/\/login(\?.*)?/, { timeout: 15000 });
+		expect(page.url()).toContain("next=%2Farticles%2Fnew");
+		await ctx.close();
+	});
+
+	test("EDIT-LOOP-7: 他人の /<slug>/edit (anon) → /login?next= redirect (#606)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		// author 側で記事を作る
+		const ctxAuthor = await browser.newContext();
+		const { csrf: csrf1 } = await loginViaApi(ctxAuthor.request, USER1);
+		const { slug } = await createPublishedArticle(
+			ctxAuthor.request,
+			csrf1,
+			"EDIT-LOOP-7 anon edit attempt",
+		);
+		await ctxAuthor.close();
+
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/articles/${slug}/edit`);
+		await page.waitForURL(/\/login(\?.*)?/, { timeout: 15000 });
+		expect(page.url()).toContain(
+			`next=%2Farticles%2F${encodeURIComponent(slug)}%2Fedit`,
+		);
+
+		// cleanup
+		const cleanCtx = await browser.newContext();
+		const { csrf: cleanCsrf } = await loginViaApi(cleanCtx.request, USER1);
+		await deleteArticleViaApi(cleanCtx.request, cleanCsrf, slug);
+		await cleanCtx.close();
+		await ctx.close();
+	});
+
+	test("EDIT-LOOP-8: 他人 (auth) の /<slug>/edit → 404 (#606)", async ({
+		browser,
+	}) => {
+		test.skip(
+			!USER2.email || !USER2.password || !USER2.handle,
+			"USER2 env 未設定",
+		);
+		// USER1 が author
+		const ctxAuthor = await browser.newContext();
+		const { csrf: csrf1 } = await loginViaApi(ctxAuthor.request, USER1);
+		const { slug } = await createPublishedArticle(
+			ctxAuthor.request,
+			csrf1,
+			"EDIT-LOOP-8 other-user edit attempt",
+		);
+		await ctxAuthor.close();
+
+		// USER2 が他人として edit URL を踏む
+		const ctxOther = await browser.newContext();
+		await loginViaApi(ctxOther.request, USER2);
+		const page = await ctxOther.newPage();
+		const resp = await page.goto(`${BASE}/articles/${slug}/edit`);
+		expect(resp?.status()).toBe(404);
+
+		// cleanup
+		const cleanCtx = await browser.newContext();
+		const { csrf: cleanCsrf } = await loginViaApi(cleanCtx.request, USER1);
+		await deleteArticleViaApi(cleanCtx.request, cleanCsrf, slug);
+		await cleanCtx.close();
+		await ctxOther.close();
 	});
 });

--- a/client/src/app/(template)/articles/[slug]/edit/page.tsx
+++ b/client/src/app/(template)/articles/[slug]/edit/page.tsx
@@ -1,16 +1,22 @@
 /**
  * /articles/<slug>/edit 記事編集ページ (#536 / Phase 6 P6-13).
  *
- * 自分の記事のみ編集可能。draft も含めて見える (backend 側で隠蔽)。
+ * 自分の記事のみ編集可能。 draft も含めて見える (backend 側で隠蔽)。
+ *
+ * #606 で SSR auth + owner gate を追加:
+ *   - anon → /login?next=... に server-side redirect
+ *   - 他人の published 記事 → notFound() で 404 (編集 form を anon に見せない)
  */
 
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
 
 import ArticleEditor from "@/components/articles/ArticleEditor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { ArticleDetail } from "@/lib/api/articles";
+import type { CurrentUser } from "@/lib/api/users";
 
 interface PageProps {
 	params: { slug: string };
@@ -30,9 +36,32 @@ async function fetchArticle(slug: string): Promise<ArticleDetail | null> {
 	}
 }
 
+type CurrentUserMini = Pick<CurrentUser, "username">;
+
+async function fetchCurrentUserSSR(): Promise<CurrentUserMini | null> {
+	try {
+		return await serverFetch<CurrentUserMini>("/users/me/");
+	} catch {
+		return null;
+	}
+}
+
 export default async function EditArticlePage({ params }: PageProps) {
-	const article = await fetchArticle(params.slug);
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	if (!isAuthenticated) {
+		redirect(`/login?next=/articles/${params.slug}/edit`);
+	}
+
+	const [article, currentUser] = await Promise.all([
+		fetchArticle(params.slug),
+		fetchCurrentUserSSR(),
+	]);
 	if (!article) notFound();
+	// 他人の記事を編集 form として render してはいけない (#606 / gan-evaluator H2)。
+	// owner 判定は detail page と同じく username == author.handle で行う。
+	if (!currentUser || currentUser.username !== article.author.handle) {
+		notFound();
+	}
 	return (
 		<>
 			<header

--- a/client/src/app/(template)/articles/new/page.tsx
+++ b/client/src/app/(template)/articles/new/page.tsx
@@ -1,14 +1,14 @@
 /**
  * /articles/new 記事新規作成ページ (#536 / Phase 6 P6-13).
  *
- * auth 必須 (未ログインは backend が 401 を返すので /login にリダイレクト
- * は client 側でも追加で示すが、Server Component の段階では fetch しない)。
- *
- * #566 (B-1-1) で外側 <main> を <div> に変更 + sticky header 追加。
+ * auth 必須。 #606 で SSR auth gate を追加: anon は server 側で /login に
+ * redirect。 backend 401 待ちで入力が消える UX 違反 (CLAUDE.md §4.5) を防ぐ。
  */
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 import ArticleEditor from "@/components/articles/ArticleEditor";
 
@@ -18,6 +18,11 @@ export const metadata: Metadata = {
 };
 
 export default function NewArticlePage() {
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	if (!isAuthenticated) {
+		redirect("/login?next=/articles/new");
+	}
+
 	return (
 		<>
 			<header

--- a/docs/specs/articles-auth-gate-spec.md
+++ b/docs/specs/articles-auth-gate-spec.md
@@ -1,0 +1,109 @@
+# /articles/new + /articles/<slug>/edit の SSR auth gate (#606)
+
+> 関連 Issue: #606
+> 関連 PR: TBD
+> 種別: security fix / UX fix (frontend)
+
+## 1. 背景
+
+`gan-evaluator` agent の HIGH バグ H2 として発見。
+
+`/articles/me/drafts` は PR #594 で `cookies().get("logged_in")` を見て server-side で `/login?next=...` に redirect していたが、 `/articles/new` と `/articles/<slug>/edit` はその対応が漏れており、 anon (未ログイン) でも editor form が render されていた。 さらに `/edit` は他人の published 記事の URL を踏むと title / body / slug が編集 form に乗った状態で見えてしまっていた (情報漏洩は無いが UX 違和感)。
+
+### 再現
+
+| URL                                  | 期待                              | 現状 (修正前)           |
+| ------------------------------------ | --------------------------------- | ----------------------- |
+| anon `/articles/new`                 | 307 → `/login?next=/articles/new` | 200 + editor form       |
+| anon `/articles/<slug>/edit`         | 307 → `/login?next=...`           | 200 + 他人の記事の form |
+| auth (他人) `/articles/<slug>/edit`  | 404 (notFound)                    | 200 + 他人の記事の form |
+| auth (owner) `/articles/<slug>/edit` | 200 + editor                      | 200 (現状通り)          |
+
+## 2. 直し方
+
+### `/articles/new/page.tsx`
+
+`/articles/me/drafts/page.tsx` と同じ pattern:
+
+```ts
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default function NewArticlePage() {
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	if (!isAuthenticated) {
+		redirect("/login?next=/articles/new");
+	}
+	// ...editor render
+}
+```
+
+### `/articles/[slug]/edit/page.tsx`
+
+1. cookie で auth gate (anon → /login)
+2. `Promise.all([fetchArticle, fetchCurrentUserSSR])` で記事と current user を並列取得
+3. 記事 404 or owner mismatch → `notFound()` (404)
+
+owner 判定は detail page (`/articles/[slug]/page.tsx:107`) と同じく `currentUser.username === article.author.handle` で行う。 `ArticleAuthor.id` は serializer 未公開なので handle で照合。
+
+```ts
+const isAuthenticated = cookies().get("logged_in")?.value === "true";
+if (!isAuthenticated) redirect(`/login?next=/articles/${params.slug}/edit`);
+
+const [article, currentUser] = await Promise.all([
+	fetchArticle(params.slug),
+	fetchCurrentUserSSR(),
+]);
+if (!article) notFound();
+if (!currentUser || currentUser.username !== article.author.handle) notFound();
+```
+
+### 採用しない選択肢
+
+- **middleware で auth gate を集約**: 既存 page は個別に `cookies().get("logged_in")` で gate しているので一貫性を保つ。 middleware 化は別タスクとして将来検討 (今やると影響範囲が広い)。
+- **/edit で `redirect("/articles/<slug>")` に飛ばす**: notFound (404) のほうが「ここは編集できる場所ではない」 ことが明示的で、 他人記事の存在を匂わせない。
+
+## 3. 受け入れ基準
+
+- [ ] anon `/articles/new` → 307 redirect to `/login?next=/articles/new`
+- [ ] anon `/articles/<other>/edit` → 307 redirect to `/login?next=...`
+- [ ] auth で他人の `/edit` を叩く → 404
+- [ ] auth で自分の `/edit` を叩く → 200 (regression なし)
+- [ ] `npx tsc --noEmit` 通過
+- [ ] Playwright e2e `article-edit-loop.spec.ts` に EDIT-LOOP-6, 7, 8 を追加して stg 緑
+
+## 4. テスト
+
+### E2E (Playwright on stg)
+
+`client/e2e/article-edit-loop.spec.ts` に 3 ケース追加:
+
+| 名前        | シナリオ                                       |
+| ----------- | ---------------------------------------------- |
+| EDIT-LOOP-6 | anon `/articles/new` → /login?next= redirect   |
+| EDIT-LOOP-7 | anon 他人記事 `/edit` → /login?next= redirect  |
+| EDIT-LOOP-8 | auth (USER2) 他人 (USER1) 記事の `/edit` → 404 |
+
+実行:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=... PLAYWRIGHT_USER1_PASSWORD=... PLAYWRIGHT_USER1_HANDLE=... \
+PLAYWRIGHT_USER2_EMAIL=... PLAYWRIGHT_USER2_PASSWORD=... PLAYWRIGHT_USER2_HANDLE=... \
+  npx playwright test e2e/article-edit-loop.spec.ts
+```
+
+env は [docs/local/e2e-stg.md](../local/e2e-stg.md) に test2 / test3 の credential 記載済み。
+
+### 手動視認 (Playwright MCP)
+
+- anon で `/articles/new` を踏み、 login へ飛ぶことを screenshot 確認
+- anon で他人記事の `/edit` URL を踏み、 login へ飛ぶ
+- 自分 (USER1) で自分の `/edit` を踏み、 editor が出るのを確認 (regression)
+- USER2 で USER1 の published `/edit` を踏み、 404 page が出るのを確認
+
+## 5. ロールアウト
+
+- `fix/issue-606-articles-auth-gate` branch で PR を出し、 CI 緑なら squash merge
+- main merge 後 5 〜 10 分で stg CD 更新
+- stg で Playwright spec を実行、 緑を確認したら issue close


### PR DESCRIPTION
## Summary

- `/articles/new` に SSR auth gate を追加 (anon → `/login?next=/articles/new`)
- `/articles/<slug>/edit` に SSR auth gate + owner gate を追加
  - anon → `/login?next=...`
  - auth で他人 → `notFound()` (404)
- Playwright e2e に 3 ケース追加 (EDIT-LOOP-6/7/8)
- spec: `docs/specs/articles-auth-gate-spec.md`

## 背景

`gan-evaluator` agent HIGH H2 として発見:

> anon (未ログイン) で stg `/articles/new` を直叩き、 もしくは他人の公開記事の `/articles/<slug>/edit` を直叩きすると、 editor form が render されてしまう。
> 期待: `/login?next=...` に server-side redirect (`/articles/me/drafts` と同流儀)。

`/articles/me/drafts` (PR #594) で確立した cookie auth gate pattern を `/new` と `/edit` にも適用。

## 影響範囲

| URL | Before | After |
|---|---|---|
| anon `/articles/new` | 200 + editor | 307 → `/login?next=/articles/new` |
| anon `/articles/<slug>/edit` | 200 + 他人記事の form | 307 → `/login?next=...` |
| auth (他人) `/articles/<slug>/edit` | 200 + 他人記事の form | 404 |
| auth (owner) `/articles/<slug>/edit` | 200 + editor | 200 (regression 無し) |

## Test plan

- [x] `npx tsc --noEmit` 通過
- [ ] CI 緑
- [ ] stg merge 後、 Playwright `article-edit-loop.spec.ts` で EDIT-LOOP-6/7/8 が緑
- [ ] Playwright MCP で anon `/new`, anon `/edit`, 他人 auth `/edit` を踏んで挙動確認
- [ ] gan-evaluator 再採点で H2 解消

Closes #606