### PR TITLE
feat(mentorship): MentorshipContract complete / cancel API + me list (P11-17)

### DIFF
--- a/apps/mentorship/services.py
+++ b/apps/mentorship/services.py
@@ -11,7 +11,7 @@ spec: ``docs/specs/phase-11-mentor-board-spec.md`` §3.2, §6.2
 from __future__ import annotations
 
 from django.contrib.auth.models import AbstractBaseUser
-from django.db import transaction
+from django.db import models, transaction
 from django.utils import timezone
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 
@@ -101,3 +101,87 @@ def get_proposal_or_404(pk: int) -> MentorProposal:
     if proposal is None:
         raise NotFound("MentorProposal not found")
     return proposal
+
+
+# --- contract state transitions (P11-17) ---
+
+
+def get_contract_or_404(pk: int) -> MentorshipContract:
+    contract = (
+        MentorshipContract.objects.select_related("mentee", "mentor", "room").filter(pk=pk).first()
+    )
+    if contract is None:
+        raise NotFound("MentorshipContract not found")
+    return contract
+
+
+def complete_contract(
+    *,
+    contract: MentorshipContract,
+    by_user: AbstractBaseUser,
+) -> MentorshipContract:
+    """契約を COMPLETED に。 mentee / mentor どちらでも実行可。
+
+    既に COMPLETED なら冪等。 CANCELED は不可 (PermissionDenied 相当の
+    ValidationError)。 完了時に DMRoom.is_archived=True にして read-only UI 用 flag を
+    立てる (P11-19 で frontend が消費)。
+    """
+
+    if by_user.pk not in {contract.mentee_id, contract.mentor_id}:
+        raise PermissionDenied("契約当事者のみ完了できます")
+
+    if contract.status == MentorshipContract.Status.COMPLETED:
+        return contract
+    if contract.status == MentorshipContract.Status.CANCELED:
+        raise ValidationError("キャンセル済の契約は完了できません")
+
+    with transaction.atomic():
+        now = timezone.now()
+        contract.status = MentorshipContract.Status.COMPLETED
+        contract.completed_at = now
+        contract.save(update_fields=["status", "completed_at", "updated_at"])
+
+        # DMRoom を archived に (composer 無効 + 「契約完了」 banner 用)。
+        room = contract.room
+        if not room.is_archived:
+            room.is_archived = True
+            room.save(update_fields=["is_archived", "updated_at"])
+
+        # mentor profile の集計 (contract_count) を atomic に +1。
+        from apps.mentorship.models import MentorProfile  # 局所 import (循環回避)
+
+        MentorProfile.objects.filter(user=contract.mentor).update(
+            contract_count=models.F("contract_count") + 1,
+        )
+
+    return contract
+
+
+def cancel_contract(
+    *,
+    contract: MentorshipContract,
+    by_user: AbstractBaseUser,
+) -> MentorshipContract:
+    """契約をキャンセル。 mentee / mentor どちらでも実行可。
+
+    既に CANCELED なら冪等。 COMPLETED は不可 (一度完了した契約は取り消せない)。
+    DMRoom も archived に。
+    """
+
+    if by_user.pk not in {contract.mentee_id, contract.mentor_id}:
+        raise PermissionDenied("契約当事者のみキャンセルできます")
+
+    if contract.status == MentorshipContract.Status.CANCELED:
+        return contract
+    if contract.status == MentorshipContract.Status.COMPLETED:
+        raise ValidationError("完了済の契約はキャンセルできません")
+
+    with transaction.atomic():
+        contract.status = MentorshipContract.Status.CANCELED
+        contract.save(update_fields=["status", "updated_at"])
+        room = contract.room
+        if not room.is_archived:
+            room.is_archived = True
+            room.save(update_fields=["is_archived", "updated_at"])
+
+    return contract

