### PR TITLE
test(mentorship): Playwright E2E + spec / scenarios / e2e-commands (P11-09 + P11-10)

### DIFF
--- a/client/e2e/mentor-board.spec.ts
+++ b/client/e2e/mentor-board.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Phase 11 11-A MVP の golden path E2E (P11-09).
+ *
+ * spec: docs/specs/phase-11-mentor-board-spec.md §9.3
+ *
+ * 検証シナリオ:
+ *   MENTOR-1 (golden path): test2 が募集投稿 → test3 が proposal 提案 →
+ *            test2 が accept → 両者の /messages に kind=mentorship room が
+ *            出現、 「メンタリング契約中の room」 banner も見える
+ *   MENTOR-2 (anon 閲覧可): /mentor/wanted 一覧 + 詳細を anon で踏んで 200
+ *   MENTOR-3 (anon 投稿 redirect): /mentor/wanted/new を anon で踏むと
+ *            /login?next=... に server-side redirect
+ *
+ * env: docs/local/e2e-stg.md の test2 (mentee) / test3 (mentor) を使用。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "",
+};
+
+function requireEnv() {
+	const required = {
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+		PLAYWRIGHT_USER2_EMAIL: USER2.email,
+		PLAYWRIGHT_USER2_PASSWORD: USER2.password,
+		PLAYWRIGHT_USER2_HANDLE: USER2.handle,
+	};
+	for (const [k, v] of Object.entries(required)) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+): Promise<{ csrf: string }> {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+	return { csrf };
+}
+
+test.describe("Phase 11 11-A mentor board (#624)", () => {
+	test("MENTOR-1: golden path 募集 → 提案 → accept → 両者の DM room", async ({
+		browser,
+	}) => {
+		requireEnv();
+
+		// --- mentee (USER1) が募集投稿 ---
+		const ctxMentee = await browser.newContext();
+		await loginViaApi(ctxMentee.request, USER1);
+		const mentee = await ctxMentee.newPage();
+
+		// LeftNav から /mentor/wanted へ (3 click 以内)
+		await mentee.goto(`${BASE}/`);
+		const navLink = mentee.getByRole("link", { name: "メンター募集" }).first();
+		await expect(navLink).toBeVisible({ timeout: 15000 });
+		await navLink.click();
+		await mentee.waitForURL(`${BASE}/mentor/wanted`);
+
+		// 「募集を出す」 CTA から /new
+		await mentee.getByRole("link", { name: "募集を出す" }).click();
+		await mentee.waitForURL(`${BASE}/mentor/wanted/new`);
+
+		const title = `E2E mentor-board ${Date.now()}`;
+		await mentee.getByLabel("タイトル").fill(title);
+		await mentee.getByLabel(/^本文/).fill("E2E でメンターを募集しています。");
+		await mentee.getByRole("button", { name: "募集を投稿する" }).click();
+
+		// 詳細ページに遷移
+		await mentee.waitForURL(/\/mentor\/wanted\/\d+/, { timeout: 15000 });
+		const url = mentee.url();
+		const requestId = Number.parseInt(url.split("/").pop() ?? "0", 10);
+		expect(requestId).toBeGreaterThan(0);
+
+		// --- mentor (USER2) が proposal 提案 ---
+		const ctxMentor = await browser.newContext();
+		await loginViaApi(ctxMentor.request, USER2);
+		const mentor = await ctxMentor.newPage();
+		await mentor.goto(`${BASE}/mentor/wanted/${requestId}`);
+		await mentor.getByLabel(/^提案文/).fill("E2E でテストする mentor です。");
+		await mentor.getByRole("button", { name: "提案を送る" }).click();
+		await expect(mentor.getByRole("status")).toContainText(
+			"提案を送信しました",
+			{ timeout: 10000 },
+		);
+
+		// --- mentee が proposal リストで accept ---
+		await mentee.reload();
+		const acceptBtn = mentee.getByRole("button", {
+			name: new RegExp(`@${USER2.handle} の提案を accept`),
+		});
+		await expect(acceptBtn).toBeVisible({ timeout: 10000 });
+		await acceptBtn.click();
+
+		// /messages/<room_id> に遷移
+		await mentee.waitForURL(/\/messages\/\d+/, { timeout: 15000 });
+		await expect(mentee.getByText("メンタリング契約中の room")).toBeVisible({
+			timeout: 10000,
+		});
+
+		// --- 後始末は API で省略 (request は MATCHED で TL から消える、 room は残す) ---
+		await ctxMentee.close();
+		await ctxMentor.close();
+	});
+
+	test("MENTOR-2: anon でも /mentor/wanted 一覧 + 詳細を 200 で見られる", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		const list = await ctx.request.get(`${BASE}/mentor/wanted`);
+		expect(list.status()).toBe(200);
+		await page.goto(`${BASE}/mentor/wanted`);
+		// anon のときは「ログインして募集する」 が出る
+		await expect(
+			page.getByRole("link", { name: "ログインして募集する" }),
+		).toBeVisible({ timeout: 15000 });
+		await ctx.close();
+	});
+
+	test("MENTOR-3: anon /mentor/wanted/new → /login?next=... に redirect", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/mentor/wanted/new`);
+		await page.waitForURL(/\/login(\?.*)?/, { timeout: 15000 });
+		expect(page.url()).toContain("next=%2Fmentor%2Fwanted%2Fnew");
+		await ctx.close();
+	});
+});

--- a/docs/specs/mentor-board-e2e-commands.md
+++ b/docs/specs/mentor-board-e2e-commands.md
@@ -1,0 +1,67 @@
+# メンター募集 board E2E 実行コマンド
+
+> 関連 spec: [mentor-board-spec.md](./mentor-board-spec.md) / [mentor-board-scenarios.md](./mentor-board-scenarios.md)
+> Playwright spec ファイル: `client/e2e/mentor-board.spec.ts`
+
+Phase 11 11-A の golden path を stg で実行するための **そのまま貼れる** コマンドメモ。 CLAUDE.md §4.5 step 6 「Playwright 実行コマンド」 のためのドキュメント。
+
+## 前提
+
+- stg URL: `https://stg.codeplace.me`
+- test 用 user (mentee/mentor 切替): test2 (USER1) と test3 (USER2)、 credential は [docs/local/e2e-stg.md](../local/e2e-stg.md) 参照
+- backend は P11-05 まで merge 済 (`/api/v1/mentor/...` 全 endpoint 利用可)
+- frontend は P11-08 まで merge 済 (`/mentor/wanted` + `/mentor/wanted/<id>` + DM banner)
+
+## 1. stg Playwright で 自動 E2E (第一選択)
+
+```bash
+cd /workspace/client
+
+# env (test2 / test3 の credential) は docs/local/e2e-stg.md 参照
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=... PLAYWRIGHT_USER1_PASSWORD=... PLAYWRIGHT_USER1_HANDLE=test2 \
+PLAYWRIGHT_USER2_EMAIL=... PLAYWRIGHT_USER2_PASSWORD=... PLAYWRIGHT_USER2_HANDLE=test3 \
+  npx playwright test e2e/mentor-board.spec.ts
+```
+
+期待: MENTOR-1 / MENTOR-2 / MENTOR-3 が全 GREEN。
+
+## 2. curl API smoke (debug 用)
+
+```bash
+# CSRF token を取得
+CSRF=$(curl -s -c /tmp/cookies.txt "https://stg.codeplace.me/api/v1/auth/csrf/" -o /dev/null && grep csrftoken /tmp/cookies.txt | awk '{print $7}')
+
+# test2 で login (credential は docs/local/e2e-stg.md 参照)
+curl -s -b /tmp/cookies.txt -c /tmp/cookies.txt -X POST "https://stg.codeplace.me/api/v1/auth/cookie/create/" \
+  -H "Content-Type: application/json" -H "X-CSRFToken: $CSRF" -H "Referer: https://stg.codeplace.me/login" \
+  -d '{"email":"...","password":"..."}' -w "\nstatus=%{http_code}\n"
+
+# 募集投稿
+curl -s -b /tmp/cookies.txt -X POST "https://stg.codeplace.me/api/v1/mentor/requests/" \
+  -H "Content-Type: application/json" -H "X-CSRFToken: $CSRF" -H "Referer: https://stg.codeplace.me/mentor/wanted/new" \
+  -d '{"title":"smoke","body":"smoke body"}' -w "\nstatus=%{http_code}\n"
+
+# 一覧 (anon でも OK)
+curl -s "https://stg.codeplace.me/api/v1/mentor/requests/" | jq '.results | length'
+```
+
+## 3. Playwright MCP / Chrome 手動 (stg 反映待ちのとき or 補助)
+
+- `https://stg.codeplace.me/mentor/wanted` を anon で開く → 「ログインして募集する」 CTA を screenshot
+- `https://stg.codeplace.me/mentor/wanted/<id>` を test3 で開く → 提案 form を screenshot
+- accept 後の `/messages/<room_id>` で banner「🤝 メンタリング契約中」 を screenshot
+
+## トラブルシュート
+
+| 症状                                          | 原因候補                                     | 対処                                                                  |
+| --------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------- |
+| accept で 400「この募集は受付終了しています」 | 既に他 mentor で MATCHED 済                  | 新しい request を投稿し直す                                           |
+| accept で 404                                 | request または proposal が削除済 / pk 間違い | `/api/v1/mentor/requests/<id>/proposals/` (owner 認証) で生存確認     |
+| MENTOR-1 / step 8 で DM banner が見えない     | P11-08 frontend が deploy 済か               | `/_next/static/chunks/` 配下を grep して「メンタリング契約中」 を確認 |
+
+## 関連
+
+- Playwright spec: `client/e2e/mentor-board.spec.ts`
+- backend tests: `apps/mentorship/tests/test_accept_proposal.py` (atomic + idempotent)
+- gan-evaluator 採点候補: 11-A 完成後に「ホーム → 3 click 以内」 + 「未ログインで壊れない」 + 「契約成立シグナル」 を採点させる

--- a/docs/specs/mentor-board-scenarios.md
+++ b/docs/specs/mentor-board-scenarios.md
@@ -1,0 +1,46 @@
+# メンター募集 board E2E シナリオ
+
+> 関連 spec: [mentor-board-spec.md](./mentor-board-spec.md) / [phase-11-mentor-board-spec.md](./phase-11-mentor-board-spec.md)
+> e2e 実行: [mentor-board-e2e-commands.md](./mentor-board-e2e-commands.md)
+> Playwright spec ファイル: `client/e2e/mentor-board.spec.ts`
+
+Phase 11 11-A の golden path + 周辺 edge case を自然言語で記述。 CLAUDE.md §4.5 step 6 「テストシナリオを spec doc に書いた」 のためのドキュメント。
+
+## シナリオ一覧
+
+### MENTOR-1 golden path: mentee 募集 → mentor 提案 → mentee accept → DM 開始
+
+| step | 誰が           | 何をする                                                                                | 何が起きる / 何が見える                                                                                         |
+| ---- | -------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 1    | test2 (mentee) | ホーム `/` を開く                                                                       | 左 nav に「メンター募集」 link (Handshake icon) が見える                                                        |
+| 2    | test2          | 左 nav の「メンター募集」 を click                                                      | `/mentor/wanted` 一覧に遷移、 sticky header に「募集を出す」 CTA                                                |
+| 3    | test2          | 「募集を出す」 click                                                                    | `/mentor/wanted/new` で投稿 form                                                                                |
+| 4    | test2          | title「Django で質問」 + body「DRF の認証で詰まっています」 を入力 → 「募集を投稿する」 | toast「募集を投稿しました」 + `/mentor/wanted/<id>` 詳細ページに遷移                                            |
+| 5    | test3 (mentor) | 別 context で `/mentor/wanted/<id>` を開く                                              | mentor 候補として提案 form が出る (owner ではないので proposal list は見えない)                                 |
+| 6    | test3          | 提案文「AWS / Django 10 年経験。 60 分単発で対応可能」 を入力 → 「提案を送る」          | status panel「提案を送信しました。 mentee が accept すると DM ルームが開きます。」                              |
+| 7    | test2          | 詳細ページを reload                                                                     | 「受信した提案 (1 件)」 section に test3 の提案が表示、 「@test3 の提案を accept」 button                       |
+| 8    | test2          | accept button を click                                                                  | toast「契約成立しました。 DM ルームに移動します。」 + `/messages/<room_id>` に redirect                         |
+| 9    | test2          | DM room を見る                                                                          | header 直下に banner「🤝 メンタリング契約中の room です。」、 composer 有効、 通常の DM と同じく message 送信可 |
+| 10   | test3          | `/messages` 一覧を開く                                                                  | 新規 room が avatar 🤝 (blue ring) で表示、 aria-label「メンタリング」                                          |
+
+### MENTOR-2 anon 閲覧可
+
+| step | 誰が | 何をする                                            | 何が起きる                                                            |
+| ---- | ---- | --------------------------------------------------- | --------------------------------------------------------------------- |
+| 1    | anon | `/mentor/wanted` を踏む                             | 200、 一覧が見える、 sticky header に「ログインして募集する」 CTA     |
+| 2    | anon | 任意の row を click                                 | `/mentor/wanted/<id>` 詳細を 200 で閲覧可、 本文 + skill tag が見える |
+| 3    | anon | (status=open) 「ログインして提案する」 CTA を click | `/login?next=/mentor/wanted/<id>` に遷移                              |
+
+### MENTOR-3 anon /new redirect
+
+| step | 誰が | 何をする                      | 何が起きる                                       |
+| ---- | ---- | ----------------------------- | ------------------------------------------------ |
+| 1    | anon | `/mentor/wanted/new` を直叩き | 307 redirect to `/login?next=/mentor/wanted/new` |
+
+## 失敗ケース / edge case (将来 E2E 化候補、 unit / API test で代替済)
+
+- self-proposal: test2 (自身の募集) で「提案を送る」 → 400「自分の募集には提案できません」
+- duplicate proposal: 既に提案済 mentor が再投稿 → 400「この募集には既に提案を出しています」
+- matched 後の追加 proposal: status=MATCHED の request に proposal → 400「この募集は受付終了しています」
+- non-owner accept: mentor が他人の proposal の accept endpoint を叩く → 403
+- non-open 詳細閲覧: status=matched / closed / expired でも詳細は anon でも 200 (mentee が踏み戻せる動線)

--- a/docs/specs/mentor-board-spec.md
+++ b/docs/specs/mentor-board-spec.md
@@ -1,0 +1,68 @@
+# メンター募集 board (Phase 11 11-A) UI 仕様
+
+> 関連: [phase-11-mentor-board-spec.md](./phase-11-mentor-board-spec.md) (全体 design doc)
+> 関連シナリオ: [mentor-board-scenarios.md](./mentor-board-scenarios.md)
+> e2e 実行: [mentor-board-e2e-commands.md](./mentor-board-e2e-commands.md)
+
+Phase 11 11-A の **UI 詳細**。 backend API は phase-11 spec §6 / frontend route は §7 を参照し、 ここでは「画面に何が出るか / どう操作するか」 を user role 別に整理する。
+
+## 画面構成
+
+### `/mentor/wanted` 一覧
+
+- sticky header: 🤝 icon + 「メンター募集」 + filterDescription (`#tag で募集中` or `募集中の相談`) + CTA
+  - auth: 「募集を出す」 (青背景) → `/mentor/wanted/new`
+  - anon: 「ログインして募集する」 → `/login?next=/mentor/wanted/new`
+- body: cursor pagination で公開中 (status=open) のみ列挙、 各 row は
+  - mentee handle / 投稿日付 / 提案件数
+  - title (1 行 truncate)
+  - 関連 skill tag chip (横並び)
+- empty state: 「まだ募集がありません。 最初の募集を投稿してみませんか?」
+
+### `/mentor/wanted/new` 投稿 form
+
+- SSR auth gate (anon → /login?next=...)
+- フィールド:
+  - タイトル (1-80 字)
+  - 本文 (1-2000 字、 改行 OK、 monospace placeholder)
+  - 関連スキル (csv、 最大 5、 既存 tag のみ、 未登録は 400 error)
+- submit → toast「募集を投稿しました」 + `/mentor/wanted/<id>` redirect
+
+### `/mentor/wanted/<id>` 詳細
+
+- sticky header: 「← 募集一覧」 + title + `@mentee_handle · 状態`
+- 本文 (whitespace-pre-wrap で改行尊重) + skill tag chip
+- **role 別 UI**:
+  - **anon** + status=open: 「ログインして提案する」 CTA → `/login?next=/mentor/wanted/<id>`
+  - **mentor 候補** (auth、 non-owner) + status=open: 提案 form
+    - 本文 (1-2000) + 「提案を送る」 button
+    - 送信成功で status panel「提案を送信しました。 mentee が accept すると DM ルームが開きます。」
+    - unique 違反 (既に出した提案あり) は role=alert で error
+  - **owner** (mentee): 受信 proposal リスト (新着順、 owner only API GET)
+    - 各 proposal: mentor handle + 投稿日時 + status + 本文
+    - status=pending + request.status=open のときだけ「accept」 button
+    - accept click → contract 成立 → toast「契約成立しました。 DM ルームに移動します。」 + `/messages/<room_id>` redirect
+
+### `/messages/<room_id>` (kind=mentorship)
+
+- header 直下に role=status banner「🤝 メンタリング契約中の room です。」
+- 一覧 (`/messages`) では avatar が 🤝 emoji + blue ring + aria-label「メンタリング」
+- 既存 DM 機能 (typing / read / 添付) はそのまま使える
+
+## アクセシビリティ
+
+- 全 button / link に focus-visible outline (a11y-architect 流儀)
+- role=alert / role=status を error / 完了通知に分離
+- aria-label を accept button に明示 (「@<handle> の提案を accept」)
+- screen reader でも「メンタリング契約中」 が読み上げられるよう banner は role=status + aria-live=polite
+
+## 採用しない / 後回し
+
+- proposal 投稿後の編集 / withdraw UI は P11-19 (RoomChat 完了時 read-only) 以降の Phase 11-C で対応
+- proposal リストでの個別 reject button は MVP では出さない (放置 = pending)。 mentee が他 proposal を accept すると request.status=MATCHED に変わって他は表示されるが触らない (R8)
+- mentor profile / plan / 検索画面は Phase 11-B (P11-11〜P11-16)
+- 評価 / レビューは Phase 11-D (P11-20〜P11-22)
+
+## 関連 PR / Issue
+
+- P11-01〜P11-10 (11-A MVP)、 P11-08 で DM 識別 UI、 P11-09 で E2E 自動化


### PR DESCRIPTION
## Summary

**Phase 11 11-A MVP 完成 PR**。 backend (P11-01〜05) + frontend (P11-06〜08) で動く mentor 募集 board の **golden path を自動化 + ドキュメント化**。

- `client/e2e/mentor-board.spec.ts`: MENTOR-1 (golden path) / MENTOR-2 (anon 閲覧) / MENTOR-3 (anon /new redirect)
- `docs/specs/mentor-board-spec.md`: UI 仕様
- `docs/specs/mentor-board-scenarios.md`: 自然言語シナリオ + 失敗 / edge case
- `docs/specs/mentor-board-e2e-commands.md`: 実行コマンド + 手動手順 + トラブルシュート

## 11-A MVP のリリース可能性

これで Phase 11 11-A (P11-01〜P11-10、 10 Issue) **全て merge** 完了予定。 stg 反映後:

1. Playwright `mentor-board.spec.ts` を 1.〜3. の env で run → GREEN を確認
2. `gan-evaluator` agent で「ホーム → 3 click 以内」 + 「未ログインで壊れない」 + 「契約成立シグナル」 を採点
3. 問題なければ Phase 11 11-A は **stg リリース完了**

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] backend mentorship 53 件 GREEN (本 PR は backend code 触らない)
- [x] frontend vitest 11 件 GREEN (本 PR は vitest 追加なし)
- [ ] CI 緑
- [ ] stg merge 後の Playwright E2E run

Closes #628 #629