### PR TITLE
fix(mentorship): ALeftNav に「メンター募集」 link + accept button 日本語化 (P11-09 follow-up)

### DIFF
--- a/client/e2e/mentor-board.spec.ts
+++ b/client/e2e/mentor-board.spec.ts
@@ -111,7 +111,7 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 		// --- mentee が proposal リストで accept ---
 		await mentee.reload();
 		const acceptBtn = mentee.getByRole("button", {
-			name: new RegExp(`@${USER2.handle} の提案を accept`),
+			name: new RegExp(`@${USER2.handle} の提案を承諾する`),
 		});
 		await expect(acceptBtn).toBeVisible({ timeout: 10000 });
 		await acceptBtn.click();
@@ -149,7 +149,10 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 		const page = await ctx.newPage();
 		await page.goto(`${BASE}/mentor/wanted/new`);
 		await page.waitForURL(/\/login(\?.*)?/, { timeout: 15000 });
-		expect(page.url()).toContain("next=%2Fmentor%2Fwanted%2Fnew");
+		// URL は raw / encoded どちらの形でも next=/mentor/wanted/new に
+		// なっていれば仕様通り (Next.js は redirect target を raw で URL に乗せる)。
+		const decoded = decodeURIComponent(page.url());
+		expect(decoded).toContain("next=/mentor/wanted/new");
 		await ctx.close();
 	});
 });

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -23,6 +23,7 @@ import {
 	Feather,
 	FileText,
 	Flame,
+	Handshake,
 	Hash,
 	Home,
 	LogOut,
@@ -72,6 +73,11 @@ const NAV_ITEMS: NavItemDef[] = [
 	},
 	{ href: "/articles", label: "記事", Icon: FileText },
 	{ href: "/boards", label: "掲示板", Icon: Flame },
+	// Phase 11 11-A (P11-09 follow-up): home (A direction) でも「メンター募集」 を
+	// 1 click 到達できるようにする。 既存 `leftNavLinks` (LeftNavbar / MobileNavbar
+	// 用、 X 風レイアウト) には追加済だが、 home が使う ALeftNav は別 list を持つ
+	// (#550 POC) ため、 ここにも明示する。
+	{ href: "/mentor/wanted", label: "メンター募集", Icon: Handshake },
 ];
 
 function BrandMark({ size = 22 }: { size?: number }) {

--- a/client/src/components/mentorship/MentorProposalList.tsx
+++ b/client/src/components/mentorship/MentorProposalList.tsx
@@ -101,9 +101,9 @@ export default function MentorProposalList({
 								onClick={() => handleAccept(p.id)}
 								disabled={acceptingId !== null}
 								className="shrink-0 rounded-full bg-primary px-4 py-1.5 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-								aria-label={`@${p.mentor.handle} の提案を accept`}
+								aria-label={`@${p.mentor.handle} の提案を承諾する`}
 							>
-								{acceptingId === p.id ? "成立中…" : "accept"}
+								{acceptingId === p.id ? "成立中…" : "承諾する"}
 							</button>
 						)}
 					</div>

--- a/client/src/components/mentorship/__tests__/MentorProposalList.test.tsx
+++ b/client/src/components/mentorship/__tests__/MentorProposalList.test.tsx
@@ -59,7 +59,7 @@ describe("MentorProposalList (P11-07)", () => {
 			<MentorProposalList proposals={[makeProposal(1)]} requestStatus="open" />,
 		);
 		expect(
-			screen.getByRole("button", { name: /@mentor1 の提案を accept/ }),
+			screen.getByRole("button", { name: /@mentor1 の提案を承諾する/ }),
 		).toBeInTheDocument();
 	});
 
@@ -71,7 +71,7 @@ describe("MentorProposalList (P11-07)", () => {
 			/>,
 		);
 		expect(
-			screen.queryByRole("button", { name: /accept/ }),
+			screen.queryByRole("button", { name: /承諾する/ }),
 		).not.toBeInTheDocument();
 	});
 
@@ -82,7 +82,7 @@ describe("MentorProposalList (P11-07)", () => {
 		);
 		await act(async () => {
 			fireEvent.click(
-				screen.getByRole("button", { name: /@mentor1 の提案を accept/ }),
+				screen.getByRole("button", { name: /@mentor1 の提案を承諾する/ }),
 			);
 		});
 		expect(acceptMock).toHaveBeenCalledWith(1);


### PR DESCRIPTION
## Summary

Phase 11 11-A 初採点 `gan-evaluator` (6.4/10) で発見した CRITICAL + HIGH を follow-up fix。

### CRITICAL #1 LeftNav に「メンター募集」 が出ない
- home (A direction) は `ALeftNav.tsx` の hardcoded `NAV_ITEMS` を使う **別 nav**
- P11-06 で追加した `leftNavLinks` (LeftNavbar / MobileNavbar 用) は scope 外で ALeftNav に反映されず
- 修正: `NAV_ITEMS` に `{ href: "/mentor/wanted", label: "メンター募集", Icon: Handshake }` を追加 → home から **1 click 到達**

### HIGH #3 MENTOR-3 spec assertion bug
- URL encoded 期待値だが Next.js は raw を返す → `decodeURIComponent` で正規化

### HIGH #4 accept button が英語
- 「accept」 → 「承諾する」 に日本語化、 aria-label も合わせて変更
- vitest + e2e spec も追従

## Test plan

- [x] vitest ALeftNav 6 件 + MentorProposalList 4 件 GREEN
- [x] tsc 通過
- [ ] CI 緑
- [ ] stg merge 後、 home で LeftNav に「メンター募集」 が出るのを実画面確認
- [ ] `gan-evaluator` 再採点で 6.4 → 7.0+ 目標

Closes (follow-up): #628