### PR TITLE
feat(mentorship): contract page に review form + /mentors/<handle> に review list (P11-21)

### DIFF
--- a/client/src/app/(template)/mentor/contracts/[id]/page.tsx
+++ b/client/src/app/(template)/mentor/contracts/[id]/page.tsx
@@ -12,7 +12,11 @@ import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 
 import ContractActions from "@/components/mentorship/ContractActions";
-import { type MentorshipContractDetail } from "@/lib/api/mentor";
+import ReviewForm from "@/components/mentorship/ReviewForm";
+import {
+	type MentorReview,
+	type MentorshipContractDetail,
+} from "@/lib/api/mentor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { CurrentUser } from "@/lib/api/users";
 
@@ -51,6 +55,21 @@ async function fetchCurrentUser(): Promise<CurrentUser | null> {
 	}
 }
 
+async function fetchExistingReview(
+	mentorHandle: string,
+	contractId: number,
+): Promise<MentorReview | null> {
+	// 公開 review 一覧から該当 contract の review を引く (mentee は自分の投稿を編集可能)。
+	try {
+		const reviews = await serverFetch<MentorReview[]>(
+			`/mentors/${mentorHandle}/reviews/`,
+		);
+		return reviews.find((r) => r.contract === contractId) ?? null;
+	} catch {
+		return null;
+	}
+}
+
 export default async function ContractDetailPage({ params }: PageProps) {
 	const isAuthenticated = cookies().get("logged_in")?.value === "true";
 	if (!isAuthenticated) {
@@ -72,6 +91,13 @@ export default async function ContractDetailPage({ params }: PageProps) {
 				? "mentor"
 				: "third";
 	if (role === "third") notFound();
+
+	// P11-21: mentee が completed 契約に review 投稿 / 編集できる。 既存 review を
+	// 先に取得して form に pre-populate (上書き編集対応)。
+	const existingReview =
+		role === "mentee" && contract.status === "completed"
+			? await fetchExistingReview(contract.mentor.handle, contract.id)
+			: null;
 
 	const statusLabel =
 		contract.status === "active"
@@ -173,6 +199,17 @@ export default async function ContractDetailPage({ params }: PageProps) {
 						</p>
 					)}
 				</section>
+
+				{role === "mentee" && contract.status === "completed" && (
+					<section aria-label="メンターレビュー">
+						<h2 className="mb-2 text-sm font-semibold">
+							{existingReview
+								? "あなたのレビュー (編集可能)"
+								: "メンターを評価"}
+						</h2>
+						<ReviewForm contractId={contract.id} existing={existingReview} />
+					</section>
+				)}
 			</div>
 		</>
 	);

--- a/client/src/app/(template)/mentors/[handle]/page.tsx
+++ b/client/src/app/(template)/mentors/[handle]/page.tsx
@@ -9,7 +9,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { type MentorProfileDetail } from "@/lib/api/mentor";
+import { type MentorProfileDetail, type MentorReview } from "@/lib/api/mentor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 
 interface PageProps {
@@ -27,6 +27,14 @@ async function fetchProfile(
 	}
 }
 
+async function fetchReviews(handle: string): Promise<MentorReview[]> {
+	try {
+		return await serverFetch<MentorReview[]>(`/mentors/${handle}/reviews/`);
+	} catch {
+		return [];
+	}
+}
+
 export async function generateMetadata({
 	params,
 }: PageProps): Promise<Metadata> {
@@ -40,7 +48,10 @@ export async function generateMetadata({
 }
 
 export default async function MentorDetailPage({ params }: PageProps) {
-	const profile = await fetchProfile(params.handle);
+	const [profile, reviews] = await Promise.all([
+		fetchProfile(params.handle),
+		fetchReviews(params.handle),
+	]);
 	if (!profile) notFound();
 
 	const rating =
@@ -170,6 +181,43 @@ export default async function MentorDetailPage({ params }: PageProps) {
 						</div>
 					</dl>
 				</section>
+
+				{reviews.length > 0 && (
+					<section aria-label="メンターレビュー">
+						<h2 className="mb-2 text-sm font-semibold">レビュー</h2>
+						<ul role="list" className="grid gap-3">
+							{reviews.map((r) => (
+								<li
+									key={r.id}
+									className="rounded-lg border border-[color:var(--a-border)] p-3"
+								>
+									<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">
+										<span
+											aria-label={`★ ${r.rating} / 5`}
+											className="text-yellow-500"
+										>
+											{"★".repeat(r.rating)}
+											<span className="text-[color:var(--a-text-muted)]">
+												{"★".repeat(5 - r.rating)}
+											</span>
+										</span>
+										<span aria-hidden="true">·</span>
+										<span>
+											@{r.mentee ? r.mentee.handle : "退会済ユーザー"}
+										</span>
+										<span aria-hidden="true">·</span>
+										<time dateTime={r.created_at}>
+											{new Date(r.created_at).toLocaleDateString("ja-JP")}
+										</time>
+									</div>
+									<p className="mt-1 whitespace-pre-wrap text-sm text-[color:var(--a-text)]">
+										{r.comment}
+									</p>
+								</li>
+							))}
+						</ul>
+					</section>
+				)}
 			</div>
 		</>
 	);

--- a/client/src/components/mentorship/ReviewForm.tsx
+++ b/client/src/components/mentorship/ReviewForm.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+/**
+ * ReviewForm (P11-21).
+ *
+ * 契約完了後の mentee が mentor を ★1-5 + comment で評価する form。
+ * 既存 review があれば pre-populate して上書き編集も可能。
+ */
+
+import { useState, type FormEvent } from "react";
+import { toast } from "react-toastify";
+
+import { submitContractReview, type MentorReview } from "@/lib/api/mentor";
+
+function describeApiError(err: unknown, fallback: string): string {
+	if (err && typeof err === "object") {
+		const e = err as {
+			response?: { data?: Record<string, unknown> };
+			message?: string;
+		};
+		const data = e.response?.data;
+		if (data && typeof data === "object") {
+			const detail = (data as { detail?: string }).detail;
+			if (typeof detail === "string") return detail;
+		}
+		if (typeof e.message === "string") return e.message;
+	}
+	return fallback;
+}
+
+export default function ReviewForm({
+	contractId,
+	existing,
+}: {
+	contractId: number;
+	existing?: MentorReview | null;
+}) {
+	const [rating, setRating] = useState<number>(existing?.rating ?? 5);
+	const [comment, setComment] = useState<string>(existing?.comment ?? "");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [done, setDone] = useState(false);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		if (!comment.trim()) {
+			setError("コメントを入力してください");
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await submitContractReview(contractId, rating, comment.trim());
+			toast.success(
+				existing ? "レビューを更新しました" : "レビューを投稿しました",
+			);
+			setDone(true);
+		} catch (err) {
+			setError(describeApiError(err, "送信に失敗しました"));
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	if (done) {
+		return (
+			<p
+				role="status"
+				className="rounded border border-[color:var(--a-border)] bg-[color:var(--a-bg-muted)] px-3 py-2 text-sm"
+			>
+				✅ レビューを送信しました。 mentor のプロフィールに表示されます。
+			</p>
+		);
+	}
+
+	return (
+		<form
+			onSubmit={handleSubmit}
+			aria-label="メンターレビューフォーム"
+			className="space-y-3 rounded-lg border border-[color:var(--a-border)] p-4"
+		>
+			{error && (
+				<p
+					role="alert"
+					className="rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+				>
+					{error}
+				</p>
+			)}
+			<fieldset>
+				<legend className="block text-sm font-medium">評価</legend>
+				<div className="mt-1 flex items-center gap-1">
+					{[1, 2, 3, 4, 5].map((n) => (
+						<button
+							key={n}
+							type="button"
+							onClick={() => setRating(n)}
+							aria-label={`★ ${n}`}
+							className={`size-8 rounded-full text-lg font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+								n <= rating
+									? "text-yellow-500"
+									: "text-[color:var(--a-text-muted)]"
+							}`}
+						>
+							★
+						</button>
+					))}
+					<span className="ml-2 text-sm">{rating} / 5</span>
+				</div>
+			</fieldset>
+			<label className="block">
+				<span className="block text-sm font-medium">コメント</span>
+				<textarea
+					value={comment}
+					onChange={(e) => setComment(e.target.value)}
+					maxLength={2000}
+					rows={5}
+					placeholder="どのような点が良かったか、 具体的に書くと他の mentee の参考になります。"
+					className="mt-1 h-[8rem] w-full rounded border border-border bg-background p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				/>
+				<p className="mt-1 text-xs text-muted-foreground">
+					{comment.length} / 2000 文字
+				</p>
+			</label>
+			<button
+				type="submit"
+				disabled={submitting}
+				className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+			>
+				{submitting
+					? "送信中…"
+					: existing
+						? "レビューを更新"
+						: "レビューを投稿"}
+			</button>
+		</form>
+	);
+}

--- a/client/src/lib/api/mentor.ts
+++ b/client/src/lib/api/mentor.ts
@@ -312,3 +312,38 @@ export async function cancelContract(
 	);
 	return res.data;
 }
+
+// --- MentorReview (Phase 11-D P11-21) ---
+
+export interface MentorReview {
+	id: number;
+	contract: number;
+	mentor: MentorMiniUser;
+	mentee: MentorMiniUser | null;
+	rating: number;
+	comment: string;
+	is_visible: boolean;
+	created_at: string;
+	updated_at: string;
+}
+
+export async function submitContractReview(
+	contractId: number,
+	rating: number,
+	comment: string,
+	client: AxiosInstance = api,
+): Promise<MentorReview> {
+	const res = await client.post<MentorReview>(
+		`/mentor/contracts/${contractId}/review/`,
+		{ rating, comment },
+	);
+	return res.data;
+}
+
+export async function listMentorReviews(
+	handle: string,
+	client: AxiosInstance = api,
+): Promise<MentorReview[]> {
+	const res = await client.get<MentorReview[]>(`/mentors/${handle}/reviews/`);
+	return res.data;
+}


### PR DESCRIPTION
## Summary

11-D 第 2 弾。 mentee の review 投稿 UI + mentor 公開ページの review 表示。

- `ReviewForm` (client): ★1-5 button + comment、 既存 review があれば pre-populate (edit mode)
- `/mentor/contracts/[id]` で `role=mentee + status=completed` のとき表示
- `/mentors/[handle]` SSR で reviews を並列 fetch、 ★ + コメント + 投稿者 handle で render
- API client helper (`submitContractReview` / `listMentorReviews`)

## Test plan

- [x] tsc 通過
- [ ] CI 緑

Closes #640