--- a/apps/mentorship/tests/test_contract_actions.py
+++ b/apps/mentorship/tests/test_contract_actions.py
@@ -1,0 +1,205 @@
+"""Tests for MentorshipContract complete / cancel + list / detail API (P11-17)。
+
+spec §6.4
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.dm.models import DMRoom
+from apps.mentorship.models import (
+    MentorProfile,
+    MentorProposal,
+    MentorRequest,
+    MentorshipContract,
+)
+
+User = get_user_model()
+
+
+def _user(username: str):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",  # pragma: allowlist secret
+        first_name="F",
+        last_name="L",
+    )
+
+
+@pytest.fixture
+def alice():
+    return _user("alice")
+
+
+@pytest.fixture
+def bob():
+    return _user("bob")
+
+
+@pytest.fixture
+def carol():
+    return _user("carol")
+
+
+def _auth(user) -> APIClient:
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+def _make_contract(mentee, mentor) -> MentorshipContract:
+    """ACTIVE contract を 1 つ作るヘルパ。"""
+    req = MentorRequest.objects.create(mentee=mentee, title="t", body="b")
+    proposal = MentorProposal.objects.create(
+        request=req, mentor=mentor, body="hi", status=MentorProposal.Status.ACCEPTED
+    )
+    room = DMRoom.objects.create(kind=DMRoom.Kind.MENTORSHIP)
+    return MentorshipContract.objects.create(
+        proposal=proposal, mentee=mentee, mentor=mentor, room=room
+    )
+
+
+# ---- list (me) ----
+
+
+@pytest.mark.django_db
+def test_list_me_returns_both_roles(alice, bob, carol):
+    """mentee 側 + mentor 側 両方の contract が default で返る。"""
+    c1 = _make_contract(alice, bob)  # alice mentee
+    c2 = _make_contract(carol, alice)  # alice mentor
+    res = _auth(alice).get(reverse("mentor-contract-me-list"))
+    assert res.status_code == 200
+    ids = sorted(r["id"] for r in res.data)
+    assert ids == sorted([c1.pk, c2.pk])
+
+
+@pytest.mark.django_db
+def test_list_me_role_filter(alice, bob, carol):
+    c_mentee = _make_contract(alice, bob)
+    c_mentor = _make_contract(carol, alice)
+    res = _auth(alice).get(reverse("mentor-contract-me-list"), {"role": "mentee"})
+    assert [r["id"] for r in res.data] == [c_mentee.pk]
+    res2 = _auth(alice).get(reverse("mentor-contract-me-list"), {"role": "mentor"})
+    assert [r["id"] for r in res2.data] == [c_mentor.pk]
+
+
+@pytest.mark.django_db
+def test_list_me_anon_forbidden():
+    res = APIClient().get(reverse("mentor-contract-me-list"))
+    assert res.status_code in {401, 403}
+
+
+# ---- detail ----
+
+
+@pytest.mark.django_db
+def test_detail_party_only(alice, bob, carol):
+    """contract 当事者 (mentee or mentor) のみ閲覧可。"""
+    contract = _make_contract(alice, bob)
+    res_mentee = _auth(alice).get(reverse("mentor-contract-detail", args=[contract.pk]))
+    res_mentor = _auth(bob).get(reverse("mentor-contract-detail", args=[contract.pk]))
+    res_third = _auth(carol).get(reverse("mentor-contract-detail", args=[contract.pk]))
+    assert res_mentee.status_code == 200
+    assert res_mentor.status_code == 200
+    assert res_third.status_code == 403
+
+
+@pytest.mark.django_db
+def test_detail_404(alice):
+    res = _auth(alice).get(reverse("mentor-contract-detail", args=[999_999]))
+    assert res.status_code == 404
+
+
+# ---- complete ----
+
+
+@pytest.mark.django_db
+def test_complete_by_mentee(alice, bob):
+    contract = _make_contract(alice, bob)
+    res = _auth(alice).post(reverse("mentor-contract-complete", args=[contract.pk]))
+    assert res.status_code == 200
+    contract.refresh_from_db()
+    assert contract.status == MentorshipContract.Status.COMPLETED
+    assert contract.completed_at is not None
+    # DMRoom.is_archived=True
+    assert contract.room.is_archived is True
+
+
+@pytest.mark.django_db
+def test_complete_by_mentor_also_allowed(alice, bob):
+    contract = _make_contract(alice, bob)
+    res = _auth(bob).post(reverse("mentor-contract-complete", args=[contract.pk]))
+    assert res.status_code == 200
+    contract.refresh_from_db()
+    assert contract.status == MentorshipContract.Status.COMPLETED
+
+
+@pytest.mark.django_db
+def test_complete_third_party_forbidden(alice, bob, carol):
+    contract = _make_contract(alice, bob)
+    res = _auth(carol).post(reverse("mentor-contract-complete", args=[contract.pk]))
+    assert res.status_code == 403
+
+
+@pytest.mark.django_db
+def test_complete_idempotent(alice, bob):
+    contract = _make_contract(alice, bob)
+    _auth(alice).post(reverse("mentor-contract-complete", args=[contract.pk]))
+    # 2 回目は同じ contract を返す (200、 status は COMPLETED のまま)
+    res = _auth(alice).post(reverse("mentor-contract-complete", args=[contract.pk]))
+    assert res.status_code == 200
+    contract.refresh_from_db()
+    assert contract.status == MentorshipContract.Status.COMPLETED
+
+
+@pytest.mark.django_db
+def test_complete_after_cancel_rejected(alice, bob):
+    contract = _make_contract(alice, bob)
+    contract.status = MentorshipContract.Status.CANCELED
+    contract.save(update_fields=["status"])
+    res = _auth(alice).post(reverse("mentor-contract-complete", args=[contract.pk]))
+    assert res.status_code == 400
+
+
+@pytest.mark.django_db
+def test_complete_increments_mentor_contract_count(alice, bob):
+    """mentor profile が存在すると complete で contract_count が +1 されることを検証。"""
+    MentorProfile.objects.create(user=bob, headline="m", bio="b", experience_years=1)
+    contract = _make_contract(alice, bob)
+    _auth(alice).post(reverse("mentor-contract-complete", args=[contract.pk]))
+    bob_profile = MentorProfile.objects.get(user=bob)
+    assert bob_profile.contract_count == 1
+
+
+# ---- cancel ----
+
+
+@pytest.mark.django_db
+def test_cancel_by_party(alice, bob):
+    contract = _make_contract(alice, bob)
+    res = _auth(bob).post(reverse("mentor-contract-cancel", args=[contract.pk]))
+    assert res.status_code == 200
+    contract.refresh_from_db()
+    assert contract.status == MentorshipContract.Status.CANCELED
+    assert contract.room.is_archived is True
+
+
+@pytest.mark.django_db
+def test_cancel_after_complete_rejected(alice, bob):
+    contract = _make_contract(alice, bob)
+    contract.status = MentorshipContract.Status.COMPLETED
+    contract.save(update_fields=["status"])
+    res = _auth(alice).post(reverse("mentor-contract-cancel", args=[contract.pk]))
+    assert res.status_code == 400
+
+
+@pytest.mark.django_db
+def test_cancel_third_party_forbidden(alice, bob, carol):
+    contract = _make_contract(alice, bob)
+    res = _auth(carol).post(reverse("mentor-contract-cancel", args=[contract.pk]))
+    assert res.status_code == 403

--- a/apps/mentorship/urls.py
+++ b/apps/mentorship/urls.py
@@ -1,7 +1,6 @@
 """URL routing for /api/v1/mentor/... endpoints.
 
