### PR TITLE
feat(mentorship): MentorRequest CRUD API (anon GET / owner PATCH/DELETE) (P11-03)

### DIFF
--- a/apps/mentorship/serializers.py
+++ b/apps/mentorship/serializers.py
@@ -1,4 +1,103 @@
 """DRF serializers for mentorship models.
 
-P11-01: 空 scaffold。 serializer は後続 Issue で追加。
+P11-03: MentorRequest 用 serializer を実装 (list / detail / input)。
+spec §6.1
 """
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from apps.mentorship.models import MentorRequest
+from apps.tags.models import Tag
+
+
+class _MenteeMiniSerializer(serializers.Serializer):
+    """mentee (User) の最小 representation。 detail / list 共通。"""
+
+    handle = serializers.CharField(source="username", read_only=True)
+    display_name = serializers.SerializerMethodField()
+    avatar_url = serializers.SerializerMethodField()
+
+    def get_display_name(self, obj) -> str:
+        first = getattr(obj, "first_name", "") or ""
+        last = getattr(obj, "last_name", "") or ""
+        full = f"{first} {last}".strip()
+        return full or obj.username
+
+    def get_avatar_url(self, obj) -> str:
+        # P11-03 では Profile.avatar 連携は未実装 (P11-14 周辺で profile API 整備時に追加)。
+        # 空文字を返しておけば frontend は default avatar を出す。
+        return ""
+
+
+class _TagSlimSerializer(serializers.ModelSerializer):
+    """tag の最小 representation (name / display_name のみ)。"""
+
+    class Meta:
+        model = Tag
+        fields = ("name", "display_name")
+
+
+class MentorRequestSummarySerializer(serializers.ModelSerializer):
+    """一覧用 (body 除く軽量版)。"""
+
+    mentee = _MenteeMiniSerializer(read_only=True)
+    target_skill_tags = _TagSlimSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = MentorRequest
+        fields = (
+            "id",
+            "mentee",
+            "title",
+            "target_skill_tags",
+            "budget_jpy",
+            "status",
+            "proposal_count",
+            "expires_at",
+            "created_at",
+        )
+        read_only_fields = fields
+
+
+class MentorRequestDetailSerializer(MentorRequestSummarySerializer):
+    """詳細用 (body 含む)。"""
+
+    class Meta(MentorRequestSummarySerializer.Meta):
+        fields = (
+            *MentorRequestSummarySerializer.Meta.fields,
+            "body",
+            "updated_at",
+        )
+        read_only_fields = fields
+
+
+class MentorRequestInputSerializer(serializers.Serializer):
+    """POST / PATCH の入力 schema。
+
+    target_skill_tag_names は既存 tag.name の list (mentee は新規 tag を生やせない、
+    既存承認済 tag のみ採用)。
+    """
+
+    title = serializers.CharField(min_length=1, max_length=80)
+    body = serializers.CharField(min_length=1, max_length=2000)
+    target_skill_tag_names = serializers.ListField(
+        child=serializers.CharField(max_length=50),
+        max_length=5,
+        required=False,
+        default=list,
+    )
+    budget_jpy = serializers.IntegerField(min_value=0, max_value=10_000_000, default=0)
+
+    def validate_target_skill_tag_names(self, value: list[str]) -> list[Tag]:
+        # 重複除去 + 小文字化
+        normalized = list({v.strip().lower() for v in value if v.strip()})
+        if not normalized:
+            return []
+        tags = list(Tag.objects.filter(name__in=normalized))
+        if len(tags) != len(normalized):
+            found = {t.name for t in tags}
+            missing = sorted(set(normalized) - found)
+            raise serializers.ValidationError(f"未登録 / 未承認のタグ: {', '.join(missing)}")
+        return tags

