### PR TITLE
fix(search): NotAuthenticated (401) for anon near_me=1 (#683)

### DIFF
--- a/apps/users/tests/test_user_search_near_me.py
+++ b/apps/users/tests/test_user_search_near_me.py
@@ -37,12 +37,14 @@ def _set_residence(user, lat: str, lng: str, radius_m: int = 500) -> UserResiden
 @pytest.mark.django_db
 @pytest.mark.integration
 class TestNearMeSearch:
-    def test_near_me_requires_auth(self, api_client: APIClient, search_url: str) -> None:
+    def test_near_me_requires_auth_returns_401_for_anon(
+        self, api_client: APIClient, search_url: str
+    ) -> None:
+        """#683 fix: anon は NotAuthenticated (401) で返す。 PermissionDenied (403)
+        だと frontend が「ログインが必要」 でなく generic error を出す。
+        DRF 慣行的にも 「未認証 = 401、 auth 済だが forbidden = 403」 が正しい。"""
         res = api_client.get(search_url, {"near_me": "1", "radius_km": "10"})
-        assert res.status_code in (
-            status.HTTP_401_UNAUTHORIZED,
-            status.HTTP_403_FORBIDDEN,
-        )
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_near_me_400_when_self_residence_missing(
         self, api_client: APIClient, user_factory, search_url: str

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -8,7 +8,7 @@ from django.db.models.expressions import RawSQL
 from django.shortcuts import get_object_or_404
 from djoser.social.views import ProviderAuthView
 from rest_framework import serializers, status
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import NotAuthenticated, ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.pagination import CursorPagination
 from rest_framework.parsers import JSONParser
@@ -925,11 +925,14 @@ class UserFullTextSearchView(ListAPIView):
         center: tuple[float, float] | None = None
         if near_me:
             if not self.request.user.is_authenticated:
-                # 401/403 は DRF の permission レイヤで返したいが、 ここまで来た時点で
-                # AllowAny なので明示的に PermissionDenied で 403 を返す。
+                # anon は 401 (NotAuthenticated)、 「auth 済だが forbidden」 は
+                # 403 (PermissionDenied) という DRF 慣行に合わせる (#683 fix)。
+                # frontend は 401 を「ログインが必要」 outcome に map している
+                # (page.tsx の loadUserSearch)。 ここで PermissionDenied (403)
+                # を投げると frontend は generic error 扱いになって誤誘導する。
                 # (near=lat,lng は anon 可なので permission_classes は AllowAny の
                 # まま、 near_me のみ in-method で auth を要求する pragmatic 分岐)
-                raise PermissionDenied("near_me には認証が必要です")
+                raise NotAuthenticated("near_me には認証が必要です")
             residence = UserResidence.objects.filter(user=self.request.user).first()
             if residence is None:
                 raise ValidationError(


### PR DESCRIPTION
## Summary

Phase 12 stg Playwright で唯一 fail した NEAR-1 (anon で /search/users?near_me=1 → 「ログインが必要」 が出ない) を修正。

- backend: anon が \`near_me=1\` を踏んだとき \`PermissionDenied\` (403) → \`NotAuthenticated\` (401) に変更
- frontend (page.tsx) は既に 401 を \`needs_login\` outcome に map 済 (P12-05 typescript-reviewer 修正の意図通り) — 触らない
- DRF 慣行的にも 「未認証 = 401、 auth 済だが forbidden = 403」 が正しい

Issue: #683

## Test plan

- [x] \`docker compose -f local.yml exec api pytest apps/users/tests/test_user_search_near_me.py -v\` → 12 passed
- [ ] CI 緑
- [ ] stg 反映後 \`PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/near-me-search.spec.ts\` で 4/4 passed