### PR TITLE
feat(mentorship): /mentors/ public search + /mentors/<handle>/ detail (P11-13)

### DIFF
--- a/apps/mentorship/tests/test_mentor_search_api.py
+++ b/apps/mentorship/tests/test_mentor_search_api.py
@@ -1,0 +1,135 @@
+"""Tests for /mentors/ public search + /mentors/<handle>/ detail (P11-13)。
+
+spec §6.3
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.mentorship.models import MentorPlan, MentorProfile
+from apps.tags.models import Tag
+
+User = get_user_model()
+
+
+def _user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+def _approved_tag(name: str) -> Tag:
+    return Tag.all_objects.create(name=name, display_name=name.capitalize(), is_approved=True)
+
+
+def _profile(user, **kwargs) -> MentorProfile:
+    defaults = {"headline": "m", "bio": "b", "experience_years": 3}
+    defaults.update(kwargs)
+    return MentorProfile.objects.create(user=user, **defaults)
+
+
+# ---- LIST ----
+
+
+@pytest.mark.django_db
+def test_list_anon_default_only_accepting():
+    """default で is_accepting=True のみ可視。"""
+    a = _user("alice")
+    b = _user("bob")
+    _profile(a, is_accepting=True)
+    _profile(b, is_accepting=False)
+    res = APIClient().get(reverse("mentor-list"))
+    assert res.status_code == 200
+    handles = [r["user"]["handle"] for r in res.data["results"]]
+    assert handles == ["alice"]
+
+
+@pytest.mark.django_db
+def test_list_accepting_all_includes_inactive():
+    a = _user("alice")
+    b = _user("bob")
+    _profile(a, is_accepting=True)
+    _profile(b, is_accepting=False)
+    res = APIClient().get(reverse("mentor-list"), {"accepting": "all"})
+    handles = sorted(r["user"]["handle"] for r in res.data["results"])
+    assert handles == ["alice", "bob"]
+
+
+@pytest.mark.django_db
+def test_list_tag_filter():
+    a = _user("alice")
+    b = _user("bob")
+    aws = _approved_tag("aws")
+    django_tag = _approved_tag("django")
+    pa = _profile(a)
+    pa.skill_tags.add(aws)
+    pb = _profile(b)
+    pb.skill_tags.add(django_tag)
+    res = APIClient().get(reverse("mentor-list"), {"tag": "aws"})
+    handles = [r["user"]["handle"] for r in res.data["results"]]
+    assert handles == ["alice"]
+
+
+@pytest.mark.django_db
+def test_list_includes_plans_inline():
+    """list response の各 row は plans を埋め込む (P11-12 で SerializerMethod)。"""
+    a = _user("alice")
+    profile = _profile(a)
+    MentorPlan.objects.create(
+        profile=profile, title="60 min", description="d", billing_cycle="one_time"
+    )
+    res = APIClient().get(reverse("mentor-list"))
+    plans = res.data["results"][0]["plans"]
+    assert len(plans) == 1
+    assert plans[0]["title"] == "60 min"
+
+
+@pytest.mark.django_db
+def test_list_ordering_by_avg_rating_desc():
+    """avg_rating 降順で並ぶ。"""
+    a = _user("alice")
+    b = _user("bob")
+    c = _user("carol")
+    _profile(a, headline="A", avg_rating=Decimal("4.50"))
+    _profile(b, headline="B", avg_rating=Decimal("4.80"))
+    _profile(c, headline="C", avg_rating=Decimal("3.00"))
+    res = APIClient().get(reverse("mentor-list"))
+    handles = [r["user"]["handle"] for r in res.data["results"]]
+    assert handles == ["bob", "alice", "carol"]
+
+
+# ---- DETAIL ----
+
+
+@pytest.mark.django_db
+def test_detail_anon_can_view():
+    a = _user("alice")
+    _profile(a, headline="AWS mentor")
+    res = APIClient().get(reverse("mentor-detail", args=["alice"]))
+    assert res.status_code == 200
+    assert res.data["headline"] == "AWS mentor"
+    assert res.data["user"]["handle"] == "alice"
+
+
+@pytest.mark.django_db
+def test_detail_404_for_user_without_profile():
+    """profile 未作成の user は 404。"""
+    _user("bob")
+    res = APIClient().get(reverse("mentor-detail", args=["bob"]))
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_detail_404_for_unknown_handle():
+    res = APIClient().get(reverse("mentor-detail", args=["nobody"]))
+    assert res.status_code == 404

--- a/apps/mentorship/urls_mentors.py
+++ b/apps/mentorship/urls_mentors.py
@@ -7,13 +7,18 @@ mentor profile / plan 関連 endpoint で使う。
 from django.urls import path
 
 from apps.mentorship.views import (
+    MentorDetailView,
+    MentorListView,
     MentorPlanDetailView,
     MentorPlanListCreateView,
     MentorProfileMeView,
 )
 
 urlpatterns = [
+    # P11-13: 公開 mentor 検索 (anon 可、 default is_accepting=True + tag filter)。
+    path("", MentorListView.as_view(), name="mentor-list"),
     # 自分の mentor profile を GET / PATCH (PATCH は auto-create)。
+    # `me/` は `<handle>/` より上に置く (URL resolver の登録順優先)。
     path(
         "me/",
         MentorProfileMeView.as_view(),
@@ -30,5 +35,11 @@ urlpatterns = [
         "me/plans/<int:pk>/",
         MentorPlanDetailView.as_view(),
         name="mentor-plan-detail",
+    ),
+    # P11-13: 公開 mentor profile (anon 可)。 `me/` の後ろに置いて衝突回避。
+    path(
+        "<str:handle>/",
+        MentorDetailView.as_view(),
+        name="mentor-detail",
     ),
 ]

--- a/apps/mentorship/views.py
+++ b/apps/mentorship/views.py
@@ -358,6 +358,62 @@ class MentorPlanListCreateView(APIView):
         )
 
 
+# --- MentorProfile public search / detail (P11-13) ---
+
+
+class _MentorListPagination(CursorPagination):
+    """mentor 検索の cursor pagination (avg_rating 降順)。"""
+
+    page_size = 20
+    ordering = "-avg_rating"
+    cursor_query_param = "cursor"
+
+
+class MentorListView(GenericAPIView):
+    """`GET /api/v1/mentors/` (anon 可) — mentor 検索 + skill filter。
+
+    spec §6.3。 ?tag=python で skill_tags filter、 ?accepting=all で受付停止
+    含む。 default は is_accepting=True のみ。 ordering avg_rating 降順 + cursor。
+    """
+
+    permission_classes = [permissions.AllowAny]
+    pagination_class = _MentorListPagination
+
+    def get_queryset(self):
+        accepting = self.request.query_params.get("accepting")
+        qs = MentorProfile.objects.select_related("user").prefetch_related(
+            "skill_tags",
+        )
+        if accepting is None or accepting.lower() != "all":
+            qs = qs.filter(is_accepting=True)
+        tag = self.request.query_params.get("tag")
+        if tag:
+            qs = qs.filter(skill_tags__name=tag.lower()).distinct()
+        return qs
+
+    def get(self, request: Request) -> Response:
+        page = self.paginate_queryset(self.get_queryset())
+        serializer = MentorProfileSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
+
+
+class MentorDetailView(APIView):
+    """`GET /api/v1/mentors/<handle>/` (anon 可) — mentor profile 公開出力。"""
+
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request: Request, handle: str) -> Response:
+        try:
+            profile = (
+                MentorProfile.objects.select_related("user")
+                .prefetch_related("skill_tags", "plans")
+                .get(user__username=handle)
+            )
+        except MentorProfile.DoesNotExist as exc:
+            raise NotFound("MentorProfile not found") from exc
+        return Response(MentorProfileSerializer(profile).data)
+
+
 class MentorPlanDetailView(APIView):
     """`/mentors/me/plans/<id>/` — PATCH 編集 / DELETE 論理削除 (is_active=False)。"""
 


### PR DESCRIPTION
## Summary

11-B 第 3 弾 (spec §6.3)。 mentor 検索 + 個別 profile 公開 API (anon 可)。

- `GET /api/v1/mentors/` (anon、 cursor 20、 `-avg_rating` ordering)
  - default `is_accepting=True` のみ
  - `?accepting=all` で停止 mentor も含む
  - `?tag=<name>` で skill_tags filter
- `GET /api/v1/mentors/<handle>/` (anon、 user.username で lookup、 404 fallback)
- urls_mentors に list (`""`) / detail (`<str:handle>/`) route 追加
- pytest 8 件、 mentorship 全 79 件 GREEN

## Test plan

- [x] pytest 8 件 + 既存 71 件 GREEN
- [ ] CI 緑

Closes #632