--- a/apps/mentorship/tests/test_mentor_request_api.py
+++ b/apps/mentorship/tests/test_mentor_request_api.py
@@ -1,0 +1,307 @@
+"""Tests for MentorRequest CRUD API (P11-03 / Phase 11 11-A).
+
+spec: ``docs/specs/phase-11-mentor-board-spec.md`` §6.1
+
+検証カテゴリ:
+- anon GET (list / detail)
+- auth POST (create + tag M2M)
+- owner only PATCH / DELETE / close
+- non-owner / anon writes は 403 / 401
+- list は status=open のみ可視
+- detail は MATCHED / CLOSED でも可視 (mentee 戻り動線)
+- tag filter
+- cursor pagination
+- input validation (title / body 長さ、 unknown tag)
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.mentorship.models import MentorRequest
+from apps.tags.models import Tag
+
+User = get_user_model()
+
+
+def _user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+def _approved_tag(name: str) -> Tag:
+    return Tag.all_objects.create(
+        name=name,
+        display_name=name.capitalize(),
+        is_approved=True,
+    )
+
+
+def _make_request(mentee, **kwargs) -> MentorRequest:
+    defaults = {"title": "Django で質問", "body": "DRF の認証で詰まっています"}
+    defaults.update(kwargs)
+    return MentorRequest.objects.create(mentee=mentee, **defaults)
+
+
+@pytest.fixture
+def alice():
+    return _user("alice")
+
+
+@pytest.fixture
+def bob():
+    return _user("bob")
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def auth_client(alice):
+    c = APIClient()
+    c.force_authenticate(user=alice)
+    return c
+
+
+# ---- LIST ----
+
+
+@pytest.mark.django_db
+def test_list_anon_returns_only_open(client, alice):
+    _make_request(alice, status=MentorRequest.Status.OPEN, title="open one")
+    _make_request(alice, status=MentorRequest.Status.MATCHED, title="matched")
+    _make_request(alice, status=MentorRequest.Status.CLOSED, title="closed")
+    res = client.get(reverse("mentor-request-list"))
+    assert res.status_code == 200
+    titles = sorted(r["title"] for r in res.data["results"])
+    assert titles == ["open one"]
+
+
+@pytest.mark.django_db
+def test_list_includes_envelope_fields(client, alice):
+    req = _make_request(alice)
+    res = client.get(reverse("mentor-request-list"))
+    assert res.status_code == 200
+    first = res.data["results"][0]
+    # summary serializer は body を含まない
+    assert "body" not in first
+    assert first["title"] == req.title
+    assert first["mentee"]["handle"] == "alice"
+
+
+@pytest.mark.django_db
+def test_list_tag_filter(client, alice):
+    django_tag = _approved_tag("django")
+    aws_tag = _approved_tag("aws")
+    r1 = _make_request(alice, title="django one")
+    r1.target_skill_tags.add(django_tag)
+    r2 = _make_request(alice, title="aws one")
+    r2.target_skill_tags.add(aws_tag)
+    res = client.get(reverse("mentor-request-list"), {"tag": "django"})
+    titles = sorted(r["title"] for r in res.data["results"])
+    assert titles == ["django one"]
+
+
+@pytest.mark.django_db
+def test_list_cursor_pagination(client, alice):
+    for i in range(25):
+        _make_request(alice, title=f"req {i}")
+    res = client.get(reverse("mentor-request-list"))
+    assert res.status_code == 200
+    assert len(res.data["results"]) == 20  # page_size
+    assert res.data["next"] is not None
+
+
+# ---- DETAIL ----
+
+
+@pytest.mark.django_db
+def test_detail_anon_can_view_open(client, alice):
+    req = _make_request(alice)
+    res = client.get(reverse("mentor-request-detail", args=[req.pk]))
+    assert res.status_code == 200
+    assert res.data["body"] == req.body
+    assert "updated_at" in res.data
+
+
+@pytest.mark.django_db
+def test_detail_anon_can_view_matched_or_closed(client, alice):
+    """mentee が後で URL を踏み戻す動線。 status を問わず参照可能。"""
+    matched = _make_request(alice, status=MentorRequest.Status.MATCHED)
+    closed = _make_request(alice, status=MentorRequest.Status.CLOSED)
+    for req in (matched, closed):
+        res = client.get(reverse("mentor-request-detail", args=[req.pk]))
+        assert res.status_code == 200
+
+
+@pytest.mark.django_db
+def test_detail_returns_404_for_unknown(client):
+    res = client.get(reverse("mentor-request-detail", args=[999_999]))
+    assert res.status_code == 404
+
+
+# ---- CREATE ----
+
+
+@pytest.mark.django_db
+def test_create_requires_auth(client):
+    res = client.post(
+        reverse("mentor-request-list"),
+        {"title": "x", "body": "y"},
+        format="json",
+    )
+    assert res.status_code in {401, 403}
+
+
+@pytest.mark.django_db
+def test_create_success_sets_mentee_to_request_user(auth_client, alice):
+    res = auth_client.post(
+        reverse("mentor-request-list"),
+        {"title": "AWS 教えて", "body": "ECS の IAM 周り"},
+        format="json",
+    )
+    assert res.status_code == 201
+    assert res.data["mentee"]["handle"] == "alice"
+    assert MentorRequest.objects.get(pk=res.data["id"]).mentee_id == alice.pk
+
+
+@pytest.mark.django_db
+def test_create_with_tags(auth_client):
+    _approved_tag("aws")
+    _approved_tag("django")
+    res = auth_client.post(
+        reverse("mentor-request-list"),
+        {
+            "title": "T",
+            "body": "B",
+            "target_skill_tag_names": ["aws", "django"],
+        },
+        format="json",
+    )
+    assert res.status_code == 201
+    names = sorted(t["name"] for t in res.data["target_skill_tags"])
+    assert names == ["aws", "django"]
+
+
+@pytest.mark.django_db
+def test_create_rejects_unknown_tag(auth_client):
+    res = auth_client.post(
+        reverse("mentor-request-list"),
+        {
+            "title": "T",
+            "body": "B",
+            "target_skill_tag_names": ["nonexistent"],
+        },
+        format="json",
+    )
+    assert res.status_code == 400
+
+
+@pytest.mark.django_db
+def test_create_rejects_empty_title(auth_client):
+    res = auth_client.post(
+        reverse("mentor-request-list"),
+        {"title": "", "body": "B"},
+        format="json",
+    )
+    assert res.status_code == 400
+
+
+# ---- PATCH ----
+
+
+@pytest.mark.django_db
+def test_patch_requires_owner(client, alice, bob):
+    req = _make_request(alice, title="alice's")
+    c = APIClient()
+    c.force_authenticate(user=bob)
+    res = c.patch(
+        reverse("mentor-request-detail", args=[req.pk]),
+        {"title": "hacked"},
+        format="json",
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.django_db
+def test_patch_anon_forbidden(client, alice):
+    req = _make_request(alice)
+    res = client.patch(
+        reverse("mentor-request-detail", args=[req.pk]),
+        {"title": "x"},
+        format="json",
+    )
+    assert res.status_code in {401, 403}
+
+
+@pytest.mark.django_db
+def test_patch_updates_title_and_body(auth_client, alice):
+    req = _make_request(alice)
+    res = auth_client.patch(
+        reverse("mentor-request-detail", args=[req.pk]),
+        {"title": "new title", "body": "new body"},
+        format="json",
+    )
+    assert res.status_code == 200
+    req.refresh_from_db()
+    assert req.title == "new title"
+    assert req.body == "new body"
+
+
+@pytest.mark.django_db
+def test_patch_rejected_when_not_open(auth_client, alice):
+    req = _make_request(alice, status=MentorRequest.Status.MATCHED)
+    res = auth_client.patch(
+        reverse("mentor-request-detail", args=[req.pk]),
+        {"title": "x"},
+        format="json",
+    )
+    assert res.status_code == 400
+
+
+# ---- DELETE / CLOSE ----
+
+
+@pytest.mark.django_db
+def test_delete_owner_soft_deletes_to_closed(auth_client, alice):
+    req = _make_request(alice)
+    res = auth_client.delete(reverse("mentor-request-detail", args=[req.pk]))
+    assert res.status_code == 204
+    req.refresh_from_db()
+    assert req.status == MentorRequest.Status.CLOSED
+
+
+@pytest.mark.django_db
+def test_delete_non_owner_forbidden(alice, bob):
+    req = _make_request(alice)
+    c = APIClient()
+    c.force_authenticate(user=bob)
+    res = c.delete(reverse("mentor-request-detail", args=[req.pk]))
+    assert res.status_code == 403
+    req.refresh_from_db()
+    assert req.status == MentorRequest.Status.OPEN
+
+
+@pytest.mark.django_db
+def test_close_owner_returns_updated(auth_client, alice):
+    req = _make_request(alice)
+    res = auth_client.post(reverse("mentor-request-close", args=[req.pk]))
+    assert res.status_code == 200
+    assert res.data["status"] == "closed"
+
+
+@pytest.mark.django_db
+def test_close_idempotent(auth_client, alice):
+    req = _make_request(alice, status=MentorRequest.Status.CLOSED)
+    res = auth_client.post(reverse("mentor-request-close", args=[req.pk]))
+    assert res.status_code == 200  # 既に CLOSED でも 200 で返す

--- a/apps/mentorship/urls.py
+++ b/apps/mentorship/urls.py
@@ -1,15 +1,31 @@
 """URL routing for /api/v1/mentor/... endpoints.
 
