### PR TITLE
feat(mentorship): /mentor/wanted 一覧 + /mentor/wanted/new (P11-06)

### DIFF
--- a/client/src/app/(template)/mentor/wanted/new/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/new/page.tsx
@@ -1,0 +1,65 @@
+/**
+ * /mentor/wanted/new — mentee が募集を投稿 (P11-06 / Phase 11 11-A).
+ *
+ * auth 必須。 PR #606 で確立した SSR auth gate と同流儀で、 cookie 未保持なら
+ * /login?next=/mentor/wanted/new に redirect。
+ *
+ * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import MentorRequestForm from "@/components/mentorship/MentorRequestForm";
+
+export const metadata: Metadata = {
+	title: "メンター募集を出す — エンジニア SNS",
+	robots: { index: false },
+};
+
+export default function NewMentorRequestPage() {
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	if (!isAuthenticated) {
+		redirect("/login?next=/mentor/wanted/new");
+	}
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/mentor/wanted"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 募集一覧
+				</Link>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						メンター募集を出す
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						相談したい内容を簡潔に。 mentor が提案を返してきます。
+					</p>
+				</div>
+			</header>
+			<div className="p-5">
+				<MentorRequestForm />
+			</div>
+		</>
+	);
+}

--- a/client/src/app/(template)/mentor/wanted/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/page.tsx
@@ -1,0 +1,162 @@
+/**
+ * /mentor/wanted — メンター募集 board 一覧 (P11-06 / Phase 11 11-A).
+ *
+ * 匿名閲覧可。 SSR で公開募集 (status=open) 一覧を fetch。 sticky header に
+ * 「募集を出す」 CTA を auth のみで表示、 anon は「ログインして募集する」 で
+ * /login?next=/mentor/wanted/new に誘導 (PR #608 ALeftNav 「投稿する」 CTA と
+ * 同流儀)。
+ *
+ * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { Feather, Handshake } from "lucide-react";
+
+import {
+	listMentorRequests,
+	type MentorRequestSummary,
+} from "@/lib/api/mentor";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+
+export const metadata: Metadata = {
+	title: "メンター募集 — エンジニア SNS",
+	description:
+		"エンジニア SNS のメンター募集 board。 学習中の人が現役エンジニアに 1 on 1 で教わりたい内容を投稿、 mentor が提案を出して契約成立で DM が始まります。",
+};
+
+async function fetchListSSR(
+	tag: string | undefined,
+): Promise<MentorRequestSummary[]> {
+	try {
+		const qs = tag ? `?tag=${encodeURIComponent(tag)}` : "";
+		const page = await serverFetch<{
+			results: MentorRequestSummary[];
+			next: string | null;
+			previous: string | null;
+		}>(`/mentor/requests/${qs}`);
+		return page.results ?? [];
+	} catch (err) {
+		// anon 可 endpoint なので 401 で empty fallback。 backend が落ちている時も
+		// page は empty state で render する (article 一覧 / drafts と同流儀)。
+		if (err instanceof ApiServerError) return [];
+		return [];
+	}
+}
+
+interface PageProps {
+	searchParams?: { tag?: string };
+}
+
+export default async function MentorWantedListPage({
+	searchParams,
+}: PageProps) {
+	const items = await fetchListSSR(searchParams?.tag);
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+
+	const filterDescription = searchParams?.tag
+		? `#${searchParams.tag} で募集中`
+		: "募集中の相談";
+
+	return (
+		<>
+			<header
+				aria-label="メンター募集 board ヘッダー"
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Handshake
+					className="size-4 text-[color:var(--a-accent)]"
+					aria-hidden="true"
+				/>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						メンター募集
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{filterDescription}
+					</p>
+				</div>
+				<Link
+					href={
+						isAuthenticated
+							? "/mentor/wanted/new"
+							: "/login?next=/mentor/wanted/new"
+					}
+					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
+				>
+					<Feather className="size-3.5" aria-hidden="true" />
+					{isAuthenticated ? "募集を出す" : "ログインして募集する"}
+				</Link>
+			</header>
+
+			<div className="p-5">
+				{items.length === 0 ? (
+					<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
+						{searchParams?.tag
+							? `#${searchParams.tag} の募集はまだありません。`
+							: "まだ募集がありません。 最初の募集を投稿してみませんか?"}
+					</p>
+				) : (
+					<ul role="list" className="grid gap-3">
+						{items.map((req) => (
+							<li key={req.id}>
+								<MentorRequestCard request={req} />
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</>
+	);
+}
+
+function MentorRequestCard({ request }: { request: MentorRequestSummary }) {
+	return (
+		<Link
+			href={`/mentor/wanted/${request.id}`}
+			aria-label={`募集 ${request.title} を開く`}
+			className="block rounded-lg border border-[color:var(--a-border)] p-4 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+		>
+			<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">
+				<span>@{request.mentee.handle}</span>
+				<span aria-hidden="true">·</span>
+				<time dateTime={request.created_at}>
+					{new Date(request.created_at).toLocaleDateString("ja-JP")}
+				</time>
+				<span aria-hidden="true">·</span>
+				<span>提案 {request.proposal_count} 件</span>
+			</div>
+			<h2
+				className="mt-1 truncate font-semibold"
+				style={{ fontSize: 15, letterSpacing: -0.1 }}
+			>
+				{request.title}
+			</h2>
+			{request.target_skill_tags.length > 0 && (
+				<ul aria-label="関連スキル" className="mt-2 flex flex-wrap gap-1">
+					{request.target_skill_tags.map((t) => (
+						<li
+							key={t.name}
+							className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
+						>
+							#{t.display_name}
+						</li>
+					))}
+				</ul>
+			)}
+		</Link>
+	);
+}

--- a/client/src/components/mentorship/MentorRequestForm.tsx
+++ b/client/src/components/mentorship/MentorRequestForm.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+/**
+ * MentorRequestForm (P11-06).
+ *
+ * mentee が `/mentor/wanted/new` で投稿する form。 title (1-80) + body (1-2000) +
+ * target_skill_tag_names (csv) のシンプル構成。 成功で詳細ページに遷移 + toast。
+ *
+ * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ */
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { toast } from "react-toastify";
+
+import { createMentorRequest } from "@/lib/api/mentor";
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { data?: Record<string, unknown> };
+			message?: string;
+		};
+		const data = e.response?.data;
+		if (data && typeof data === "object") {
+			const detail = (data as { detail?: string }).detail;
+			if (typeof detail === "string") return detail;
+			const firstField = Object.values(data)[0];
+			if (Array.isArray(firstField) && typeof firstField[0] === "string") {
+				return firstField[0];
+			}
+			if (typeof firstField === "string") return firstField;
+		}
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function MentorRequestForm() {
+	const router = useRouter();
+	const [title, setTitle] = useState("");
+	const [body, setBody] = useState("");
+	const [tagsInput, setTagsInput] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const tags = tagsInput
+		.split(/[,\s]+/)
+		.map((s) => s.trim())
+		.filter(Boolean);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		const trimmedTitle = title.trim();
+		const trimmedBody = body.trim();
+		if (!trimmedTitle) {
+			setError("タイトルを入力してください");
+			return;
+		}
+		if (!trimmedBody) {
+			setError("本文を入力してください");
+			return;
+		}
+		setSubmitting(true);
+		try {
+			const created = await createMentorRequest({
+				title: trimmedTitle,
+				body: trimmedBody,
+				target_skill_tag_names: tags,
+			});
+			toast.success("募集を投稿しました");
+			router.push(`/mentor/wanted/${created.id}`);
+		} catch (err) {
+			setError(describeApiError(err, "投稿に失敗しました"));
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<form
+			onSubmit={handleSubmit}
+			className="space-y-4"
+			aria-label="メンター募集フォーム"
+		>
+			{error && (
+				<p
+					role="alert"
+					className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+				>
+					{error}
+				</p>
+			)}
+
+			<label className="block">
+				<span className="block text-sm font-medium">タイトル</span>
+				<input
+					type="text"
+					value={title}
+					onChange={(e) => setTitle(e.target.value)}
+					maxLength={80}
+					required
+					placeholder="例: Django + DRF の認証回りで詰まっています"
+					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+			</label>
+
+			<label className="block">
+				<span className="block text-sm font-medium">本文</span>
+				<textarea
+					value={body}
+					onChange={(e) => setBody(e.target.value)}
+					maxLength={2000}
+					rows={10}
+					required
+					placeholder={
+						"相談したい内容を詳しく書いてください。\n- 現状とゴール\n- 試したこと\n- どこで詰まっているか"
+					}
+					className="mt-1 h-[14rem] w-full rounded border border-border bg-background p-3 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+				<p className="mt-1 text-xs text-muted-foreground">
+					{body.length} / 2000 文字
+				</p>
+			</label>
+
+			<label className="block">
+				<span className="block text-sm font-medium">
+					関連スキル (カンマ区切り、 既存タグのみ。 最大 5 個)
+				</span>
+				<input
+					type="text"
+					value={tagsInput}
+					onChange={(e) => setTagsInput(e.target.value)}
+					placeholder="例: django, drf, python"
+					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+				{tags.length > 0 && (
+					<ul aria-label="入力中のタグ" className="mt-1 flex flex-wrap gap-1">
+						{tags.map((t) => (
+							<li
+								key={t}
+								className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+							>
+								#{t}
+							</li>
+						))}
+					</ul>
+				)}
+			</label>
+
+			<button
+				type="submit"
+				disabled={submitting}
+				className="rounded-full bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+			>
+				{submitting ? "投稿中…" : "募集を投稿する"}
+			</button>
+		</form>
+	);
+}

