### PR TITLE
fix(articles): 公開 / 下書き保存時に toast.success を表示 (#607)

### DIFF
--- a/client/src/components/articles/ArticleEditor.tsx
+++ b/client/src/components/articles/ArticleEditor.tsx
@@ -249,6 +249,9 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 					status,
 					tags,
 				});
+				toast.success(
+					status === "published" ? "公開しました" : "下書きを保存しました",
+				);
 				router.push(`/articles/${created.slug}`);
 			} else if (initial) {
 				const updated = await updateArticle(initial.slug, {
@@ -258,6 +261,9 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 					status,
 					tags,
 				});
+				toast.success(
+					status === "published" ? "公開しました" : "下書きを保存しました",
+				);
 				router.push(`/articles/${updated.slug}`);
 			}
 		} catch (err) {

--- a/client/src/components/articles/__tests__/ArticleEditor.test.tsx
+++ b/client/src/components/articles/__tests__/ArticleEditor.test.tsx
@@ -5,9 +5,10 @@
  *   T-EDIT-1 insertImageMarkdown が caret 位置に ![alt](url) を挿入し前後改行を補完
  *   T-EDIT-2 preview pane が rendered HTML (heading) を表示
  *   T-EDIT-3 「画像を追加」 button click で file input が開く + 選択 file が enqueue される
+ *   T-PUBLISH-1..4 (#607) handleSubmit 成功時に toast が出る (create/update × draft/published)
  */
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ArticleEditor, {
@@ -18,9 +19,31 @@ vi.mock("next/navigation", () => ({
 	useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
-vi.mock("react-toastify", () => ({
-	toast: { success: vi.fn(), error: vi.fn() },
+const { toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+	toastSuccessMock: vi.fn(),
+	toastErrorMock: vi.fn(),
 }));
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessMock, error: toastErrorMock },
+}));
+
+const { createArticleMock, updateArticleMock } = vi.hoisted(() => ({
+	createArticleMock: vi.fn(),
+	updateArticleMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/articles", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/articles")>(
+			"@/lib/api/articles",
+		);
+	return {
+		...actual,
+		createArticle: createArticleMock,
+		updateArticle: updateArticleMock,
+	};
+});
 
 const { enqueueMock } = vi.hoisted(() => ({
 	enqueueMock: vi.fn(),
@@ -81,6 +104,10 @@ describe("insertImageMarkdown", () => {
 describe("ArticleEditor", () => {
 	beforeEach(() => {
 		enqueueMock.mockReset();
+		toastSuccessMock.mockReset();
+		toastErrorMock.mockReset();
+		createArticleMock.mockReset();
+		updateArticleMock.mockReset();
 	});
 
 	it("T-EDIT-2 preview pane renders heading from body markdown", () => {
@@ -185,5 +212,99 @@ describe("ArticleEditor", () => {
 			dataTransfer: { files: [], types: ["text/html"] },
 		});
 		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	// #607: handleSubmit success path toast (gan-evaluator M1)。
+	// confirm dialog (status=published) は jsdom で auto-deny されるので status=draft で
+	// path をカバー + window.confirm を mock で auto-accept した published path も検証。
+	const fillForm = () => {
+		const titleInput = screen.getByLabelText(/タイトル/, {
+			selector: "input",
+		}) as HTMLInputElement;
+		const bodyInput = screen.getByLabelText(/本文/, {
+			selector: "textarea",
+		}) as HTMLTextAreaElement;
+		fireEvent.change(titleInput, { target: { value: "Hello" } });
+		fireEvent.change(bodyInput, { target: { value: "Hello body" } });
+	};
+
+	type EditableArticle = {
+		id: string;
+		slug: string;
+		title: string;
+		body_markdown: string;
+		body_html: string;
+		status: "draft" | "published";
+		published_at: string | null;
+		view_count: number;
+		author: { handle: string; display_name: string; avatar_url: string };
+		tags: { slug: string; display_name: string }[];
+		like_count: number;
+		comment_count: number;
+		created_at: string;
+		updated_at: string;
+	};
+	const buildInitial = (status: "draft" | "published"): EditableArticle => ({
+		id: "1",
+		slug: "hello",
+		title: "Hello",
+		body_markdown: "body",
+		body_html: "<p>body</p>",
+		status,
+		published_at: status === "published" ? "2026-01-01T00:00:00Z" : null,
+		view_count: 0,
+		author: { handle: "u", display_name: "U", avatar_url: "" },
+		tags: [],
+		like_count: 0,
+		comment_count: 0,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+	});
+
+	const submitButton = (name: string) =>
+		screen.getByRole("button", { name }) as HTMLButtonElement;
+
+	it("T-PUBLISH-1 create + draft で「下書きを保存しました」 toast", async () => {
+		createArticleMock.mockResolvedValueOnce({ slug: "hello" });
+		render(<ArticleEditor mode="create" />);
+		fillForm();
+		await act(async () => {
+			fireEvent.click(submitButton("下書き保存"));
+		});
+		expect(createArticleMock).toHaveBeenCalledTimes(1);
+		expect(toastSuccessMock).toHaveBeenCalledWith("下書きを保存しました");
+	});
+
+	it("T-PUBLISH-2 create + published で「公開しました」 toast", async () => {
+		createArticleMock.mockResolvedValueOnce({ slug: "hello" });
+		vi.spyOn(window, "confirm").mockReturnValue(true);
+		render(<ArticleEditor mode="create" />);
+		fillForm();
+		const publishRadio = screen.getByLabelText("公開") as HTMLInputElement;
+		fireEvent.click(publishRadio);
+		await act(async () => {
+			fireEvent.click(submitButton("公開する"));
+		});
+		expect(toastSuccessMock).toHaveBeenCalledWith("公開しました");
+	});
+
+	it("T-PUBLISH-3 edit + draft で「下書きを保存しました」 toast", async () => {
+		updateArticleMock.mockResolvedValueOnce({ slug: "hello" });
+		render(<ArticleEditor mode="edit" initial={buildInitial("draft")} />);
+		await act(async () => {
+			fireEvent.click(submitButton("更新"));
+		});
+		expect(updateArticleMock).toHaveBeenCalledTimes(1);
+		expect(toastSuccessMock).toHaveBeenCalledWith("下書きを保存しました");
+	});
+
+	it("T-PUBLISH-4 edit + published で「公開しました」 toast", async () => {
+		updateArticleMock.mockResolvedValueOnce({ slug: "hello" });
+		vi.spyOn(window, "confirm").mockReturnValue(true);
+		render(<ArticleEditor mode="edit" initial={buildInitial("published")} />);
+		await act(async () => {
+			fireEvent.click(submitButton("更新して公開"));
+		});
+		expect(toastSuccessMock).toHaveBeenCalledWith("公開しました");
 	});
 });

--- a/docs/specs/articles-publish-toast-spec.md
+++ b/docs/specs/articles-publish-toast-spec.md
@@ -1,0 +1,72 @@
+# 記事保存 / 公開時の toast 通知 (#607)
+
+> 関連 Issue: #607
+> 関連 PR: TBD
+> 種別: UX fix (frontend)
+
+## 1. 背景
+
+`gan-evaluator` agent の MEDIUM M1 として発見。
+
+`/articles/new` で記事を書いて「公開する」 button を click → 確認 dialog 「OK」 → 詳細ページに遷移するが、 **toast 通知が一切出ない**。 user は「click が効いた? 失敗していない?」 と一瞬迷う UX。
+
+`/articles/<slug>` の削除 flow は `toast.success("削除しました")` を出している (`client/src/components/articles/ArticleOwnerActions.tsx`) ので非対称。
+
+## 2. 直し方
+
+`client/src/components/articles/ArticleEditor.tsx` の `handleSubmit` 内、 `createArticle` / `updateArticle` の成功直後・ `router.push` の前に `toast.success(...)` を追加:
+
+```diff
+ if (mode === "create") {
+   const created = await createArticle({...});
++  toast.success(status === "published" ? "公開しました" : "下書きを保存しました");
+   router.push(`/articles/${created.slug}`);
+ } else if (initial) {
+   const updated = await updateArticle(initial.slug, {...});
++  toast.success(status === "published" ? "公開しました" : "下書きを保存しました");
+   router.push(`/articles/${updated.slug}`);
+ }
+```
+
+`toast` は既に line 31 で `import { toast } from "react-toastify"` 済 (画像 upload 通知で利用)、 追加 import 不要。
+
+メッセージは「公開しました」 / 「下書きを保存しました」 で create / update を区別しない (UX として「保存できた」 ことだけ伝われば十分、 削除 toast 「削除しました」 と対称)。
+
+### 採用しない選択肢
+
+- **toast.info() を使う**: 削除 toast が success なので一貫性を取る。
+- **「記事を更新しました」 などモードを分ける**: gan-evaluator 指摘は「保存できたか分からない」 で、 詳細度を上げると逆に SR / 視覚負荷が増えるのでシンプルに保つ。
+
+## 3. 受け入れ基準
+
+- [ ] create + draft → `toast.success("下書きを保存しました")` が呼ばれる
+- [ ] create + published → `toast.success("公開しました")` が呼ばれる
+- [ ] edit + draft → `toast.success("下書きを保存しました")`
+- [ ] edit + published → `toast.success("公開しました")`
+- [ ] エラー path (保存失敗) では toast.success は呼ばれない (既存 `setError` のみ、 regression なし)
+- [ ] vitest で 4 ケース (T-PUBLISH-1..4) 追加して緑
+
+## 4. テスト
+
+### Unit (vitest)
+
+`client/src/components/articles/__tests__/ArticleEditor.test.tsx` に 4 ケース追加:
+
+| ID          | mode   | status    | 期待 toast             |
+| ----------- | ------ | --------- | ---------------------- |
+| T-PUBLISH-1 | create | draft     | "下書きを保存しました" |
+| T-PUBLISH-2 | create | published | "公開しました"         |
+| T-PUBLISH-3 | edit   | draft     | "下書きを保存しました" |
+| T-PUBLISH-4 | edit   | published | "公開しました"         |
+
+`createArticle` / `updateArticle` を vi.hoisted で mock し、 各テストで成功 resolve を返す。 published 時の `window.confirm` は `vi.spyOn(window, "confirm").mockReturnValue(true)` で auto-accept。
+
+### Visual (Playwright MCP / stg)
+
+stg 反映後、 USER1 で `/articles/new` → published + confirm OK → `toast「公開しました」` が画面右下 (react-toastify default) に表示されるのを screenshot 確認。 同様に draft, edit, edit+publish も踏む。
+
+## 5. ロールアウト
+
+- `fix/issue-607-publish-toast` branch で PR を出し、 CI 緑なら squash merge
+- main merge 後、 stg CD で deploy → Playwright MCP / 手動で 4 case 確認
+- gan-evaluator 再採点で M1 解消を確認


### PR DESCRIPTION
## Summary

- `ArticleEditor.handleSubmit` の create / update 成功 path に `toast.success` を追加
  - `status="published"` → 「公開しました」
  - `status="draft"` → 「下書きを保存しました」
- vitest 4 ケース追加 (T-PUBLISH-1..4)
- spec: `docs/specs/articles-publish-toast-spec.md`

## 背景

`gan-evaluator` MEDIUM M1: 記事保存 / 公開時に toast が出ず、 user は「click 効いた?」 と一瞬迷う。 削除 flow は `toast.success("削除しました")` を出しているので対称化する。

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] vitest 15 件全部緑 (4 件追加)
- [ ] CI 緑
- [ ] stg merge 後、 Playwright MCP で /articles/new → 公開 → toast「公開しました」 を screenshot 確認
- [ ] 4 case (create×draft, create×publish, edit×draft, edit×publish) を実画面で確認
- [ ] gan-evaluator 再採点で M1 解消

Closes #607