### PR TITLE
feat(search): polish — lime→accent / 件数表示 / skeleton (#691 #693 #694)

### DIFF
--- a/client/src/app/(template)/search/users/loading.tsx
+++ b/client/src/app/(template)/search/users/loading.tsx
@@ -1,0 +1,61 @@
+/**
+ * /search/users 検索中の skeleton fallback (#694)。
+ *
+ * Next.js App Router の Suspense Boundary。 SSR 完了までこの placeholder を
+ * 出す。 page.tsx は server component で serverFetch を待つので、 何も出ない
+ * 時間帯を埋める UX 改善。
+ */
+
+export default function LoadingUserSearch() {
+	return (
+		<>
+			<header
+				className="flex items-center gap-3 px-5 py-3"
+				style={{ borderBottom: "1px solid var(--a-border)" }}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						ユーザー検索
+					</h1>
+				</div>
+			</header>
+			<div className="px-5 py-5">
+				<div
+					className="mb-6 h-10 animate-pulse rounded-md"
+					style={{ background: "var(--a-bg-muted)" }}
+					aria-hidden="true"
+				/>
+				<ul role="list" className="space-y-2" aria-label="検索結果を読み込み中">
+					{[1, 2, 3].map((i) => (
+						<li
+							key={i}
+							className="flex items-start gap-3 rounded-lg border p-3"
+							style={{ borderColor: "var(--a-border)" }}
+						>
+							<div
+								className="size-12 shrink-0 animate-pulse rounded-full"
+								style={{ background: "var(--a-bg-muted)" }}
+								aria-hidden="true"
+							/>
+							<div className="flex-1 space-y-2">
+								<div
+									className="h-4 w-1/3 animate-pulse rounded"
+									style={{ background: "var(--a-bg-muted)" }}
+									aria-hidden="true"
+								/>
+								<div
+									className="h-3 w-2/3 animate-pulse rounded"
+									style={{ background: "var(--a-bg-muted)" }}
+									aria-hidden="true"
+								/>
+							</div>
+						</li>
+					))}
+				</ul>
+			</div>
+		</>
+	);
+}

--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -261,6 +261,13 @@ export default async function UserSearchPage({
 
 				{outcome.kind === "results" && outcome.page.results.length > 0 && (
 					<section aria-label="検索結果">
+						<p
+							role="status"
+							className="mb-3 text-xs text-[color:var(--a-text-muted)]"
+						>
+							{outcome.page.results.length} 件
+							{outcome.page.next ? " (続きあり)" : ""}
+						</p>
 						<ul role="list" className="space-y-2">
 							{outcome.page.results.map((u) => (
 								<UserSearchResultCard key={u.user_id} user={u} />

--- a/client/src/components/search/UserSearchBox.tsx
+++ b/client/src/components/search/UserSearchBox.tsx
@@ -51,7 +51,8 @@ export default function UserSearchBox({
 			/>
 			<button
 				type="submit"
-				className="rounded-md bg-lime-500 px-4 py-2 text-sm font-semibold text-black hover:bg-lime-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				className="rounded-md px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+				style={{ background: "var(--a-accent)" }}
 			>
 				検索
 			</button>


### PR DESCRIPTION
## Summary

Phase 12 gan-evaluator final scoring の search 系 polish 3 件をまとめて対応 (HIGH 1 + MEDIUM 2):

- **#691 H-1**: 検索 button 色 lime → \`var(--a-accent)\` sky-blue (brand consistency 回復)
- **#693 M-2**: 検索結果 list の上に「N 件 (続きあり)」 表示 (role=status)
- **#694 M-3**: \`loading.tsx\` (Next.js App Router Suspense fallback) で skeleton card 3 枚 + 検索 bar placeholder

Closes: #691, #693, #694

## Test plan

- [x] \`npx tsc --noEmit\` → clean
- [x] \`npx vitest run\` → 既存 74 件 緑 (UserSearchBox 6 / UserSearchResultCard 10 / NearMeFilter 7 等)
- [ ] CI 緑
- [ ] stg 反映後、 視覚的に確認: 検索 button が sky-blue、 結果に件数、 検索遷移時 skeleton