### PR TITLE
feat(mentorship): DMRoom kind=mentorship の banner + avatar (P11-08)

### DIFF
--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -187,6 +187,18 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 					/>
 				</div>
 			</header>
+			{/* P11-08: メンタリング契約 room に banner。 contract.status=ACTIVE 中は
+			    composer を残し、 完了 (is_archived=true) なら別 UI で disable する想定
+			    (P11-19 で実装)。 ここでは識別 banner だけ。 */}
+			{roomQuery.data?.kind === "mentorship" ? (
+				<div
+					role="status"
+					aria-label="メンタリング契約 room"
+					className="border-baby_grey/10 bg-baby_blue/10 text-baby_blue border-b px-4 py-1.5 text-xs"
+				>
+					🤝 メンタリング契約中の room です。
+				</div>
+			) : null}
 			<MessageList
 				messages={merged}
 				currentUserId={currentUserId}

--- a/client/src/components/dm/RoomListItem.tsx
+++ b/client/src/components/dm/RoomListItem.tsx
@@ -86,7 +86,7 @@ function RoomAvatar({
 	room: DMRoom;
 	currentUserId: number;
 }) {
-	if (room.kind === "direct") {
+	if (room.kind === "direct" || room.kind === "mentorship") {
 		const peer = pickPeer(room, currentUserId);
 		// DMRoomMembership は flat な handle のみ持つ。avatar URL は別 endpoint
 		// (/api/v1/profiles/...) で解決する設計だが Phase 3 範囲外、initials のみ表示。
@@ -94,9 +94,14 @@ function RoomAvatar({
 		return (
 			<div
 				aria-hidden="true"
-				className="bg-baby_grey/30 text-baby_white flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold"
+				aria-label={room.kind === "mentorship" ? "メンタリング" : undefined}
+				className={`flex size-12 shrink-0 items-center justify-center rounded-full text-base font-semibold ${
+					room.kind === "mentorship"
+						? "bg-baby_blue/20 text-baby_blue ring-baby_blue/40 ring-2"
+						: "bg-baby_grey/30 text-baby_white"
+				}`}
 			>
-				{fallback}
+				{room.kind === "mentorship" ? "🤝" : fallback}
 			</div>
 		);
 	}

--- a/client/src/components/dm/__tests__/RoomListItem.mentorship.test.tsx
+++ b/client/src/components/dm/__tests__/RoomListItem.mentorship.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for RoomListItem rendering of mentorship rooms (P11-08).
+ *
+ * 検証:
+ *   T-DM-MS-1 kind=mentorship の room avatar は 🤝 + aria-label="メンタリング"
+ *   T-DM-MS-2 kind=direct は通常の peer initials (regression)
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import RoomListItem from "@/components/dm/RoomListItem";
+import type { DMRoom } from "@/lib/redux/features/dm/types";
+
+const baseRoom: DMRoom = {
+	id: 1,
+	kind: "direct",
+	name: "",
+	creator_id: null,
+	memberships: [
+		{
+			id: 1,
+			user_id: 10,
+			handle: "alice",
+			last_read_at: null,
+			created_at: "2026-05-12T00:00:00Z",
+		},
+		{
+			id: 2,
+			user_id: 20,
+			handle: "bob",
+			last_read_at: null,
+			created_at: "2026-05-12T00:00:00Z",
+		},
+	],
+	last_message_at: null,
+	is_archived: false,
+	created_at: "2026-05-12T00:00:00Z",
+	updated_at: "2026-05-12T00:00:00Z",
+};
+
+describe("RoomListItem mentorship avatar (P11-08)", () => {
+	it("T-DM-MS-1 mentorship room は 🤝 avatar + aria-label", () => {
+		render(
+			<RoomListItem
+				room={{ ...baseRoom, kind: "mentorship" }}
+				currentUserId={10}
+			/>,
+		);
+		// 🤝 emoji 表示
+		expect(screen.getByText("🤝")).toBeInTheDocument();
+		// aria-label="メンタリング"
+		expect(screen.getByLabelText("メンタリング")).toBeInTheDocument();
+	});
+
+	it("T-DM-MS-2 direct room は peer initial (B for bob)", () => {
+		render(<RoomListItem room={baseRoom} currentUserId={10} />);
+		expect(screen.getByText("B")).toBeInTheDocument();
+	});
+});

--- a/client/src/lib/redux/features/dm/types.ts
+++ b/client/src/lib/redux/features/dm/types.ts
@@ -6,7 +6,7 @@
  * 共有 (client/src/types/index.ts に再 export 想定だが、現状は直接 import)。
  */
 
-export type DMRoomKind = "direct" | "group";
+export type DMRoomKind = "direct" | "group" | "mentorship";
 
 /**
  * Backend (`DMRoomMembershipSerializer`) は user の入れ子オブジェクトではなく


### PR DESCRIPTION
## Summary

11-A MVP の DM 識別 UI。 P11-05 で auto-create された `mentorship` room を通常の DM と視覚的に区別する。

- `DMRoomKind` に `"mentorship"` 追加 (frontend 型)
- `RoomChat` header 直下に role=status banner「🤝 メンタリング契約中の room です」
- `RoomListItem` avatar を 🤝 emoji + ring + aria-label「メンタリング」 で出し分け
- vitest 2 件 + 既存 9 件 regression PASS

## Test plan

- [x] tsc 通過 / vitest 11 件 GREEN
- [ ] CI 緑

Closes #627