--- a/client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx
+++ b/client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for MentorRequestForm (P11-06).
+ *
+ * 検証:
+ *   T-MENTOR-FORM-1 empty title で submit すると role=alert で警告、 createMentorRequest は呼ばれない
+ *   T-MENTOR-FORM-2 empty body で submit すると role=alert で警告
+ *   T-MENTOR-FORM-3 正常入力で createMentorRequest が呼ばれ toast + router.push
+ *   T-MENTOR-FORM-4 タグ csv は trim + 空除去で配列化される
+ *   T-MENTOR-FORM-5 API エラーで error が表示される (router.push しない)
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import MentorRequestForm from "@/components/mentorship/MentorRequestForm";
+
+const { routerPushMock } = vi.hoisted(() => ({ routerPushMock: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: routerPushMock, refresh: vi.fn() }),
+}));
+
+const { toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+	toastSuccessMock: vi.fn(),
+	toastErrorMock: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessMock, error: toastErrorMock },
+}));
+
+const { createMentorRequestMock } = vi.hoisted(() => ({
+	createMentorRequestMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/mentor", () => ({
+	createMentorRequest: createMentorRequestMock,
+}));
+
+describe("MentorRequestForm (P11-06)", () => {
+	beforeEach(() => {
+		routerPushMock.mockReset();
+		toastSuccessMock.mockReset();
+		toastErrorMock.mockReset();
+		createMentorRequestMock.mockReset();
+	});
+
+	const fillForm = (title: string, body: string, tags = "") => {
+		fireEvent.change(screen.getByLabelText(/タイトル/, { selector: "input" }), {
+			target: { value: title },
+		});
+		fireEvent.change(screen.getByLabelText(/^本文/, { selector: "textarea" }), {
+			target: { value: body },
+		});
+		if (tags) {
+			fireEvent.change(
+				screen.getByLabelText(/関連スキル/, { selector: "input" }),
+				{
+					target: { value: tags },
+				},
+			);
+		}
+	};
+
+	it("T-MENTOR-FORM-1 empty title はクライアント側で reject", async () => {
+		render(<MentorRequestForm />);
+		fillForm("", "body has content");
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+		});
+		expect(screen.getByRole("alert").textContent).toMatch(/タイトル/);
+		expect(createMentorRequestMock).not.toHaveBeenCalled();
+	});
+
+	it("T-MENTOR-FORM-2 empty body も同様に reject", async () => {
+		render(<MentorRequestForm />);
+		fillForm("title", "");
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+		});
+		expect(screen.getByRole("alert").textContent).toMatch(/本文/);
+		expect(createMentorRequestMock).not.toHaveBeenCalled();
+	});
+
+	it("T-MENTOR-FORM-3 正常 submit で API call + toast + redirect", async () => {
+		createMentorRequestMock.mockResolvedValueOnce({ id: 42, title: "Hello" });
+		render(<MentorRequestForm />);
+		fillForm("Hello", "body content");
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+		});
+		expect(createMentorRequestMock).toHaveBeenCalledWith({
+			title: "Hello",
+			body: "body content",
+			target_skill_tag_names: [],
+		});
+		expect(toastSuccessMock).toHaveBeenCalledWith("募集を投稿しました");
+		expect(routerPushMock).toHaveBeenCalledWith("/mentor/wanted/42");
+	});
+
+	it("T-MENTOR-FORM-4 タグ csv は trim + 空除去で配列化", async () => {
+		createMentorRequestMock.mockResolvedValueOnce({ id: 1 });
+		render(<MentorRequestForm />);
+		fillForm("t", "b", "  django ,  drf, ,  python ");
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+		});
+		expect(createMentorRequestMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				target_skill_tag_names: ["django", "drf", "python"],
+			}),
+		);
+	});
+
+	it("T-MENTOR-FORM-5 API エラーで error 表示 + redirect しない", async () => {
+		createMentorRequestMock.mockRejectedValueOnce({
+			response: { data: { detail: "未登録 / 未承認のタグ: foo" } },
+		});
+		render(<MentorRequestForm />);
+		fillForm("t", "b", "foo");
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+		});
+		expect(screen.getByRole("alert").textContent).toMatch(/未登録/);
+		expect(routerPushMock).not.toHaveBeenCalled();
+	});
+});

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -13,6 +13,7 @@ import {
 	CircleUser,
 	Compass,
 	FileText,
+	Handshake,
 	Home,
 	MessageSquare,
 	MessagesSquare,
@@ -37,6 +38,7 @@ const ICON_MAP: Record<
 	Bell,
 	MessagesSquare,
 	FileText,
+	Handshake,
 };
 
 /** isProfile link は self handle を埋めて返す。handle 未取得時は null。 */

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -15,6 +15,7 @@ import {
 	Bell,
 	Compass,
 	FileText,
+	Handshake,
 	Home,
 	MessageSquare,
 	MessagesSquare,
@@ -38,6 +39,7 @@ const ICON_MAP: Record<
 	Bell,
 	MessagesSquare,
 	FileText,
+	Handshake,
 };
 
 function resolveLinkPath(

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -53,6 +53,13 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "FileText",
 	},
 	{
+		// Phase 11 (#625 / P11-06): mentor 募集 board。 匿名閲覧可。
+		// CLAUDE.md §9 「ホームから 3 click 以内で到達」 反省で LeftNav に追加。
+		path: "/mentor/wanted",
+		label: "メンター募集",
+		iconName: "Handshake",
+	},
+	{
 		// path は LeftNavbar 側で `/u/<self.handle>` に動的に組み替える
 		path: "",
 		label: "プロフィール",

--- a/client/src/lib/api/mentor.ts
+++ b/client/src/lib/api/mentor.ts
@@ -1,0 +1,142 @@
+/**
+ * Mentor 募集 board API client (Phase 11 11-A).
+ *
+ * spec: docs/specs/phase-11-mentor-board-spec.md §6.1, §6.2
+ */
+
+import type { AxiosInstance } from "axios";
+
+import { api } from "./client";
+
+export type MentorRequestStatus = "open" | "matched" | "closed" | "expired";
+
+export type MentorProposalStatus =
+	| "pending"
+	| "accepted"
+	| "rejected"
+	| "withdrawn";
+
+export type MentorshipContractStatus = "active" | "completed" | "canceled";
+
+export interface MentorMiniUser {
+	handle: string;
+	display_name: string;
+	avatar_url: string;
+}
+
+export interface MentorTagSlim {
+	name: string;
+	display_name: string;
+}
+
+export interface MentorRequestSummary {
+	id: number;
+	mentee: MentorMiniUser;
+	title: string;
+	target_skill_tags: MentorTagSlim[];
+	budget_jpy: number;
+	status: MentorRequestStatus;
+	proposal_count: number;
+	expires_at: string;
+	created_at: string;
+}
+
+export interface MentorRequestDetail extends MentorRequestSummary {
+	body: string;
+	updated_at: string;
+}
+
+export interface MentorProposal {
+	id: number;
+	request: number;
+	mentor: MentorMiniUser;
+	body: string;
+	status: MentorProposalStatus;
+	responded_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface MentorshipContractDetail {
+	id: number;
+	proposal: number;
+	mentee: MentorMiniUser;
+	mentor: MentorMiniUser;
+	plan_snapshot: Record<string, unknown>;
+	status: MentorshipContractStatus;
+	room_id: number;
+	started_at: string;
+	completed_at: string | null;
+	is_paid: boolean;
+	paid_amount_jpy: number;
+	updated_at: string;
+}
+
+interface PageResponse<T> {
+	results: T[];
+	next: string | null;
+	previous: string | null;
+}
+
+export async function listMentorRequests(
+	params: { tag?: string; cursor?: string } = {},
+	client: AxiosInstance = api,
+): Promise<PageResponse<MentorRequestSummary>> {
+	const qs = new URLSearchParams();
+	if (params.tag) qs.set("tag", params.tag);
+	if (params.cursor) qs.set("cursor", params.cursor);
+	const path =
+		qs.toString().length > 0
+			? `/mentor/requests/?${qs.toString()}`
+			: "/mentor/requests/";
+	const res = await client.get<PageResponse<MentorRequestSummary>>(path);
+	return res.data;
+}
+
+export async function getMentorRequest(
+	pk: number,
+	client: AxiosInstance = api,
+): Promise<MentorRequestDetail> {
+	const res = await client.get<MentorRequestDetail>(`/mentor/requests/${pk}/`);
+	return res.data;
+}
+
+export interface CreateMentorRequestInput {
+	title: string;
+	body: string;
+	target_skill_tag_names?: string[];
+	budget_jpy?: number;
+}
+
+export async function createMentorRequest(
+	input: CreateMentorRequestInput,
+	client: AxiosInstance = api,
+): Promise<MentorRequestDetail> {
+	const res = await client.post<MentorRequestDetail>(
+		"/mentor/requests/",
+		input,
+	);
+	return res.data;
+}
+
+export async function createMentorProposal(
+	requestId: number,
+	body: string,
+	client: AxiosInstance = api,
+): Promise<MentorProposal> {
+	const res = await client.post<MentorProposal>(
+		`/mentor/requests/${requestId}/proposals/`,
+		{ body },
+	);
+	return res.data;
+}
+
+export async function acceptMentorProposal(
+	proposalId: number,
+	client: AxiosInstance = api,
+): Promise<MentorshipContractDetail> {
+	const res = await client.post<MentorshipContractDetail>(
+		`/mentor/proposals/${proposalId}/accept/`,
+	);
+	return res.data;
+}

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -8,7 +8,8 @@ export type LeftNavIconName =
 	| "User"
 	| "Bell"
 	| "MessagesSquare"
-	| "FileText";
+	| "FileText"
+	| "Handshake";
 
 export interface LeftNavLink {
 	/** 静的 path。`isProfile=true` の時は無視され self handle を組み立てる。 */


### PR DESCRIPTION
## Summary

frontend: メンター募集 board の入口ページ + 投稿フォーム (spec §7)。

- `/mentor/wanted` (anon 可): SSR list fetch + sticky header CTA
- `/mentor/wanted/new` (auth required): PR #606 と同流儀の SSR auth gate
- `MentorRequestForm`: title / body / タグ csv、 submit で toast + redirect
- LeftNavbar / MobileNavbar に「メンター募集」 link + Handshake icon
- `lib/api/mentor.ts`: 全 endpoint の typed helper

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] vitest 5 件 GREEN (MentorRequestForm)
- [x] LeftNavbar test 7 件 regression PASS
- [ ] CI 緑

## 関連

- spec: `docs/specs/phase-11-mentor-board-spec.md` §7
- 後続: P11-07 (`/mentor/wanted/<id>` 詳細 + accept) + P11-08 (RoomChat banner) + P11-09 (E2E)

Closes #625