### PR TITLE
feat(mentorship): apps/mentorship app scaffold (P11-01)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 566
+        "line_number": 568
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-11T07:44:31Z"
+  "generated_at": "2026-05-13T02:23:43Z"
 }

--- a/apps/mentorship/__init__.py
+++ b/apps/mentorship/__init__.py
@@ -1,0 +1,8 @@
+"""Phase 11: メンターマッチング (Menta ライク) app.
+
+spec: ``docs/specs/phase-11-mentor-board-spec.md``
+
+P11-01 では INSTALLED_APPS 登録 + scaffold のみ。 model / API は P11-02 以降。
+"""
+
+default_app_config = "apps.mentorship.apps.MentorshipConfig"

--- a/apps/mentorship/admin.py
+++ b/apps/mentorship/admin.py
@@ -1,0 +1,4 @@
+"""Admin registration for mentorship models.
+
+P11-01: 空 scaffold。 admin は model 追加と同じ後続 Issue で登録。
+"""

--- a/apps/mentorship/apps.py
+++ b/apps/mentorship/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+
+class MentorshipConfig(AppConfig):
+    """AppConfig for the mentorship app (Phase 11).
+
+    P11-01 では空 scaffold。 model / signal / admin は後続 Issue で追加。
+    spec: ``docs/specs/phase-11-mentor-board-spec.md``
+    """
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.mentorship"
+    verbose_name = "メンターマッチング"

--- a/apps/mentorship/models.py
+++ b/apps/mentorship/models.py
@@ -1,0 +1,12 @@
+"""Mentorship models (Phase 11).
+
+P11-01: 空 scaffold。 各 model は後続 Issue で追加:
+- P11-02: MentorRequest
+- P11-04: MentorProposal
+- P11-05: MentorshipContract
+- P11-11: MentorProfile
+- P11-12: MentorPlan
+- P11-20: MentorReview
+
+spec: ``docs/specs/phase-11-mentor-board-spec.md`` §4
+"""

--- a/apps/mentorship/serializers.py
+++ b/apps/mentorship/serializers.py
@@ -1,0 +1,4 @@
+"""DRF serializers for mentorship models.
+
+P11-01: 空 scaffold。 serializer は後続 Issue で追加。
+"""

--- a/apps/mentorship/tests/test_scaffold.py
+++ b/apps/mentorship/tests/test_scaffold.py
@@ -1,0 +1,20 @@
+"""Smoke tests for apps.mentorship scaffold (P11-01)."""
+
+import pytest
+from django.apps import apps as django_apps
+
+
+@pytest.mark.django_db
+def test_mentorship_app_is_registered():
+    """INSTALLED_APPS に apps.mentorship が含まれており、 AppConfig が解決できる。"""
+    config = django_apps.get_app_config("mentorship")
+    assert config.name == "apps.mentorship"
+    assert config.verbose_name == "メンターマッチング"
+
+
+def test_mentorship_urls_module_importable():
+    """urls module が import できる (空 router でも OK)。"""
+    from apps.mentorship import urls
+
+    # default router で空 patterns、 import エラー無し
+    assert urls.urlpatterns is not None

--- a/apps/mentorship/urls.py
+++ b/apps/mentorship/urls.py
@@ -1,0 +1,15 @@
+"""URL routing for /api/v1/mentor/... endpoints.
+
+P11-01: 空 router。 endpoint は後続 Issue で追加。
+"""
+
+from rest_framework.routers import DefaultRouter
+
+router = DefaultRouter()
+# Future:
+# router.register(r"requests", MentorRequestViewSet, basename="mentor-request")
+# router.register(r"proposals", MentorProposalViewSet, basename="mentor-proposal")
+# router.register(r"contracts", MentorshipContractViewSet, basename="mentor-contract")
+# (P11-13 で /mentors/ は別 prefix で config/urls.py 直接 register)
+
+urlpatterns = router.urls

--- a/apps/mentorship/views.py
+++ b/apps/mentorship/views.py
@@ -1,0 +1,10 @@
+"""DRF viewsets for mentorship endpoints.
+
+P11-01: 空 scaffold。 viewset 実体は後続 Issue で追加:
+- P11-03: MentorRequestViewSet
+- P11-04: MentorProposalViewSet
+- P11-05: accept_proposal action
+- P11-13: MentorSearchViewSet
+- P11-17: contract complete / cancel
+- P11-20: MentorReviewViewSet
+"""

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -119,6 +119,8 @@ LOCAL_APPS = [
     "apps.bots",
     "apps.billing",
     "apps.search",
+    # Phase 11: メンターマッチング (P11-01)。 model 実装は P11-02 以降。
+    "apps.mentorship",
 ]
 
 # --- Channels / Daphne (P3-02 / Issue #227) ---

--- a/config/urls.py
+++ b/config/urls.py
@@ -85,6 +85,8 @@ urlpatterns = [
     path("api/v1/search/", include("apps.search.urls")),
     # P2-08: タイムライン (home / following / explore)
     path("api/v1/timeline/", include("apps.timeline.urls")),
+    # P11-01: メンターマッチング (Phase 11)。 endpoint は P11-03 以降で追加。
+    path("api/v1/mentor/", include("apps.mentorship.urls")),
 ]
 
 # Sentry smoke test endpoint (P0-06). DEBUG=True の環境だけ URL 登録すること自体を


### PR DESCRIPTION
## Summary

Phase 11 メンターマッチング機能の **最初の Issue** (P11-01)。 INSTALLED_APPS 登録 + 空 scaffold だけ。 model / API は後続 Issue (P11-02 以降) で追加。

- `apps/mentorship/{__init__,apps,models,admin,views,urls,serializers}.py` 新設
- `apps/mentorship/tests/test_scaffold.py` smoke test 2 件
- `config/settings/base.py` LOCAL_APPS に登録
- `config/urls.py` に `/api/v1/mentor/` include

## Test plan

- [x] `python manage.py check` 通過
- [x] `pytest apps/mentorship/` 2 件 GREEN
- [x] 既存 DM tests 202 件 PASS (regression なし)
- [ ] CI 緑

## 関連

- spec: `docs/specs/phase-11-mentor-board-spec.md` §3.1 §4
- milestone: Phase 11: メンターマッチング (#14)
- 後続: P11-02 (MentorRequest model), P11-11 (MentorProfile model) など

Closes #620