### PR TITLE
fix(auth): Google ログイン button のコントラストを修復 (PR #614 残件、 #615)

### DIFF
--- a/client/e2e/login-button-visibility.spec.ts
+++ b/client/e2e/login-button-visibility.spec.ts
@@ -38,4 +38,41 @@ test.describe("/login submit button visibility (#609)", () => {
 
 		await ctx.close();
 	});
+
+	test("LOGIN-2: Google ログイン button のコントラスト比が WCAG AA を満たす (#615)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/login`);
+
+		const button = page.getByRole("button", { name: /Google でログイン/ });
+		await expect(button).toBeVisible({ timeout: 15000 });
+
+		const { bg, fg } = await button.evaluate((el) => {
+			const cs = window.getComputedStyle(el);
+			return { bg: cs.backgroundColor, fg: cs.color };
+		});
+
+		// rgb(...) を [r,g,b] に。 contrast 計算用。
+		const parse = (s: string): [number, number, number] => {
+			const m = /(\d+(?:\.\d+)?),\s*(\d+(?:\.\d+)?),\s*(\d+(?:\.\d+)?)/.exec(s);
+			if (!m) throw new Error(`Cannot parse color: ${s}`);
+			return [Number(m[1]), Number(m[2]), Number(m[3])];
+		};
+		const luminance = (rgb: [number, number, number]) => {
+			const [r, g, b] = rgb.map((v) => {
+				const c = v / 255;
+				return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+			});
+			return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+		};
+		const l1 = luminance(parse(bg));
+		const l2 = luminance(parse(fg));
+		const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+		// WCAG AA normal text = 4.5:1 以上
+		expect(ratio).toBeGreaterThanOrEqual(4.5);
+
+		await ctx.close();
+	});
 });

--- a/client/src/components/shared/OauthButton.tsx
+++ b/client/src/components/shared/OauthButton.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import React from "react";
+
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -8,16 +9,23 @@ interface Props {
 	[rest: string]: any;
 }
 
