### PR TITLE
feat(users): User.preferred_language + auto_translate + settings UI (P13-04)

### DIFF
--- a/apps/users/migrations/0007_user_language_preferences.py
+++ b/apps/users/migrations/0007_user_language_preferences.py
@@ -1,0 +1,43 @@
+"""P13-04: User に preferred_language + auto_translate を追加。
+
+spec: docs/specs/auto-translate-spec.md §4.2
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0006_user_search_gin_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="preferred_language",
+            field=models.CharField(
+                choices=[
+                    ("ja", "日本語"),
+                    ("en", "English"),
+                    ("ko", "한국어"),
+                    ("zh-cn", "简体中文"),
+                    ("es", "Español"),
+                    ("fr", "Français"),
+                    ("pt", "Português"),
+                ],
+                default="ja",
+                help_text="UI display language and default translation target.",
+                max_length=8,
+                verbose_name="Preferred Language",
+            ),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="auto_translate",
+            field=models.BooleanField(
+                default=False,
+                help_text="Automatically translate foreign-language tweets on render.",
+                verbose_name="Auto Translate",
+            ),
+        ),
+    ]

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -157,6 +157,36 @@ class User(AbstractUser):
         validators=[_HTTPS_URL_VALIDATOR],
     )
 
+    # ---- P13-04: 翻訳設定 (Phase 13 自動翻訳機能) ----
+    # UI 表示言語 (ISO 639-1)。 default は ja (日本語話者向け SNS)。
+    # 翻訳 button の表示判定: tweet.language != user.preferred_language なら表示。
+    # choices で固定 list に絞ることで、 不正値 (xx 等) や frontend 側の typo を
+    # 弾く + Admin で select に出る (UX)。 spec: docs/specs/auto-translate-spec.md §4.2
+    PREFERRED_LANGUAGE_CHOICES = (
+        ("ja", "日本語"),
+        ("en", "English"),
+        ("ko", "한국어"),
+        ("zh-cn", "简体中文"),
+        ("es", "Español"),
+        ("fr", "Français"),
+        ("pt", "Português"),
+    )
+    preferred_language = models.CharField(
+        verbose_name=_("Preferred Language"),
+        max_length=8,
+        choices=PREFERRED_LANGUAGE_CHOICES,
+        default="ja",
+        help_text=_("UI display language and default translation target."),
+    )
+    # グローバル auto translate (default False、 X / Twitter と同じ opt-in)。
+    # ON のときは tweet.language != user.preferred_language の TL 表示で
+    # 自動的に翻訳済みに切り替わる (P13-07)。
+    auto_translate = models.BooleanField(
+        verbose_name=_("Auto Translate"),
+        default=False,
+        help_text=_("Automatically translate foreign-language tweets on render."),
+    )
+
     EMAIL_FIELD = "email"
     USERNAME_FIELD = "email"
 

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -68,6 +68,11 @@ class CustomUserSerializer(UserSerializer):
             "qiita_url",
             "note_url",
             "linkedin_url",
+            # P13-04: 翻訳設定 (Phase 13)。 settings/profile から PATCH で更新可能。
+            # choices による不正コードの reject は model field 由来 (DRF が自動生成する
+            # ChoiceField validator) で行われる。
+            "preferred_language",
+            "auto_translate",
             "date_joined",
         ]
         # username / email / is_premium は変更不可 (is_premium は Stripe webhook でのみ更新)。

--- a/apps/users/tests/test_user_language_prefs.py
+++ b/apps/users/tests/test_user_language_prefs.py
@@ -1,0 +1,92 @@
+"""
+P13-04: User.preferred_language + auto_translate のテスト。
+
+spec: docs/specs/auto-translate-spec.md §4.2 §8.1
+
+カバレッジ:
+1. 新規ユーザーは preferred_language="ja" / auto_translate=False がデフォルト。
+2. PATCH /api/v1/users/me/ で 2 field を更新できる (writable)。
+3. preferred_language に許可外コードを送ると 400。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestUserLanguageDefaults:
+    def test_new_user_defaults_to_ja_and_auto_translate_off(self):
+        """default は ja / False (日本語話者向け SNS なので、 opt-in で翻訳)。"""
+        user = User.objects.create_user(
+            email="lang-default@example.com",
+            username="lang_default",
+            first_name="L",
+            last_name="D",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        assert user.preferred_language == "ja"
+        assert user.auto_translate is False
+
+
+@pytest.mark.django_db
+class TestPatchLanguagePrefs:
+    def _client(self, user) -> APIClient:
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client
+
+    def test_patch_can_update_preferred_language(self):
+        user = User.objects.create_user(
+            email="patch-lang@example.com",
+            username="patch_lang",
+            first_name="P",
+            last_name="L",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        client = self._client(user)
+        url = reverse("users-me")
+        resp = client.patch(url, {"preferred_language": "en"}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.preferred_language == "en"
+
+    def test_patch_can_update_auto_translate(self):
+        user = User.objects.create_user(
+            email="patch-auto@example.com",
+            username="patch_auto",
+            first_name="P",
+            last_name="A",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        client = self._client(user)
+        url = reverse("users-me")
+        resp = client.patch(url, {"auto_translate": True}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.auto_translate is True
+
+    def test_patch_rejects_invalid_language_code(self):
+        """choices に無い code (xx 等) は 400。 langdetect の出力に合わせた
+        固定 list (ja/en/ko/zh-cn/es/fr/pt) のみ許可。"""
+        user = User.objects.create_user(
+            email="reject-lang@example.com",
+            username="reject_lang",
+            first_name="R",
+            last_name="L",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        client = self._client(user)
+        url = reverse("users-me")
+        resp = client.patch(url, {"preferred_language": "xx"}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "preferred_language" in resp.data
+        user.refresh_from_db()
+        # rejected な値で更新されていないこと
+        assert user.preferred_language == "ja"

--- a/apps/users/tests/test_user_language_prefs.py
+++ b/apps/users/tests/test_user_language_prefs.py
@@ -37,7 +37,7 @@ class TestUserLanguageDefaults:
 
 @pytest.mark.django_db
 class TestPatchLanguagePrefs:
-    def _client(self, user) -> APIClient:
+    def _client(self, user: User) -> APIClient:
         client = APIClient()
         client.force_authenticate(user=user)
         return client
@@ -90,3 +90,100 @@ class TestPatchLanguagePrefs:
         user.refresh_from_db()
         # rejected な値で更新されていないこと
         assert user.preferred_language == "ja"
+
+    def test_patch_accepts_zh_cn_boundary_value(self):
+        """python-reviewer MEDIUM: 最長 choice (zh-cn / 5文字 + hyphen) が
+        max_length=8 と choices 両方を通過することを確認する境界テスト。"""
+        user = User.objects.create_user(
+            email="zh-cn-boundary@example.com",
+            username="zh_cn_user",
+            first_name="Z",
+            last_name="C",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        client = self._client(user)
+        url = reverse("users-me")
+        resp = client.patch(url, {"preferred_language": "zh-cn"}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.preferred_language == "zh-cn"
+
+    def test_patch_can_toggle_auto_translate_back_to_false(self):
+        """python-reviewer MEDIUM: True から False への反転も保存される
+        (form の dirty 判定 / serializer の partial update bug への保険)。"""
+        user = User.objects.create_user(
+            email="toggle-back@example.com",
+            username="toggle_back",
+            first_name="T",
+            last_name="B",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        user.auto_translate = True
+        user.save(update_fields=["auto_translate"])
+        client = self._client(user)
+        url = reverse("users-me")
+        resp = client.patch(url, {"auto_translate": False}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.auto_translate is False
+
+    def test_unauthenticated_patch_is_rejected(self):
+        """python-reviewer MEDIUM: 認証なしで PATCH /users/me/ は 401。
+        IsAuthenticated permission の regression guard。"""
+        # 既存ユーザー作成だけして、 別の anonymous client から PATCH。
+        User.objects.create_user(
+            email="anon-target@example.com",
+            username="anon_target",
+            first_name="A",
+            last_name="T",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        anonymous = APIClient()
+        url = reverse("users-me")
+        resp = anonymous.patch(url, {"preferred_language": "en"}, format="json")
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+class TestCrossUserIsolation:
+    """python-reviewer HIGH: User A が User B の preferred_language を上書きできない
+    ことを明示的に regression guard する。 `MeView` は `request.user` を参照する
+    ので server-side で防がれるが、 view 改修時のための保険テスト。"""
+
+    def test_user_a_patch_does_not_affect_user_b(self):
+        user_a = User.objects.create_user(
+            email="cross-a@example.com",
+            username="cross_a",
+            first_name="A",
+            last_name="A",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        user_b = User.objects.create_user(
+            email="cross-b@example.com",
+            username="cross_b",
+            first_name="B",
+            last_name="B",
+            password="StrongPass!1",  # pragma: allowlist secret
+        )
+        # User B の初期値を ja (default) とは違う ko に固定。 User A が patch
+        # しても、 User B が改変されないことを確認する。
+        user_b.preferred_language = "ko"
+        user_b.save(update_fields=["preferred_language"])
+
+        client = APIClient()
+        client.force_authenticate(user=user_a)
+        url = reverse("users-me")
+        resp = client.patch(
+            url,
+            {"preferred_language": "en", "auto_translate": True},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+        user_a.refresh_from_db()
+        user_b.refresh_from_db()
+        assert user_a.preferred_language == "en"
+        assert user_a.auto_translate is True
+        # User B は手付かず
+        assert user_b.preferred_language == "ko"
+        assert user_b.auto_translate is False

--- a/client/src/components/profile/ProfileEditForm.tsx
+++ b/client/src/components/profile/ProfileEditForm.tsx
@@ -14,13 +14,27 @@ import { Textarea } from "@/components/ui/textarea";
 import type { CurrentUser } from "@/lib/api/users";
 import { updateCurrentUser } from "@/lib/api/users";
 import {
+	PREFERRED_LANGUAGES,
 	profileEditSchema,
+	type PreferredLanguage,
 	type TProfileEditSchema,
-} from "@/lib/validationSchemas";
+} from "@/lib/validationSchemas/ProfileEditSchema";
 
 interface ProfileEditFormProps {
 	initialUser: CurrentUser;
 }
+
+// P13-04: PREFERRED_LANGUAGES と同期。 backend の choices と表示名を合わせる
+// (ja: 日本語 / en: English …)。 順序は backend と同じ (ja を先頭、 主要言語順)。
+const LANGUAGE_OPTIONS: Array<{ value: PreferredLanguage; label: string }> = [
+	{ value: "ja", label: "日本語" },
+	{ value: "en", label: "English" },
+	{ value: "ko", label: "한국어" },
+	{ value: "zh-cn", label: "简体中文" },
+	{ value: "es", label: "Español" },
+	{ value: "fr", label: "Français" },
+	{ value: "pt", label: "Português" },
+];
 
 const SNS_FIELDS: Array<{
 	name: keyof Pick<
@@ -75,6 +89,13 @@ export default function ProfileEditForm({ initialUser }: ProfileEditFormProps) {
 			qiita_url: initialUser.qiita_url || "",
 			note_url: initialUser.note_url || "",
 			linkedin_url: initialUser.linkedin_url || "",
+			// P13-04: 翻訳設定の初期値 (backend default は ja / false)。
+			preferred_language: (PREFERRED_LANGUAGES.includes(
+				initialUser.preferred_language as PreferredLanguage,
+			)
+				? (initialUser.preferred_language as PreferredLanguage)
+				: "ja") as PreferredLanguage,
+			auto_translate: initialUser.auto_translate ?? false,
 		},
 	});
 
@@ -189,6 +210,59 @@ export default function ProfileEditForm({ initialUser }: ProfileEditFormProps) {
 						) : null}
 					</div>
 				))}
+			</section>
+
+			<section className="grid gap-4">
+				<h2 className="text-base font-semibold">翻訳設定</h2>
+				<p
+					className="text-[color:var(--a-text-subtle)]"
+					style={{ fontSize: 12 }}
+				>
+					UI 表示言語と異なるツイートに「翻訳」 button が出ます (Phase 13)。
+				</p>
+				<div className="grid gap-2">
+					<label htmlFor="preferred_language" className="text-sm font-medium">
+						UI 表示言語
+					</label>
+					<select
+						id="preferred_language"
+						{...register("preferred_language")}
+						className="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+						aria-invalid={errors.preferred_language ? "true" : "false"}
+					>
+						{LANGUAGE_OPTIONS.map((opt) => (
+							<option key={opt.value} value={opt.value}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+					{errors.preferred_language?.message ? (
+						<p className="text-sm text-destructive">
+							{errors.preferred_language.message}
+						</p>
+					) : null}
+				</div>
+				<div className="flex items-start gap-2">
+					<input
+						id="auto_translate"
+						type="checkbox"
+						{...register("auto_translate")}
+						className="mt-1 size-4 rounded border-input"
+						aria-describedby="auto_translate_help"
+					/>
+					<div className="grid gap-1">
+						<label htmlFor="auto_translate" className="text-sm font-medium">
+							自動翻訳を有効にする
+						</label>
+						<p
+							id="auto_translate_help"
+							className="text-[color:var(--a-text-subtle)]"
+							style={{ fontSize: 12 }}
+						>
+							ON にすると外国語のツイートが初期表示で翻訳されます。
+						</p>
+					</div>
+				</div>
 			</section>
 
 			<div className="flex items-center justify-end gap-3 border-t border-border pt-4">

--- a/client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx
+++ b/client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * P13-04: ProfileEditForm の言語 select + auto_translate toggle テスト。
+ *
+ * spec: docs/specs/auto-translate-spec.md §4.2 §7.2 §8.1
+ *
+ * カバレッジ:
+ * 1. 言語 select を切り替えて submit すると updateCurrentUser に
+ *    preferred_language が渡る
+ * 2. 自動翻訳 toggle を ON にして submit すると auto_translate=true が渡る
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ProfileEditForm from "@/components/profile/ProfileEditForm";
+import type { CurrentUser } from "@/lib/api/users";
+
+const { updateMock, pushMock, refreshMock, toastSuccessSpy } = vi.hoisted(
+	() => ({
+		updateMock: vi.fn(),
+		pushMock: vi.fn(),
+		refreshMock: vi.fn(),
+		toastSuccessSpy: vi.fn(),
+	}),
+);
+
+vi.mock("@/lib/api/users", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/users")>("@/lib/api/users");
+	return {
+		...actual,
+		updateCurrentUser: updateMock,
+	};
+});
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessSpy, error: vi.fn() },
+}));
+
+// ImageCropper は presigned URL 取得 + S3 PUT を行うので test 内で stub。
+vi.mock("@/components/shared/ImageCropper", () => ({
+	default: () => null,
+}));
+
+const BASE_USER: CurrentUser = {
+	id: "uuid-1",
+	email: "tester@example.com",
+	username: "tester",
+	full_name: "Tester One",
+	display_name: "Tester One",
+	bio: "",
+	avatar_url: "",
+	header_url: "",
+	is_premium: false,
+	needs_onboarding: false,
+	github_url: "",
+	x_url: "",
+	zenn_url: "",
+	qiita_url: "",
+	note_url: "",
+	linkedin_url: "",
+	preferred_language: "ja",
+	auto_translate: false,
+	date_joined: "2026-01-01T00:00:00Z",
+};
+
+describe("ProfileEditForm — translation preferences (P13-04)", () => {
+	beforeEach(() => {
+		updateMock.mockReset();
+		pushMock.mockReset();
+		refreshMock.mockReset();
+		toastSuccessSpy.mockReset();
+		updateMock.mockResolvedValue(BASE_USER);
+	});
+
+	it("renders language select with default 'ja' from initialUser", () => {
+		render(<ProfileEditForm initialUser={BASE_USER} />);
+		const select = screen.getByLabelText("UI 表示言語") as HTMLSelectElement;
+		expect(select).toBeInTheDocument();
+		expect(select.value).toBe("ja");
+	});
+
+	it("submits preferred_language=en when user changes select and saves", async () => {
+		render(<ProfileEditForm initialUser={BASE_USER} />);
+		const select = screen.getByLabelText("UI 表示言語");
+		await userEvent.selectOptions(select, "en");
+		await userEvent.click(screen.getByRole("button", { name: "保存" }));
+		expect(updateMock).toHaveBeenCalledTimes(1);
+		const payload = updateMock.mock.calls[0][0];
+		expect(payload.preferred_language).toBe("en");
+	});
+
+	it("submits auto_translate=true when user enables the checkbox", async () => {
+		render(<ProfileEditForm initialUser={BASE_USER} />);
+		const toggle = screen.getByLabelText(
+			"自動翻訳を有効にする",
+		) as HTMLInputElement;
+		expect(toggle.checked).toBe(false);
+		await userEvent.click(toggle);
+		expect(toggle.checked).toBe(true);
+		await userEvent.click(screen.getByRole("button", { name: "保存" }));
+		expect(updateMock).toHaveBeenCalledTimes(1);
+		const payload = updateMock.mock.calls[0][0];
+		expect(payload.auto_translate).toBe(true);
+	});
+});

--- a/client/src/lib/api/users.ts
+++ b/client/src/lib/api/users.ts
@@ -27,6 +27,9 @@ export interface CurrentUser {
 	qiita_url: string;
 	note_url: string;
 	linkedin_url: string;
+	// P13-04: Phase 13 自動翻訳機能 (auto-translate)
+	preferred_language: string;
+	auto_translate: boolean;
 	date_joined: string;
 }
 
@@ -44,6 +47,9 @@ export interface UpdateProfilePayload {
 	qiita_url?: string;
 	note_url?: string;
 	linkedin_url?: string;
+	// P13-04: 翻訳設定の更新
+	preferred_language?: string;
+	auto_translate?: boolean;
 }
 
 export async function fetchCurrentUser(

--- a/client/src/lib/validationSchemas/ProfileEditSchema.ts
+++ b/client/src/lib/validationSchemas/ProfileEditSchema.ts
@@ -15,6 +15,20 @@ const optionalUrl = z
 	.optional()
 	.default("");
 
+// P13-04: backend の User.PREFERRED_LANGUAGE_CHOICES と同期。
+// 増やすときは backend の models.py 側の choices にも追加する必要がある
+// (drift すると PATCH で 400 になる)。
+export const PREFERRED_LANGUAGES = [
+	"ja",
+	"en",
+	"ko",
+	"zh-cn",
+	"es",
+	"fr",
+	"pt",
+] as const;
+export type PreferredLanguage = (typeof PREFERRED_LANGUAGES)[number];
+
 export const profileEditSchema = z.object({
 	display_name: z
 		.string()
@@ -32,6 +46,9 @@ export const profileEditSchema = z.object({
 	qiita_url: optionalUrl,
 	note_url: optionalUrl,
 	linkedin_url: optionalUrl,
+	// P13-04: 翻訳設定
+	preferred_language: z.enum(PREFERRED_LANGUAGES).default("ja"),
+	auto_translate: z.boolean().default(false),
 });
 
 export type TProfileEditSchema = z.infer<typeof profileEditSchema>;

--- a/client/src/lib/validationSchemas/index.ts
+++ b/client/src/lib/validationSchemas/index.ts
@@ -16,5 +16,8 @@ export type {
 export { onboardingSchema } from "./OnboardingSchema";
 export type { TOnboardingSchema } from "./OnboardingSchema";
 
-export { profileEditSchema } from "./ProfileEditSchema";
-export type { TProfileEditSchema } from "./ProfileEditSchema";
+export { profileEditSchema, PREFERRED_LANGUAGES } from "./ProfileEditSchema";
+export type {
+	TProfileEditSchema,
+	PreferredLanguage,
+} from "./ProfileEditSchema";


### PR DESCRIPTION
## Summary

Phase 13 自動翻訳の前提となる User 翻訳設定。 P13-03 翻訳 endpoint (#699) が `request.user.preferred_language` を参照するので先行で投入。

| 新規 / 変更 | 内容 |
|---|---|
| \`apps/users/models.py\` | User に \`preferred_language\` (choices=7言語 / default ja) + \`auto_translate\` (default False) 追加 |
| \`apps/users/migrations/0007_user_language_preferences.py\` | migration |
| \`apps/users/serializers.py\` | \`CustomUserSerializer\` で 2 field を writable に expose (choices 由来の validator で不正値を 400 reject) |
| \`client/src/components/profile/ProfileEditForm.tsx\` | 「翻訳設定」 section 新設 (言語 select + 自動翻訳 checkbox) |
| \`client/src/lib/validationSchemas/ProfileEditSchema.ts\` | \`PREFERRED_LANGUAGES\` enum を export して backend choices と同期 |
| \`apps/users/tests/test_user_language_prefs.py\` | pytest 4 cases (default / patch lang / patch toggle / invalid reject) |
| \`client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx\` | vitest 3 cases (initial select / submit lang / submit toggle) |

Closes: #700

## Test plan

- [x] \`vitest run src/components/profile\` → 3 passed
- [x] \`vitest run\` 全 91 files / 729 tests passed
- [x] \`tsc --noEmit\` clean
- [ ] CI Backend Django pytest 緑
- [ ] stg deploy 後、 /settings/profile で言語 select + auto_translate toggle が表示・更新できる