### PR TITLE
feat(mentorship): /mentors 検索 + /mentors/<handle> 詳細 frontend (P11-14)

### DIFF
--- a/client/src/app/(template)/mentors/[handle]/page.tsx
+++ b/client/src/app/(template)/mentors/[handle]/page.tsx
@@ -1,0 +1,176 @@
+/**
+ * /mentors/<handle> — mentor profile 詳細 (P11-14 / Phase 11-B).
+ *
+ * 匿名閲覧可。 mentor profile + 公開 plan + 集計を render。
+ * spec §7
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { type MentorProfileDetail } from "@/lib/api/mentor";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+
+interface PageProps {
+	params: { handle: string };
+}
+
+async function fetchProfile(
+	handle: string,
+): Promise<MentorProfileDetail | null> {
+	try {
+		return await serverFetch<MentorProfileDetail>(`/mentors/${handle}/`);
+	} catch (err) {
+		if (err instanceof ApiServerError && err.status === 404) return null;
+		throw err;
+	}
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const profile = await fetchProfile(params.handle);
+	if (!profile) return { title: "メンターが見つかりません" };
+	const name = profile.user.display_name || profile.user.handle;
+	return {
+		title: `${name} — メンタープロフィール`,
+		description: profile.headline,
+	};
+}
+
+export default async function MentorDetailPage({ params }: PageProps) {
+	const profile = await fetchProfile(params.handle);
+	if (!profile) notFound();
+
+	const rating =
+		profile.avg_rating !== null ? Number(profile.avg_rating).toFixed(1) : null;
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/mentors"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← メンター一覧
+				</Link>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						{profile.user.display_name || profile.user.handle}
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						@{profile.user.handle} · 経験 {profile.experience_years} 年
+						{rating ? ` · ★ ${rating} (${profile.review_count})` : ""}
+					</p>
+				</div>
+			</header>
+
+			<div className="space-y-6 p-5">
+				{!profile.is_accepting && (
+					<p
+						role="status"
+						className="rounded border border-yellow-400/60 bg-yellow-50/80 px-3 py-2 text-sm text-yellow-900 dark:border-yellow-500/30 dark:bg-yellow-900/20 dark:text-yellow-100"
+					>
+						このメンターは現在新規受付を停止しています。
+					</p>
+				)}
+
+				<section aria-label="プロフィール紹介">
+					<h2 className="mb-2 text-sm font-semibold">紹介</h2>
+					<p className="whitespace-pre-wrap text-sm text-[color:var(--a-text)]">
+						{profile.headline}
+					</p>
+				</section>
+
+				<section aria-label="メンタープロフィール本文">
+					<h2 className="mb-2 text-sm font-semibold">プロフィール</h2>
+					<p className="whitespace-pre-wrap text-sm text-[color:var(--a-text)]">
+						{profile.bio}
+					</p>
+				</section>
+
+				{profile.skill_tags.length > 0 && (
+					<section aria-label="スキル">
+						<h2 className="mb-2 text-sm font-semibold">スキル</h2>
+						<ul className="flex flex-wrap gap-1">
+							{profile.skill_tags.map((t) => (
+								<li
+									key={t.name}
+									className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
+								>
+									#{t.display_name}
+								</li>
+							))}
+						</ul>
+					</section>
+				)}
+
+				{profile.plans.length > 0 && (
+					<section aria-label="提供 plan">
+						<h2 className="mb-2 text-sm font-semibold">提供 plan</h2>
+						<ul role="list" className="grid gap-3">
+							{profile.plans.map((p) => (
+								<li
+									key={p.id}
+									className="rounded-lg border border-[color:var(--a-border)] p-3"
+								>
+									<div className="flex items-baseline justify-between gap-3">
+										<h3 className="font-semibold">{p.title}</h3>
+										<span className="shrink-0 text-xs text-[color:var(--a-text-muted)]">
+											{p.billing_cycle === "monthly" ? "月額" : "単発"}
+											{p.price_jpy > 0
+												? ` · ¥${p.price_jpy.toLocaleString()}`
+												: " · 無償ベータ"}
+										</span>
+									</div>
+									<p className="mt-1 whitespace-pre-wrap text-sm text-[color:var(--a-text-muted)]">
+										{p.description}
+									</p>
+								</li>
+							))}
+						</ul>
+					</section>
+				)}
+
+				<section aria-label="実績">
+					<h2 className="mb-2 text-sm font-semibold">実績</h2>
+					<dl className="grid grid-cols-3 gap-2 text-xs text-[color:var(--a-text-muted)]">
+						<div>
+							<dt>提案数</dt>
+							<dd className="text-base font-semibold text-[color:var(--a-text)]">
+								{profile.proposal_count}
+							</dd>
+						</div>
+						<div>
+							<dt>契約数</dt>
+							<dd className="text-base font-semibold text-[color:var(--a-text)]">
+								{profile.contract_count}
+							</dd>
+						</div>
+						<div>
+							<dt>レビュー数</dt>
+							<dd className="text-base font-semibold text-[color:var(--a-text)]">
+								{profile.review_count}
+							</dd>
+						</div>
+					</dl>
+				</section>
+			</div>
+		</>
+	);
+}

--- a/client/src/app/(template)/mentors/page.tsx
+++ b/client/src/app/(template)/mentors/page.tsx
@@ -1,0 +1,145 @@
+/**
+ * /mentors — mentor 検索一覧 (P11-14 / Phase 11-B).
+ *
+ * 匿名閲覧可。 SSR で list を fetch、 sticky header + card 形式で並べる。
+ *
+ * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Users } from "lucide-react";
+
+import { type MentorProfileDetail } from "@/lib/api/mentor";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+
+export const metadata: Metadata = {
+	title: "メンターを探す — エンジニア SNS",
+	description:
+		"エンジニア SNS のメンター一覧。 受付中のメンターをスキルタグで絞り込み、 提案前にプロフィールと plan を確認できます。",
+};
+
+interface PageProps {
+	searchParams?: { tag?: string };
+}
+
+async function fetchMentorsSSR(
+	tag: string | undefined,
+): Promise<MentorProfileDetail[]> {
+	try {
+		const qs = tag ? `?tag=${encodeURIComponent(tag)}` : "";
+		const page = await serverFetch<{
+			results: MentorProfileDetail[];
+			next: string | null;
+			previous: string | null;
+		}>(`/mentors/${qs}`);
+		return page.results ?? [];
+	} catch (err) {
+		if (err instanceof ApiServerError) return [];
+		return [];
+	}
+}
+
+export default async function MentorsListPage({ searchParams }: PageProps) {
+	const tag = searchParams?.tag;
+	const items = await fetchMentorsSSR(tag);
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Users
+					className="size-4 text-[color:var(--a-accent)]"
+					aria-hidden="true"
+				/>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						メンターを探す
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{tag ? `#${tag} の mentor` : "受付中の mentor"}
+					</p>
+				</div>
+			</header>
+
+			<div className="p-5">
+				{items.length === 0 ? (
+					<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
+						{tag
+							? `#${tag} の mentor はまだいません。`
+							: "受付中の mentor はまだいません。 自分が最初の 1 人になりませんか?"}
+					</p>
+				) : (
+					<ul role="list" className="grid gap-3">
+						{items.map((m) => (
+							<li key={m.id}>
+								<MentorCard profile={m} />
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</>
+	);
+}
+
+function MentorCard({ profile }: { profile: MentorProfileDetail }) {
+	const rating =
+		profile.avg_rating !== null ? Number(profile.avg_rating).toFixed(1) : null;
+	return (
+		<Link
+			href={`/mentors/${profile.user.handle}`}
+			aria-label={`mentor @${profile.user.handle} のプロフィールを開く`}
+			className="block rounded-lg border border-[color:var(--a-border)] p-4 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+		>
+			<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">
+				<span>@{profile.user.handle}</span>
+				<span aria-hidden="true">·</span>
+				<span>経験 {profile.experience_years} 年</span>
+				{rating ? (
+					<>
+						<span aria-hidden="true">·</span>
+						<span>
+							★ {rating} ({profile.review_count})
+						</span>
+					</>
+				) : (
+					<>
+						<span aria-hidden="true">·</span>
+						<span>レビュー無し</span>
+					</>
+				)}
+			</div>
+			<h2
+				className="mt-1 truncate font-semibold"
+				style={{ fontSize: 15, letterSpacing: -0.1 }}
+			>
+				{profile.headline}
+			</h2>
+			{profile.skill_tags.length > 0 && (
+				<ul aria-label="スキル" className="mt-2 flex flex-wrap gap-1">
+					{profile.skill_tags.map((t) => (
+						<li
+							key={t.name}
+							className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
+						>
+							#{t.display_name}
+						</li>
+					))}
+				</ul>
+			)}
+		</Link>
+	);
+}

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -31,6 +31,7 @@ import {
 	Search,
 	Settings,
 	User,
+	Users,
 	type LucideIcon,
 } from "lucide-react";
 
@@ -78,6 +79,8 @@ const NAV_ITEMS: NavItemDef[] = [
 	// 用、 X 風レイアウト) には追加済だが、 home が使う ALeftNav は別 list を持つ
 	// (#550 POC) ため、 ここにも明示する。
 	{ href: "/mentor/wanted", label: "メンター募集", Icon: Handshake },
+	// Phase 11-B (P11-14): mentor 検索 (anon 可)。 「募集」 と区別する label。
+	{ href: "/mentors", label: "メンターを探す", Icon: Users },
 ];
 
 function BrandMark({ size = 22 }: { size?: number }) {

--- a/client/src/lib/api/mentor.ts
+++ b/client/src/lib/api/mentor.ts
@@ -140,3 +140,57 @@ export async function acceptMentorProposal(
 	);
 	return res.data;
 }
+
+// --- /mentors/ (Phase 11-B) ---
+
+export type MentorPlanBilling = "one_time" | "monthly";
+
+export interface MentorPlanSummary {
+	id: number;
+	title: string;
+	description: string;
+	price_jpy: number;
+	billing_cycle: MentorPlanBilling;
+	is_active: boolean;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface MentorProfileDetail {
+	id: number;
+	user: MentorMiniUser;
+	headline: string;
+	bio: string;
+	experience_years: number;
+	is_accepting: boolean;
+	skill_tags: MentorTagSlim[];
+	plans: MentorPlanSummary[];
+	proposal_count: number;
+	contract_count: number;
+	avg_rating: string | null;
+	review_count: number;
+	created_at: string;
+	updated_at: string;
+}
+
+export async function listMentors(
+	params: { tag?: string; accepting?: "all"; cursor?: string } = {},
+	client: AxiosInstance = api,
+): Promise<PageResponse<MentorProfileDetail>> {
+	const qs = new URLSearchParams();
+	if (params.tag) qs.set("tag", params.tag);
+	if (params.accepting) qs.set("accepting", params.accepting);
+	if (params.cursor) qs.set("cursor", params.cursor);
+	const path =
+		qs.toString().length > 0 ? `/mentors/?${qs.toString()}` : "/mentors/";
+	const res = await client.get<PageResponse<MentorProfileDetail>>(path);
+	return res.data;
+}
+
+export async function getMentorByHandle(
+	handle: string,
+	client: AxiosInstance = api,
+): Promise<MentorProfileDetail> {
+	const res = await client.get<MentorProfileDetail>(`/mentors/${handle}/`);
+	return res.data;
+}


### PR DESCRIPTION
## Summary

11-B 第 4 弾。 mentor 検索一覧 + 個別 profile 詳細 (anon 可、 SSR)。

- `/mentors` (anon): SSR list、 sticky header、 ?tag= filter、 mentor card
- `/mentors/[handle]` (anon): profile 詳細 (紹介 / 本文 / スキル / 提供 plan / 実績)
- `lib/api/mentor.ts` 拡張: `MentorPlanSummary` / `MentorProfileDetail` 型 + `listMentors` / `getMentorByHandle`
- ALeftNav に「メンターを探す」 link (Users icon) — home から 1 click

## Test plan

- [x] tsc 通過、 ALeftNav vitest 6 件 regression PASS
- [ ] CI 緑

Closes #633