### PR TITLE
feat(onboarding): /onboarding/residence step 2 prompt — Phase 12 完了 (P12-03)

### DIFF
--- a/client/e2e/onboarding-residence.spec.ts
+++ b/client/e2e/onboarding-residence.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Phase 12 P12-03 onboarding 居住地 step E2E.
+ *
+ * spec: docs/specs/phase-12-residence-map-spec.md §7.6
+ *
+ * 検証シナリオ:
+ *   ONBOARD-RES-1 (anon): /onboarding/residence を anon で踏んでも認証エラーで
+ *                落ちず、 prompt が見える (page 自体は public、 link 先で auth gate)
+ *   ONBOARD-RES-2 (golden): /onboarding/residence を踏む → 「あとで設定する」
+ *                を click → / に遷移
+ *   ONBOARD-RES-3 (set now): /onboarding/residence → 「今すぐ設定する」 →
+ *                /settings/residence に遷移して「保存する」 button が見える
+ *                (要 auth、 anon は /login に redirect される)
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+};
+
+function requireEnv() {
+	for (const [k, v] of Object.entries({
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+	})) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+): Promise<void> {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+}
+
+test.describe("Phase 12 P12-03 onboarding residence (#675)", () => {
+	test("ONBOARD-RES-1: anon で /onboarding/residence は public で見える", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/onboarding/residence`);
+		await expect(
+			page.getByRole("heading", { name: /住んでる場所を設定しますか/ }),
+		).toBeVisible({ timeout: 15000 });
+		await ctx.close();
+	});
+
+	test("ONBOARD-RES-2: skip ボタンで / に遷移", async ({ browser }) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/onboarding/residence`);
+		await page.getByRole("link", { name: /あとで設定する/ }).click();
+		await page.waitForURL(`${BASE}/`, { timeout: 15000 });
+		await ctx.close();
+	});
+
+	test("ONBOARD-RES-3: 今すぐ → /settings/residence で保存ボタンが見える", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const ctx = await browser.newContext();
+		await loginViaApi(ctx.request, USER1);
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/onboarding/residence`);
+		await page.getByRole("link", { name: /今すぐ設定する/ }).click();
+		await page.waitForURL(`${BASE}/settings/residence`, { timeout: 15000 });
+		await expect(page.getByRole("button", { name: "保存する" })).toBeVisible({
+			timeout: 15000,
+		});
+		await ctx.close();
+	});
+});

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -24,19 +24,13 @@ export default function OnboardingPage() {
 					<span className="flex size-6 items-center justify-center rounded-full border">
 						2
 					</span>
-					スキルタグ (近日公開)
-				</li>
-				<li className="flex items-center gap-2 opacity-50">
-					<span className="flex size-6 items-center justify-center rounded-full border">
-						3
-					</span>
-					興味タグ (近日公開)
+					居住地 (任意)
 				</li>
 			</ol>
 			<header className="mb-6 space-y-2">
 				<h1 className="text-2xl font-bold">ようこそ 🎉</h1>
 				<p className="text-sm text-muted-foreground">
-					最初に表示名と自己紹介だけ設定しましょう。タグ設定はあとから追加できます。
+					最初に表示名と自己紹介を設定しましょう。次のステップで居住地マップも任意で設定できます。
 				</p>
 			</header>
 			<OnboardingForm />

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -15,13 +15,20 @@ export default function OnboardingPage() {
 					className="flex items-center gap-2 font-semibold text-foreground"
 					aria-current="step"
 				>
-					<span className="flex size-6 items-center justify-center rounded-full bg-foreground text-background">
+					<span
+						aria-hidden="true"
+						className="flex size-6 items-center justify-center rounded-full bg-foreground text-background"
+					>
 						1
 					</span>
 					プロフィール
+					<span className="sr-only">（ステップ 1 / 2、 現在地）</span>
 				</li>
-				<li className="flex items-center gap-2 opacity-50">
-					<span className="flex size-6 items-center justify-center rounded-full border">
+				<li className="flex items-center gap-2 text-muted-foreground">
+					<span
+						aria-hidden="true"
+						className="flex size-6 items-center justify-center rounded-full border"
+					>
 						2
 					</span>
 					居住地 (任意)

--- a/client/src/app/onboarding/residence/__tests__/page.test.tsx
+++ b/client/src/app/onboarding/residence/__tests__/page.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Tests for /onboarding/residence (P12-03).
+ *
+ * Step 2 prompt: 「居住地を設定するか?」 + 「あとで」 / 「今すぐ」 の link。
+ * Pure presentational client component なので render snapshot 風の検証で十分。
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import OnboardingResidencePage from "@/app/onboarding/residence/page";
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+	usePathname: () => "/onboarding/residence",
+}));
+
+describe("OnboardingResidencePage", () => {
+	it("shows the step 2 prompt heading and privacy explanation", () => {
+		render(<OnboardingResidencePage />);
+		expect(
+			screen.getByRole("heading", { name: /住んでる場所を設定しますか/ }),
+		).toBeInTheDocument();
+		// プライバシー説明: 半径 500m / ピンポイント不可
+		expect(screen.getByText(/500m/)).toBeInTheDocument();
+		expect(screen.getByText(/ピンポイント/)).toBeInTheDocument();
+	});
+
+	it("renders both 'set now' and 'skip' CTAs as proper links", () => {
+		render(<OnboardingResidencePage />);
+		const setNow = screen.getByRole("link", { name: /今すぐ設定する/ });
+		expect(setNow).toHaveAttribute("href", "/settings/residence");
+		const skip = screen.getByRole("link", { name: /あとで設定する/ });
+		expect(skip).toHaveAttribute("href", "/");
+	});
+
+	it("step indicator marks step 2 (居住地) as current", () => {
+		render(<OnboardingResidencePage />);
+		// 「居住地 (任意)」 (step indicator) を指す。 本文の「居住地」 とは区別。
+		const currentStep = screen
+			.getByRole("list", { name: "オンボーディングの進行状況" })
+			.querySelector("li[aria-current='step']");
+		expect(currentStep).not.toBeNull();
+		expect(currentStep?.textContent).toMatch(/居住地/);
+	});
+});

--- a/client/src/app/onboarding/residence/page.tsx
+++ b/client/src/app/onboarding/residence/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * /onboarding/residence — onboarding step 2 (Phase 12 P12-03)。
+ *
+ * Step 1 (`/onboarding`) で ``needs_onboarding=False`` に flip した後、
+ * 任意で居住地を設定できる prompt を出す。 設定すると `/settings/residence` に
+ * 飛んで Leaflet editor を使う (P12-02 と同じ画面で省実装)。 skip すると `/` へ。
+ *
+ * 既存の `useOnboardingGuard` は `needs_onboarding=True` のときだけ
+ * /onboarding に redirect するが、 本 page は step 1 完了後 (= False) の user
+ * しか辿り着かない経路なので gate しない。 直接 URL を踏まれても害は無い
+ * (residence は anytime 設定可なので)。
+ */
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export default function OnboardingResidencePage() {
+	return (
+		<main className="mx-auto flex min-h-screen max-w-xl flex-col justify-center px-6 py-12">
+			<ol
+				className="mb-6 flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground"
+				aria-label="オンボーディングの進行状況"
+			>
+				<li className="flex items-center gap-2 opacity-50">
+					<span className="flex size-6 items-center justify-center rounded-full border">
+						1
+					</span>
+					プロフィール
+				</li>
+				<li
+					className="flex items-center gap-2 font-semibold text-foreground"
+					aria-current="step"
+				>
+					<span className="flex size-6 items-center justify-center rounded-full bg-foreground text-background">
+						2
+					</span>
+					居住地 (任意)
+				</li>
+			</ol>
+
+			<header className="mb-6 space-y-2">
+				<h1 className="text-2xl font-bold">住んでる場所を設定しますか？</h1>
+				<p className="text-sm text-muted-foreground">
+					地図に <strong>円</strong> で居住地を表示します。 半径 500m
+					以上で公開され、 ピンポイントの住所は他のユーザーに見えません。
+					あとから設定 / 削除もできます。
+				</p>
+				<p className="text-sm text-muted-foreground">
+					「自分の近所のエンジニア」 を検索する機能も使えるようになります。
+				</p>
+			</header>
+
+			<div className="flex flex-col gap-3">
+				<Button asChild className="w-full">
+					<Link href="/settings/residence">今すぐ設定する</Link>
+				</Button>
+				<Button asChild variant="outline" className="w-full">
+					<Link href="/">あとで設定する</Link>
+				</Button>
+			</div>
+
+			<p className="mt-6 text-xs text-muted-foreground">
+				居住地は{" "}
+				<Link href="/settings/residence" className="underline">
+					/settings/residence
+				</Link>{" "}
+				からいつでも変更できます。
+			</p>
+		</main>
+	);
+}

--- a/client/src/app/onboarding/residence/page.tsx
+++ b/client/src/app/onboarding/residence/page.tsx
@@ -31,8 +31,11 @@ export default function OnboardingResidencePage() {
 				className="mb-6 flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground"
 				aria-label="オンボーディングの進行状況"
 			>
-				<li className="flex items-center gap-2 opacity-50">
-					<span className="flex size-6 items-center justify-center rounded-full border">
+				<li className="flex items-center gap-2 text-muted-foreground">
+					<span
+						aria-hidden="true"
+						className="flex size-6 items-center justify-center rounded-full border"
+					>
 						1
 					</span>
 					プロフィール
@@ -41,19 +44,23 @@ export default function OnboardingResidencePage() {
 					className="flex items-center gap-2 font-semibold text-foreground"
 					aria-current="step"
 				>
-					<span className="flex size-6 items-center justify-center rounded-full bg-foreground text-background">
+					<span
+						aria-hidden="true"
+						className="flex size-6 items-center justify-center rounded-full bg-foreground text-background"
+					>
 						2
 					</span>
 					居住地 (任意)
+					<span className="sr-only">（ステップ 2 / 2、 現在地）</span>
 				</li>
 			</ol>
 
 			<header className="mb-6 space-y-2">
 				<h1 className="text-2xl font-bold">住んでる場所を設定しますか？</h1>
 				<p className="text-sm text-muted-foreground">
-					地図に <strong>円</strong> で居住地を表示します。 半径 500m
-					以上で公開され、 ピンポイントの住所は他のユーザーに見えません。
-					あとから設定 / 削除もできます。
+					地図に円で居住地を表示します。 半径 500m 以上で公開され、
+					ピンポイントの住所は他のユーザーに見えません。 あとから設定 /
+					削除もできます。
 				</p>
 				<p className="text-sm text-muted-foreground">
 					「自分の近所のエンジニア」 を検索する機能も使えるようになります。
@@ -71,8 +78,12 @@ export default function OnboardingResidencePage() {
 
 			<p className="mt-6 text-xs text-muted-foreground">
 				居住地は{" "}
-				<Link href="/settings/residence" className="underline">
-					/settings/residence
+				<Link
+					href="/settings/residence"
+					className="underline"
+					aria-label="居住地設定ページを開く"
+				>
+					居住地設定ページ
 				</Link>{" "}
 				からいつでも変更できます。
 			</p>

--- a/client/src/app/onboarding/residence/page.tsx
+++ b/client/src/app/onboarding/residence/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 /**
  * /onboarding/residence — onboarding step 2 (Phase 12 P12-03)。
  *
@@ -11,11 +9,20 @@
  * /onboarding に redirect するが、 本 page は step 1 完了後 (= False) の user
  * しか辿り着かない経路なので gate しない。 直接 URL を踏まれても害は無い
  * (residence は anytime 設定可なので)。
+ *
+ * State なし / hooks なしの presentational page なので Server Component で動かす
+ * (typescript-reviewer P12-03 MEDIUM 指摘 — hydration payload 削減)。
  */
 
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+	title: "居住地の設定 — オンボーディング",
+	robots: { index: false },
+};
 
 export default function OnboardingResidencePage() {
 	return (

--- a/client/src/components/forms/onboarding/OnboardingForm.tsx
+++ b/client/src/components/forms/onboarding/OnboardingForm.tsx
@@ -38,8 +38,11 @@ export default function OnboardingForm() {
 		onSuccess: () => {
 			// P12-03: step 1 完了後は step 2 (居住地、 任意) に遷移。
 			// 既存実装は `/` に飛ばしていたが、 prompt → skip / 設定 の選択肢を挟む。
+			// `router.refresh()` は呼ばない: 遷移先 (/onboarding/residence) は
+			// presentational で server data を持たないので revalidate 不要、
+			// `push` と race して navigation を取りこぼす懸念もある
+			// (typescript-reviewer P12-03 HIGH 指摘)。
 			router.push("/onboarding/residence");
-			router.refresh();
 		},
 	});
 

--- a/client/src/components/forms/onboarding/OnboardingForm.tsx
+++ b/client/src/components/forms/onboarding/OnboardingForm.tsx
@@ -36,7 +36,9 @@ export default function OnboardingForm() {
 		form,
 		mutate: (values) => completeOnboarding(values).then(() => undefined),
 		onSuccess: () => {
-			router.push("/");
+			// P12-03: step 1 完了後は step 2 (居住地、 任意) に遷移。
+			// 既存実装は `/` に飛ばしていたが、 prompt → skip / 設定 の選択肢を挟む。
+			router.push("/onboarding/residence");
 			router.refresh();
 		},
 	});

--- a/client/src/components/forms/onboarding/__tests__/OnboardingForm.test.tsx
+++ b/client/src/components/forms/onboarding/__tests__/OnboardingForm.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Tests for OnboardingForm (P1-14 / P12-03).
+ *
+ * 主要シナリオは P12-03 で追加した step 2 (/onboarding/residence) への遷移。
+ * 既存 step 1 (display_name / bio 入力 → completeOnboarding) のロジックも回帰
+ * チェック対象。
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import OnboardingForm from "@/components/forms/onboarding/OnboardingForm";
+
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+	usePathname: () => "/onboarding",
+}));
+
+// completeOnboarding を successful な promise に mock。
+const completeOnboardingMock = vi.fn();
+vi.mock("@/lib/api/users", () => ({
+	completeOnboarding: (...args: Parameters<typeof completeOnboardingMock>) =>
+		completeOnboardingMock(...args),
+}));
+
+describe("OnboardingForm", () => {
+	beforeEach(() => {
+		mockPush.mockClear();
+		mockRefresh.mockClear();
+		completeOnboardingMock.mockClear();
+	});
+
+	it("renders display_name input and submit button", () => {
+		render(<OnboardingForm />);
+		expect(screen.getByLabelText(/表示名/)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /はじめる/ }),
+		).toBeInTheDocument();
+	});
+
+	it("redirects to /onboarding/residence on successful submit (P12-03)", async () => {
+		completeOnboardingMock.mockResolvedValue({
+			id: "u1",
+			username: "alice",
+			display_name: "Alice",
+			needs_onboarding: false,
+		});
+		render(<OnboardingForm />);
+
+		await userEvent.type(screen.getByLabelText(/表示名/), "Alice");
+		fireEvent.click(screen.getByRole("button", { name: /はじめる/ }));
+
+		await waitFor(() => {
+			expect(mockPush).toHaveBeenCalledWith("/onboarding/residence");
+		});
+		// `/` ではない (P12-03 前は `/` だった)
+		expect(mockPush).not.toHaveBeenCalledWith("/");
+		expect(completeOnboardingMock).toHaveBeenCalledWith({
+			display_name: "Alice",
+			bio: "",
+		});
+	});
+
+	it("does not navigate when submit fails", async () => {
+		completeOnboardingMock.mockRejectedValue(new Error("boom"));
+		render(<OnboardingForm />);
+
+		await userEvent.type(screen.getByLabelText(/表示名/), "Bob");
+		fireEvent.click(screen.getByRole("button", { name: /はじめる/ }));
+
+		await waitFor(() => {
+			expect(completeOnboardingMock).toHaveBeenCalled();
+		});
+		expect(mockPush).not.toHaveBeenCalled();
+	});
+});

--- a/docs/specs/phase-12-residence-map-spec.md
+++ b/docs/specs/phase-12-residence-map-spec.md
@@ -253,6 +253,35 @@ cd client && npx vitest run src/lib/api/__tests__/userSearch.test.ts src/compone
 PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/near-me-search.spec.ts
 ```
 
+### 7.6 サインアップ wizard 統合 (P12-03)
+
+step 1 (`/onboarding`) の display_name + bio 入力後に step 2 (`/onboarding/residence`)
+の prompt を挟む。 prompt 自体は presentational で API call なし、 「今すぐ設定」
+は `/settings/residence` (Leaflet editor、 P12-02 と同じ画面)、 「あとで設定」
+は `/` に飛ばす。 既存 `useOnboardingGuard` は step 1 完了で `needs_onboarding=False`
+が立つので step 2 は anytime 訪問可能な普通の page。
+
+vitest:
+
+- `OnboardingForm.test.tsx` (3 cases): submit 成功で `/onboarding/residence` に
+  redirect / submit 失敗で redirect なし / form の input 表示
+- `app/onboarding/residence/__tests__/page.test.tsx` (3 cases): heading / 2 つの
+  link href / step indicator が「居住地 (任意)」 を current にする
+
+E2E (`client/e2e/onboarding-residence.spec.ts` 3 cases):
+
+- ONBOARD-RES-1 (anon): /onboarding/residence は anon でも 200 (prompt は
+  public、 link 先で auth gate される)
+- ONBOARD-RES-2 (skip): 「あとで設定する」 → `/` 遷移
+- ONBOARD-RES-3 (golden): 「今すぐ設定する」 → /settings/residence の保存 button
+
+実行:
+
+```bash
+cd client && npx vitest run src/components/forms/onboarding/__tests__/ src/app/onboarding/residence/__tests__/
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/onboarding-residence.spec.ts
+```
+
 ---
 
 ## 8. ロールアウト順序
@@ -260,7 +289,7 @@ PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/near-me-sea
 1. ✅ **P12-01** (#678 merged): model + API + tests
 2. ✅ **P12-02** (#679 merged): 設定 UI + プロフィール map 表示 (Leaflet + OSM)
 3. ✅ **P12-04** (#680 merged): 汎用 user search page (full-text、 cursor pagination)
-4. **P12-05** (本 PR): 近所検索 (haversine SQL, near_me=1 / near=lat,lng)
-5. P12-03: signup wizard 統合 (任意フェーズ、 完成度的に最後)
+4. ✅ **P12-05** (#681 merged): 近所検索 (haversine SQL, near_me=1 / near=lat,lng)
+5. **P12-03** (本 PR): signup wizard step 2 (居住地 prompt) — Phase 12 完了
 
 各段階で `gan-evaluator` agent に採点させて UX を確認 (新 route 追加なので Phase 11 同様の必須運用)。


### PR DESCRIPTION
## Summary

**Phase 12 最終 PR**。 サインアップ wizard に居住地設定 step 2 を追加して Phase 12 を完了させる。

- 新規 page `/onboarding/residence`: prompt のみ (presentational、 API call なし)
  - 「住んでる場所を設定しますか?」 + プライバシー説明 (半径 500m / ピンポイント不可)
  - 「今すぐ設定する」 → `/settings/residence` (Leaflet editor は P12-02 と同画面で省実装)
  - 「あとで設定する」 → `/`
- `OnboardingForm`: step 1 成功時の遷移先を `/` → `/onboarding/residence` に変更
- step indicator: 1 (プロフィール) → 2 (居住地、 任意)。 旧「スキル / 興味 タグ (近日公開)」 placeholder は撤去
- 「居住地はあとから /settings/residence でいつでも変更可能」 と注記

Issue: #675 (Phase 12 milestone #15)
spec: \`docs/specs/phase-12-residence-map-spec.md\` §7.6

## Test plan

- [x] \`npx vitest run src/components/forms/onboarding/__tests__/ src/app/onboarding/residence/__tests__/\` → 6 passed
- [x] \`npx tsc --noEmit\` → clean
- [ ] CI 緑 (eslint / tsc / vitest / coverage / build)
- [ ] stg deploy 後 Playwright \`e2e/onboarding-residence.spec.ts\` 実行
- [ ] \`gan-evaluator\` で第三者 UX 採点

## Phase 12 完了状況 (全 5 / 5)

| ID | PR | 内容 | 状態 |
|----|----|----|----|
| P12-01 | #678 | UserResidence model + CRUD API (min 500m) | ✅ |
| P12-02 | #679 | Leaflet map UI + /settings/residence | ✅ |
| P12-04 | #680 | /search/users 汎用検索 page | ✅ |
| P12-05 | #681 | 近所検索 (haversine SQL) | ✅ |
| P12-03 | 本 PR | onboarding 居住地 step 2 prompt | 本 PR |