### PR TITLE
fix(articles): editor で title と body 先頭 h1 の重複に inline warning (#616)

### DIFF
--- a/client/src/components/articles/ArticleEditor.tsx
+++ b/client/src/components/articles/ArticleEditor.tsx
@@ -70,6 +70,31 @@ function describeApiError(err: unknown, fallback: string): string {
 }
 
 /**
+ * #616: body 先頭の h1 (`# ...`) が title と一致するなら重複表示の origin になる。
+ * editor 側で warning を出すための判定。 先頭の whitespace / blank line を許容し、
+ * trim 後の大文字小文字無視で照合する (タイポ修正の途中状態を warn し過ぎない)。
+ *
+ * 一致しない / そもそも body が `#` で始まらない時は null を返して非表示にする。
+ */
+export function detectBodyH1MatchesTitle(
+	title: string,
+	body: string,
+): string | null {
+	const t = title.trim();
+	if (!t) return null;
+	const lines = body.split("\n");
+	const firstNonBlank = lines.find((l) => l.trim().length > 0);
+	if (!firstNonBlank) return null;
+	const m = /^#\s+(.+?)\s*$/.exec(firstNonBlank.trim());
+	if (!m) return null;
+	const h1Text = m[1].trim();
+	if (h1Text.toLowerCase() === t.toLowerCase()) {
+		return h1Text;
+	}
+	return null;
+}
+
+/**
  * upload 完了で textarea の caret 位置に `![filename](url)` を挿入する。
  * 行頭・行末でない場合は前後に改行を補完して画像が文中で潰れないようにする。
  */
@@ -276,6 +301,9 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 		(r) => r.state === "queued" || r.state === "uploading",
 	);
 