-P11-03: MentorRequest CRUD + close を配線。
-spec §6.1
+spec §6.1, §6.2, §6.4
 """
 
 from django.urls import path
@@ -12,6 +11,10 @@ from apps.mentorship.views import (
     MentorRequestCloseView,
     MentorRequestDetailView,
     MentorRequestListCreateView,
+    MentorshipContractCancelView,
+    MentorshipContractCompleteView,
+    MentorshipContractDetailView,
+    MentorshipContractMeListView,
 )
 
 urlpatterns = [
@@ -41,5 +44,26 @@ urlpatterns = [
         "proposals/<int:pk>/accept/",
         MentorProposalAcceptView.as_view(),
         name="mentor-proposal-accept",
+    ),
+    # P11-17: contract list / detail / complete / cancel
+    path(
+        "contracts/me/",
+        MentorshipContractMeListView.as_view(),
+        name="mentor-contract-me-list",
+    ),
+    path(
+        "contracts/<int:pk>/",
+        MentorshipContractDetailView.as_view(),
+        name="mentor-contract-detail",
+    ),
+    path(
+        "contracts/<int:pk>/complete/",
+        MentorshipContractCompleteView.as_view(),
+        name="mentor-contract-complete",
+    ),
+    path(
+        "contracts/<int:pk>/cancel/",
+        MentorshipContractCancelView.as_view(),
+        name="mentor-contract-cancel",
     ),
 ]

--- a/apps/mentorship/views.py
+++ b/apps/mentorship/views.py
@@ -454,3 +454,71 @@ class MentorPlanDetailView(APIView):
             plan.is_active = False
             plan.save(update_fields=["is_active", "updated_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# --- MentorshipContract list / detail / complete / cancel (P11-17) ---
+
+
+class MentorshipContractMeListView(APIView):
+    """`GET /mentor/contracts/me/` — 自分が当事者の契約一覧 (mentee + mentor 両方)。
+
+    `?role=mentee` or `?role=mentor` で絞り込み可。
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        from django.db.models import Q
+
+        from apps.mentorship.models import MentorshipContract
+
+        role = request.query_params.get("role")
+        qs = MentorshipContract.objects.select_related("mentee", "mentor", "room")
+        if role == "mentee":
+            qs = qs.filter(mentee=request.user)
+        elif role == "mentor":
+            qs = qs.filter(mentor=request.user)
+        else:
+            qs = qs.filter(Q(mentee=request.user) | Q(mentor=request.user))
+        qs = qs.order_by("-started_at")
+        return Response(MentorshipContractDetailSerializer(qs, many=True).data)
+
+
+class MentorshipContractDetailView(APIView):
+    """`GET /mentor/contracts/<id>/` — 契約詳細 (mentee or mentor のみ可)。"""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request: Request, pk: int) -> Response:
+        from apps.mentorship.services import get_contract_or_404
+
+        contract = get_contract_or_404(pk)
+        if request.user.pk not in {contract.mentee_id, contract.mentor_id}:
+            raise PermissionDenied("契約当事者のみ閲覧できます")
+        return Response(MentorshipContractDetailSerializer(contract).data)
+
+
+class MentorshipContractCompleteView(APIView):
+    """`POST /mentor/contracts/<id>/complete/`。"""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request: Request, pk: int) -> Response:
+        from apps.mentorship.services import complete_contract, get_contract_or_404
+
+        contract = get_contract_or_404(pk)
+        contract = complete_contract(contract=contract, by_user=request.user)
+        return Response(MentorshipContractDetailSerializer(contract).data)
+
+
+class MentorshipContractCancelView(APIView):
+    """`POST /mentor/contracts/<id>/cancel/`。"""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request: Request, pk: int) -> Response:
+        from apps.mentorship.services import cancel_contract, get_contract_or_404
+
+        contract = get_contract_or_404(pk)
+        contract = cancel_contract(contract=contract, by_user=request.user)
+        return Response(MentorshipContractDetailSerializer(contract).data)


### PR DESCRIPTION
## Summary

11-C 第 1 弾 (spec §6.4)。

- `services.complete_contract / cancel_contract`:
  - mentee / mentor 当事者のみ実行可
  - complete 冪等 / CANCELED 後 → 400
  - cancel 冪等 / COMPLETED 後 → 400
  - 両者で DMRoom.is_archived=True (P11-19 frontend の read-only UI 用 flag)
  - complete 時に MentorProfile.contract_count を F() +1
- 4 endpoint:
  - `GET /mentor/contracts/me/` (?role=mentee|mentor)
  - `GET /mentor/contracts/<id>/` (当事者のみ)
  - `POST /mentor/contracts/<id>/complete/`
  - `POST /mentor/contracts/<id>/cancel/`

## Test plan

- [x] pytest 13 件追加、 mentorship 全 93 件 GREEN
- [ ] CI 緑

Closes #636