### PR TITLE
fix(settings): residence h1 で tab label 重複を解消 (#692)

### DIFF
--- a/client/src/app/(template)/settings/residence/page.tsx
+++ b/client/src/app/(template)/settings/residence/page.tsx
@@ -55,7 +55,7 @@ export default async function ResidenceSettingsPage() {
 						className="truncate font-semibold tracking-tight"
 						style={{ fontSize: 15, letterSpacing: -0.2 }}
 					>
-						居住地マップ
+						居住地マップの編集
 					</h1>
 					<p
 						className="truncate text-[color:var(--a-text-subtle)]"


### PR DESCRIPTION
## Summary

Phase 12 gan-evaluator final scoring MEDIUM #692:

\`/settings/residence\` で SettingsTabs の active tab「居住地マップ」 と \`<h1>居住地マップ</h1>\` の文字列が完全一致して視覚的に重複していた。 1 行修正で「居住地マップの編集」 に変更 (profile page の「プロフィール編集」 と同様の接尾辞)。

他 4 page は接尾辞で区別済 (重複なし):
| page | tab | h1 |
|----|----|----|
| profile | プロフィール | プロフィール編集 |
| notifications | 通知 | 通知の設定 |
| blocks | ブロック | ブロック中のユーザー |
| mutes | ミュート | ミュート中のユーザー |
| **residence** | 居住地マップ | **居住地マップの編集** (本 PR) |

Closes: #692

## Test plan

- [x] grep 確認: 1 行のみ変更
- [ ] CI 緑
- [ ] stg 反映後、 tab「居住地マップ」 active + h1「居住地マップの編集」 で重複なし確認