### PR TITLE
feat(tweets): POST /api/v1/tweets/<id>/translate/ endpoint (P13-03)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 575
+        "line_number": 581
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T02:40:02Z"
+  "generated_at": "2026-05-14T03:34:11Z"
 }

--- a/apps/tweets/tests/test_translate_endpoint.py
+++ b/apps/tweets/tests/test_translate_endpoint.py
@@ -1,0 +1,219 @@
+"""
+P13-03: POST /api/v1/tweets/<id>/translate/ のテスト。
+
+spec: docs/specs/auto-translate-spec.md §6 §8.1
+
+カバレッジ (8 cases):
+1. 401 未認証
+2. 404 存在しないツイート
+3. 422 tweet.language が NULL (検出失敗 / 短すぎ)
+4. 422 同一言語 (tweet.language == user.preferred_language)
+5. 200 cache miss → translator 呼び出し → cache 作成
+6. 200 cache hit → translator 呼ばれない / cached=true
+7. 200 NoopTranslator (API key 未設定) → 原文返却 + cache に noop は残さない
+8. 429 rate limit (translate scope: 60/hour)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.tweets.models import Tweet, TweetTranslation
+
+User = get_user_model()
+
+
+def _make_user(email: str, username: str, preferred_language: str = "en") -> User:
+    u = User.objects.create_user(
+        email=email,
+        username=username,
+        first_name="F",
+        last_name="L",
+        password="StrongPass!1",  # pragma: allowlist secret
+    )
+    u.preferred_language = preferred_language
+    u.save(update_fields=["preferred_language"])
+    return u
+
+
+def _make_tweet(author, body: str, language: str | None) -> Tweet:
+    """language は pre_save signal で上書きされるので post-create に明示 set。"""
+    t = Tweet.objects.create(author=author, body=body)
+    t.language = language
+    t.save(update_fields=["language"])
+    return t
+
+
+@pytest.mark.django_db
+class TestTranslateAuth:
+    def test_unauthenticated_returns_401(self):
+        author = _make_user("auth-a@example.com", "auth_a", preferred_language="ja")
+        tweet = _make_tweet(author, "Hello, world.", language="en")
+        anonymous = APIClient()
+        url = reverse("tweets-translate", kwargs={"tweet_id": tweet.pk})
+        resp = anonymous.post(url, {}, format="json")
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+class TestTranslate422Cases:
+    def _client(self, user) -> APIClient:
+        c = APIClient()
+        c.force_authenticate(user=user)
+        return c
+
+    def test_returns_404_for_missing_tweet(self):
+        viewer = _make_user("viewer-404@example.com", "viewer_404")
+        url = reverse("tweets-translate", kwargs={"tweet_id": 99999999})
+        resp = self._client(viewer).post(url, {}, format="json")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_422_when_tweet_language_is_null(self):
+        """言語が検出できなかったツイート (絵文字のみ / 短すぎ等) は翻訳不可。"""
+        author = _make_user("a-null@example.com", "a_null", preferred_language="ja")
+        tweet = _make_tweet(author, "🚀🚀🚀", language=None)
+        viewer = _make_user("v-null@example.com", "v_null", preferred_language="ja")
+        url = reverse("tweets-translate", kwargs={"tweet_id": tweet.pk})
+        resp = self._client(viewer).post(url, {}, format="json")
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "Language not detected" in resp.data.get("detail", "")
+
+    def test_returns_422_when_source_equals_target_language(self):
+        author = _make_user("a-same@example.com", "a_same", preferred_language="ja")
+        tweet = _make_tweet(author, "こんにちは世界", language="ja")
+        viewer = _make_user("v-same@example.com", "v_same", preferred_language="ja")
+        url = reverse("tweets-translate", kwargs={"tweet_id": tweet.pk})
+        resp = self._client(viewer).post(url, {}, format="json")
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.django_db
+class TestTranslateCacheBehavior:
+    def _client(self, user) -> APIClient:
+        c = APIClient()
+        c.force_authenticate(user=user)
+        return c
+
+    @override_settings(OPENAI_API_KEY="sk-test")  # pragma: allowlist secret
+    @patch("apps.tweets.views_translate.get_translator")
+    def test_cache_miss_calls_translator_and_creates_row(self, mock_factory):
+        translator = MagicMock()
+        translator.ENGINE_TAG = "openai:gpt-4o-mini"
+        translator.translate.return_value = "こんにちは、 世界"
+        mock_factory.return_value = translator
+
+        author = _make_user("a-miss@example.com", "a_miss", preferred_language="en")
+        tweet = _make_tweet(author, "Hello, world.", language="en")
+        viewer = _make_user("v-miss@example.com", "v_miss", preferred_language="ja")
+        url = reverse("tweets-translate", kwargs={"tweet_id": tweet.pk})
+        resp = self._client(viewer).post(url, {}, format="json")
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data == {
+            "translated_text": "こんにちは、 世界",
+            "source_language": "en",
+            "target_language": "ja",
+            "cached": False,
+        }
+        translator.translate.assert_called_once()
+        assert TweetTranslation.objects.filter(tweet=tweet, target_language="ja").exists()
+
+    @override_settings(OPENAI_API_KEY="sk-test")  # pragma: allowlist secret
+    @patch("apps.tweets.views_translate.get_translator")
+    def test_cache_hit_returns_db_row_without_calling_translator(self, mock_factory):
+        translator = MagicMock()
+        mock_factory.return_value = translator  # 呼ばれないことを確認するので戻り値は不要
+
+        author = _make_user("a-hit@example.com", "a_hit", preferred_language="en")
+        tweet = _make_tweet(author, "Hello, world.", language="en")
+        TweetTranslation.objects.create(
+            tweet=tweet,
+            target_language="ja",
+            translated_text="DBから来た翻訳",
+            engine="openai:gpt-4o-mini",
+        )
+
+        viewer = _make_user("v-hit@example.com", "v_hit", preferred_language="ja")
+        url = reverse("tweets-translate", kwargs={"tweet_id": tweet.pk})
+        resp = self._client(viewer).post(url, {}, format="json")
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["translated_text"] == "DBから来た翻訳"
+        assert resp.data["cached"] is True
+        translator.translate.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestNoopFallback:
+    @override_settings(OPENAI_API_KEY="")  # NoopTranslator にフォールバック
+    def test_noop_returns_original_and_does_not_cache(self):
+        author = _make_user("a-noop@example.com", "a_noop", preferred_language="en")
+        tweet = _make_tweet(author, "Hello, world.", language="en")
+        viewer = _make_user("v-noop@example.com", "v_noop", preferred_language="ja")
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+        url = reverse("tweets-translate", kwargs={"tweet_id": tweet.pk})
+        resp = client.post(url, {}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        # Noop は原文を返す
+        assert resp.data["translated_text"] == "Hello, world."
+        # cache 行を作らない (key が後で設定されたとき、 原文が DB に残ったままに
+        # ならないようにするため)
+        assert not TweetTranslation.objects.filter(tweet=tweet).exists()
+
+
+@pytest.mark.django_db
+class TestTranslateRateLimit:
+    """``ScopedRateThrottle.THROTTLE_RATES`` はクラス属性として import 時に
+    凍結されるので、 settings override では効かない (test_crud_api の同種テスト
+    参照)。 代わりに class attribute を monkeypatch で書き換える。"""
+
+    @override_settings(OPENAI_API_KEY="sk-test")  # pragma: allowlist secret
+    @patch("apps.tweets.views_translate.get_translator")
+    def test_429_after_exceeding_translate_scope(self, mock_factory, monkeypatch):
+        from django.core.cache import cache
+        from rest_framework.throttling import ScopedRateThrottle
+
+        monkeypatch.setattr(
+            ScopedRateThrottle,
+            "THROTTLE_RATES",
+            {**ScopedRateThrottle.THROTTLE_RATES, "translate": "2/hour"},
+        )
+        cache.clear()
+
+        translator = MagicMock()
+        translator.ENGINE_TAG = "openai:gpt-4o-mini"
+        translator.translate.return_value = "translated"
+        mock_factory.return_value = translator
+
+        author = _make_user("a-rl@example.com", "a_rl", preferred_language="en")
+        viewer = _make_user("v-rl@example.com", "v_rl", preferred_language="ja")
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+
+        # 2 件まで成功 (rate=2/hour)、 3 件目で 429
+        for i in range(2):
+            t = _make_tweet(author, f"Hello {i}", language="en")
+            r = client.post(
+                reverse("tweets-translate", kwargs={"tweet_id": t.pk}),
+                {},
+                format="json",
+            )
+            assert (
+                r.status_code == status.HTTP_200_OK
+            ), f"call {i + 1} should pass (got {r.status_code})"
+
+        t = _make_tweet(author, "Hello over-limit", language="en")
+        r = client.post(
+            reverse("tweets-translate", kwargs={"tweet_id": t.pk}),
+            {},
+            format="json",
+        )
+        assert r.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/apps/tweets/tests/test_translate_endpoint.py
+++ b/apps/tweets/tests/test_translate_endpoint.py
@@ -151,6 +151,40 @@ class TestTranslateCacheBehavior:
 
 
 @pytest.mark.django_db
+class TestBlockCheck:
+    """security-reviewer HIGH: 双方向 block 関係なら 403。 views_actions.py の
+    repost / quote / reply と同じ contract。 翻訳結果は本文の paraphrase なので
+    block contract に違反しないようガードする。"""
+
+    @override_settings(OPENAI_API_KEY="sk-test")  # pragma: allowlist secret
+    @patch("apps.tweets.views_translate.get_translator")
+    def test_blocked_viewer_gets_403(self, mock_factory):
+        from apps.moderation.models import Block
+
+        translator = MagicMock()
+        translator.ENGINE_TAG = "openai:gpt-4o-mini"
+        translator.translate.return_value = "should not be called"
+        mock_factory.return_value = translator
+
+        author = _make_user("a-block@example.com", "a_block", preferred_language="en")
+        tweet = _make_tweet(author, "Hello, world.", language="en")
+        viewer = _make_user("v-block@example.com", "v_block", preferred_language="ja")
+
+        # author が viewer を block している。 双方向チェックなので方向は問わない。
+        Block.objects.create(blocker=author, blockee=viewer)
+
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+        url = reverse("tweets-translate", kwargs={"tweet_id": tweet.pk})
+        resp = client.post(url, {}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        # block されているなら OpenAI も叩かれない (cost 漏れ防止)
+        translator.translate.assert_not_called()
+        # cache 行も作らない
+        assert not TweetTranslation.objects.filter(tweet=tweet).exists()
+
+
+@pytest.mark.django_db
 class TestNoopFallback:
     @override_settings(OPENAI_API_KEY="")  # NoopTranslator にフォールバック
     def test_noop_returns_original_and_does_not_cache(self):

--- a/apps/tweets/urls.py
+++ b/apps/tweets/urls.py
@@ -26,6 +26,7 @@ from rest_framework.routers import DefaultRouter
 
 from apps.tweets.views import TweetViewSet
 from apps.tweets.views_actions import QuoteView, ReplyView, RepostView
+from apps.tweets.views_translate import TweetTranslateView
 
 router = DefaultRouter()
 router.register(r"", TweetViewSet, basename="tweets")
@@ -46,6 +47,12 @@ urlpatterns = [
         "<int:tweet_id>/reply/",
         ReplyView.as_view(),
         name="tweets-reply",
+    ),
+    # Phase 13 P13-03: 自動翻訳
+    path(
+        "<int:tweet_id>/translate/",
+        TweetTranslateView.as_view(),
+        name="tweets-translate",
     ),
     *router.urls,
 ]

--- a/apps/tweets/views_translate.py
+++ b/apps/tweets/views_translate.py
@@ -1,0 +1,111 @@
+"""Phase 13 P13-03: POST /api/v1/tweets/<id>/translate/ endpoint.
+
+ユーザーの preferred_language に翻訳結果を返す。 DB cache (TweetTranslation)
+を先に lookup し、 miss のとき初めて OpenAI を呼ぶ (cost / latency 削減)。
+
+spec: docs/specs/auto-translate-spec.md §6
+
+Response:
+    200: {"translated_text", "source_language", "target_language", "cached"}
+    401: 未認証
+    404: ツイート不在
+    422: tweet.language が NULL / 同一言語 / 翻訳不可
+    429: rate limit (translate scope, 60/hour)
+"""
+
+from __future__ import annotations
+
+from django.db import IntegrityError, transaction
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.views import APIView
+
+from apps.common.cookie_auth import CookieAuthentication
+from apps.translation.services import NoopTranslator, get_translator
+from apps.tweets.models import Tweet, TweetTranslation
+
+
+class TweetTranslateView(APIView):
+    """POST /api/v1/tweets/<tweet_id>/translate/
+
+    Cookie auth + CSRF (DRF default with SessionAuth は使わず、 ADR-0003 の
+    Cookie-JWT を使う)。 throttle scope ``translate`` を ``60/hour`` で適用する
+    (Phase 13 仕様; settings.py の DEFAULT_THROTTLE_RATES で定義)。
+    """
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [CookieAuthentication]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "translate"
+
+    def post(self, request: Request, tweet_id: int) -> Response:
+        tweet = get_object_or_404(Tweet, pk=tweet_id)
+
+        source_lang = tweet.language
+        target_lang = request.user.preferred_language
+
+        # langdetect が失敗していた / 短すぎる本文は翻訳不可 (422)。
+        if not source_lang:
+            return Response(
+                {"detail": "Language not detected"},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+        # 同一言語は翻訳不要 (button が表示されない仕様だが、 直 POST 経路防衛)。
+        if source_lang == target_lang:
+            return Response(
+                {"detail": "Tweet is already in target language"},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+
+        # DB cache lookup (UniqueConstraint by (tweet, target_language))。
+        cached = TweetTranslation.objects.filter(tweet=tweet, target_language=target_lang).first()
+        if cached is not None:
+            return Response(
+                {
+                    "translated_text": cached.translated_text,
+                    "source_language": source_lang,
+                    "target_language": target_lang,
+                    "cached": True,
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        # Cache miss → translator 呼び出し。
+        translator = get_translator()
+        translated_text = translator.translate(
+            tweet.body,
+            target_language=target_lang,
+            source_language=source_lang,
+        )
+
+        # NoopTranslator の出力 (= 原文) は cache に残さない。 後で API key を
+        # 設定したときに、 cache が原文で固まったまま real 翻訳に到達しないため。
+        if not isinstance(translator, NoopTranslator):
+            try:
+                with transaction.atomic():
+                    TweetTranslation.objects.update_or_create(
+                        tweet=tweet,
+                        target_language=target_lang,
+                        defaults={
+                            "translated_text": translated_text,
+                            "engine": translator.ENGINE_TAG,
+                        },
+                    )
+            except IntegrityError:
+                # race condition (同 tweet/lang を別 request が同時に作成) の保険。
+                # 既に書かれていれば良いので無視。
+                pass
+
+        return Response(
+            {
+                "translated_text": translated_text,
+                "source_language": source_lang,
+                "target_language": target_lang,
+                "cached": False,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/apps/tweets/views_translate.py
+++ b/apps/tweets/views_translate.py
@@ -24,6 +24,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
+from apps.common.blocking import is_blocked_relationship
 from apps.common.cookie_auth import CookieAuthentication
 from apps.translation.services import NoopTranslator, get_translator
 from apps.tweets.models import Tweet, TweetTranslation
@@ -44,6 +45,15 @@ class TweetTranslateView(APIView):
 
     def post(self, request: Request, tweet_id: int) -> Response:
         tweet = get_object_or_404(Tweet, pk=tweet_id)
+
+        # security-reviewer HIGH: 双方向 block 関係なら 403。 views_actions.py の
+        # repost / quote / reply と同じ規約。 翻訳結果は本文の paraphrase なので、
+        # block していても閲覧できてしまうと block contract に違反する。
+        if is_blocked_relationship(request.user, tweet.author):
+            return Response(
+                {"detail": "このツイートに対する操作は許可されていません。"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         source_lang = tweet.language
         target_lang = request.user.preferred_language

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -485,6 +485,12 @@ _THROTTLE_RATES_BASE = {
     # /api/v1/users/search/ 専用の per-minute scope を切る。
     # 60/min = SearchBox を 1 秒間隔で叩いても 1 分は持つ余裕。 bot 抑止としても十分。
     "user_search_anon": "60/min" if not _IS_STG else "600/min",
+    # Phase 13 P13-03 (auto-translate-spec §5.2 / §6):
+    # POST /api/v1/tweets/<id>/translate/ は OpenAI 課金が発生するので
+    # 1 ユーザー 60 翻訳/時間に制限 (= 1 分に 1 件ペース)。
+    # TL を眺めながら数件押す通常 UX に十分な余裕、 cache hit は OpenAI を叩かないので
+    # 同一ツイートを繰り返し押しても枠は消費しない (cache miss だけがコスト要因)。
+    "translate": "60/hour" if not _IS_STG else "600/hour",
 }
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
## Summary

Phase 13 自動翻訳 API。 認証済みユーザーが任意のツイートを自分の \`preferred_language\` に翻訳して取得する endpoint。

| 変更 | 内容 |
|---|---|
| \`apps/tweets/views_translate.py\` | \`TweetTranslateView\` (APIView, Cookie auth + ScopedRateThrottle) — cache lookup → miss なら OpenAI 呼び出し |
| \`apps/tweets/urls.py\` | \`POST /api/v1/tweets/<tweet_id>/translate/\` を name=\`tweets-translate\` で登録 |
| \`config/settings/base.py\` | \`translate\` throttle scope を \`60/hour\` (stg \`600/hour\`) で追加 |
| \`apps/tweets/tests/test_translate_endpoint.py\` | pytest 8 cases (auth / 404 / 422×2 / 200 miss / 200 hit / noop / 429) |

### Behavior

- **200 cache miss**: translator (OpenAI) を呼び TweetTranslation 行を作成、 cached=false
- **200 cache hit**: DB 行をそのまま返却、 translator は呼ばれない、 cached=true
- **200 Noop fallback**: \`OPENAI_API_KEY\` 未設定時に原文返却。 cache 行は作らない (key 設定後に原文が cache に居座らないため)
- **404**: ツイート不在
- **401**: 未認証
- **422 \"Language not detected\"**: tweet.language が NULL (検出失敗 / 短文)
- **422 \"already in target language\"**: tweet.language == user.preferred_language
- **429**: rate limit (translate scope, 60/hour per user)

Closes: #699

## Test plan

- [x] \`pytest apps/tweets/tests/test_translate_endpoint.py\` → 8 passed (local)
- [x] \`pytest apps/tweets/ apps/translation/ apps/users/tests/test_user_language_prefs.py\` regression → 284 passed
- [ ] CI Backend Django 緑
- [ ] stg deploy 後 curl / Playwright で翻訳 POST が cache miss → cache hit に切り替わることを確認