-export default function OauthButton({ provider, children, ...rest }: Props) {
-	const className = clsx(
-		"text-babyPowder mt-3 flex-1 rounded-md px-3 py-2 font-medium",
-		{
-			"electricIndigo-gradient hover:bg-blue-700": provider === "google",
-		},
-	);
+/**
+ * Social login button. (#615)
+ *
+ * 以前は `text-babyPowder` / `electricIndigo-gradient` の未定義 Tailwind class を
+ * 当てており、 結果として 黒文字 on 紺背景 (contrast ≈ 1.06:1) で判読不能だった。
+ * shadcn `<Button>` の default variant (bg-primary / text-primary-foreground) に
+ * 統一して幅 100% で表示する。 PR #614 (5 form の透明 button 修正) と同じアプローチ。
+ */
+export default function OauthButton({
+	provider: _provider,
+	children,
+	...rest
+}: Props) {
+	const className = clsx("mt-3 w-full");
 	return (
 		<Button className={className} {...rest}>
-			<span className="flex items-center justify-start">{children}</span>
+			<span className="flex items-center justify-center gap-2">{children}</span>
 		</Button>
 	);
 }

--- a/docs/specs/oauth-button-contrast-fix-spec.md
+++ b/docs/specs/oauth-button-contrast-fix-spec.md
@@ -1,0 +1,78 @@
+# Google ログイン button のコントラスト修正 (#615)
+
+> 関連 Issue: #615
+> 関連 PR: TBD
+> 種別: a11y / UX fix (frontend)
+
+## 1. 背景
+
+`gan-evaluator` 再採点 (2026-05-11) で HIGH-NEW-1 として発見。
+
+`/login` `/register` の「Google でログイン」 button が **黒文字 on 紺背景** で計測コントラスト比 **≈ 1.06:1** (WCAG AA 4.5:1 を大幅違反)。 事実上 文字が見えず Google OAuth 経路が **死んでいた**。
+
+PR #614 (`fix(auth): /login submit button の透明化 bug を修正、 5 form 共通`) が `bg-eerieBlack` / `pumpkin` / `h4-semibold` の未定義 class を 5 form から一斉削除したが、 `client/src/components/shared/OauthButton.tsx` は scope 外で取り残されていた。
+
+## 2. 原因
+
+`OauthButton.tsx` (line 11-23):
+
+```tsx
+const className = clsx(
+	"text-babyPowder mt-3 flex-1 rounded-md px-3 py-2 font-medium",
+	{
+		"electricIndigo-gradient hover:bg-blue-700": provider === "google",
+	},
+);
+```
+
+- `text-babyPowder` → tailwind config に未定義 → 効かず、 親要素から継承された 既定色 (≈ 黒) のまま
+- `electricIndigo-gradient` → 同上、 効かず、 shadcn `<Button>` default variant の `bg-primary` (= navy CSS variable) がそのまま残る
+- 結果: navy bg + 黒文字 = コントラスト 1.06
+
+## 3. 直し方
+
+PR #614 と同じく、 未定義 class を全削除して shadcn `<Button>` の default variant に任せる。 layout 用の `w-full` だけ残す:
+
+```diff
+- const className = clsx(
+-   "text-babyPowder mt-3 flex-1 rounded-md px-3 py-2 font-medium",
+-   {
+-     "electricIndigo-gradient hover:bg-blue-700": provider === "google",
+-   },
+- );
++ const className = clsx("mt-3 w-full");
+```
+
+shadcn `<Button>` の default variant は `bg-primary text-primary-foreground` で navy bg + 白文字 → コントラスト ≈ 15+:1 (WCAG AAA も余裕)。
+
+### 採用しない選択肢
+
+- **`text-babyPowder` を tailwind config に定義する**: 既存 component (LoginForm 等) は同じ理由で全部 default variant に統一されたので、 OauthButton だけ legacy 維持しても意味がない。
+- **Google 公式 brand color (white bg / Google logo) に変更**: 採用しても良いが、 spec を超える変更で別 PR (ブランディング考慮) のほうが適切。 今回は最小修正 (contrast 違反だけ潰す) に絞る。
+
+## 4. 受け入れ基準
+
+- [ ] `/login` の「Google でログイン」 button text と background のコントラスト比 ≥ 4.5
+- [ ] `/register` でも同様
+- [ ] click → Google OAuth flow に進む (regression なし、 `onGoogleClick` handler は変更しない)
+- [ ] `npx tsc --noEmit` 通過
+- [ ] Playwright e2e `login-button-visibility.spec.ts` LOGIN-2 で WCAG AA 比率を assert (4.5:1+)
+
+## 5. テスト
+
+### E2E (Playwright)
+
+`client/e2e/login-button-visibility.spec.ts` に 1 ケース追加:
+
+| ID      | シナリオ                                                                                                                                       |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| LOGIN-2 | `/login` の Google button の computed `background-color` と `color` を取り、 相対輝度 (WCAG 2.x 式) でコントラスト比を算出。 4.5 以上を assert |
+
+### 手動視認 (Playwright MCP / Chrome)
+
+`/login` で button を screenshot → 文字「Google でログイン」 が読める + click で `/google` への OAuth redirect (regression なし)
+
+## 6. ロールアウト
+
+- `fix/issue-615-oauth-button-contrast` branch で PR、 CI 緑なら squash merge
+- stg CD 反映後 gan-evaluator 再採点で HIGH-NEW-1 解消を確認


### PR DESCRIPTION
## Summary

PR #614 の scope 漏れ。 `OauthButton.tsx` だけ `text-babyPowder` / `electricIndigo-gradient` の **未定義 class** が残っており、 Google ログイン button が **黒文字 on 紺背景 (contrast 1.06:1)** で 判読不能 + Google OAuth 経路が事実上死んでいた。

PR #614 と同じく shadcn `<Button>` default variant に統一:

```diff
- "text-babyPowder mt-3 flex-1 rounded-md px-3 py-2 font-medium"
- { "electricIndigo-gradient hover:bg-blue-700": provider === "google" }
+ "mt-3 w-full"
```

→ navy bg + 白文字 (contrast 15+:1)、 WCAG AAA も余裕でクリア。

## Test plan

- [x] `npx tsc --noEmit` 通過
- [ ] CI 緑
- [ ] stg merge 後、 Playwright `login-button-visibility.spec.ts` LOGIN-2 (computed bg/fg → コントラスト比 4.5+) 緑
- [ ] Playwright MCP で /login + /register の Google button screenshot 確認
- [ ] click → Google OAuth redirect (regression なし)
- [ ] gan-evaluator 再々採点で HIGH-NEW-1 解消

Closes #615