### PR TITLE
feat(mentorship): /mentor/wanted/<id> 詳細 + proposal form + accept (P11-07)

### DIFF
--- a/apps/mentorship/tests/test_mentor_proposal_api.py
+++ b/apps/mentorship/tests/test_mentor_proposal_api.py
@@ -72,7 +72,7 @@ def test_anon_cannot_propose(alice, bob):
     req = _open_request(alice)
     c = APIClient()
     res = c.post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "I can mentor you"},
         format="json",
     )
@@ -83,7 +83,7 @@ def test_anon_cannot_propose(alice, bob):
 def test_self_proposal_forbidden(alice):
     req = _open_request(alice)
     res = _auth(alice).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "I propose to myself"},
         format="json",
     )
@@ -94,7 +94,7 @@ def test_self_proposal_forbidden(alice):
 @pytest.mark.django_db
 def test_404_when_request_missing(bob):
     res = _auth(bob).post(
-        reverse("mentor-proposal-create", args=[999_999]),
+        reverse("mentor-proposal-list", args=[999_999]),
         {"body": "hi"},
         format="json",
     )
@@ -105,7 +105,7 @@ def test_404_when_request_missing(bob):
 def test_empty_body_rejected(alice, bob):
     req = _open_request(alice)
     res = _auth(bob).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": ""},
         format="json",
     )
@@ -127,7 +127,7 @@ def test_empty_body_rejected(alice, bob):
 def test_cannot_propose_to_non_open_request(alice, bob, status_value):
     req = _open_request(alice, status=status_value)
     res = _auth(bob).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "hi"},
         format="json",
     )
@@ -141,7 +141,7 @@ def test_cannot_propose_to_non_open_request(alice, bob, status_value):
 def test_create_proposal_success(alice, bob):
     req = _open_request(alice)
     res = _auth(bob).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "I can help. AWS infra で 10 年経験あります。"},
         format="json",
     )
@@ -159,7 +159,7 @@ def test_proposal_count_incremented(alice, bob):
     req = _open_request(alice)
     assert req.proposal_count == 0
     _auth(bob).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "x"},
         format="json",
     )
@@ -174,14 +174,14 @@ def test_proposal_count_incremented(alice, bob):
 def test_unique_request_mentor_pair(alice, bob):
     req = _open_request(alice)
     res1 = _auth(bob).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "first"},
         format="json",
     )
     assert res1.status_code == 201
     # 2 回目は unique 違反で 400
     res2 = _auth(bob).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "second"},
         format="json",
     )
@@ -195,12 +195,12 @@ def test_unique_request_mentor_pair(alice, bob):
 def test_different_mentors_can_propose_to_same_request(alice, bob, carol):
     req = _open_request(alice)
     res_bob = _auth(bob).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "from bob"},
         format="json",
     )
     res_carol = _auth(carol).post(
-        reverse("mentor-proposal-create", args=[req.pk]),
+        reverse("mentor-proposal-list", args=[req.pk]),
         {"body": "from carol"},
         format="json",
     )

