### PR TITLE
fix(nav): sibling sub-route の二重 active を解消 (#685)

### DIFF
--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -37,6 +37,7 @@ import {
 } from "lucide-react";
 
 import { dispatchAComposeOpen } from "@/components/layout-a/AComposeDialogHost";
+import { resolveActiveHref } from "@/lib/nav-active";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -158,39 +159,39 @@ export default function ALeftNav() {
 				</span>
 			</div>
 
-			{visibleItems.map((item) => {
-				// nested route (例: `/search/users`) で親 (`/search`) と二重 active に
-				// ならないよう、 完全一致 or `/<seg>/...` のときだけ active にする
-				// (P12-04 HIGH 修正)。
-				const isActive =
-					item.href === "/"
-						? pathname === "/"
-						: pathname === item.href || pathname.startsWith(`${item.href}/`);
-				const badgeCount = itemBadgeCount(item.badgeKey);
-				return (
-					<Link
-						key={item.href}
-						href={item.href}
-						aria-current={isActive || undefined}
-						className={`flex items-center gap-3 rounded-md py-1.5 pr-2.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
-							isActive ? "" : "hover:bg-[color:var(--a-bg-muted)]"
-						}`}
-						style={{
-							paddingLeft: 7,
-							borderLeft: `2px solid ${
-								isActive ? "var(--a-accent)" : "transparent"
-							}`,
-							background: isActive ? "var(--a-bg-muted)" : "transparent",
-							color: isActive ? "var(--a-text)" : "var(--a-text-muted)",
-							fontSize: 13.5,
-						}}
-					>
-						<item.Icon className="size-4" />
-						<span className="flex-1 truncate">{item.label}</span>
-						<NavBadge count={badgeCount} />
-					</Link>
-				);
-			})}
+			{(() => {
+				// nested sibling route (例: `/search` と `/search/users`) で両方が
+				// active にならないよう、 sibling 全体の中で最長 prefix の 1 個だけ
+				// active にする (#685 fix)。 `resolveActiveHref` で 1 度だけ計算。
+				const activeHref = resolveActiveHref(visibleItems, pathname);
+				return visibleItems.map((item) => {
+					const isActive = item.href === activeHref;
+					const badgeCount = itemBadgeCount(item.badgeKey);
+					return (
+						<Link
+							key={item.href}
+							href={item.href}
+							aria-current={isActive ? "page" : undefined}
+							className={`flex items-center gap-3 rounded-md py-1.5 pr-2.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+								isActive ? "" : "hover:bg-[color:var(--a-bg-muted)]"
+							}`}
+							style={{
+								paddingLeft: 7,
+								borderLeft: `2px solid ${
+									isActive ? "var(--a-accent)" : "transparent"
+								}`,
+								background: isActive ? "var(--a-bg-muted)" : "transparent",
+								color: isActive ? "var(--a-text)" : "var(--a-text-muted)",
+								fontSize: 13.5,
+							}}
+						>
+							<item.Icon className="size-4" />
+							<span className="flex-1 truncate">{item.label}</span>
+							<NavBadge count={badgeCount} />
+						</Link>
+					);
+				});
+			})()}
 
 			{isAuthenticated && profile && (
 				<Link

--- a/client/src/components/layout-a/AMobileShell.tsx
+++ b/client/src/components/layout-a/AMobileShell.tsx
@@ -34,6 +34,7 @@ import {
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useAuthNavigation } from "@/hooks";
 import { useUserProfile } from "@/hooks/useUseProfile";
+import { resolveActiveHref } from "@/lib/nav-active";
 
 interface BottomTabItem {
 	href: string;
@@ -172,17 +173,18 @@ export default function AMobileAppBar({ children }: { children?: ReactNode }) {
 					fontFamily: "var(--a-font-sans)",
 				}}
 			>
-				{BOTTOM_TABS.filter((t) => !t.requiresAuth || isAuthenticated).map(
-					(tab) => {
-						const isActive =
-							tab.href === "/"
-								? pathname === "/"
-								: pathname.startsWith(tab.href);
+				{(() => {
+					const visible = BOTTOM_TABS.filter(
+						(t) => !t.requiresAuth || isAuthenticated,
+					);
+					const activeHref = resolveActiveHref(visible, pathname);
+					return visible.map((tab) => {
+						const isActive = tab.href === activeHref;
 						return (
 							<Link
 								key={tab.href}
 								href={tab.href}
-								aria-current={isActive || undefined}
+								aria-current={isActive ? "page" : undefined}
 								className="flex flex-1 flex-col items-center justify-center gap-0.5 py-2 transition-colors focus-visible:outline-none"
 								style={{
 									color: isActive ? "var(--a-accent)" : "var(--a-text-muted)",
@@ -193,8 +195,8 @@ export default function AMobileAppBar({ children }: { children?: ReactNode }) {
 								<span>{tab.label}</span>
 							</Link>
 						);
-					},
-				)}
+					});
+				})()}
 				{isAuthenticated && profile ? (
 					<Link
 						href={`/u/${profile.username}`}
@@ -256,19 +258,19 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 
 	return (
 		<div className="flex flex-col gap-0.5">
-			{items
-				.filter((it) => !it.requiresAuth || isAuthenticated)
-				.map((item) => {
-					const isActive =
-						item.href === "/"
-							? pathname === "/"
-							: pathname.startsWith(item.href);
+			{(() => {
+				const visible = items.filter(
+					(it) => !it.requiresAuth || isAuthenticated,
+				);
+				const activeHref = resolveActiveHref(visible, pathname);
+				return visible.map((item) => {
+					const isActive = item.href === activeHref;
 					return (
 						<Link
 							key={item.href}
 							href={item.href}
 							onClick={onItemClick}
-							aria-current={isActive || undefined}
+							aria-current={isActive ? "page" : undefined}
 							className="flex items-center gap-3 rounded-md py-2 pr-2.5"
 							style={{
 								paddingLeft: 7,
@@ -284,7 +286,8 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 							<span>{item.label}</span>
 						</Link>
 					);
-				})}
+				});
+			})()}
 		</div>
 	);
 }

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { resolveActiveHref } from "@/lib/nav-active";
 import SettingsMenu from "@/components/shared/navbar/SettingsMenu";
 import ComposeTweetDialog from "@/components/tweets/ComposeTweetDialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -114,67 +115,71 @@ export default function LeftNavbar() {
 				aria-label="メインナビゲーション"
 				className="flex flex-1 flex-col gap-2"
 			>
-				{filteredNavLinks.map((linkItem) => {
-					const href = resolveLinkPath(linkItem, selfHandle);
-					if (!href) {
-						// プロフィール link で self handle が未取得の場合は disabled 扱い
+				{(() => {
+					// 全 link の resolved href から「最長 prefix の 1 個」 を選んで active
+					// 判定する (#685 fix: `/search/users` 表示中に `/search` も active に
+					// なる問題を回避)。
+					const resolvedHrefs = filteredNavLinks
+						.map((link) => ({ href: resolveLinkPath(link, selfHandle) }))
+						.filter((x): x is { href: string } => Boolean(x.href));
+					const activeHref = resolveActiveHref(resolvedHrefs, pathname);
+					return filteredNavLinks.map((linkItem) => {
+						const href = resolveLinkPath(linkItem, selfHandle);
+						if (!href) {
+							// プロフィール link で self handle が未取得の場合は disabled 扱い
+							return (
+								<span
+									key={linkItem.label}
+									aria-disabled="true"
+									title="プロフィール情報を取得中..."
+									className="text-baby_richBlack/50 flex items-center justify-start gap-4 p-4"
+								>
+									<NavIcon link={linkItem} isActive={false} />
+									<p className="base-medium max-lg:hidden">{linkItem.label}</p>
+								</span>
+							);
+						}
+						const isActive = href === activeHref;
 						return (
-							<span
+							<Link
+								href={href}
 								key={linkItem.label}
-								aria-disabled="true"
-								title="プロフィール情報を取得中..."
-								className="text-baby_richBlack/50 flex items-center justify-start gap-4 p-4"
+								aria-label={
+									linkItem.path === "/notifications" && unreadCount > 0
+										? `${linkItem.label} (${unreadCount} 件の未読)`
+										: linkItem.label
+								}
+								aria-current={isActive ? "page" : undefined}
+								className={`${
+									isActive
+										? "electricIndigo-gradient text-babyPowder rounded-lg"
+										: "text-baby_richBlack hover:bg-baby_richBlack/5"
+								} flex items-center justify-start gap-4 bg-transparent p-4 transition`}
 							>
-								<NavIcon link={linkItem} isActive={false} />
-								<p className="base-medium max-lg:hidden">{linkItem.label}</p>
-							</span>
-						);
-					}
-					// path-prefix match: 「`/search` が `/search/users` も active 化させる」
-					// 問題 (typescript-reviewer P12-04 HIGH) を回避するため、完全一致または
-					// `/<segment>/...` で始まるかどうかを active 扱いにする。
-					const isActive =
-						pathname === href ||
-						(href.length > 1 && pathname.startsWith(`${href}/`));
-					return (
-						<Link
-							href={href}
-							key={linkItem.label}
-							aria-label={
-								linkItem.path === "/notifications" && unreadCount > 0
-									? `${linkItem.label} (${unreadCount} 件の未読)`
-									: linkItem.label
-							}
-							aria-current={isActive ? "page" : undefined}
-							className={`${
-								isActive
-									? "electricIndigo-gradient text-babyPowder rounded-lg"
-									: "text-baby_richBlack hover:bg-baby_richBlack/5"
-							} flex items-center justify-start gap-4 bg-transparent p-4 transition`}
-						>
-							<NavIcon link={linkItem} isActive={isActive} />
-							{/* lg 以下では label を視覚的に隠すが、a11y のため Link 自体に
+								<NavIcon link={linkItem} isActive={isActive} />
+								{/* lg 以下では label を視覚的に隠すが、a11y のため Link 自体に
 							    aria-label を付与している (max-lg で text を display:none に
 							    した場合も SR からは label が display:none に
 							    した場合も SR からは label が読み上げられる)。 */}
-							<p
-								aria-hidden="true"
-								className={`${isActive ? "base-bold" : "base-medium"} max-lg:hidden`}
-							>
-								{linkItem.label}
-							</p>
-							{/* #412: 通知 link の右側に未読バッジ。0 件のときは出さない。 */}
-							{linkItem.path === "/notifications" && unreadCount > 0 ? (
-								<span
+								<p
 									aria-hidden="true"
-									className="ml-auto inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-red-500 px-2 py-0.5 text-xs font-semibold text-white max-lg:absolute max-lg:right-2 max-lg:top-2 max-lg:ml-0"
+									className={`${isActive ? "base-bold" : "base-medium"} max-lg:hidden`}
 								>
-									{unreadCount > 99 ? "99+" : unreadCount}
-								</span>
-							) : null}
-						</Link>
-					);
-				})}
+									{linkItem.label}
+								</p>
+								{/* #412: 通知 link の右側に未読バッジ。0 件のときは出さない。 */}
+								{linkItem.path === "/notifications" && unreadCount > 0 ? (
+									<span
+										aria-hidden="true"
+										className="ml-auto inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-red-500 px-2 py-0.5 text-xs font-semibold text-white max-lg:absolute max-lg:right-2 max-lg:top-2 max-lg:ml-0"
+									>
+										{unreadCount > 99 ? "99+" : unreadCount}
+									</span>
+								) : null}
+							</Link>
+						);
+					});
+				})()}
 
 				{/* #396: + ポストボタン (認証済みのみ)。lg+ は label "ポスト"、
 				    sm〜lg は icon のみ。click → ComposeTweetDialog を open。

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/sheet";
 import { useAuthNavigation } from "@/hooks";
 import { useUserProfile } from "@/hooks/useUseProfile";
+import { resolveActiveHref } from "@/lib/nav-active";
 import type { LeftNavIconName, LeftNavLink } from "@/types";
 import { HomeModernIcon } from "@heroicons/react/24/solid";
 import {
@@ -88,40 +89,44 @@ function LeftNavContent() {
 			aria-label="メインナビゲーション"
 			className="flex h-full flex-col gap-2 pt-16"
 		>
-			{filteredNavLinks.map((linkItem) => {
-				const href = resolveLinkPath(linkItem, selfHandle);
-				if (!href) {
+			{(() => {
+				// 全 link の resolved href から最長 prefix の 1 個を active にする
+				// (#685 fix: `/search` と `/search/users` の二重 active を回避)。
+				const resolvedHrefs = filteredNavLinks
+					.map((link) => ({ href: resolveLinkPath(link, selfHandle) }))
+					.filter((x): x is { href: string } => Boolean(x.href));
+				const activeHref = resolveActiveHref(resolvedHrefs, pathname);
+				return filteredNavLinks.map((linkItem) => {
+					const href = resolveLinkPath(linkItem, selfHandle);
+					if (!href) {
+						return (
+							<span
+								key={linkItem.label}
+								aria-disabled="true"
+								className="text-baby_richBlack/50 flex items-center justify-start gap-4 p-4"
+							>
+								<NavIcon link={linkItem} isActive={false} />
+								<p className="base-medium">{linkItem.label}</p>
+							</span>
+						);
+					}
+					const isActive = href === activeHref;
 					return (
-						<span
-							key={linkItem.label}
-							aria-disabled="true"
-							className="text-baby_richBlack/50 flex items-center justify-start gap-4 p-4"
-						>
-							<NavIcon link={linkItem} isActive={false} />
-							<p className="base-medium">{linkItem.label}</p>
-						</span>
+						<SheetClose asChild key={linkItem.label}>
+							<Link
+								href={href}
+								aria-current={isActive ? "page" : undefined}
+								className={`${isActive ? "electricIndigo-gradient text-babyPowder rounded-lg" : "text-baby_richBlack"} flex items-center justify-start gap-4 bg-transparent p-4`}
+							>
+								<NavIcon link={linkItem} isActive={isActive} />
+								<p className={`${isActive ? "base-bold" : "base-medium"}`}>
+									{linkItem.label}
+								</p>
+							</Link>
+						</SheetClose>
 					);
-				}
-				// path-prefix match: nested route (`/search/users`) で親 (`/search`) と
-				// 二重に active になる substring match を避ける (P12-04 HIGH 修正)。
-				const isActive =
-					pathname === href ||
-					(href.length > 1 && pathname.startsWith(`${href}/`));
-				return (
-					<SheetClose asChild key={linkItem.label}>
-						<Link
-							href={href}
-							aria-current={isActive ? "page" : undefined}
-							className={`${isActive ? "electricIndigo-gradient text-babyPowder rounded-lg" : "text-baby_richBlack"} flex items-center justify-start gap-4 bg-transparent p-4`}
-						>
-							<NavIcon link={linkItem} isActive={isActive} />
-							<p className={`${isActive ? "base-bold" : "base-medium"}`}>
-								{linkItem.label}
-							</p>
-						</Link>
-					</SheetClose>
-				);
-			})}
+				});
+			})()}
 		</nav>
 	);
 }

--- a/client/src/lib/__tests__/nav-active.test.ts
+++ b/client/src/lib/__tests__/nav-active.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for nav-active helper (#685).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isNavItemActive, resolveActiveHref } from "@/lib/nav-active";
+
+const ITEMS = [
+	{ href: "/" },
+	{ href: "/search" },
+	{ href: "/search/users" },
+	{ href: "/messages" },
+	{ href: "/articles" },
+];
+
+describe("resolveActiveHref", () => {
+	it("exact match on root", () => {
+		expect(resolveActiveHref(ITEMS, "/")).toBe("/");
+	});
+
+	it("does NOT activate root for deeper paths", () => {
+		expect(resolveActiveHref(ITEMS, "/search")).toBe("/search");
+		expect(resolveActiveHref(ITEMS, "/messages/123")).toBe("/messages");
+	});
+
+	it("picks the longest prefix when nested siblings exist (#685 root cause)", () => {
+		// `/search` と `/search/users` の両方が match するが、 longer prefix が勝つ
+		expect(resolveActiveHref(ITEMS, "/search/users")).toBe("/search/users");
+	});
+
+	it("activates /search (not /search/users) when pathname is /search exactly", () => {
+		expect(resolveActiveHref(ITEMS, "/search")).toBe("/search");
+	});
+
+	it("activates /messages for descendant paths", () => {
+		expect(resolveActiveHref(ITEMS, "/messages/42")).toBe("/messages");
+		expect(resolveActiveHref(ITEMS, "/messages/42/edit")).toBe("/messages");
+	});
+
+	it("returns null when no item matches", () => {
+		expect(resolveActiveHref(ITEMS, "/explore")).toBeNull();
+		expect(resolveActiveHref(ITEMS, "/u/test2")).toBeNull();
+	});
+
+	it("does NOT false-positive partial-segment match (e.g. /searchbar vs /search)", () => {
+		// `/searchbar` は `/search` の descendant ではないので非 active
+		expect(resolveActiveHref(ITEMS, "/searchbar")).toBeNull();
+	});
+
+	it("empty items returns null", () => {
+		expect(resolveActiveHref([], "/anything")).toBeNull();
+	});
+});
+
+describe("isNavItemActive", () => {
+	it("returns true only for the most specific match", () => {
+		expect(isNavItemActive("/search", ITEMS, "/search/users")).toBe(false);
+		expect(isNavItemActive("/search/users", ITEMS, "/search/users")).toBe(true);
+	});
+
+	it("activates /search on its own page", () => {
+		expect(isNavItemActive("/search", ITEMS, "/search")).toBe(true);
+		expect(isNavItemActive("/search/users", ITEMS, "/search")).toBe(false);
+	});
+
+	it("activates / only on root", () => {
+		expect(isNavItemActive("/", ITEMS, "/")).toBe(true);
+		expect(isNavItemActive("/", ITEMS, "/search")).toBe(false);
+	});
+});

--- a/client/src/lib/nav-active.ts
+++ b/client/src/lib/nav-active.ts
@@ -1,0 +1,65 @@
+/**
+ * LeftNav / MobileNav / ALeftNav 等で「現在 active な link」 を判定する共通ヘルパー
+ * (Phase 12 follow-up #685 fix)。
+ *
+ * Nav に \`/search\` と \`/search/users\` の sibling sub-route が並んでいるとき、
+ * 単純な \`pathname.startsWith(href + "/")\` だと \`/search/users\` 表示中に
+ * **両方** が active になり、 a11y 上 \`aria-current=\"page\"\` が 2 link に同時に
+ * 立つ問題 (WCAG 違反 + 視覚的二重ハイライト) を回避する。
+ *
+ * 判定: nav item の中で **pathname に matching する最長 prefix** を持つもの 1 つだけが
+ * active。 root (\`/\`) は exact-match のみ。
+ */
+
+export interface NavActiveItem {
+	href: string;
+}
+
+/**
+ * `items` の中で `pathname` に対して 1 つだけ active な href を選ぶ。
+ * 「より長い prefix の sibling」 がいる場合、 短い prefix の item は active にならない。
+ *
+ * 例: items = [{href: "/search"}, {href: "/search/users"}], pathname = "/search/users"
+ *   → "/search/users" だけ active、 "/search" は非 active。
+ *
+ * @returns 最も specific な match の href、 または none なら null。
+ */
+export function resolveActiveHref<T extends NavActiveItem>(
+	items: ReadonlyArray<T>,
+	pathname: string,
+): string | null {
+	let bestMatchLen = -1;
+	let bestMatchHref: string | null = null;
+
+	for (const item of items) {
+		const href = item.href;
+		if (href === "/") {
+			if (pathname === "/" && bestMatchLen < 1) {
+				bestMatchLen = 1;
+				bestMatchHref = href;
+			}
+			continue;
+		}
+		const isExact = pathname === href;
+		const isDescendant = pathname.startsWith(`${href}/`);
+		if (!isExact && !isDescendant) continue;
+		// より specific (= longer href) を優先。
+		if (href.length > bestMatchLen) {
+			bestMatchLen = href.length;
+			bestMatchHref = href;
+		}
+	}
+
+	return bestMatchHref;
+}
+
+/**
+ * 単一 item の active 判定。 `resolveActiveHref` の結果と href を比較する shorthand。
+ */
+export function isNavItemActive<T extends NavActiveItem>(
+	href: string,
+	items: ReadonlyArray<T>,
+	pathname: string,
+): boolean {
+	return resolveActiveHref(items, pathname) === href;
+}


### PR DESCRIPTION
## Summary

Phase 12 gan-evaluator が見つけた **CRITICAL #685**: \`/search\` と \`/search/users\` が同時に \`aria-current=\"page\"\` になる a11y バグの修正。

- 共通 helper \`client/src/lib/nav-active.ts\` を新設して「最長 prefix の 1 個」 を選ぶ \`resolveActiveHref\` を実装
- ALeftNav / AMobileShell (bottom-tabs + drawer) / LeftNavbar / MobileNavbar の 4 component で同 helper を利用
- ALeftNav / AMobileShell の \`aria-current={isActive || undefined}\` を ARIA 標準 \`isActive ? \"page\" : undefined\` に修正

Issue: #685

## Test plan

- [x] \`npx vitest run src/lib/__tests__/nav-active.test.ts\` → 11 passed (root exact / nested sibling longest match / partial-segment-not-prefix / empty 等)
- [x] \`npx tsc --noEmit\` → clean
- [ ] CI 緑
- [ ] stg 反映後 LeftNav で /search/users 表示中に /search が active にならないことを実画面確認