### PR TITLE
fix(mentorship): orphan review + 404 fallback + e2e role=status filter (#669 #670 #671)

### DIFF
--- a/apps/mentorship/services.py
+++ b/apps/mentorship/services.py
@@ -70,6 +70,21 @@ def accept_proposal(
         DMRoomMembership.objects.create(room=room, user=request.mentee)
         DMRoomMembership.objects.create(room=room, user=proposal.mentor)
 
+        # P11 follow-up #669: mentor が proposal を送って accept されたら mentor
+        # activity あり判定なので、 MentorProfile が未作成なら placeholder で
+        # auto-create する。 これがないと review が投稿されても /mentors/<handle>
+        # が 404 になって review が表示先を失う (orphan review 問題)。
+        from apps.mentorship.models import MentorProfile  # 循環回避の局所 import
+
+        MentorProfile.objects.get_or_create(
+            user=proposal.mentor,
+            defaults={
+                "headline": "メンター",
+                "bio": "プロフィールは未設定です。 /mentors/me/edit から編集できます。",
+                "experience_years": 0,
+            },
+        )
+
         # contract row。 plan_snapshot は P11-12 で plan 連携時に詳細を埋める。
         contract = MentorshipContract.objects.create(
             proposal=proposal,

--- a/client/e2e/mentor-board.spec.ts
+++ b/client/e2e/mentor-board.spec.ts
@@ -103,10 +103,11 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 		await mentor.goto(`${BASE}/mentor/wanted/${requestId}`);
 		await mentor.getByLabel(/^提案文/).fill("E2E でテストする mentor です。");
 		await mentor.getByRole("button", { name: "提案を送る" }).click();
-		await expect(mentor.getByRole("status")).toContainText(
-			"提案を送信しました",
-			{ timeout: 10000 },
-		);
+		// follow-up #670: role=status は sr-only aria-live + 表示 panel の 2 個が
+		// 同時 DOM にあるので filter で 1 個に絞る。
+		await expect(
+			mentor.getByRole("status").filter({ hasText: /提案を送信しました/ }),
+		).toBeVisible({ timeout: 10000 });
 
 		// --- mentee が proposal リストで accept ---
 		await mentee.reload();

--- a/client/e2e/mentor-review.spec.ts
+++ b/client/e2e/mentor-review.spec.ts
@@ -136,10 +136,12 @@ test.describe("Phase 11-D review flow (#641)", () => {
 		await menteePage
 			.getByRole("button", { name: /レビューを投稿|レビューを更新/ })
 			.click();
-		await expect(menteePage.getByRole("status")).toContainText(
-			"レビューを送信しました",
-			{ timeout: 10000 },
-		);
+		// follow-up #670: filter で sr-only aria-live と panel を区別する。
+		await expect(
+			menteePage
+				.getByRole("status")
+				.filter({ hasText: /レビューを送信しました/ }),
+		).toBeVisible({ timeout: 10000 });
 
 		// --- 6) /mentors/<USER2 handle>/ で review が公開表示されるか確認 (anon でも OK) ---
 		const anon = await browser.newContext();

--- a/client/src/app/(template)/mentors/[handle]/page.tsx
+++ b/client/src/app/(template)/mentors/[handle]/page.tsx
@@ -7,7 +7,6 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
 
 import { type MentorProfileDetail, type MentorReview } from "@/lib/api/mentor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
@@ -52,7 +51,54 @@ export default async function MentorDetailPage({ params }: PageProps) {
 		fetchProfile(params.handle),
 		fetchReviews(params.handle),
 	]);
-	if (!profile) notFound();
+	if (!profile) {
+		// follow-up #671: 生 404 ではなく空状態 page を返して mentor 探索動線に戻す。
+		return (
+			<>
+				<header
+					className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+					style={{
+						borderBottom: "1px solid var(--a-border)",
+						background: "rgba(255,255,255,0.85)",
+						backdropFilter: "blur(8px)",
+					}}
+				>
+					<Link
+						href="/mentors"
+						className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+						style={{ fontSize: 12.5 }}
+					>
+						← メンター一覧
+					</Link>
+					<div className="ml-2 min-w-0 flex-1">
+						<h1
+							className="truncate font-semibold tracking-tight"
+							style={{ fontSize: 15, letterSpacing: -0.2 }}
+						>
+							@{params.handle}
+						</h1>
+					</div>
+				</header>
+				<div className="space-y-4 p-5">
+					<p
+						role="status"
+						className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]"
+					>
+						このユーザーはまだメンター活動を始めていません。
+					</p>
+					<div className="flex justify-center">
+						<Link
+							href="/mentors"
+							className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white"
+							style={{ background: "var(--a-accent)", fontSize: 12.5 }}
+						>
+							メンターを探す
+						</Link>
+					</div>
+				</div>
+			</>
+		);
+	}
 
 	const rating =
 		profile.avg_rating !== null ? Number(profile.avg_rating).toFixed(1) : null;


### PR DESCRIPTION
## Summary

Phase 11 最終採点 (gan-evaluator 7.6/10) で残った **HIGH 2 + MEDIUM 1** を 1 PR で fix。

- **#669 (HIGH)** orphan review: `accept_proposal()` で `MentorProfile.get_or_create()` を呼び、 placeholder profile (headline=「メンター」 / 編集 CTA 付き bio) を auto-create。 これで review 投稿後に `/mentors/<handle>` が 200 で見える状態に。
- **#670 (HIGH)** E2E strict mode violation: `getByRole('status')` を `filter({ hasText: /.../ })` で 1 個に絞る (mentor-board / mentor-review 両 spec)
- **#671 (MEDIUM)** `/mentors/<handle>` 404 → 「まだメンター活動を始めていません」 + 「メンターを探す」 CTA の空状態 page に置換

## Test plan

- [x] backend pytest `apps/mentorship/` 全 104 件 GREEN
- [x] `npx tsc --noEmit` 通過
- [ ] CI 緑
- [ ] stg merge 後、 Playwright mentor-board / mentor-review が GREEN になる

Closes #669 #670 #671