### PR TITLE
feat(mentorship): /mentor/contracts/me + 詳細 + complete/cancel button (P11-18)

### DIFF
--- a/client/src/app/(template)/mentor/contracts/[id]/page.tsx
+++ b/client/src/app/(template)/mentor/contracts/[id]/page.tsx
@@ -1,0 +1,179 @@
+/**
+ * /mentor/contracts/<id> — 契約詳細 + complete / cancel button (P11-18).
+ *
+ * auth 必須。 server-side で current user を取得し party 判定。 第三者は 404 隠蔽。
+ *
+ * spec §7
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+
+import ContractActions from "@/components/mentorship/ContractActions";
+import { type MentorshipContractDetail } from "@/lib/api/mentor";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { CurrentUser } from "@/lib/api/users";
+
+interface PageProps {
+	params: { id: string };
+}
+
+export const metadata: Metadata = {
+	title: "メンタリング契約 — エンジニア SNS",
+	robots: { index: false },
+};
+
+async function fetchContract(
+	id: number,
+): Promise<MentorshipContractDetail | null> {
+	try {
+		return await serverFetch<MentorshipContractDetail>(
+			`/mentor/contracts/${id}/`,
+		);
+	} catch (err) {
+		if (
+			err instanceof ApiServerError &&
+			(err.status === 404 || err.status === 403)
+		) {
+			return null;
+		}
+		throw err;
+	}
+}
+
+async function fetchCurrentUser(): Promise<CurrentUser | null> {
+	try {
+		return await serverFetch<CurrentUser>("/users/me/");
+	} catch {
+		return null;
+	}
+}
+
+export default async function ContractDetailPage({ params }: PageProps) {
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	if (!isAuthenticated) {
+		redirect(`/login?next=/mentor/contracts/${params.id}`);
+	}
+	const id = Number.parseInt(params.id, 10);
+	if (!Number.isFinite(id)) notFound();
+
+	const [contract, currentUser] = await Promise.all([
+		fetchContract(id),
+		fetchCurrentUser(),
+	]);
+	if (!contract) notFound();
+
+	const role: "mentee" | "mentor" | "third" =
+		currentUser?.username === contract.mentee.handle
+			? "mentee"
+			: currentUser?.username === contract.mentor.handle
+				? "mentor"
+				: "third";
+	if (role === "third") notFound();
+
+	const statusLabel =
+		contract.status === "active"
+			? "進行中"
+			: contract.status === "completed"
+				? "完了"
+				: "キャンセル";
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<Link
+					href="/mentor/contracts/me"
+					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					style={{ fontSize: 12.5 }}
+				>
+					← 契約一覧
+				</Link>
+				<div className="ml-2 min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						契約 #{contract.id}
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{statusLabel} ·{" "}
+						{new Date(contract.started_at).toLocaleString("ja-JP")}
+					</p>
+				</div>
+			</header>
+
+			<div className="space-y-6 p-5">
+				<section aria-label="契約当事者">
+					<h2 className="mb-2 text-sm font-semibold">当事者</h2>
+					<dl className="grid grid-cols-2 gap-2 text-sm">
+						<div>
+							<dt className="text-[color:var(--a-text-muted)]">mentee</dt>
+							<dd>
+								<Link
+									href={`/u/${contract.mentee.handle}`}
+									className="font-semibold underline-offset-2 hover:underline"
+								>
+									@{contract.mentee.handle}
+								</Link>
+							</dd>
+						</div>
+						<div>
+							<dt className="text-[color:var(--a-text-muted)]">mentor</dt>
+							<dd>
+								<Link
+									href={`/u/${contract.mentor.handle}`}
+									className="font-semibold underline-offset-2 hover:underline"
+								>
+									@{contract.mentor.handle}
+								</Link>
+							</dd>
+						</div>
+					</dl>
+				</section>
+
+				<section aria-label="DM ルームへ">
+					<Link
+						href={`/messages/${contract.room_id}`}
+						className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--a-border)] px-3 py-1.5 text-sm transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+					>
+						🤝 DM ルームを開く
+					</Link>
+				</section>
+
+				<section aria-label="契約状況">
+					<h2 className="mb-2 text-sm font-semibold">契約状況</h2>
+					{contract.status === "active" ? (
+						<ContractActions contractId={contract.id} />
+					) : (
+						<p
+							role="status"
+							className="rounded border border-[color:var(--a-border)] bg-[color:var(--a-bg-muted)] px-3 py-2 text-sm"
+						>
+							この契約は{" "}
+							<strong>
+								{contract.status === "completed" ? "完了済" : "キャンセル済"}
+							</strong>{" "}
+							です
+							{contract.completed_at
+								? ` (${new Date(contract.completed_at).toLocaleString("ja-JP")} 完了)`
+								: ""}
+							。
+						</p>
+					)}
+				</section>
+			</div>
+		</>
+	);
+}

--- a/client/src/app/(template)/mentor/contracts/me/page.tsx
+++ b/client/src/app/(template)/mentor/contracts/me/page.tsx
@@ -1,0 +1,176 @@
+/**
+ * /mentor/contracts/me — 自分の契約一覧 (P11-18 / Phase 11-C).
+ *
+ * auth 必須。 SSR で list を fetch、 mentee tab / mentor tab で切替表示。
+ *
+ * spec §7
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { type MentorshipContractDetail } from "@/lib/api/mentor";
+import { serverFetch, ApiServerError } from "@/lib/api/server";
+
+export const metadata: Metadata = {
+	title: "メンタリング契約一覧 — エンジニア SNS",
+	robots: { index: false },
+};
+
+interface PageProps {
+	searchParams?: { role?: string };
+}
+
+type Role = "all" | "mentee" | "mentor";
+
+function resolveRole(raw: string | undefined): Role {
+	if (raw === "mentee") return "mentee";
+	if (raw === "mentor") return "mentor";
+	return "all";
+}
+
+async function fetchContracts(role: Role): Promise<MentorshipContractDetail[]> {
+	try {
+		const path =
+			role === "all"
+				? "/mentor/contracts/me/"
+				: `/mentor/contracts/me/?role=${role}`;
+		return await serverFetch<MentorshipContractDetail[]>(path);
+	} catch (err) {
+		if (err instanceof ApiServerError) return [];
+		return [];
+	}
+}
+
+export default async function ContractsMePage({ searchParams }: PageProps) {
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+	if (!isAuthenticated) {
+		redirect("/login?next=/mentor/contracts/me");
+	}
+
+	const role = resolveRole(searchParams?.role);
+	const contracts = await fetchContracts(role);
+
+	const tabs: { key: Role; label: string; href: string }[] = [
+		{ key: "all", label: "すべて", href: "/mentor/contracts/me" },
+		{
+			key: "mentee",
+			label: "教わる側",
+			href: "/mentor/contracts/me?role=mentee",
+		},
+		{
+			key: "mentor",
+			label: "教える側",
+			href: "/mentor/contracts/me?role=mentor",
+		},
+	];
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						メンタリング契約
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						{role === "mentee"
+							? "あなたが教わる契約"
+							: role === "mentor"
+								? "あなたが教える契約"
+								: "成立済の契約 (mentee + mentor 両方)"}
+					</p>
+				</div>
+			</header>
+
+			<nav
+				aria-label="契約 role タブ"
+				className="mt-2 flex border-b border-[color:var(--a-border)] px-4"
+			>
+				{tabs.map((t) => (
+					<Link
+						key={t.key}
+						href={t.href}
+						aria-current={role === t.key ? "page" : undefined}
+						className={`relative px-4 py-2 text-sm font-medium transition ${
+							role === t.key
+								? "text-[color:var(--a-text)]"
+								: "text-[color:var(--a-text-muted)] hover:bg-[color:var(--a-bg-muted)]"
+						}`}
+					>
+						{t.label}
+						{role === t.key ? (
+							<span
+								aria-hidden="true"
+								className="absolute inset-x-2 bottom-0 h-0.5 rounded-full"
+								style={{ background: "var(--a-accent)" }}
+							/>
+						) : null}
+					</Link>
+				))}
+			</nav>
+
+			<div className="p-5">
+				{contracts.length === 0 ? (
+					<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
+						契約がありません。
+					</p>
+				) : (
+					<ul role="list" className="grid gap-3">
+						{contracts.map((c) => (
+							<li key={c.id}>
+								<ContractCard contract={c} />
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</>
+	);
+}
+
+function ContractCard({ contract }: { contract: MentorshipContractDetail }) {
+	const statusLabel =
+		contract.status === "active"
+			? "進行中"
+			: contract.status === "completed"
+				? "完了"
+				: "キャンセル";
+	return (
+		<Link
+			href={`/mentor/contracts/${contract.id}`}
+			aria-label={`契約 #${contract.id} を開く`}
+			className="block rounded-lg border border-[color:var(--a-border)] p-4 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+		>
+			<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">
+				<span>#{contract.id}</span>
+				<span aria-hidden="true">·</span>
+				<span>{statusLabel}</span>
+				<span aria-hidden="true">·</span>
+				<time dateTime={contract.started_at}>
+					{new Date(contract.started_at).toLocaleDateString("ja-JP")}
+				</time>
+			</div>
+			<p className="mt-1 text-sm">
+				<span className="text-[color:var(--a-text-muted)]">mentee:</span>{" "}
+				<span className="font-semibold">@{contract.mentee.handle}</span>{" "}
+				<span className="text-[color:var(--a-text-muted)]">/ mentor:</span>{" "}
+				<span className="font-semibold">@{contract.mentor.handle}</span>
+			</p>
+		</Link>
+	);
+}

--- a/client/src/components/mentorship/ContractActions.tsx
+++ b/client/src/components/mentorship/ContractActions.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+/**
+ * ContractActions (P11-18).
+ *
+ * active な契約に対して mentee / mentor が complete / cancel を実行する button。
+ * いずれも confirm dialog で誤クリック防止、 成功で page refresh。
+ */
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+import { cancelContract, completeContract } from "@/lib/api/mentor";
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { data?: Record<string, unknown> };
+			message?: string;
+		};
+		const data = e.response?.data;
+		if (data && typeof data === "object") {
+			const detail = (data as { detail?: string }).detail;
+			if (typeof detail === "string") return detail;
+		}
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function ContractActions({
+	contractId,
+}: {
+	contractId: number;
+}) {
+	const router = useRouter();
+	const [busy, setBusy] = useState<"complete" | "cancel" | null>(null);
+
+	const handleComplete = async () => {
+		if (!window.confirm("契約を完了しますか? 完了後はキャンセルできません。")) {
+			return;
+		}
+		setBusy("complete");
+		try {
+			await completeContract(contractId);
+			toast.success("契約を完了しました");
+			router.refresh();
+		} catch (err) {
+			toast.error(describeApiError(err, "完了に失敗しました"));
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	const handleCancel = async () => {
+		if (!window.confirm("契約をキャンセルしますか? 履歴は残ります。")) {
+			return;
+		}
+		setBusy("cancel");
+		try {
+			await cancelContract(contractId);
+			toast.success("契約をキャンセルしました");
+			router.refresh();
+		} catch (err) {
+			toast.error(describeApiError(err, "キャンセルに失敗しました"));
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	return (
+		<div className="flex flex-wrap items-center gap-3">
+			<button
+				type="button"
+				onClick={handleComplete}
+				disabled={busy !== null}
+				className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+			>
+				{busy === "complete" ? "完了中…" : "契約を完了する"}
+			</button>
+			<button
+				type="button"
+				onClick={handleCancel}
+				disabled={busy !== null}
+				className="rounded-full border border-destructive/40 px-5 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-destructive disabled:opacity-50"
+			>
+				{busy === "cancel" ? "キャンセル中…" : "キャンセルする"}
+			</button>
+		</div>
+	);
+}

--- a/client/src/lib/api/mentor.ts
+++ b/client/src/lib/api/mentor.ts
@@ -266,3 +266,49 @@ export async function deleteMyMentorPlan(
 ): Promise<void> {
 	await client.delete(`/mentors/me/plans/${planId}/`);
 }
+
+// --- MentorshipContract (Phase 11-C P11-18) ---
+
+export async function listMyContracts(
+	params: { role?: "mentee" | "mentor" } = {},
+	client: AxiosInstance = api,
+): Promise<MentorshipContractDetail[]> {
+	const qs = new URLSearchParams();
+	if (params.role) qs.set("role", params.role);
+	const path =
+		qs.toString().length > 0
+			? `/mentor/contracts/me/?${qs.toString()}`
+			: "/mentor/contracts/me/";
+	const res = await client.get<MentorshipContractDetail[]>(path);
+	return res.data;
+}
+
+export async function getMentorshipContract(
+	id: number,
+	client: AxiosInstance = api,
+): Promise<MentorshipContractDetail> {
+	const res = await client.get<MentorshipContractDetail>(
+		`/mentor/contracts/${id}/`,
+	);
+	return res.data;
+}
+
+export async function completeContract(
+	id: number,
+	client: AxiosInstance = api,
+): Promise<MentorshipContractDetail> {
+	const res = await client.post<MentorshipContractDetail>(
+		`/mentor/contracts/${id}/complete/`,
+	);
+	return res.data;
+}
+
+export async function cancelContract(
+	id: number,
+	client: AxiosInstance = api,
+): Promise<MentorshipContractDetail> {
+	const res = await client.post<MentorshipContractDetail>(
+		`/mentor/contracts/${id}/cancel/`,
+	);
+	return res.data;
+}


### PR DESCRIPTION
## Summary

11-C 第 2 弾。 自分の契約一覧 + 個別詳細 + complete / cancel 操作 UI。

- `lib/api/mentor.ts`: `listMyContracts` / `getMentorshipContract` / `completeContract` / `cancelContract` helper
- `/mentor/contracts/me` (auth、 SSR): role tab (all/mentee/mentor) + contract card
- `/mentor/contracts/[id]` (auth、 SSR): party 判定 (third → 404 隠蔽) + DM ルーム link + `ContractActions`
- `ContractActions` (client): complete / cancel button + confirm dialog + router.refresh

## Test plan

- [x] tsc 通過
- [ ] CI 緑

Closes #637