+	// #616: title と body 1 行目の h1 が一致しているか。 null なら警告なし。
+	const titleH1Duplicate = detectBodyH1MatchesTitle(title, body);
+
 	return (
 		<form onSubmit={handleSubmit} className="space-y-4">
 			{error && (
@@ -403,6 +431,19 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 						画像はドラッグ&ドロップ / ペースト / 「画像を追加」 button
 						で挿入できます (jpeg / png / webp / gif、 5 MiB まで)。
 					</p>
+					{titleH1Duplicate !== null && (
+						// #616: title と body 先頭 h1 が一致するなら、 詳細ページで H1 が
+						// 重複表示されるので作者に警告。 inline で非モーダル、 author の
+						// 意図的な選択は妨げない (block しない、 publish も通す)。
+						<p
+							role="status"
+							aria-live="polite"
+							className="mt-1 rounded border border-yellow-400/60 bg-yellow-50/80 px-2 py-1 text-xs text-yellow-900 dark:border-yellow-500/30 dark:bg-yellow-900/20 dark:text-yellow-100"
+						>
+							タイトルと本文 1 行目「# {titleH1Duplicate}」 が同じです。
+							詳細ページで見出しが二重に表示される可能性があります。
+						</p>
+					)}
 				</div>
 				<div className="block">
 					<span className="block text-sm font-medium">プレビュー</span>

--- a/client/src/components/articles/__tests__/ArticleEditor.test.tsx
+++ b/client/src/components/articles/__tests__/ArticleEditor.test.tsx
@@ -12,6 +12,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ArticleEditor, {
+	detectBodyH1MatchesTitle,
 	insertImageMarkdown,
 } from "@/components/articles/ArticleEditor";
 
@@ -98,6 +99,50 @@ describe("insertImageMarkdown", () => {
 		// typescript-reviewer H-1 反映: [/]/\\ を全て除去して malformed markdown
 		// (`![[shot.png](url)`) にならないようにする。
 		expect(result.next).toBe("![shot.png](https://cdn.example.com/foo.png)");
+	});
+});
+
+describe("detectBodyH1MatchesTitle (#616)", () => {
+	it("T-H1-DUP-1 body 先頭 h1 が title と完全一致 → h1 text を返す", () => {
+		expect(detectBodyH1MatchesTitle("Hello", "# Hello\n\nbody")).toBe("Hello");
+	});
+
+	it("T-H1-DUP-2 大文字小文字無視で一致判定", () => {
+		expect(detectBodyH1MatchesTitle("Hello", "# hello\n\nbody")).toBe("hello");
+	});
+
+	it("T-H1-DUP-3 title の前後 whitespace を許容", () => {
+		expect(detectBodyH1MatchesTitle("  Hello  ", "# Hello\n\nbody")).toBe(
+			"Hello",
+		);
+	});
+
+	it("T-H1-DUP-4 body 先頭の blank line を許容", () => {
+		expect(detectBodyH1MatchesTitle("Hello", "\n\n# Hello\n\nbody")).toBe(
+			"Hello",
+		);
+	});
+
+	it("T-H1-DUP-5 body が h2 (##) で始まる場合は null", () => {
+		expect(detectBodyH1MatchesTitle("Hello", "## Hello\n\nbody")).toBeNull();
+	});
+
+	it("T-H1-DUP-6 title と h1 text が違うなら null", () => {
+		expect(detectBodyH1MatchesTitle("Hello", "# World\n\nbody")).toBeNull();
+	});
+
+	it("T-H1-DUP-7 body に h1 が無いなら null", () => {
+		expect(
+			detectBodyH1MatchesTitle("Hello", "body without heading"),
+		).toBeNull();
+	});
+
+	it("T-H1-DUP-8 title が空文字なら null (誤検知防止)", () => {
+		expect(detectBodyH1MatchesTitle("", "# Hello\n\nbody")).toBeNull();
+	});
+
+	it("T-H1-DUP-9 body が空文字なら null", () => {
+		expect(detectBodyH1MatchesTitle("Hello", "")).toBeNull();
 	});
 });
 

--- a/docs/specs/articles-title-h1-duplicate-spec.md
+++ b/docs/specs/articles-title-h1-duplicate-spec.md
@@ -1,0 +1,73 @@
+# 記事 title と body 先頭 h1 の重複警告 (#616)
+
+> 関連 Issue: #616
+> 関連 PR: TBD
+> 種別: UX fix (frontend)
+
+## 1. 背景
+
+`gan-evaluator` 再採点 (2026-05-11) MEDIUM-NEW-1: 記事詳細で title が body 先頭 `# title` と同じだと **H1 が二重に描画** され、 視覚的に違和感がある。
+
+実例として E2E 投稿で test 用に「タイトル == body の `# タイトル`」 だった record が stg に複数あり、 詳細ページで `<h1>EDIT-LOOP-1 self</h1>` の直下に また `<h1>EDIT-LOOP-1 self</h1>` が出ていた。
+
+## 2. 採用するアプローチ
+
+**editor で inline warning を出す (silent strip しない)**。
+
+- author の意図的な選択は妨げない (warning のみで publish はブロックしない)
+- render 時に勝手に消すと「なぜ消えたか分からない」 magic 動作 (option 2) — 採用しない
+- 検出条件: body の最初の non-blank 行が `# <text>` で、 `<text>` を trim + lowercase した値が title の trim + lowercase と一致する場合のみ
+
+判定は pure function `detectBodyH1MatchesTitle(title, body) -> string | null` に切り出して unit test しやすくする。
+
+### Warning の表示
+
+body textarea の help 文 (`画像はドラッグ&ドロップ…`) の下に黄色の info bar:
+
+> タイトルと本文 1 行目「# <h1 text>」 が同じです。 詳細ページで見出しが二重に表示される可能性があります。
+
+`role="status"` + `aria-live="polite"` で screen reader にも通知。
+
+## 3. 採用しない選択肢
+
+- **render 時に body 先頭 h1 を strip**: 上記の通り magic 動作。 「なぜ消えた?」 サポート question が増える。
+- **publish を block**: 重複 h1 は accessibility 違反ではない (heading 順序破綻するわけではない)。 推奨度低の cosmetic な指摘なので block は過剰。
+- **toast で警告**: toast は ephemeral で気付かないことがある。 inline で常時表示のほうが UX 良い。
+
+## 4. 受け入れ基準
+
+- [ ] editor で title=「Hello」、 body 1 行目=「# Hello」 のとき warning が表示
+- [ ] body=「# hello」 (大文字小文字 違い) でも warning (lowercase 比較)
+- [ ] body 1 行目が「## Hello」 (h2) なら warning **無し**
+- [ ] body 1 行目が「# World」 (text 違い) なら warning 無し
+- [ ] body が空 / title が空 のときは warning 無し (誤検知防止)
+- [ ] warning が出ても publish は通る (block しない)
+- [ ] vitest で 9 ケース (T-H1-DUP-1..9) 緑
+
+## 5. テスト
+
+### Unit (vitest)
+
+`detectBodyH1MatchesTitle` の 9 ケース:
+
+| ID         | 条件                                           | 期待    |
+| ---------- | ---------------------------------------------- | ------- |
+| T-H1-DUP-1 | title=Hello, body=`# Hello\n\nbody`            | "Hello" |
+| T-H1-DUP-2 | title=Hello, body=`# hello\n\nbody` (大小違い) | "hello" |
+| T-H1-DUP-3 | title=`  Hello  ` (前後 ws)                    | "Hello" |
+| T-H1-DUP-4 | body 先頭 blank line `\n\n# Hello`             | "Hello" |
+| T-H1-DUP-5 | h2 (`## Hello`)                                | null    |
+| T-H1-DUP-6 | h1 text 違い (`# World`)                       | null    |
+| T-H1-DUP-7 | h1 なし                                        | null    |
+| T-H1-DUP-8 | title 空                                       | null    |
+| T-H1-DUP-9 | body 空                                        | null    |
+
+### 視認 (Playwright MCP / stg)
+
+stg merge 後、 `/articles/new` で title=「Hello」 + body=`# Hello`\n本文 を入力 → 黄色 warning bar が表示。 body を「# 概要」 に変えると消える。 重複 published 記事 (例 EDIT-LOOP-1) の詳細ページに行って `<h1>` が依然 2 個並ぶ (silent strip しないため意図通り) ことを確認。
+
+## 6. ロールアウト
+
+- `fix/issue-616-title-h1-duplicate` branch で PR、 CI 緑 → squash merge
+- stg CD 反映後 Playwright MCP で warning 表示確認
+- gan-evaluator 再採点で MEDIUM-NEW-1 解消 (warning 設置で「気付ける」 状態) を確認


### PR DESCRIPTION
## Summary

`gan-evaluator` MEDIUM-NEW-1: 記事詳細で title が body 先頭 `# title` と一致すると H1 が二重描画されて違和感。 silent strip (magic 動作) は避け、 editor 側に inline 警告に留める。

- `detectBodyH1MatchesTitle(title, body)` pure helper を export
- body textarea help 文の下に 黄色 info bar
- 判定: body 1 行目が `# <text>`、 trim + lowercase が title と一致
- vitest 9 ケース (T-H1-DUP-1..9) で大小違い / blank line / h2 / 空文字 を網羅
- spec: `docs/specs/articles-title-h1-duplicate-spec.md`

publish は block しない (warning のみ)。

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] vitest 24 件全緑 (9 件追加)
- [ ] CI 緑
- [ ] stg merge 後 Playwright MCP で /articles/new に title「Hello」+ body「# Hello」 を入力 → 黄色 warning が出るか
- [ ] body を「# 概要」 に変えると warning が消える
- [ ] gan-evaluator 再採点で MEDIUM-NEW-1 解消

Closes #616