### PR TITLE
fix(auth): /login submit button の透明化 bug を修正 (5 form 共通、 #609)

### DIFF
--- a/client/e2e/login-button-visibility.spec.ts
+++ b/client/e2e/login-button-visibility.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * /login submit button が視認可能か検証 (#609).
+ *
+ * gan-evaluator MEDIUM M3 で発見した「submit button が透明 / 非表示」 を回帰防止。
+ * 透明色 / 0 size は本質的に visual だが、 Playwright の visible check + computed
+ * background-color check で最低限の回帰防御を入れる。
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+test.describe("/login submit button visibility (#609)", () => {
+	test("LOGIN-1: 「ログイン」 submit button が見え、 不透明な背景を持つ", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/login`);
+
+		const button = page.getByRole("button", { name: "ログイン" });
+		await expect(button).toBeVisible({ timeout: 15000 });
+
+		// width / height が 0 ではない
+		const box = await button.boundingBox();
+		expect(box).not.toBeNull();
+		expect(box!.width).toBeGreaterThan(0);
+		expect(box!.height).toBeGreaterThan(20);
+
+		// background-color が transparent / 透明 でないことを確認 (rgba 4 要素目 > 0)
+		const bg = await button.evaluate(
+			(el) => window.getComputedStyle(el).backgroundColor,
+		);
+		// rgb(...) or rgba(..., alpha) のいずれか。 alpha が無い rgb(...) は alpha=1。
+		expect(bg).toMatch(/rgba?\([^)]+\)/);
+		expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+		expect(bg).not.toBe("transparent");
+
+		await ctx.close();
+	});
+});

--- a/client/src/components/forms/auth/LoginForm.tsx
+++ b/client/src/components/forms/auth/LoginForm.tsx
@@ -91,12 +91,12 @@ export default function LoginForm() {
 					isPassword={true}
 					link={{ linkText: "Forgot Password?", linkUrl: "/forgot-password" }}
 				/>
-				<Button
-					type="submit"
-					className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-					disabled={isLoading}
-				>
-					{isLoading ? <Spinner size="sm" /> : `Sign In`}
+				{/* #609: 以前は `h4-semibold bg-eerieBlack dark:bg-pumpkin text-white`
+				    という未定義 class を使っており、 text-white だけが効いて白文字 / 透明背景
+				    で submit button が見えなかった。 shadcn Button default variant
+				    (bg-primary / text-primary-foreground) を使い、 label も 日本語化。 */}
+				<Button type="submit" className="w-full" disabled={isLoading}>
+					{isLoading ? <Spinner size="sm" /> : "ログイン"}
 				</Button>
 			</form>
 		</main>

--- a/client/src/components/forms/auth/PasswordResetConfirmForm.tsx
+++ b/client/src/components/forms/auth/PasswordResetConfirmForm.tsx
@@ -65,11 +65,8 @@ export default function PasswordResetConfirmForm() {
 				placeholder="もう一度入力"
 				isPassword
 			/>
-			<Button
-				type="submit"
-				className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-				disabled={isSubmitting}
-			>
+			{/* #609: 未定義 class で submit button が透明だった。 default variant に統一。 */}
+			<Button type="submit" className="w-full" disabled={isSubmitting}>
 				{isSubmitting ? <Spinner size="sm" /> : "パスワードを再設定"}
 			</Button>
 		</form>

--- a/client/src/components/forms/auth/PasswordResetRequestForm.tsx
+++ b/client/src/components/forms/auth/PasswordResetRequestForm.tsx
@@ -55,11 +55,8 @@ export default function PasswordResetRequestForm() {
 				type="email"
 				startIcon={<MailIcon className="dark:text-babyPowder size-8" />}
 			/>
-			<Button
-				type="submit"
-				className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-				disabled={isSubmitting}
-			>
+			{/* #609: 未定義 class で submit button が透明だった。 default variant に統一。 */}
+			<Button type="submit" className="w-full" disabled={isSubmitting}>
 				{isSubmitting ? <Spinner size="sm" /> : "再設定リンクを送信"}
 			</Button>
 		</form>

--- a/client/src/components/forms/auth/RegisterForm.tsx
+++ b/client/src/components/forms/auth/RegisterForm.tsx
@@ -146,11 +146,9 @@ export default function RegisterForm() {
 				</span>
 			)}
 
-			<Button
-				type="submit"
-				className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-				disabled={isSubmitting}
-			>
+			{/* #609: LoginForm と同じく `bg-eerieBlack dark:bg-pumpkin` の未定義 class
+			    で submit button が透明になっていた。 default variant に揃える。 */}
+			<Button type="submit" className="w-full" disabled={isSubmitting}>
 				{isSubmitting ? <Spinner size="sm" /> : "アカウント作成"}
 			</Button>
 		</form>

--- a/client/src/components/forms/onboarding/OnboardingForm.tsx
+++ b/client/src/components/forms/onboarding/OnboardingForm.tsx
@@ -64,11 +64,8 @@ export default function OnboardingForm() {
 				placeholder="あなたについて、一言どうぞ"
 				isTextArea
 			/>
-			<Button
-				type="submit"
-				className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
-				disabled={isSubmitting}
-			>
+			{/* #609: 未定義 class で submit button が透明だった。 default variant に統一。 */}
+			<Button type="submit" className="w-full" disabled={isSubmitting}>
 				{isSubmitting ? <Spinner size="sm" /> : "はじめる"}
 			</Button>
 		</form>

--- a/docs/specs/login-button-fix-spec.md
+++ b/docs/specs/login-button-fix-spec.md
@@ -1,0 +1,90 @@
+# /login submit button が透明 / 非表示で見えない (#609)
+
+> 関連 Issue: #609
+> 関連 PR: TBD
+> 種別: bug fix (frontend, UX critical)
+
+## 1. 背景
+
+`gan-evaluator` MEDIUM M3 として発見。 Phase 6 で他の bug を踏んで anon が `/login?next=...` にリダイレクトされた際、 **submit button が透明で見えず**、 user はログインできずに詰む状態だった。
+
+Phase 6 関連の他 bug (`#606` SSR auth gate / `#608` anon 誤誘導) を 1 個直すごとに /login に飛ばされる頻度が増えるので、 ここを潰さないと「ログイン詰み」 の出口が無くなる。
+
+## 2. 原因
+
+`client/src/components/forms/auth/LoginForm.tsx:94` の `<Button>` className:
+
+```
+h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white
+```
+
+- `h4-semibold`: tailwind / globals.css に未定義 → 効かない
+- `bg-eerieBlack`: tailwind.config.ts の `colors` に **未定義** → 効かない
+- `dark:bg-pumpkin`: 同上 → 効かない
+- `text-white`: 効く → **白文字 + 透明背景** で 真っ白な login frame の上では完全に見えない
+
+shadcn `<Button>` の default variant は `bg-primary text-primary-foreground shadow hover:bg-primary/90` を当てるが、 `text-white` が `text-primary-foreground` を上書きする上に背景は無効 class のため透明になる。
+
+同じ class pattern は以下 4 ファイルでも繰り返し使われていて、 同じ問題:
+
+| ファイル                       | submit text                                 |
+| ------------------------------ | ------------------------------------------- |
+| `LoginForm.tsx`                | "Sign In" (日本語 SNS なのに英語のまま放置) |
+| `RegisterForm.tsx`             | "アカウント作成"                            |
+| `PasswordResetRequestForm.tsx` | "再設定リンクを送信"                        |
+| `PasswordResetConfirmForm.tsx` | "パスワードを再設定"                        |
+| `OnboardingForm.tsx`           | "はじめる"                                  |
+
+5 箇所 全て同じ bug。
+
+## 3. 直し方
+
+不要な未定義 class を全削除し、 shadcn `<Button>` の default variant (`bg-primary text-primary-foreground`) に任せる。 layout 用の `w-full` だけ残す:
+
+```diff
+- <Button
+-   type="submit"
+-   className="h4-semibold bg-eerieBlack dark:bg-pumpkin w-full text-white"
+-   disabled={isLoading}
+- >
+-   {isLoading ? <Spinner size="sm" /> : `Sign In`}
+- </Button>
++ <Button type="submit" className="w-full" disabled={isLoading}>
++   {isLoading ? <Spinner size="sm" /> : "ログイン"}
++ </Button>
+```
+
+LoginForm はついでに label を "Sign In" → "ログイン" に 日本語化 (日本語話者エンジニア向け SNS なので)。 他 4 form は 既に 日本語 label なので変更不要。
+
+### 採用しない選択肢
+
+- **`bg-eerieBlack` / `pumpkin` を tailwind config に定義する**: 設計意図が不明、 1 箇所しか使われていない (Pagination / UsersSearch にも見えるが装飾レベル)。 default variant に統一するほうがメンテ容易。
+- **dark mode で別 accent**: shadcn の default variant は dark mode 自動対応 (`bg-primary` は CSS variable `--primary` で切り替わる) なので追加対応不要。
+
+## 4. 受け入れ基準
+
+- [ ] `/login` で「ログイン」 submit button が **見える** (background 不透明、 boundingBox.height > 20px)
+- [ ] click → POST `/api/v1/auth/cookie/create/` → cookie 取得 → home redirect (regression なし)
+- [ ] `/register` / `/forgot-password` / `/password-reset-confirm/...` / `/onboarding` の submit button も同様に見える
+- [ ] `npx tsc --noEmit` 通過
+- [ ] Playwright e2e LOGIN-1 で button visible + background opaque を assert
+
+## 5. テスト
+
+### E2E (Playwright)
+
+`client/e2e/login-button-visibility.spec.ts` を新規追加:
+
+| ID      | シナリオ                                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| LOGIN-1 | `/login` の「ログイン」 button が visible + background-color が `rgba(0,0,0,0)` / `transparent` でない + boundingBox の height > 20px |
+
+### 手動視認 (Playwright MCP)
+
+- `/login`, `/register`, `/forgot-password`, `/onboarding` で submit button を screenshot し、 文字 + 背景が両方視認できるか目視
+
+## 6. ロールアウト
+
+- `fix/issue-609-login-button` branch で PR、 CI 緑なら squash merge
+- stg CD 反映後 `/login` を Playwright MCP で踏んで完了
+- gan-evaluator 再採点で M3 解消


### PR DESCRIPTION
## Summary

`gan-evaluator` MEDIUM M3: /login の「ログイン」 submit button が **透明** で見えず、 anon が /login にリダイレクトされたら **ログインできず詰む** 状態だった。

原因: `bg-eerieBlack dark:bg-pumpkin w-full text-white` の background color class (`bg-eerieBlack` / `pumpkin` / `h4-semibold`) が tailwind config に **未定義** で、 `text-white` だけが効いて 白文字 / 透明背景になっていた。

同じ pattern が **5 form** で重複していたので一括修正:

| ファイル | 変更後 |
|---|---|
| `LoginForm.tsx` | label "Sign In" → "ログイン"、 default variant |
| `RegisterForm.tsx` | default variant |
| `PasswordResetRequestForm.tsx` | default variant |
| `PasswordResetConfirmForm.tsx` | default variant |
| `OnboardingForm.tsx` | default variant |

## Test plan

- [x] `npx tsc --noEmit` 通過
- [ ] CI 緑
- [ ] stg merge 後、 Playwright `login-button-visibility.spec.ts` LOGIN-1 緑
- [ ] Playwright MCP / Chrome で /login, /register, /forgot-password, /onboarding を踏んで submit button が見えるか screenshot 確認
- [ ] /login → email/password 入力 → click → home redirect (regression)
- [ ] gan-evaluator 再採点で M3 解消

Closes #609