### PR TITLE
feat(mentorship): RoomChat 完了時 read-only UI (P11-19)

### DIFF
--- a/client/src/components/dm/RoomChat.tsx
+++ b/client/src/components/dm/RoomChat.tsx
@@ -187,17 +187,29 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 					/>
 				</div>
 			</header>
-			{/* P11-08: メンタリング契約 room に banner。 contract.status=ACTIVE 中は
-			    composer を残し、 完了 (is_archived=true) なら別 UI で disable する想定
-			    (P11-19 で実装)。 ここでは識別 banner だけ。 */}
+			{/* P11-08 + P11-19: mentorship room banner。
+			    - is_archived=false (contract.status=ACTIVE): 「契約中」 の青 banner、
+			      composer は通常通り利用可能
+			    - is_archived=true (contract complete / cancel 済): 「終了」 黄色 banner +
+			      composer は disabled (read-only history mode) */}
 			{roomQuery.data?.kind === "mentorship" ? (
-				<div
-					role="status"
-					aria-label="メンタリング契約 room"
-					className="border-baby_grey/10 bg-baby_blue/10 text-baby_blue border-b px-4 py-1.5 text-xs"
-				>
-					🤝 メンタリング契約中の room です。
-				</div>
+				roomQuery.data.is_archived ? (
+					<div
+						role="status"
+						aria-label="メンタリング契約終了 room"
+						className="border-baby_grey/10 border-b bg-yellow-400/10 px-4 py-1.5 text-xs text-yellow-200"
+					>
+						🤝 このメンタリング契約は終了しました。 履歴のみ閲覧できます。
+					</div>
+				) : (
+					<div
+						role="status"
+						aria-label="メンタリング契約 room"
+						className="border-baby_grey/10 bg-baby_blue/10 text-baby_blue border-b px-4 py-1.5 text-xs"
+					>
+						🤝 メンタリング契約中の room です。
+					</div>
+				)
 			) : null}
 			<MessageList
 				messages={merged}
@@ -217,7 +229,11 @@ export default function RoomChat({ roomId, currentUserId }: RoomChatProps) {
 			<MessageComposer
 				onSubmit={onSubmit}
 				onTyping={socket.sendTyping}
-				disabled={socket.status !== "open"}
+				// P11-19: archived room (mentorship 契約完了) は composer 無効化。
+				// 既存仕様 (socket closed で無効) と OR 結合。
+				disabled={
+					socket.status !== "open" || (roomQuery.data?.is_archived ?? false)
+				}
 				roomId={roomId}
 			/>
 		</section>


### PR DESCRIPTION
## Summary

11-C 最終 PR。 P11-17 で立てた `DMRoom.is_archived=True` (mentorship 契約 complete / cancel) を frontend で消費。

- `kind === "mentorship"` + `is_archived === true` の場合:
  - 黄色 banner「🤝 このメンタリング契約は終了しました。 履歴のみ閲覧できます。」
  - `MessageComposer.disabled` に `is_archived` を OR 結合 → 入力欄無効
- `is_archived === false` (active) は従来の青 banner 維持

## Phase 11-C 完成

mentor 募集 → 提案 → accept → DM → complete → 履歴 read-only の **end-to-end loop** が動く状態。

## Test plan

- [x] tsc 通過
- [ ] CI 緑
- [ ] stg merge 後、 mentorship room を complete → composer 無効 + 黄色 banner を実画面確認

Closes #638