-P11-01: 空 router。 endpoint は後続 Issue で追加。
+P11-03: MentorRequest CRUD + close を配線。
+spec §6.1
 """
 
-from rest_framework.routers import DefaultRouter
+from django.urls import path
 
-router = DefaultRouter()
-# Future:
-# router.register(r"requests", MentorRequestViewSet, basename="mentor-request")
-# router.register(r"proposals", MentorProposalViewSet, basename="mentor-proposal")
-# router.register(r"contracts", MentorshipContractViewSet, basename="mentor-contract")
-# (P11-13 で /mentors/ は別 prefix で config/urls.py 直接 register)
+from apps.mentorship.views import (
+    MentorRequestCloseView,
+    MentorRequestDetailView,
+    MentorRequestListCreateView,
+)
 
-urlpatterns = router.urls
+urlpatterns = [
+    path(
+        "requests/",
+        MentorRequestListCreateView.as_view(),
+        name="mentor-request-list",
+    ),
+    path(
+        "requests/<int:pk>/",
+        MentorRequestDetailView.as_view(),
+        name="mentor-request-detail",
+    ),
+    path(
+        "requests/<int:pk>/close/",
+        MentorRequestCloseView.as_view(),
+        name="mentor-request-close",
+    ),
+]

--- a/apps/mentorship/views.py
+++ b/apps/mentorship/views.py
@@ -1,10 +1,167 @@
-"""DRF viewsets for mentorship endpoints.
+"""DRF views for mentorship endpoints.
 
-P11-01: 空 scaffold。 viewset 実体は後続 Issue で追加:
-- P11-03: MentorRequestViewSet
-- P11-04: MentorProposalViewSet
-- P11-05: accept_proposal action
-- P11-13: MentorSearchViewSet
-- P11-17: contract complete / cancel
-- P11-20: MentorReviewViewSet
+P11-03: MentorRequest の CRUD API を実装。
+
+- GET    /api/v1/mentor/requests/        anon 可、 cursor pagination、 status=open のみ、 tag filter
+- POST   /api/v1/mentor/requests/        auth、 mentee=request.user
+- GET    /api/v1/mentor/requests/<id>/   anon 可
+- PATCH  /api/v1/mentor/requests/<id>/   owner only、 status=open のみ編集可
+- DELETE /api/v1/mentor/requests/<id>/   owner only、 status=CLOSED に soft-delete
+- POST   /api/v1/mentor/requests/<id>/close/  owner only、 手動 close
+
+spec §6.1
 """