--- a/apps/mentorship/urls.py
+++ b/apps/mentorship/urls.py
@@ -8,7 +8,7 @@ from django.urls import path
 
 from apps.mentorship.views import (
     MentorProposalAcceptView,
-    MentorProposalCreateView,
+    MentorProposalListCreateView,
     MentorRequestCloseView,
     MentorRequestDetailView,
     MentorRequestListCreateView,
@@ -30,11 +30,11 @@ urlpatterns = [
         MentorRequestCloseView.as_view(),
         name="mentor-request-close",
     ),
-    # P11-04: mentor が提案を出す。
+    # P11-04/P11-07: GET = owner が proposal list を取得 / POST = mentor が提案投稿
     path(
         "requests/<int:request_id>/proposals/",
-        MentorProposalCreateView.as_view(),
-        name="mentor-proposal-create",
+        MentorProposalListCreateView.as_view(),
+        name="mentor-proposal-list",
     ),
     # P11-05: mentee が proposal を accept → Contract + DMRoom 自動作成。
     path(

--- a/apps/mentorship/views.py
+++ b/apps/mentorship/views.py
@@ -173,27 +173,40 @@ class MentorRequestCloseView(APIView):
         return Response(MentorRequestDetailSerializer(req).data)
 
 
-# --- MentorProposal (P11-04) ---
+# --- MentorProposal (P11-04 + P11-07 list) ---
 
 
-class MentorProposalCreateView(APIView):
-    """`POST /mentor/requests/<request_id>/proposals/` — mentor が提案を出す。
+class MentorProposalListCreateView(APIView):
+    """`/mentor/requests/<request_id>/proposals/` — GET (owner only) + POST (auth)。
 
     spec §6.2。
-    - auth 必須
-    - mentor == request.mentee は禁止 (自分の募集に提案できない)
-    - request.status == OPEN のみ受付
-    - 1 request に 1 mentor は 1 proposal のみ (unique constraint)
-    - 提案投稿成功で request.proposal_count を atomic に +1
+    - GET: owner (request.mentee) のみ可視、 新着順 proposal list
+    - POST: auth 必須、 self-proposal 禁止、 request.status==OPEN のみ受付、
+      1 request 1 mentor 1 proposal の unique constraint、 成功で proposal_count +1
     """
 
     permission_classes = [permissions.IsAuthenticated]
 
-    def post(self, request: Request, request_id: int) -> Response:
+    def _get_request(self, request_id: int) -> MentorRequest:
         try:
-            mentor_request = MentorRequest.objects.select_related("mentee").get(pk=request_id)
+            return MentorRequest.objects.select_related("mentee").get(pk=request_id)
         except MentorRequest.DoesNotExist as exc:
             raise NotFound("MentorRequest not found") from exc
+
+    def get(self, request: Request, request_id: int) -> Response:
+        mentor_request = self._get_request(request_id)
+        _ensure_owner(mentor_request, request.user)
+        proposals = (
+            MentorProposal.objects.select_related("mentor")
+            .filter(request=mentor_request)
+            .order_by("-created_at")
+        )
+        return Response(
+            MentorProposalDetailSerializer(proposals, many=True).data,
+        )
+
+    def post(self, request: Request, request_id: int) -> Response:
+        mentor_request = self._get_request(request_id)
 
         # 自分の募集には提案できない
         if mentor_request.mentee_id == request.user.pk:

--- a/client/src/app/(template)/mentor/wanted/[id]/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/[id]/page.tsx
@@ -1,0 +1,198 @@
+/**
+ * /mentor/wanted/<id> — メンター募集詳細 (P11-07 / Phase 11 11-A).
+ *
+ * anon 可閲覧。 status を問わず詳細は見える (mentee が「過去出した募集」 を踏み戻せる)。
+ * - anon: 本文 + mentee + tags のみ表示、 「ログインして提案する」 CTA
+ * - mentor (auth、 non-owner): proposal 投稿 form
+ * - owner (mentee): 受信した proposal 一覧 + accept button
+ *
+ * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
+
+import MentorProposalForm from "@/components/mentorship/MentorProposalForm";
+import MentorProposalList from "@/components/mentorship/MentorProposalList";
+import {
+	type MentorProposal,
+	type MentorRequestDetail,
+} from "@/lib/api/mentor";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+
+interface PageProps {
+	params: { id: string };
+}
+
+interface CurrentUserMini {
+	username: string;
+}
+
+async function fetchRequest(pk: number): Promise<MentorRequestDetail | null> {
+	try {
+		return await serverFetch<MentorRequestDetail>(`/mentor/requests/${pk}/`);
+	} catch (err) {
+		if (err instanceof ApiServerError && err.status === 404) return null;
+		throw err;
+	}
+}
+
+async function fetchCurrentUser(): Promise<CurrentUserMini | null> {
+	try {
+		return await serverFetch<CurrentUserMini>("/users/me/");
+	} catch {
+		return null;
+	}
+}
+
+async function fetchOwnerProposals(pk: number): Promise<MentorProposal[]> {
+	// owner のみ叩ける endpoint。 anon / 他人は 403。 try/catch で 403 を握る。
+	try {
+		return await serverFetch<MentorProposal[]>(
+			`/mentor/requests/${pk}/proposals/`,
+		);
+	} catch {
+		return [];
+	}
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const pk = Number.parseInt(params.id, 10);
+	if (!Number.isFinite(pk)) return { title: "募集 — エンジニア SNS" };
+	const req = await fetchRequest(pk);
+	if (!req) return { title: "募集が見つかりません" };
+	return {
+		title: `${req.title} — メンター募集`,
+		description: req.body.slice(0, 160),
+		robots: req.status === "open" ? undefined : { index: false },
+	};
+}
+
+export default async function MentorRequestDetailPage({ params }: PageProps) {
+	const pk = Number.parseInt(params.id, 10);
+	if (!Number.isFinite(pk)) notFound();
+
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+
+	const [req, currentUser] = await Promise.all([
+		fetchRequest(pk),
+		isAuthenticated ? fetchCurrentUser() : Promise.resolve(null),
+	]);
+	if (!req) notFound();
+
+	const isOwner =
+		currentUser !== null && currentUser.username === req.mentee.handle;
+	const isMentorCandidate = isAuthenticated && !isOwner;
+
+	const proposals = isOwner ? await fetchOwnerProposals(pk) : [];
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/mentor/wanted"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 募集一覧
+				</Link>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						{req.title}
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						@{req.mentee.handle} ·{" "}
+						{req.status === "open"
+							? "募集中"
+							: req.status === "matched"
+								? "成立済"
+								: req.status === "closed"
+									? "終了"
+									: "期限切れ"}
+					</p>
+				</div>
+			</header>
+
+			<div className="space-y-6 p-5">
+				<article aria-label="募集本文" className="space-y-3">
+					<div className="whitespace-pre-wrap text-sm text-[color:var(--a-text)]">
+						{req.body}
+					</div>
+					{req.target_skill_tags.length > 0 && (
+						<ul aria-label="関連スキル" className="flex flex-wrap gap-1">
+							{req.target_skill_tags.map((t) => (
+								<li
+									key={t.name}
+									className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
+								>
+									#{t.display_name}
+								</li>
+							))}
+						</ul>
+					)}
+				</article>
+
+				{/* 役割別 UI */}
+				{!isAuthenticated && req.status === "open" && (
+					<aside
+						className="rounded-lg border border-[color:var(--a-border)] p-4 text-sm"
+						aria-label="ログイン誘導"
+					>
+						<p className="mb-2 text-[color:var(--a-text-muted)]">
+							この募集に提案するにはログインが必要です。
+						</p>
+						<Link
+							href={`/login?next=/mentor/wanted/${req.id}`}
+							className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white"
+							style={{ background: "var(--a-accent)", fontSize: 12.5 }}
+						>
+							ログインして提案する
+						</Link>
+					</aside>
+				)}
+
+				{isMentorCandidate && req.status === "open" && (
+					<section
+						aria-label="提案フォーム"
+						className="rounded-lg border border-[color:var(--a-border)] p-4"
+					>
+						<h2 className="mb-3 text-sm font-semibold">この募集に提案する</h2>
+						<MentorProposalForm requestId={req.id} />
+					</section>
+				)}
+
+				{isOwner && (
+					<section
+						aria-label="受信した提案"
+						className="rounded-lg border border-[color:var(--a-border)] p-4"
+					>
+						<h2 className="mb-3 text-sm font-semibold">
+							受信した提案 ({proposals.length} 件)
+						</h2>
+						<MentorProposalList
+							proposals={proposals}
+							requestStatus={req.status}
+						/>
+					</section>
+				)}
+			</div>
+		</>
+	);
+}

--- a/client/src/components/mentorship/MentorProposalForm.tsx
+++ b/client/src/components/mentorship/MentorProposalForm.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * MentorProposalForm (P11-07).
+ *
+ * mentor (非 owner) が `/mentor/wanted/<id>` で proposal を投稿する form。
+ * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ */
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { toast } from "react-toastify";
+
+import { createMentorProposal } from "@/lib/api/mentor";
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { data?: Record<string, unknown> };
+			message?: string;
+		};
+		const data = e.response?.data;
+		if (data && typeof data === "object") {
+			const detail = (data as { detail?: string }).detail;
+			if (typeof detail === "string") return detail;
+		}
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function MentorProposalForm({
+	requestId,
+}: {
+	requestId: number;
+}) {
+	const router = useRouter();
+	const [body, setBody] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [submitted, setSubmitted] = useState(false);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		const trimmed = body.trim();
+		if (!trimmed) {
+			setError("提案文を入力してください");
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await createMentorProposal(requestId, trimmed);
+			toast.success("提案を送信しました");
+			setSubmitted(true);
+			setBody("");
+			router.refresh();
+		} catch (err) {
+			setError(describeApiError(err, "提案の送信に失敗しました"));
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	if (submitted) {
+		return (
+			<p
+				role="status"
+				className="rounded border border-[color:var(--a-border)] bg-[color:var(--a-bg-muted)] px-3 py-2 text-sm text-[color:var(--a-text-muted)]"
+			>
+				提案を送信しました。 mentee が accept すると DM ルームが開きます。
+			</p>
+		);
+	}
+
+	return (
+		<form
+			onSubmit={handleSubmit}
+			aria-label="メンター提案フォーム"
+			className="space-y-3"
+		>
+			{error && (
+				<p
+					role="alert"
+					className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+				>
+					{error}
+				</p>
+			)}
+			<label className="block">
+				<span className="block text-sm font-medium">提案文</span>
+				<textarea
+					value={body}
+					onChange={(e) => setBody(e.target.value)}
+					maxLength={2000}
+					rows={6}
+					required
+					placeholder={
+						"例: AWS infra を 10 年やっています。 ECS の IAM 周りなら 30 分の単発でも対応可能です。"
+					}
+					className="mt-1 h-[10rem] w-full rounded border border-border bg-background p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+				<p className="mt-1 text-xs text-muted-foreground">
+					{body.length} / 2000 文字
+				</p>
+			</label>
+			<button
+				type="submit"
+				disabled={submitting}
+				className="rounded-full bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+			>
+				{submitting ? "送信中…" : "提案を送る"}
+			</button>
+		</form>
+	);
+}

--- a/client/src/components/mentorship/MentorProposalList.tsx
+++ b/client/src/components/mentorship/MentorProposalList.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * MentorProposalList (P11-07).
+ *
+ * request owner が受信した proposal 一覧を表示し、 PENDING の proposal は
+ * 「accept」 ボタンで契約成立 → DM ルーム遷移。
+ *
+ * spec §6.2, §7
+ */
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+import {
+	acceptMentorProposal,
+	type MentorProposal,
+	type MentorRequestStatus,
+} from "@/lib/api/mentor";
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { data?: Record<string, unknown> };
+			message?: string;
+		};
+		const data = e.response?.data;
+		if (data && typeof data === "object") {
+			const detail = (data as { detail?: string }).detail;
+			if (typeof detail === "string") return detail;
+		}
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function MentorProposalList({
+	proposals,
+	requestStatus,
+}: {
+	proposals: MentorProposal[];
+	requestStatus: MentorRequestStatus;
+}) {
+	const router = useRouter();
+	const [acceptingId, setAcceptingId] = useState<number | null>(null);
+
+	if (proposals.length === 0) {
+		return (
+			<p className="text-sm text-[color:var(--a-text-muted)]">
+				まだ提案は届いていません。
+			</p>
+		);
+	}
+
+	const handleAccept = async (proposalId: number) => {
+		setAcceptingId(proposalId);
+		try {
+			const contract = await acceptMentorProposal(proposalId);
+			toast.success("契約成立しました。 DM ルームに移動します。");
+			router.push(`/messages/${contract.room_id}`);
+		} catch (err) {
+			toast.error(describeApiError(err, "accept に失敗しました"));
+			setAcceptingId(null);
+		}
+	};
+
+	return (
+		<ul role="list" className="space-y-3">
+			{proposals.map((p) => (
+				<li
+					key={p.id}
+					className="rounded-lg border border-[color:var(--a-border)] p-3"
+				>
+					<div className="flex items-center justify-between gap-3">
+						<div className="min-w-0 flex-1">
+							<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">
+								<span>@{p.mentor.handle}</span>
+								<span aria-hidden="true">·</span>
+								<time dateTime={p.created_at}>
+									{new Date(p.created_at).toLocaleString("ja-JP")}
+								</time>
+								<span aria-hidden="true">·</span>
+								<span>
+									{p.status === "pending"
+										? "保留中"
+										: p.status === "accepted"
+											? "成立済"
+											: p.status === "rejected"
+												? "却下"
+												: "取下げ"}
+								</span>
+							</div>
+							<p className="mt-2 whitespace-pre-wrap text-sm text-[color:var(--a-text)]">
+								{p.body}
+							</p>
+						</div>
+						{requestStatus === "open" && p.status === "pending" && (
+							<button
+								type="button"
+								onClick={() => handleAccept(p.id)}
+								disabled={acceptingId !== null}
+								className="shrink-0 rounded-full bg-primary px-4 py-1.5 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+								aria-label={`@${p.mentor.handle} の提案を accept`}
+							>
+								{acceptingId === p.id ? "成立中…" : "accept"}
+							</button>
+						)}
+					</div>
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/client/src/components/mentorship/__tests__/MentorProposalForm.test.tsx
+++ b/client/src/components/mentorship/__tests__/MentorProposalForm.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for MentorProposalForm (P11-07).
+ *
+ * 検証:
+ *   T-PROP-FORM-1 空 body は client side で reject
+ *   T-PROP-FORM-2 正常 submit で createMentorProposal + toast + 「送信済」 表示
+ *   T-PROP-FORM-3 unique 違反 API エラーで error 表示
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import MentorProposalForm from "@/components/mentorship/MentorProposalForm";
+
+const { routerRefreshMock } = vi.hoisted(() => ({
+	routerRefreshMock: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), refresh: routerRefreshMock }),
+}));
+
+const { toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+	toastSuccessMock: vi.fn(),
+	toastErrorMock: vi.fn(),
+}));
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessMock, error: toastErrorMock },
+}));
+
+const { createMentorProposalMock } = vi.hoisted(() => ({
+	createMentorProposalMock: vi.fn(),
+}));
+vi.mock("@/lib/api/mentor", () => ({
+	createMentorProposal: createMentorProposalMock,
+}));
+
+describe("MentorProposalForm (P11-07)", () => {
+	beforeEach(() => {
+		routerRefreshMock.mockReset();
+		toastSuccessMock.mockReset();
+		toastErrorMock.mockReset();
+		createMentorProposalMock.mockReset();
+	});
+
+	it("T-PROP-FORM-1 空 body は reject", async () => {
+		render(<MentorProposalForm requestId={1} />);
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター提案フォーム"));
+		});
+		expect(screen.getByRole("alert").textContent).toMatch(/提案文/);
+		expect(createMentorProposalMock).not.toHaveBeenCalled();
+	});
+
+	it("T-PROP-FORM-2 正常 submit で API + toast + 送信済表示", async () => {
+		createMentorProposalMock.mockResolvedValueOnce({ id: 99 });
+		render(<MentorProposalForm requestId={42} />);
+		fireEvent.change(
+			screen.getByLabelText(/提案文/, { selector: "textarea" }),
+			{
+				target: { value: "I can help" },
+			},
+		);
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター提案フォーム"));
+		});
+		expect(createMentorProposalMock).toHaveBeenCalledWith(42, "I can help");
+		expect(toastSuccessMock).toHaveBeenCalledWith("提案を送信しました");
+		expect(screen.getByRole("status").textContent).toMatch(
+			/提案を送信しました/,
+		);
+	});
+
+	it("T-PROP-FORM-3 unique 違反で error", async () => {
+		createMentorProposalMock.mockRejectedValueOnce({
+			response: { data: { detail: "この募集には既に提案を出しています" } },
+		});
+		render(<MentorProposalForm requestId={42} />);
+		fireEvent.change(
+			screen.getByLabelText(/提案文/, { selector: "textarea" }),
+			{
+				target: { value: "dup" },
+			},
+		);
+		await act(async () => {
+			fireEvent.submit(screen.getByLabelText("メンター提案フォーム"));
+		});
+		expect(screen.getByRole("alert").textContent).toMatch(/既に提案/);
+	});
+});

--- a/client/src/components/mentorship/__tests__/MentorProposalList.test.tsx
+++ b/client/src/components/mentorship/__tests__/MentorProposalList.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for MentorProposalList (P11-07).
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import MentorProposalList from "@/components/mentorship/MentorProposalList";
+import type { MentorProposal } from "@/lib/api/mentor";
+
+const { routerPushMock } = vi.hoisted(() => ({ routerPushMock: vi.fn() }));
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: routerPushMock }),
+}));
+
+const { toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+	toastSuccessMock: vi.fn(),
+	toastErrorMock: vi.fn(),
+}));
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessMock, error: toastErrorMock },
+}));
+
+const { acceptMock } = vi.hoisted(() => ({ acceptMock: vi.fn() }));
+vi.mock("@/lib/api/mentor", () => ({
+	acceptMentorProposal: acceptMock,
+}));
+
+const makeProposal = (
+	id: number,
+	overrides: Partial<MentorProposal> = {},
+): MentorProposal => ({
+	id,
+	request: 1,
+	mentor: { handle: `mentor${id}`, display_name: `M${id}`, avatar_url: "" },
+	body: `proposal body ${id}`,
+	status: "pending",
+	responded_at: null,
+	created_at: "2026-05-12T10:00:00Z",
+	updated_at: "2026-05-12T10:00:00Z",
+	...overrides,
+});
+
+describe("MentorProposalList (P11-07)", () => {
+	beforeEach(() => {
+		routerPushMock.mockReset();
+		toastSuccessMock.mockReset();
+		toastErrorMock.mockReset();
+		acceptMock.mockReset();
+	});
+
+	it("T-PROP-LIST-1 empty で「まだ提案は届いていません」", () => {
+		render(<MentorProposalList proposals={[]} requestStatus="open" />);
+		expect(screen.getByText(/まだ提案は届いて/)).toBeInTheDocument();
+	});
+
+	it("T-PROP-LIST-2 pending proposal は accept button が出る", () => {
+		render(
+			<MentorProposalList proposals={[makeProposal(1)]} requestStatus="open" />,
+		);
+		expect(
+			screen.getByRole("button", { name: /@mentor1 の提案を accept/ }),
+		).toBeInTheDocument();
+	});
+
+	it("T-PROP-LIST-3 status=matched なら accept button は出ない", () => {
+		render(
+			<MentorProposalList
+				proposals={[makeProposal(1)]}
+				requestStatus="matched"
+			/>,
+		);
+		expect(
+			screen.queryByRole("button", { name: /accept/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it("T-PROP-LIST-4 accept click で API + toast + router.push to /messages/<room_id>", async () => {
+		acceptMock.mockResolvedValueOnce({ id: 7, room_id: 99 });
+		render(
+			<MentorProposalList proposals={[makeProposal(1)]} requestStatus="open" />,
+		);
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole("button", { name: /@mentor1 の提案を accept/ }),
+			);
+		});
+		expect(acceptMock).toHaveBeenCalledWith(1);
+		expect(toastSuccessMock).toHaveBeenCalled();
+		expect(routerPushMock).toHaveBeenCalledWith("/messages/99");
+	});
+});


### PR DESCRIPTION
## Summary

**11-A MVP の最大山場**。 これで mentor 募集 board の golden path が user role 別 UI で完成。

### backend
- `MentorProposalCreateView` → `MentorProposalListCreateView` にリネーム
  - GET: owner (request.mentee) のみ proposal 一覧を取得 (新着順)
  - POST: 既存挙動 (mentor が提案投稿) を維持

### frontend
- `/mentor/wanted/<id>` (anon 可、 SSR 並列 fetch)
  - anon + open: 「ログインして提案する」 CTA → /login?next=...
  - mentor 候補 (auth + non-owner) + open: `MentorProposalForm`
  - owner: `MentorProposalList` で受信 proposal + accept button
- accept click → `acceptMentorProposal` → toast「契約成立」 → `/messages/<room_id>` redirect

## Test plan

- [x] backend pytest 53 件 GREEN (url name rename を既存テストも追従)
- [x] frontend vitest 12 件 GREEN (Form 3 + List 4 + 既存 5)
- [x] `npx tsc --noEmit` 通過
- [ ] CI 緑
- [ ] **次** P11-08 (RoomChat banner) + P11-09 (Playwright E2E) で 11-A MVP 完成

Closes #626