### PR TITLE
feat(settings): settings hub layout で 5 routes 横断 sub-nav (#687)

### DIFF
--- a/client/src/app/(template)/settings/blocks/page.tsx
+++ b/client/src/app/(template)/settings/blocks/page.tsx
@@ -17,11 +17,10 @@ export default function BlockedSettingsPage() {
 	return (
 		<>
 			<header
-				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				className="flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
 					background: "rgba(255,255,255,0.85)",
-					backdropFilter: "blur(8px)",
 				}}
 			>
 				<h1

--- a/client/src/app/(template)/settings/layout.tsx
+++ b/client/src/app/(template)/settings/layout.tsx
@@ -1,0 +1,24 @@
+/**
+ * /settings/* shared layout (Phase 12 follow-up #687)。
+ *
+ * 5 つの settings ルート (profile / residence / notifications / blocks / mutes)
+ * を横断する sub-nav (`SettingsTabs`) を共通化する。 これで home → 設定 →
+ * 居住地マップ 等の 3 click 動線が確保される (gan-evaluator CRITICAL #687)。
+ */
+
+import type { ReactNode } from "react";
+
+import SettingsTabs from "@/components/settings/SettingsTabs";
+
+interface SettingsLayoutProps {
+	children: ReactNode;
+}
+
+export default function SettingsLayout({ children }: SettingsLayoutProps) {
+	return (
+		<>
+			<SettingsTabs />
+			{children}
+		</>
+	);
+}

--- a/client/src/app/(template)/settings/mutes/page.tsx
+++ b/client/src/app/(template)/settings/mutes/page.tsx
@@ -17,11 +17,10 @@ export default function MutedSettingsPage() {
 	return (
 		<>
 			<header
-				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				className="flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
 					background: "rgba(255,255,255,0.85)",
-					backdropFilter: "blur(8px)",
 				}}
 			>
 				<h1

--- a/client/src/app/(template)/settings/notifications/page.tsx
+++ b/client/src/app/(template)/settings/notifications/page.tsx
@@ -17,11 +17,10 @@ export default function NotificationSettingsPage() {
 	return (
 		<>
 			<header
-				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				className="flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
 					background: "rgba(255,255,255,0.85)",
-					backdropFilter: "blur(8px)",
 				}}
 			>
 				<h1

--- a/client/src/app/(template)/settings/profile/page.tsx
+++ b/client/src/app/(template)/settings/profile/page.tsx
@@ -26,7 +26,7 @@ export default async function ProfileSettingsPage() {
 	return (
 		<>
 			<header
-				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				className="flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
 					background: "rgba(255,255,255,0.85)",

--- a/client/src/app/(template)/settings/residence/page.tsx
+++ b/client/src/app/(template)/settings/residence/page.tsx
@@ -44,11 +44,10 @@ export default async function ResidenceSettingsPage() {
 	return (
 		<>
 			<header
-				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
+				className="flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
 					background: "rgba(255,255,255,0.85)",
-					backdropFilter: "blur(8px)",
 				}}
 			>
 				<div className="min-w-0 flex-1">

--- a/client/src/components/settings/SettingsTabs.tsx
+++ b/client/src/components/settings/SettingsTabs.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * /settings/* 全 page 共通の sticky sub-nav (Phase 12 follow-up #687)。
+ *
+ * gan-evaluator CRITICAL: home → 設定 → 居住地マップ 等への 3 click 動線が
+ * 無かった (#546 / #687 で再発)。 5 つの settings ルートを横断できる tab bar を
+ * `settings/layout.tsx` に挟むことで解消。
+ *
+ * - sticky top-0 で常時表示
+ * - mobile では横スクロール (overflow-x-auto + whitespace-nowrap)
+ * - `resolveActiveHref` で sibling sub-route 二重 active を回避 (#685)
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+	Ban,
+	Bell,
+	MapPin,
+	User,
+	VolumeX,
+	type LucideIcon,
+} from "lucide-react";
+
+import { resolveActiveHref } from "@/lib/nav-active";
+
+interface SettingsTab {
+	href: string;
+	label: string;
+	Icon: LucideIcon;
+}
+
+const TABS: SettingsTab[] = [
+	{ href: "/settings/profile", label: "プロフィール", Icon: User },
+	{ href: "/settings/residence", label: "居住地マップ", Icon: MapPin },
+	{ href: "/settings/notifications", label: "通知", Icon: Bell },
+	{ href: "/settings/blocks", label: "ブロック", Icon: Ban },
+	{ href: "/settings/mutes", label: "ミュート", Icon: VolumeX },
+];
+
+export default function SettingsTabs() {
+	const pathname = usePathname();
+	const activeHref = resolveActiveHref(TABS, pathname);
+
+	return (
+		<nav
+			aria-label="設定 サブナビゲーション"
+			className="sticky top-0 z-20 flex gap-1 overflow-x-auto whitespace-nowrap px-3 py-2"
+			style={{
+				borderBottom: "1px solid var(--a-border)",
+				background: "rgba(255,255,255,0.92)",
+				backdropFilter: "blur(8px)",
+			}}
+		>
+			{TABS.map((tab) => {
+				const isActive = tab.href === activeHref;
+				return (
+					<Link
+						key={tab.href}
+						href={tab.href}
+						aria-current={isActive ? "page" : undefined}
+						className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+							isActive
+								? "bg-[color:var(--a-bg-muted)] font-semibold text-[color:var(--a-text)]"
+								: "text-[color:var(--a-text-muted)] hover:bg-[color:var(--a-bg-muted)]"
+						}`}
+					>
+						<tab.Icon className="size-4" aria-hidden="true" />
+						<span>{tab.label}</span>
+					</Link>
+				);
+			})}
+		</nav>
+	);
+}

--- a/client/src/components/settings/__tests__/SettingsTabs.test.tsx
+++ b/client/src/components/settings/__tests__/SettingsTabs.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for SettingsTabs (#687).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import SettingsTabs from "@/components/settings/SettingsTabs";
+
+const mockPath = vi.fn(() => "/settings/profile");
+vi.mock("next/navigation", () => ({
+	usePathname: () => mockPath(),
+}));
+
+describe("SettingsTabs", () => {
+	it("renders all 5 settings tabs", () => {
+		mockPath.mockReturnValue("/settings/profile");
+		render(<SettingsTabs />);
+		const labels = [
+			"プロフィール",
+			"居住地マップ",
+			"通知",
+			"ブロック",
+			"ミュート",
+		];
+		for (const label of labels) {
+			expect(
+				screen.getByRole("link", { name: new RegExp(label) }),
+			).toBeInTheDocument();
+		}
+	});
+
+	it("marks the active tab with aria-current='page'", () => {
+		mockPath.mockReturnValue("/settings/residence");
+		render(<SettingsTabs />);
+		const active = screen.getByRole("link", { name: /居住地マップ/ });
+		expect(active).toHaveAttribute("aria-current", "page");
+		// 他の tab は active 化されない
+		const profile = screen.getByRole("link", { name: /プロフィール/ });
+		expect(profile).not.toHaveAttribute("aria-current");
+	});
+
+	it("uses correct hrefs for each tab", () => {
+		mockPath.mockReturnValue("/settings/profile");
+		render(<SettingsTabs />);
+		const map: Record<string, string> = {
+			プロフィール: "/settings/profile",
+			居住地マップ: "/settings/residence",
+			通知: "/settings/notifications",
+			ブロック: "/settings/blocks",
+			ミュート: "/settings/mutes",
+		};
+		for (const [label, href] of Object.entries(map)) {
+			expect(
+				screen.getByRole("link", { name: new RegExp(label) }),
+			).toHaveAttribute("href", href);
+		}
+	});
+
+	it("activates exactly one tab when on a settings page", () => {
+		mockPath.mockReturnValue("/settings/notifications");
+		render(<SettingsTabs />);
+		const allLinks = screen.getAllByRole("link");
+		const activeLinks = allLinks.filter(
+			(l) => l.getAttribute("aria-current") === "page",
+		);
+		expect(activeLinks).toHaveLength(1);
+		expect(activeLinks[0]).toHaveAttribute("href", "/settings/notifications");
+	});
+});


### PR DESCRIPTION
## Summary

Phase 12 gan-evaluator CRITICAL #687: home → 設定 → 居住地マップ への 3 click 動線が無かった (\`/settings/profile\` に他の settings link なし、 URL 直叩きしか手段がなかった、 CLAUDE.md §9 #546 再発)。

- 新規 \`SettingsTabs\` component: 5 tab 横断 sub-nav (プロフィール / 居住地マップ / 通知 / ブロック / ミュート)、 sticky top-0、 mobile 横スクロール
- 新規 \`settings/layout.tsx\`: SettingsTabs を全 /settings/* page の上に挿入
- 5 page の sticky header と nav の z-index fight を避けるため、 page の \`sticky top-0 z-10\` を削除 (sub-nav 1 つだけが sticky に)
- vitest 4 cases

これで home → avatar dropdown「設定」 → SettingsTabs「居住地マップ」 の 3 click 動線が確保される。 X / Meta の typical pattern。

Issue: #687

## Test plan

- [x] \`npx vitest run src/components/settings/__tests__/SettingsTabs.test.tsx\` → 4 passed
- [x] \`npx tsc --noEmit\` → clean
- [ ] CI 緑
- [ ] stg 反映後、 home → avatar dropdown → 設定 → 「居住地マップ」 tab で /settings/residence に遷移 (3 click) を確認
- [ ] gan-evaluator で C-1 解消を採点

## Phase 12 CRITICAL fix まとめ

| # | issue | PR |
|---|----|----|
| C-3 | #685 (active state bug) | #688 ✅ |
| C-2 | #686 (mobile drawer) | #689 ✅ |
| C-1 | #687 (settings hub) | 本 PR |