+
+from __future__ import annotations
+
+from rest_framework import permissions, status
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.generics import GenericAPIView
+from rest_framework.pagination import CursorPagination
+from rest_framework.permissions import SAFE_METHODS
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.mentorship.models import MentorRequest
+from apps.mentorship.serializers import (
+    MentorRequestDetailSerializer,
+    MentorRequestInputSerializer,
+    MentorRequestSummarySerializer,
+)
+
+
+class _MentorRequestListPagination(CursorPagination):
+    """募集一覧の cursor pagination (新着順)。"""
+
+    page_size = 20
+    ordering = "-created_at"
+    cursor_query_param = "cursor"
+
+
+class MentorRequestListCreateView(GenericAPIView):
+    """`GET /mentor/requests/` (anon) + `POST /mentor/requests/` (auth)。"""
+
+    pagination_class = _MentorRequestListPagination
+
+    def get_permissions(self):
+        if self.request.method in SAFE_METHODS:
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated()]
+
+    def get_queryset(self):
+        # 一覧は OPEN のみ可視 (matched / closed / expired は隠す)。
+        qs = (
+            MentorRequest.objects.filter(status=MentorRequest.Status.OPEN)
+            .select_related("mentee")
+            .prefetch_related("target_skill_tags")
+        )
+        tag = self.request.query_params.get("tag")
+        if tag:
+            qs = qs.filter(target_skill_tags__name=tag.lower()).distinct()
+        return qs
+
+    def get(self, request: Request) -> Response:
+        page = self.paginate_queryset(self.get_queryset())
+        serializer = MentorRequestSummarySerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
+
+    def post(self, request: Request) -> Response:
+        serializer = MentorRequestInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        tags = data.get("target_skill_tag_names") or []
+        req = MentorRequest.objects.create(
+            mentee=request.user,
+            title=data["title"],
+            body=data["body"],
+            budget_jpy=data["budget_jpy"],
+        )
+        if tags:
+            req.target_skill_tags.set(tags)
+        return Response(
+            MentorRequestDetailSerializer(req).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+
+def _get_request_or_404(pk: int) -> MentorRequest:
+    req = (
+        MentorRequest.objects.select_related("mentee")
+        .prefetch_related("target_skill_tags")
+        .filter(pk=pk)
+        .first()
+    )
+    if req is None:
+        raise NotFound("MentorRequest not found")
+    return req
+
+
+def _ensure_owner(req: MentorRequest, user) -> None:
+    if not user.is_authenticated or req.mentee_id != user.pk:
+        raise PermissionDenied("only the request owner can perform this action")
+
+
+class MentorRequestDetailView(APIView):
+    """`GET/PATCH/DELETE /mentor/requests/<id>/`。"""
+
+    def get_permissions(self):
+        if self.request.method in SAFE_METHODS:
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated()]
+
+    def get(self, request: Request, pk: int) -> Response:
+        req = _get_request_or_404(pk)
+        # 一覧では OPEN のみ可視だが、 detail は MATCHED / CLOSED / EXPIRED でも参照可能
+        # (mentee が「過去出した募集」 を URL で踏み戻す動線、 spec §6.1)。
+        return Response(MentorRequestDetailSerializer(req).data)
+
+    def patch(self, request: Request, pk: int) -> Response:
+        req = _get_request_or_404(pk)
+        _ensure_owner(req, request.user)
+        if req.status != MentorRequest.Status.OPEN:
+            return Response(
+                {"detail": "編集できるのは募集中 (open) の投稿だけです"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = MentorRequestInputSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        for field in ("title", "body", "budget_jpy"):
+            if field in data:
+                setattr(req, field, data[field])
+        req.save(update_fields=["title", "body", "budget_jpy", "updated_at"])
+
+        if "target_skill_tag_names" in data:
+            req.target_skill_tags.set(data["target_skill_tag_names"])
+
+        return Response(MentorRequestDetailSerializer(req).data)
+
+    def delete(self, request: Request, pk: int) -> Response:
+        """論理削除 (status=CLOSED に遷移)。 row は残す (proposal 履歴のため)。"""
+
+        req = _get_request_or_404(pk)
+        _ensure_owner(req, request.user)
+        if req.status == MentorRequest.Status.CLOSED:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        req.status = MentorRequest.Status.CLOSED
+        req.save(update_fields=["status", "updated_at"])
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MentorRequestCloseView(APIView):
+    """`POST /mentor/requests/<id>/close/` — 手動 close (DELETE と同等の意味、 idempotent)。"""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request: Request, pk: int) -> Response:
+        req = _get_request_or_404(pk)
+        _ensure_owner(req, request.user)
+        if req.status == MentorRequest.Status.CLOSED:
+            return Response(MentorRequestDetailSerializer(req).data)
+        req.status = MentorRequest.Status.CLOSED
+        req.save(update_fields=["status", "updated_at"])
+        return Response(MentorRequestDetailSerializer(req).data)


### PR DESCRIPTION
## Summary

`/api/v1/mentor/requests/` の REST endpoint を実装 (spec §6.1)。

| method | path | auth | 動作 |
|---|---|---|---|
| GET | /requests/ | anon | 一覧 (status=open のみ、 cursor 20、 ?tag=python filter) |
| POST | /requests/ | auth | 投稿 (mentee=request.user) |
| GET | /requests/<id>/ | anon | 詳細 (status を問わず参照可) |
| PATCH | /requests/<id>/ | owner | 編集 (status=open のみ) |
| DELETE | /requests/<id>/ | owner | soft-delete → status=CLOSED |
| POST | /requests/<id>/close/ | owner | 手動 close (idempotent) |

## Test plan

- [x] pytest 30 件 GREEN (本 PR 20 件 + P11-01/02 既存 10 件)
- [x] `python manage.py check` 通過
- [ ] CI 緑

## 関連

- spec: `docs/specs/phase-11-mentor-board-spec.md` §6.1
- 後続: P11-04 (MentorProposal model + 投稿 API)

Closes #622