### PR TITLE
feat(search): /search/users 汎用ユーザー検索 page + full-text API (P12-04)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 568
+        "line_number": 573
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-13T02:23:43Z"
+  "generated_at": "2026-05-13T13:06:30Z"
 }

--- a/apps/users/migrations/0006_user_search_gin_indexes.py
+++ b/apps/users/migrations/0006_user_search_gin_indexes.py
@@ -1,0 +1,57 @@
+"""Add pg_trgm GIN indexes for user full-text search (P12-04).
+
+``UserFullTextSearchView`` (``GET /api/v1/users/search/``) does
+``Q(username__icontains=q) | Q(display_name__icontains=q) | Q(bio__icontains=q)``.
+Without trigram indexes, ``ILIKE '%q%'`` falls back to a sequential scan on
+three VARCHAR columns of the user table — slow as the user base grows.
+
+``pg_trgm`` extension is already enabled by ``apps.common.migrations.0001_extensions``
+(``TrigramExtension``), so this migration only adds the three ``gin_trgm_ops``
+indexes via raw SQL. Raw SQL is used (vs ``GinIndex`` in ``Meta.indexes``) to
+keep this migration self-contained — the indexes are pure performance and don't
+need to round-trip through model state (``makemigrations`` won't auto-detect or
+remove them since the model state knows nothing about them).
+
+python-reviewer (P12-04) HIGH 指摘の修正。
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0005_user_residence"),
+        ("common", "0001_extensions"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=(
+                "CREATE INDEX IF NOT EXISTS user_username_trgm_gin "
+                'ON users_user USING gin ("username" gin_trgm_ops);'
+            ),
+            reverse_sql=(
+                "DROP INDEX IF EXISTS user_username_trgm_gin;"
+            ),
+        ),
+        migrations.RunSQL(
+            sql=(
+                "CREATE INDEX IF NOT EXISTS user_disp_name_trgm_gin "
+                'ON users_user USING gin ("display_name" gin_trgm_ops);'
+            ),
+            reverse_sql=(
+                "DROP INDEX IF EXISTS user_disp_name_trgm_gin;"
+            ),
+        ),
+        migrations.RunSQL(
+            sql=(
+                "CREATE INDEX IF NOT EXISTS user_bio_trgm_gin "
+                'ON users_user USING gin ("bio" gin_trgm_ops);'
+            ),
+            reverse_sql=(
+                "DROP INDEX IF EXISTS user_bio_trgm_gin;"
+            ),
+        ),
+    ]

--- a/apps/users/tests/test_user_search_fulltext.py
+++ b/apps/users/tests/test_user_search_fulltext.py
@@ -1,0 +1,125 @@
+"""
+Full-text user search API (P12-04).
+
+対象エンドポイント: ``GET /api/v1/users/search/?q=<query>&cursor=...``
+
+既存の ``GET /api/v1/users/?q=`` (handle 前方一致 autocomplete) とは別物。
+本 endpoint は anon 閲覧可、 handle / display_name / bio の部分一致、
+cursor pagination 付き。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def search_url() -> str:
+    return reverse("users-fulltext-search")
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUserFullTextSearch:
+    def test_anon_can_search(self, api_client: APIClient, user_factory, search_url: str) -> None:
+        """harvest 防止は handle 単体 endpoint (autocomplete) に任せて、
+        full text 検索 page は anon でも 200 を返す。"""
+        user_factory(username="alice", display_name="Alice")
+        res = api_client.get(search_url, {"q": "alice"})
+        assert res.status_code == status.HTTP_200_OK
+        assert any(r["username"] == "alice" for r in res.data["results"])
+
+    def test_empty_query_returns_empty(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        user_factory(username="bob")
+        res = api_client.get(search_url, {"q": ""})
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["results"] == []
+
+    def test_matches_username_icontains(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        user_factory(username="taroyamada")
+        user_factory(username="ichiro")
+        res = api_client.get(search_url, {"q": "yama"})
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "taroyamada" in usernames
+        assert "ichiro" not in usernames
+
+    def test_matches_display_name_icontains(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        user_factory(username="u_a", display_name="Hanako Suzuki")
+        user_factory(username="u_b", display_name="Goro Tanaka")
+        res = api_client.get(search_url, {"q": "Hanako"})
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "u_a" in usernames
+        assert "u_b" not in usernames
+
+    def test_matches_bio_icontains(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        user_factory(username="u_c", bio="Rust と Go が好きです")
+        user_factory(username="u_d", bio="React 専門")
+        res = api_client.get(search_url, {"q": "Rust"})
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "u_c" in usernames
+        assert "u_d" not in usernames
+
+    def test_excludes_inactive(self, api_client: APIClient, user_factory, search_url: str) -> None:
+        user_factory(username="active_user")
+        user_factory(username="hidden_user", is_active=False)
+        res = api_client.get(search_url, {"q": "user"})
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "active_user" in usernames
+        assert "hidden_user" not in usernames
+
+    def test_paginates_with_cursor(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        for i in range(25):
+            user_factory(username=f"member_{i:03d}", display_name=f"Member {i}")
+
+        res = api_client.get(search_url, {"q": "member"})
+        assert res.status_code == status.HTTP_200_OK
+        assert "next" in res.data
+        # cursor pagination: 1 page で全件出ない (page_size 20)
+        assert len(res.data["results"]) == 20
+        assert res.data["next"] is not None
+
+        # next page
+        next_url = res.data["next"]
+        res2 = api_client.get(next_url)
+        assert res2.status_code == status.HTTP_200_OK
+        assert len(res2.data["results"]) == 5
+        assert res2.data["next"] is None
+
+    def test_response_shape_includes_display_name_and_bio(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        """search page で display_name / bio を card に出すので response に含む."""
+        user_factory(username="card_user", display_name="Card User", bio="hello")
+        res = api_client.get(search_url, {"q": "card"})
+        assert res.status_code == status.HTTP_200_OK
+        result = res.data["results"][0]
+        assert "username" in result
+        assert "display_name" in result
+        assert "bio" in result
+        assert "avatar_url" in result
+        # PII (email, is_premium) は出さない
+        assert "email" not in result
+        assert "is_premium" not in result
+
+    def test_excludes_email_and_internal_fields(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        user_factory(username="privacy_test", display_name="Privacy", email="leak@example.com")
+        res = api_client.get(search_url, {"q": "privacy"})
+        for result in res.data["results"]:
+            assert "email" not in result
+            assert "is_premium" not in result
+            assert "needs_onboarding" not in result

--- a/apps/users/urls_profile.py
+++ b/apps/users/urls_profile.py
@@ -5,7 +5,8 @@
 管理する。
 
 ルーティング:
-- ``GET                /api/v1/users/``                          → UserSearchView (#480)
+- ``GET                /api/v1/users/``                          → UserSearchView (#480, handle 前方一致 autocomplete)
+- ``GET                /api/v1/users/search/``                   → UserFullTextSearchView (P12-04, anon 可、 full-text + pagination)
 - ``GET/PATCH          /api/v1/users/me/``                       → MeView
 - ``POST               /api/v1/users/me/avatar-upload-url/``     → AvatarUploadUrlView (P1-04)
 - ``POST               /api/v1/users/me/header-upload-url/``     → HeaderUploadUrlView (P1-04)
@@ -27,6 +28,7 @@ from .views import (
     MeView,
     MyUserResidenceView,
     PublicProfileView,
+    UserFullTextSearchView,
     UserResidenceByHandleView,
     UserSearchView,
 )
@@ -35,6 +37,13 @@ urlpatterns = [
     # Issue #480: handle 前方一致検索 (autocomplete 用)。
     # 静的 path として `<str:username>/` より先に登録する (greedy 対策)。
     path("", UserSearchView.as_view(), name="users-search"),
+    # P12-04: 汎用ユーザー検索 page 用 full-text endpoint (anon 可)。
+    # 静的 path なので `<str:username>/` より前。
+    path(
+        "search/",
+        UserFullTextSearchView.as_view(),
+        name="users-fulltext-search",
+    ),
     path("me/", MeView.as_view(), name="users-me"),
     # P1-04: avatar / header 画像 S3 presigned URL 発行。
     path(

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -2,10 +2,12 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from djoser.social.views import ProviderAuthView
 from rest_framework import serializers, status
-from rest_framework.generics import RetrieveAPIView
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.pagination import CursorPagination
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
@@ -761,3 +763,63 @@ class UserResidenceByHandleView(APIView):
         if residence is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(UserResidenceSerializer(residence).data, status=status.HTTP_200_OK)
+
+
+# ---------------------------------------------------------------------------
+# Phase 12 P12-04: 汎用ユーザー検索 (handle / display_name / bio に部分一致)
+# ---------------------------------------------------------------------------
+
+
+class UserFullTextSerializer(serializers.ModelSerializer):
+    """汎用ユーザー検索結果。 ``UserSearchSerializer`` (handle autocomplete) と
+    別物で、 search card UI 用に ``display_name`` と ``bio`` を追加する。
+    PII は引き続き出さない。
+    """
+
+    user_id = serializers.UUIDField(source="id", read_only=True)
+
+    class Meta:
+        model = User
+        fields = (
+            "user_id",
+            "username",
+            "display_name",
+            "bio",
+            "avatar_url",
+        )
+        read_only_fields = fields
+
+
+class UserSearchCursorPagination(CursorPagination):
+    """user search 用の cursor pagination。 page_size=20。 ordering は username。"""
+
+    page_size = 20
+    max_page_size = 50
+    ordering = "username"
+    cursor_query_param = "cursor"
+
+
+class UserFullTextSearchView(ListAPIView):
+    """``GET /api/v1/users/search/?q=<text>&cursor=...``: 汎用ユーザー検索 (P12-04)。
+
+    - anon 閲覧可 (`AllowAny`)。 handle harvest は既存 autocomplete endpoint
+      (``UserSearchView``) で制限する分業。
+    - case-insensitive 部分一致 (``__icontains``) を handle / display_name / bio に。
+    - ``is_active=False`` を除外。
+    - cursor pagination (page_size=20)。 ``ordering="username"`` で安定。
+    - 空 q は空配列 (lookup 空打ちさせない)。
+    """
+
+    serializer_class = UserFullTextSerializer
+    permission_classes = [AllowAny]
+    pagination_class = UserSearchCursorPagination
+
+    def get_queryset(self):
+        q = (self.request.query_params.get("q") or "").strip()
+        if not q:
+            return User.objects.none()
+        return (
+            User.objects.filter(is_active=True)
+            .filter(Q(username__icontains=q) | Q(display_name__icontains=q) | Q(bio__icontains=q))
+            .order_by("username")
+        )

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.shortcuts import get_object_or_404
 from djoser.social.views import ProviderAuthView
 from rest_framework import serializers, status
@@ -799,6 +799,18 @@ class UserSearchCursorPagination(CursorPagination):
     cursor_query_param = "cursor"
 
 
+class UserSearchAnonThrottle(AnonRateThrottle):
+    """``/users/search/`` 専用 throttle (anon).
+
+    python-reviewer (P12-04 HIGH) 指摘:
+    既定 ``anon`` (200/day) は SearchBox の keystroke で簡単に枯渇する。
+    text-search 用には分単位の bucket が適切。 rate は settings.base の
+    ``_THROTTLE_RATES_BASE['user_search_anon']`` で管理。
+    """
+
+    scope = "user_search_anon"
+
+
 class UserFullTextSearchView(ListAPIView):
     """``GET /api/v1/users/search/?q=<text>&cursor=...``: 汎用ユーザー検索 (P12-04)。
 
@@ -808,13 +820,18 @@ class UserFullTextSearchView(ListAPIView):
     - ``is_active=False`` を除外。
     - cursor pagination (page_size=20)。 ``ordering="username"`` で安定。
     - 空 q は空配列 (lookup 空打ちさせない)。
+
+    パフォーマンス: ``username`` / ``display_name`` / ``bio`` には pg_trgm の
+    ``gin_trgm_ops`` GIN index を貼って ``ILIKE '%q%'`` を index 利用可にする
+    (apps/users/migrations/0006_user_search_gin_indexes.py)。
     """
 
     serializer_class = UserFullTextSerializer
     permission_classes = [AllowAny]
     pagination_class = UserSearchCursorPagination
+    throttle_classes = [UserSearchAnonThrottle]
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet:
         q = (self.request.query_params.get("q") or "").strip()
         if not q:
             return User.objects.none()

--- a/client/e2e/user-search.spec.ts
+++ b/client/e2e/user-search.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Phase 12 P12-04 ユーザー検索 E2E spec.
+ *
+ * spec: docs/specs/phase-12-residence-map-spec.md §7.4
+ *
+ * 検証シナリオ:
+ *   USER-SEARCH-1 (anon): /search/users に anon で踏んで search 200
+ *   USER-SEARCH-2 (golden): test2 handle で検索 → 自分の handle カードが結果に出る →
+ *                クリック → /u/<test2> プロフィール
+ *   USER-SEARCH-3 (nav): home からナビ「ユーザー検索」 click で 1 click 到達
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireHandle() {
+	if (!USER1.handle) {
+		throw new Error("PLAYWRIGHT_USER1_HANDLE is not set");
+	}
+}
+
+test.describe("Phase 12 P12-04 user search (#676)", () => {
+	test("USER-SEARCH-1: anon で /search/users が 200 で表示される", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/search/users`);
+		await expect(
+			page.getByRole("heading", { name: "ユーザー検索" }),
+		).toBeVisible({ timeout: 15000 });
+		await expect(
+			page.getByRole("search", { name: "ユーザー検索" }),
+		).toBeVisible();
+		await ctx.close();
+	});
+
+	test("USER-SEARCH-2: 検索 → user card → プロフィール", async ({
+		browser,
+	}) => {
+		requireHandle();
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(
+			`${BASE}/search/users?q=${encodeURIComponent(USER1.handle)}`,
+		);
+		// 該当 handle のカード (link to /u/<handle>) が見える
+		const card = page.getByRole("link", {
+			name: new RegExp(`@${USER1.handle}\\b`),
+		});
+		await expect(card.first()).toBeVisible({ timeout: 15000 });
+		await card.first().click();
+		await page.waitForURL(new RegExp(`/u/${USER1.handle}(\\?|$)`), {
+			timeout: 15000,
+		});
+		await ctx.close();
+	});
+
+	test("USER-SEARCH-3: home から 1 click でユーザー検索に到達", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/`);
+		const link = page.getByRole("link", { name: "ユーザー検索" }).first();
+		await expect(link).toBeVisible({ timeout: 15000 });
+		await link.click();
+		await page.waitForURL(/\/search\/users(\?|$)/, { timeout: 15000 });
+		await ctx.close();
+	});
+});

--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -1,0 +1,158 @@
+/**
+ * /search/users — 汎用ユーザー検索 page (Phase 12 P12-04)。
+ *
+ * spec: docs/specs/phase-12-residence-map-spec.md / phase-12 milestone #15
+ *
+ * - anon 閲覧可。 SSR で結果を取得。
+ * - GET /api/v1/users/search/?q= の cursor pagination を消費。
+ *   本 page は 1 page のみ render し、 「次の 20 件 →」 link で page 遷移。
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import UserSearchBox from "@/components/search/UserSearchBox";
+import UserSearchResultCard from "@/components/search/UserSearchResultCard";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { UserSearchPage as UserSearchPageData } from "@/lib/api/userSearch";
+
+interface SearchPageProps {
+	searchParams: { q?: string; cursor?: string };
+}
+
+export const metadata: Metadata = {
+	title: "ユーザー検索 — エンジニア SNS",
+	description: "ユーザー名 / 表示名 / 自己紹介で検索する。",
+};
+
+async function loadUserSearch(
+	query: string,
+	cursor?: string,
+): Promise<UserSearchPageData> {
+	const params = new URLSearchParams();
+	if (query) params.set("q", query);
+	if (cursor) params.set("cursor", cursor);
+	const qs = params.toString();
+	const url = qs ? `/users/search/?${qs}` : "/users/search/";
+	try {
+		return await serverFetch<UserSearchPageData>(url);
+	} catch (error) {
+		if (error instanceof ApiServerError) {
+			return { results: [], next: null, previous: null };
+		}
+		throw error;
+	}
+}
+
+/** cursor URL から `cursor=...` だけ抽出して相対 path にする。 */
+function extractCursor(absoluteUrl: string | null): string | null {
+	if (!absoluteUrl) return null;
+	try {
+		const u = new URL(absoluteUrl);
+		return u.searchParams.get("cursor");
+	} catch {
+		// URL constructor が失敗するケース (相対 URL) は素朴に search を切り出す
+		const m = /[?&]cursor=([^&]+)/.exec(absoluteUrl);
+		return m ? decodeURIComponent(m[1]) : null;
+	}
+}
+
+export default async function UserSearchPage({
+	searchParams,
+}: SearchPageProps) {
+	const query = (searchParams.q ?? "").trim();
+	const cursor = searchParams.cursor;
+	const page = query
+		? await loadUserSearch(query, cursor)
+		: { results: [], next: null, previous: null };
+
+	const nextCursor = extractCursor(page.next);
+	const prevCursor = extractCursor(page.previous);
+
+	return (
+		<>
+			<header
+				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						ユーザー検索
+					</h1>
+					{query && (
+						<p
+							className="truncate text-[color:var(--a-text-subtle)]"
+							style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+						>
+							「{query}」
+						</p>
+					)}
+				</div>
+			</header>
+
+			<div className="px-5 py-5">
+				<div className="mb-6">
+					<UserSearchBox initialValue={query} />
+				</div>
+
+				{!query && (
+					<p className="text-sm text-[color:var(--a-text-muted)]">
+						ユーザー名 / 表示名 / 自己紹介 (bio) で部分一致検索できます。
+					</p>
+				)}
+
+				{query && page.results.length === 0 && (
+					<p
+						role="status"
+						className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]"
+					>
+						「{query}」 に一致するユーザーは見つかりませんでした。
+					</p>
+				)}
+
+				{query && page.results.length > 0 && (
+					<section aria-label="検索結果">
+						<ul role="list" className="space-y-2">
+							{page.results.map((u) => (
+								<UserSearchResultCard key={u.user_id} user={u} />
+							))}
+						</ul>
+
+						<nav
+							aria-label="ページ送り"
+							className="mt-6 flex items-center justify-between text-sm"
+						>
+							{prevCursor ? (
+								<Link
+									href={`/search/users?q=${encodeURIComponent(query)}&cursor=${encodeURIComponent(prevCursor)}`}
+									className="rounded-md border border-border px-3 py-1.5 hover:bg-muted/40"
+								>
+									← 前の 20 件
+								</Link>
+							) : (
+								<span aria-hidden="true" />
+							)}
+							{nextCursor ? (
+								<Link
+									href={`/search/users?q=${encodeURIComponent(query)}&cursor=${encodeURIComponent(nextCursor)}`}
+									className="rounded-md border border-border px-3 py-1.5 hover:bg-muted/40"
+								>
+									次の 20 件 →
+								</Link>
+							) : (
+								<span aria-hidden="true" />
+							)}
+						</nav>
+					</section>
+				)}
+			</div>
+		</>
+	);
+}

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -31,6 +31,7 @@ import {
 	Search,
 	Settings,
 	User,
+	UserSearch,
 	Users,
 	type LucideIcon,
 } from "lucide-react";
@@ -59,6 +60,8 @@ const NAV_ITEMS: NavItemDef[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
 	{ href: "/explore", label: "Explore", Icon: Hash },
 	{ href: "/search", label: "検索", Icon: Search },
+	// Phase 12 (P12-04 / #676): 汎用ユーザー検索。 既存「検索」 は tweet 用なので別 link。
+	{ href: "/search/users", label: "ユーザー検索", Icon: UserSearch },
 	{
 		href: "/notifications",
 		label: "通知",

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -159,8 +159,13 @@ export default function ALeftNav() {
 			</div>
 
 			{visibleItems.map((item) => {
+				// nested route (例: `/search/users`) で親 (`/search`) と二重 active に
+				// ならないよう、 完全一致 or `/<seg>/...` のときだけ active にする
+				// (P12-04 HIGH 修正)。
 				const isActive =
-					item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+					item.href === "/"
+						? pathname === "/"
+						: pathname === item.href || pathname.startsWith(`${item.href}/`);
 				const badgeCount = itemBadgeCount(item.badgeKey);
 				return (
 					<Link

--- a/client/src/components/search/UserSearchBox.tsx
+++ b/client/src/components/search/UserSearchBox.tsx
@@ -44,6 +44,9 @@ export default function UserSearchBox({
 				onChange={(e) => setValue(e.target.value)}
 				placeholder="ユーザー名 / 表示名 / 自己紹介で検索"
 				aria-label="ユーザー検索クエリ"
+				// 異常に長いクエリで URL を肥大化させない防御 (typescript-reviewer
+				// P12-04 MEDIUM)。 backend は VARCHAR 制約があるので 100 で十分。
+				maxLength={100}
 				className="flex-1 rounded-md border border-border bg-card px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 			/>
 			<button

--- a/client/src/components/search/UserSearchBox.tsx
+++ b/client/src/components/search/UserSearchBox.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * UserSearchBox — /search/users 用の search input (Phase 12 P12-04)。
+ *
+ * 既存の SearchBox は tweet 用に演算子サジェスト UI を持っていて user 検索とは
+ * UX が違うので別 component。 submit で /search/users?q=<value> に遷移。
+ */
+
+import { useRouter } from "next/navigation";
+import { type FormEvent, useState } from "react";
+
+interface UserSearchBoxProps {
+	initialValue?: string;
+}
+
+export default function UserSearchBox({
+	initialValue = "",
+}: UserSearchBoxProps) {
+	const router = useRouter();
+	const [value, setValue] = useState(initialValue);
+
+	const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const trimmed = value.trim();
+		if (!trimmed) {
+			router.push("/search/users");
+			return;
+		}
+		router.push(`/search/users?q=${encodeURIComponent(trimmed)}`);
+	};
+
+	return (
+		<form
+			role="search"
+			aria-label="ユーザー検索"
+			onSubmit={onSubmit}
+			className="flex gap-2"
+		>
+			<input
+				type="search"
+				name="q"
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
+				placeholder="ユーザー名 / 表示名 / 自己紹介で検索"
+				aria-label="ユーザー検索クエリ"
+				className="flex-1 rounded-md border border-border bg-card px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			/>
+			<button
+				type="submit"
+				className="rounded-md bg-lime-500 px-4 py-2 text-sm font-semibold text-black hover:bg-lime-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			>
+				検索
+			</button>
+		</form>
+	);
+}

--- a/client/src/components/search/UserSearchResultCard.tsx
+++ b/client/src/components/search/UserSearchResultCard.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+import type { UserSearchResultItem } from "@/lib/api/userSearch";
+
+interface UserSearchResultCardProps {
+	user: UserSearchResultItem;
+}
+
+/**
+ * Single user card row for the /search/users page (Phase 12 P12-04).
+ * Avatar + display_name + @handle + bio (3 line clamp)。
+ */
+export default function UserSearchResultCard({
+	user,
+}: UserSearchResultCardProps) {
+	const handle = user.username;
+	const name = user.display_name || user.username;
+	return (
+		<li>
+			<Link
+				href={`/u/${handle}`}
+				className="flex items-start gap-3 rounded-lg border border-border p-3 transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			>
+				{user.avatar_url ? (
+					// eslint-disable-next-line @next/next/no-img-element
+					<img
+						src={user.avatar_url}
+						alt=""
+						className="size-12 shrink-0 rounded-full bg-muted object-cover"
+					/>
+				) : (
+					<div className="size-12 shrink-0 rounded-full bg-muted" aria-hidden />
+				)}
+				<div className="min-w-0 flex-1">
+					<div className="flex items-baseline gap-2">
+						<span className="truncate text-sm font-semibold">{name}</span>
+						<span
+							className="truncate text-xs text-muted-foreground"
+							style={{ fontFamily: "var(--a-font-mono)" }}
+						>
+							@{handle}
+						</span>
+					</div>
+					{user.bio && (
+						<p className="mt-1 line-clamp-3 whitespace-pre-wrap text-xs text-muted-foreground">
+							{user.bio}
+						</p>
+					)}
+				</div>
+			</Link>
+		</li>
+	);
+}

--- a/client/src/components/search/UserSearchResultCard.tsx
+++ b/client/src/components/search/UserSearchResultCard.tsx
@@ -7,6 +7,25 @@ interface UserSearchResultCardProps {
 }
 
 /**
+ * バックエンドから来た avatar_url が http(s) スキームに限定されていることを確認する。
+ * `javascript:` / `data:` のような scheme 注入を防ぐ防御 (typescript-reviewer
+ * P12-04 HIGH 対応)。 backend validate_media_url で同じ enforcement をしているが、
+ * 表示直前にも二重防御する。 失敗時は null を返して `<img>` を出さない。
+ */
+function safeAvatarUrl(url: string): string | null {
+	if (!url) return null;
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+			return null;
+		}
+		return url;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Single user card row for the /search/users page (Phase 12 P12-04).
  * Avatar + display_name + @handle + bio (3 line clamp)。
  */
@@ -15,16 +34,17 @@ export default function UserSearchResultCard({
 }: UserSearchResultCardProps) {
 	const handle = user.username;
 	const name = user.display_name || user.username;
+	const safeAvatar = safeAvatarUrl(user.avatar_url);
 	return (
 		<li>
 			<Link
 				href={`/u/${handle}`}
 				className="flex items-start gap-3 rounded-lg border border-border p-3 transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 			>
-				{user.avatar_url ? (
+				{safeAvatar ? (
 					// eslint-disable-next-line @next/next/no-img-element
 					<img
-						src={user.avatar_url}
+						src={safeAvatar}
 						alt=""
 						className="size-12 shrink-0 rounded-full bg-muted object-cover"
 					/>

--- a/client/src/components/search/__tests__/UserSearchBox.test.tsx
+++ b/client/src/components/search/__tests__/UserSearchBox.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for UserSearchBox (P12-04).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import UserSearchBox from "@/components/search/UserSearchBox";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush }),
+	usePathname: () => "/search/users",
+}));
+
+describe("UserSearchBox", () => {
+	beforeEach(() => {
+		mockPush.mockClear();
+	});
+
+	it("renders a search input and submit button", () => {
+		render(<UserSearchBox />);
+		expect(screen.getByRole("searchbox")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /検索/ })).toBeInTheDocument();
+	});
+
+	it("uses the provided initialValue", () => {
+		render(<UserSearchBox initialValue="alice" />);
+		expect(screen.getByRole("searchbox")).toHaveValue("alice");
+	});
+
+	it("navigates to /search/users?q=... on submit", async () => {
+		render(<UserSearchBox />);
+		await userEvent.type(screen.getByRole("searchbox"), "bob");
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).toHaveBeenCalledWith("/search/users?q=bob");
+	});
+
+	it("clears query (navigates to /search/users) on empty submit", () => {
+		render(<UserSearchBox initialValue="alice" />);
+		const input = screen.getByRole("searchbox") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "  " } });
+		fireEvent.submit(screen.getByRole("search"));
+		expect(mockPush).toHaveBeenCalledWith("/search/users");
+	});
+
+	it("encodes special characters in the URL", async () => {
+		render(<UserSearchBox />);
+		await userEvent.type(screen.getByRole("searchbox"), "山田 太郎");
+		fireEvent.submit(screen.getByRole("search"));
+		const target = mockPush.mock.calls[0]?.[0] ?? "";
+		expect(target).toContain("/search/users?q=");
+		expect(target).toContain(encodeURIComponent("山田 太郎"));
+	});
+
+	it("enforces maxLength=100 on the input", () => {
+		render(<UserSearchBox />);
+		const input = screen.getByRole("searchbox") as HTMLInputElement;
+		expect(input.maxLength).toBe(100);
+	});
+});

--- a/client/src/components/search/__tests__/UserSearchResultCard.test.tsx
+++ b/client/src/components/search/__tests__/UserSearchResultCard.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for UserSearchResultCard (P12-04).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import UserSearchResultCard from "@/components/search/UserSearchResultCard";
+import type { UserSearchResultItem } from "@/lib/api/userSearch";
+
+function makeUser(
+	overrides: Partial<UserSearchResultItem> = {},
+): UserSearchResultItem {
+	return {
+		user_id: "u1",
+		username: "alice",
+		display_name: "Alice",
+		bio: "Engineer in Tokyo",
+		avatar_url: "https://cdn.example.com/avatar.png",
+		...overrides,
+	};
+}
+
+function getAvatarImg(container: HTMLElement): HTMLImageElement | null {
+	return container.querySelector("img");
+}
+
+describe("UserSearchResultCard", () => {
+	it("renders display_name + @handle + bio + avatar", () => {
+		const { container } = render(<UserSearchResultCard user={makeUser()} />);
+		expect(screen.getByText("Alice")).toBeInTheDocument();
+		expect(screen.getByText("@alice")).toBeInTheDocument();
+		expect(screen.getByText("Engineer in Tokyo")).toBeInTheDocument();
+		const avatar = getAvatarImg(container);
+		expect(avatar).not.toBeNull();
+		expect(avatar).toHaveAttribute("src", "https://cdn.example.com/avatar.png");
+	});
+
+	it("falls back to username when display_name is empty", () => {
+		render(<UserSearchResultCard user={makeUser({ display_name: "" })} />);
+		// name + @handle 両方に出るので 2 つ以上 hit する
+		expect(screen.getAllByText(/alice/).length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("renders avatar placeholder div when avatar_url is empty", () => {
+		const { container } = render(
+			<UserSearchResultCard user={makeUser({ avatar_url: "" })} />,
+		);
+		expect(getAvatarImg(container)).toBeNull();
+		expect(container.querySelector("[aria-hidden]")).toBeTruthy();
+	});
+
+	it("rejects javascript: avatar_url (XSS guard)", () => {
+		const { container } = render(
+			<UserSearchResultCard
+				user={makeUser({ avatar_url: "javascript:alert(1)" })}
+			/>,
+		);
+		// safeAvatarUrl が null を返すので <img> は出さない
+		expect(getAvatarImg(container)).toBeNull();
+	});
+
+	it("rejects malformed avatar_url (URL parse fail)", () => {
+		const { container } = render(
+			<UserSearchResultCard user={makeUser({ avatar_url: "not a url" })} />,
+		);
+		expect(getAvatarImg(container)).toBeNull();
+	});
+
+	it("links to /u/<handle>", () => {
+		render(<UserSearchResultCard user={makeUser()} />);
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("href", "/u/alice");
+	});
+
+	it("hides bio when empty", () => {
+		render(<UserSearchResultCard user={makeUser({ bio: "" })} />);
+		// bio は描画されないので testing-library の検索でも null
+		expect(screen.queryByText("Engineer in Tokyo")).toBeNull();
+	});
+});

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -130,8 +130,12 @@ export default function LeftNavbar() {
 							</span>
 						);
 					}
+					// path-prefix match: 「`/search` が `/search/users` も active 化させる」
+					// 問題 (typescript-reviewer P12-04 HIGH) を回避するため、完全一致または
+					// `/<segment>/...` で始まるかどうかを active 扱いにする。
 					const isActive =
-						(pathname.includes(href) && href.length > 1) || pathname === href;
+						pathname === href ||
+						(href.length > 1 && pathname.startsWith(`${href}/`));
 					return (
 						<Link
 							href={href}

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -20,6 +20,7 @@ import {
 	Plus,
 	Search,
 	User,
+	UserSearch,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -35,6 +36,7 @@ const ICON_MAP: Record<
 	Search,
 	MessageSquare,
 	User,
+	UserSearch,
 	Bell,
 	MessagesSquare,
 	FileText,

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -21,6 +21,7 @@ import {
 	MessagesSquare,
 	Search,
 	User,
+	UserSearch,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -36,6 +37,7 @@ const ICON_MAP: Record<
 	Search,
 	MessageSquare,
 	User,
+	UserSearch,
 	Bell,
 	MessagesSquare,
 	FileText,

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -102,8 +102,11 @@ function LeftNavContent() {
 						</span>
 					);
 				}
+				// path-prefix match: nested route (`/search/users`) で親 (`/search`) と
+				// 二重に active になる substring match を避ける (P12-04 HIGH 修正)。
 				const isActive =
-					(pathname.includes(href) && href.length > 1) || pathname === href;
+					pathname === href ||
+					(href.length > 1 && pathname.startsWith(`${href}/`));
 				return (
 					<SheetClose asChild key={linkItem.label}>
 						<Link

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -27,6 +27,13 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "Search",
 	},
 	{
+		// Phase 12 (P12-04 / #676): 汎用ユーザー検索 page。 既存 /search は tweet
+		// 用、 こちらは handle / display_name / bio の部分一致で人を探す。
+		path: "/search/users",
+		label: "ユーザー検索",
+		iconName: "UserSearch",
+	},
+	{
 		// #412 / Phase 4A: 通知
 		path: "/notifications",
 		label: "通知",

--- a/client/src/lib/api/__tests__/userSearch.test.ts
+++ b/client/src/lib/api/__tests__/userSearch.test.ts
@@ -1,0 +1,85 @@
+/**
+ * userSearch helper tests (Phase 12 P12-04).
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+
+import { createApiClient } from "@/lib/api/client";
+import { fetchUserSearch } from "@/lib/api/userSearch";
+
+function stub() {
+	const client = createApiClient();
+	const mock = new MockAdapter(client);
+	mock.onGet("/auth/csrf/").reply(200, { detail: "CSRF cookie set" });
+	return { client, mock };
+}
+
+describe("userSearch API", () => {
+	it("fetchUserSearch sends ?q= when query is non-empty", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply((config) => {
+			expect(config.params).toEqual({ q: "alice" });
+			return [
+				200,
+				{
+					results: [
+						{
+							user_id: "u1",
+							username: "alice",
+							display_name: "Alice",
+							bio: "hi",
+							avatar_url: "",
+						},
+					],
+					next: null,
+					previous: null,
+				},
+			];
+		});
+		const page = await fetchUserSearch("alice", {}, client);
+		expect(page.results).toHaveLength(1);
+		expect(page.results[0].username).toBe("alice");
+	});
+
+	it("fetchUserSearch trims whitespace and omits empty q", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply((config) => {
+			expect(config.params).toEqual({});
+			return [200, { results: [], next: null, previous: null }];
+		});
+		const page = await fetchUserSearch("   ", {}, client);
+		expect(page.results).toHaveLength(0);
+	});
+
+	it("fetchUserSearch forwards cursor for pagination", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply((config) => {
+			expect(config.params).toEqual({ q: "bob", cursor: "abc123" });
+			return [200, { results: [], next: null, previous: "prev=xyz" }];
+		});
+		const page = await fetchUserSearch("bob", { cursor: "abc123" }, client);
+		expect(page.previous).toBe("prev=xyz");
+	});
+
+	it("fetchUserSearch returns shape with results / next / previous", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply(200, {
+			results: [
+				{
+					user_id: "u2",
+					username: "bob",
+					display_name: "Bob",
+					bio: "",
+					avatar_url: "",
+				},
+			],
+			next: "cursor=def456",
+			previous: null,
+		});
+		const page = await fetchUserSearch("bob", {}, client);
+		expect(page.next).toBe("cursor=def456");
+		expect(page.previous).toBeNull();
+		expect(page.results[0].user_id).toBe("u2");
+	});
+});

--- a/client/src/lib/api/__tests__/userSearch.test.ts
+++ b/client/src/lib/api/__tests__/userSearch.test.ts
@@ -82,4 +82,10 @@ describe("userSearch API", () => {
 		expect(page.previous).toBeNull();
 		expect(page.results[0].user_id).toBe("u2");
 	});
+
+	it("fetchUserSearch rethrows non-2xx errors (no silent swallow)", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply(500, { detail: "boom" });
+		await expect(fetchUserSearch("alice", {}, client)).rejects.toThrow();
+	});
 });

--- a/client/src/lib/api/userSearch.ts
+++ b/client/src/lib/api/userSearch.ts
@@ -1,0 +1,41 @@
+/**
+ * 汎用ユーザー検索 API helpers (Phase 12 P12-04).
+ *
+ * Backend P12-04 spec §4.5 通り、 ``GET /api/v1/users/search/?q=&cursor=``
+ * の cursor pagination をラップする。 anon 閲覧可。
+ *
+ * 既存の handle 前方一致 autocomplete (``/api/v1/users/?q=``、
+ * `lib/api/users.ts` の ``UserSearchView``) とは別物。 こちらは検索 page 用で
+ * display_name / bio も含む部分一致。
+ */
+
+import type { AxiosInstance } from "axios";
+
+import { api } from "@/lib/api/client";
+
+export interface UserSearchResultItem {
+	user_id: string;
+	username: string;
+	display_name: string;
+	bio: string;
+	avatar_url: string;
+}
+
+export interface UserSearchPage {
+	results: UserSearchResultItem[];
+	next: string | null;
+	previous: string | null;
+}
+
+/** ``GET /users/search/?q=`` を呼ぶ。 cursor を渡せば next/prev page。 */
+export async function fetchUserSearch(
+	query: string,
+	options: { cursor?: string | null } = {},
+	client: AxiosInstance = api,
+): Promise<UserSearchPage> {
+	const params: Record<string, string> = {};
+	if (query.trim()) params.q = query.trim();
+	if (options.cursor) params.cursor = options.cursor;
+	const res = await client.get<UserSearchPage>("/users/search/", { params });
+	return res.data;
+}

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -6,6 +6,7 @@ export type LeftNavIconName =
 	| "Search"
 	| "MessageSquare"
 	| "User"
+	| "UserSearch"
 	| "Bell"
 	| "MessagesSquare"
 	| "FileText"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -478,6 +478,11 @@ _THROTTLE_RATES_BASE = {
     # 30/hour は記事 1 本に画像 10 枚貼っても 3 本/時 = 通常運用十分。
     "article_image_presign": "30/hour" if not _IS_STG else "300/hour",
     "article_image_confirm": "30/hour" if not _IS_STG else "300/hour",
+    # Phase 12 user search (P12-04 / #676):
+    # 共有 anon (200/day) は keystroke search で簡単に枯渇するので
+    # /api/v1/users/search/ 専用の per-minute scope を切る。
+    # 60/min = SearchBox を 1 秒間隔で叩いても 1 分は持つ余裕。 bot 抑止としても十分。
+    "user_search_anon": "60/min" if not _IS_STG else "600/min",
 }
 
 REST_FRAMEWORK = {

--- a/docs/specs/phase-12-residence-map-spec.md
+++ b/docs/specs/phase-12-residence-map-spec.md
@@ -189,14 +189,40 @@ cd client && npx vitest run src/lib/api/__tests__/residence.test.ts
 PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/residence.spec.ts
 ```
 
+### 7.4 ユーザー検索 (P12-04)
+
+backend pytest (`apps/users/tests/test_user_search_fulltext.py` 9 cases):
+
+- anon 可 / 空 query は空配列 / handle / display_name / bio に部分一致
+- is_active=False を除外 / cursor pagination で 20+5 件
+- response は user_id / username / display_name / bio / avatar_url のみ (email / is_premium 等は出さない)
+
+frontend vitest (`client/src/lib/api/__tests__/userSearch.test.ts` 4 cases):
+
+- non-empty q を ?q= に / 空 query は param 無し / cursor 引き継ぎ / response shape
+
+E2E (`client/e2e/user-search.spec.ts` 3 cases):
+
+- USER-SEARCH-1 (anon): /search/users が 200、 search form が見える
+- USER-SEARCH-2 (golden): 検索 → user card → /u/<handle> プロフィール遷移
+- USER-SEARCH-3 (nav): home から「ユーザー検索」 link で 1 click で到達
+
+実行:
+
+```bash
+docker compose -f local.yml exec api pytest apps/users/tests/test_user_search_fulltext.py -v --no-cov
+cd client && npx vitest run src/lib/api/__tests__/userSearch.test.ts
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/user-search.spec.ts
+```
+
 ---
 
 ## 8. ロールアウト順序
 
 1. ✅ **P12-01** (#678 merged): model + API + tests
-2. **P12-02** (本 PR): 設定 UI + プロフィール map 表示 (Leaflet + OSM)
-3. P12-03: signup wizard 統合
-4. P12-04: 汎用 user search page
+2. ✅ **P12-02** (#679 merged): 設定 UI + プロフィール map 表示 (Leaflet + OSM)
+3. **P12-04** (本 PR): 汎用 user search page (full-text、 cursor pagination)
+4. P12-03: signup wizard 統合 (P12-04 後に依存しない順序で着手)
 5. P12-05: 近所検索 (haversine SQL)
 
 各段階で `gan-evaluator` agent に採点させて UX を確認 (新 route 追加なので Phase 11 同様の必須運用)。


### PR DESCRIPTION
## Summary

Phase 12 第三弾。 ユーザー検索 page (#676 受け入れ基準を満たす実装)。

- **backend**: \`GET /api/v1/users/search/?q=&cursor=\` (anon 可、 ListAPIView + CursorPagination)
  - handle / display_name / bio に \`icontains\` で部分一致、 is_active=False 除外
  - response: user_id / username / display_name / bio / avatar_url のみ (PII 漏洩なし)
- **frontend**: \`/search/users\` SSR page (anon 可、 prev/next 20 件ナビ)
  - UserSearchBox + UserSearchResultCard 新規 (tweet 用 SearchBox とは別)
  - LeftNav 3 経路 (ALeftNav / LeftNavbar / MobileNavbar) に「ユーザー検索」 link
- **tests**: pytest 9 / vitest 4 / Playwright spec 3 (anon / golden / 1-click 導線)

既存「検索」 (tweet 用) との分離を明確化。 LeftNav 並びは「検索 → ユーザー検索 → 通知」 の順。

Issue: #676 (Phase 12 milestone #15)
spec: \`docs/specs/phase-12-residence-map-spec.md\` §7.4

## Test plan

- [x] \`docker compose -f local.yml exec api pytest apps/users/tests/test_user_search_fulltext.py -v\` → 9 passed
- [x] \`npx vitest run src/lib/api/__tests__/userSearch.test.ts\` → 4 passed
- [x] \`npx tsc --noEmit\` → clean
- [ ] CI 緑 (eslint / tsc / vitest / build)
- [ ] stg deploy 後 Playwright \`e2e/user-search.spec.ts\` 実行
- [ ] \`gan-evaluator\` で第三者 UX 採点

## 次の PR

- P12-03 (#675): signup wizard 統合
- P12-05 (#677): 近所検索 (haversine SQL)