### PR TITLE
feat(tweets): TweetCard 翻訳 button + 原文を表示 toggle (P13-05)

### DIFF
--- a/client/src/app/(template)/page.tsx
+++ b/client/src/app/(template)/page.tsx
@@ -147,6 +147,7 @@ export default async function HomePage({
 				initialTab={initialTab}
 				initialTweets={initialTweets}
 				currentUserHandle={user.username}
+				currentUserPreferredLanguage={user.preferred_language}
 			/>
 		</>
 	);

--- a/client/src/components/timeline/HomeFeed.tsx
+++ b/client/src/components/timeline/HomeFeed.tsx
@@ -31,6 +31,8 @@ interface HomeFeedProps {
 	initialTab: TabValue;
 	initialTweets: TweetSummary[];
 	currentUserHandle?: string;
+	/** P13-05: viewer の preferred_language (翻訳 button の表示判定に使う). */
+	currentUserPreferredLanguage?: string;
 }
 
 /**
@@ -49,6 +51,7 @@ export default function HomeFeed({
 	initialTab,
 	initialTweets,
 	currentUserHandle,
+	currentUserPreferredLanguage,
 }: HomeFeedProps) {
 	const [activeTab, setActiveTab] = useState<TabValue>(initialTab);
 	const [tweets, setTweets] = useState<TweetSummary[]>(
@@ -153,6 +156,7 @@ export default function HomeFeed({
 								setsize={tweets.length}
 								onDescendantPosted={handleDescendantPosted}
 								currentUserHandle={currentUserHandle}
+								currentUserPreferredLanguage={currentUserPreferredLanguage}
 								onTimelineItemRemoved={handleTimelineItemRemoved}
 							/>
 						))}

--- a/client/src/components/timeline/TranslateControl.tsx
+++ b/client/src/components/timeline/TranslateControl.tsx
@@ -14,7 +14,7 @@
  * TweetCard 側で「本文を翻訳テキストに差し替える」 を一元管理できる。
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Languages } from "lucide-react";
 
@@ -46,6 +46,16 @@ export default function TranslateControl(props: TranslateControlProps) {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
+	// typescript-reviewer HIGH: unmount race ガード。 fetch 中に component が
+	// unmount された場合、 解決後の setState / onTranslated を抑止する。
+	const isMountedRef = useRef(true);
+	useEffect(
+		() => () => {
+			isMountedRef.current = false;
+		},
+		[],
+	);
+
 	if (!shouldOfferTranslation(props)) return null;
 
 	// 翻訳済 state: 「原文を表示」 link を出す。
@@ -69,11 +79,13 @@ export default function TranslateControl(props: TranslateControlProps) {
 		setError(null);
 		try {
 			const resp = await translateTweet(tweetId);
+			if (!isMountedRef.current) return;
 			onTranslated(resp.translated_text);
 		} catch {
+			if (!isMountedRef.current) return;
 			setError("翻訳に失敗しました。 もう一度試してください。");
 		} finally {
-			setLoading(false);
+			if (isMountedRef.current) setLoading(false);
 		}
 	};
 
@@ -82,6 +94,7 @@ export default function TranslateControl(props: TranslateControlProps) {
 			<button
 				type="button"
 				disabled={loading}
+				aria-busy={loading}
 				onClick={handleTranslate}
 				className="inline-flex items-center gap-1 self-start text-xs font-medium text-[color:var(--a-accent)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] disabled:opacity-50"
 			>

--- a/client/src/components/timeline/TranslateControl.tsx
+++ b/client/src/components/timeline/TranslateControl.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * P13-05: 翻訳 button + 「原文を表示」 toggle (TweetCard 用).
+ *
+ * spec: docs/specs/auto-translate-spec.md §7.1
+ *
+ * 表示ルール:
+ *   - tweet.language が null / 同一言語 / 自分のツイート → 何も描画しない
+ *   - translatedText === null → 「翻訳する」 button
+ *   - translatedText !== null  → 「原文を表示」 link (本文側で翻訳結果を描画している前提)
+ *
+ * state は親 (TweetCard) が持つ。 ここはイベントを emit するのみ。 こうすると
+ * TweetCard 側で「本文を翻訳テキストに差し替える」 を一元管理できる。
+ */
+
+import { useState } from "react";
+
+import { Languages } from "lucide-react";
+
+import { translateTweet } from "@/lib/api/tweets";
+
+export interface TranslateControlProps {
+	tweetId: number;
+	tweetLanguage?: string | null;
+	authorHandle: string;
+	viewerHandle?: string;
+	viewerLanguage?: string;
+	/** null=未翻訳、 string=翻訳済 (= 親側で本文差し替え中). */
+	translatedText: string | null;
+	onTranslated: (text: string) => void;
+	onRevert: () => void;
+}
+
+function shouldOfferTranslation(props: TranslateControlProps): boolean {
+	const { tweetLanguage, authorHandle, viewerHandle, viewerLanguage } = props;
+	if (!tweetLanguage) return false;
+	if (!viewerLanguage) return false;
+	if (tweetLanguage === viewerLanguage) return false;
+	if (viewerHandle && authorHandle === viewerHandle) return false;
+	return true;
+}
+
+export default function TranslateControl(props: TranslateControlProps) {
+	const { tweetId, translatedText, onTranslated, onRevert } = props;
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	if (!shouldOfferTranslation(props)) return null;
+
+	// 翻訳済 state: 「原文を表示」 link を出す。
+	if (translatedText !== null) {
+		return (
+			<button
+				type="button"
+				className="self-start text-xs font-medium text-[color:var(--a-text-muted)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+				onClick={() => {
+					setError(null);
+					onRevert();
+				}}
+			>
+				原文を表示
+			</button>
+		);
+	}
+
+	const handleTranslate = async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const resp = await translateTweet(tweetId);
+			onTranslated(resp.translated_text);
+		} catch {
+			setError("翻訳に失敗しました。 もう一度試してください。");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-1">
+			<button
+				type="button"
+				disabled={loading}
+				onClick={handleTranslate}
+				className="inline-flex items-center gap-1 self-start text-xs font-medium text-[color:var(--a-accent)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] disabled:opacity-50"
+			>
+				<Languages className="size-3.5" aria-hidden="true" />
+				{loading ? "翻訳中…" : "翻訳する"}
+			</button>
+			{error ? (
+				<p role="alert" className="text-xs text-destructive">
+					{error}
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -18,6 +18,7 @@ import BookmarkButton from "@/components/boxes/BookmarkButton";
 import ReactionBar from "@/components/reactions/ReactionBar";
 import ReactionSummary from "@/components/reactions/ReactionSummary";
 import ExpandableBody from "@/components/timeline/ExpandableBody";
+import TranslateControl from "@/components/timeline/TranslateControl";
 import ReportDialog from "@/components/moderation/ReportDialog";
 import PostDialog from "@/components/tweets/PostDialog";
 import RepostButton from "@/components/tweets/RepostButton";
@@ -48,6 +49,12 @@ interface TweetCardProps {
 	onDescendantPosted?: (tweet: TweetSummary) => void;
 	/** Login viewer handle. Used to decide source-tweet delete permissions. */
 	currentUserHandle?: string;
+	/**
+	 * P13-05: Login viewer の preferred_language (ISO 639-1)。
+	 * tweet.language と異なれば「翻訳する」 button を表示する。
+	 * undefined / 未認証では翻訳 button を出さない。
+	 */
+	currentUserPreferredLanguage?: string;
 	/** Called when this timeline row should disappear after unrepost. */
 	onTimelineItemRemoved?: (tweetId: number) => void;
 }
@@ -155,6 +162,7 @@ export default function TweetCard({
 	setsize,
 	onDescendantPosted,
 	currentUserHandle,
+	currentUserPreferredLanguage,
 	onTimelineItemRemoved,
 }: TweetCardProps) {
 	const router = useRouter();
@@ -278,6 +286,16 @@ export default function TweetCard({
 			DOMPurify.sanitize(initialHtml, { USE_PROFILES: { html: true } }),
 		);
 	}, [initialHtml]);
+
+	// P13-05: 翻訳 state (per-card, page reload で reset = X / Twitter と同じ)。
+	// 翻訳中は本文を翻訳結果 (plain text) に差し替えて表示する。
+	const [translatedText, setTranslatedText] = useState<string | null>(null);
+	const displayedBodyHtml = translatedText
+		? escapeHtml(translatedText)
+		: safeHtml;
+	const displayedCharCount = translatedText
+		? translatedText.length
+		: (displayTweet.char_count ?? displayTweet.body.length);
 
 	const relativeTime = useMemo(
 		() => formatRelativeTime(displayTweet.created_at),
@@ -462,11 +480,24 @@ export default function TweetCard({
 				</div>
 			</header>
 
-			{/* Tweet body — DOMPurify sanitized HTML, P2-18 expandable. */}
+			{/* Tweet body — DOMPurify sanitized HTML, P2-18 expandable.
+			    P13-05: 翻訳 ON のときは翻訳結果 (plain text を escape) を出す。 */}
 			<ExpandableBody
-				html={safeHtml}
-				charCount={displayTweet.char_count ?? displayTweet.body.length}
+				html={displayedBodyHtml}
+				charCount={displayedCharCount}
 				className="prose prose-sm dark:prose-invert max-w-none text-sm text-foreground"
+			/>
+
+			{/* P13-05: 翻訳 button / 「原文を表示」 toggle (Phase 13). */}
+			<TranslateControl
+				tweetId={displayTweet.id}
+				tweetLanguage={displayTweet.language}
+				authorHandle={displayTweet.author_handle}
+				viewerHandle={currentUserHandle}
+				viewerLanguage={currentUserPreferredLanguage}
+				translatedText={translatedText}
+				onTranslated={setTranslatedText}
+				onRevert={() => setTranslatedText(null)}
 			/>
 
 			{/* Images grid (up to 4 images) */}

--- a/client/src/components/timeline/TweetCardList.tsx
+++ b/client/src/components/timeline/TweetCardList.tsx
@@ -33,6 +33,8 @@ interface TweetCardListProps {
 	 */
 	onDescendantPosted?: (tweet: TweetSummary) => void;
 	currentUserHandle?: string;
+	/** P13-05: viewer の preferred_language (翻訳 button の表示判定に使う). */
+	currentUserPreferredLanguage?: string;
 }
 
 export default function TweetCardList({
@@ -41,6 +43,7 @@ export default function TweetCardList({
 	emptyMessage = "ツイートがありません。",
 	onDescendantPosted,
 	currentUserHandle,
+	currentUserPreferredLanguage,
 }: TweetCardListProps) {
 	const [visibleTweets, setVisibleTweets] = useState(tweets);
 	useEffect(() => {
@@ -68,6 +71,7 @@ export default function TweetCardList({
 					setsize={visibleTweets.length}
 					onDescendantPosted={onDescendantPosted}
 					currentUserHandle={currentUserHandle}
+					currentUserPreferredLanguage={currentUserPreferredLanguage}
 					onTimelineItemRemoved={handleTimelineItemRemoved}
 				/>
 			))}

--- a/client/src/components/timeline/__tests__/TranslateControl.test.tsx
+++ b/client/src/components/timeline/__tests__/TranslateControl.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * P13-05: TweetCard 翻訳 button + 原文を表示 toggle (TranslateControl).
+ *
+ * spec: docs/specs/auto-translate-spec.md §7.1 §8.2
+ *
+ * カバレッジ (5 cases):
+ * 1. 表示条件: tweet.language && tweet.language !== viewerLanguage && author !== viewer → button visible
+ * 2. hidden: 同一言語 / language=null / 自分の tweet
+ * 3. translate flow: click → API call → translated text rendered + 「原文を表示」 link 出現
+ * 4. revert: 「原文を表示」 click → 元 body に戻る + 「翻訳する」 button 再表示
+ * 5. error: API 失敗時に error message を出す
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import TranslateControl from "@/components/timeline/TranslateControl";
+
+const { translateMock } = vi.hoisted(() => ({
+	translateMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/tweets", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/tweets")>(
+			"@/lib/api/tweets",
+		);
+	return {
+		...actual,
+		translateTweet: translateMock,
+	};
+});
+
+describe("TranslateControl (P13-05)", () => {
+	beforeEach(() => {
+		translateMock.mockReset();
+	});
+
+	it("shows '翻訳する' button when tweet.language !== viewerLanguage and author !== viewer", () => {
+		render(
+			<TranslateControl
+				tweetId={1}
+				tweetLanguage="en"
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				onTranslated={vi.fn()}
+				onRevert={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.getByRole("button", { name: "翻訳する" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders nothing when language is null / matches viewer / tweet is viewer's own", () => {
+		// language null
+		const { rerender, container } = render(
+			<TranslateControl
+				tweetId={1}
+				tweetLanguage={null}
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				onTranslated={vi.fn()}
+				onRevert={vi.fn()}
+			/>,
+		);
+		expect(container).toBeEmptyDOMElement();
+
+		// same language
+		rerender(
+			<TranslateControl
+				tweetId={1}
+				tweetLanguage="ja"
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				onTranslated={vi.fn()}
+				onRevert={vi.fn()}
+			/>,
+		);
+		expect(container).toBeEmptyDOMElement();
+
+		// own tweet
+		rerender(
+			<TranslateControl
+				tweetId={1}
+				tweetLanguage="en"
+				authorHandle="bob"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				onTranslated={vi.fn()}
+				onRevert={vi.fn()}
+			/>,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("calls translateTweet on click and emits onTranslated with translated_text", async () => {
+		translateMock.mockResolvedValueOnce({
+			translated_text: "こんにちは、 世界",
+			source_language: "en",
+			target_language: "ja",
+			cached: false,
+		});
+
+		const onTranslated = vi.fn();
+		render(
+			<TranslateControl
+				tweetId={42}
+				tweetLanguage="en"
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				onTranslated={onTranslated}
+				onRevert={vi.fn()}
+			/>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "翻訳する" }));
+		await waitFor(() => {
+			expect(translateMock).toHaveBeenCalledWith(42);
+		});
+		expect(onTranslated).toHaveBeenCalledWith("こんにちは、 世界");
+	});
+
+	it("shows '原文を表示' link when translatedText is provided", async () => {
+		const onRevert = vi.fn();
+		render(
+			<TranslateControl
+				tweetId={1}
+				tweetLanguage="en"
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText="こんにちは、 世界"
+				onTranslated={vi.fn()}
+				onRevert={onRevert}
+			/>,
+		);
+		const revert = screen.getByRole("button", { name: "原文を表示" });
+		expect(revert).toBeInTheDocument();
+		await userEvent.click(revert);
+		expect(onRevert).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders error feedback when translateTweet rejects", async () => {
+		translateMock.mockRejectedValueOnce(new Error("network"));
+		render(
+			<TranslateControl
+				tweetId={1}
+				tweetLanguage="en"
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				onTranslated={vi.fn()}
+				onRevert={vi.fn()}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: "翻訳する" }));
+		await screen.findByText(/翻訳に失敗/);
+	});
+});

--- a/client/src/lib/api/tweets.ts
+++ b/client/src/lib/api/tweets.ts
@@ -34,6 +34,11 @@ export interface TweetMini {
 	body: string;
 	html?: string;
 	char_count?: number;
+	/**
+	 * P13-01: 自動検出された言語コード (ISO 639-1)。
+	 * 検出不可 / 短文の場合は null。 翻訳 button の表示判定に使う。
+	 */
+	language?: string | null;
 	created_at: string;
 	edit_count?: number;
 	last_edited_at?: string | null;
@@ -90,6 +95,11 @@ export interface TweetSummary {
 	 * backend が未付与の段階では undefined → 空配列扱い。
 	 */
 	bookmark_folder_ids?: number[];
+	/**
+	 * P13-01: 自動検出された言語コード (ISO 639-1)。
+	 * 検出不可 / 短文の場合は null。 翻訳 button の表示判定に使う。
+	 */
+	language?: string | null;
 }
 
 export async function createTweet(
@@ -146,4 +156,31 @@ export async function deleteTweet(
 ): Promise<void> {
 	await ensureCsrfToken(client);
 	await client.delete(`/tweets/${id}/`);
+}
+
+// ---- Phase 13 P13-03: 自動翻訳 ----
+
+export interface TweetTranslationResponse {
+	translated_text: string;
+	source_language: string;
+	target_language: string;
+	/** true なら DB cache hit (OpenAI を呼んでいない). */
+	cached: boolean;
+}
+
+/**
+ * POST /api/v1/tweets/<id>/translate/
+ *
+ * 翻訳結果を取得する。 viewer の preferred_language に翻訳される。 同一言語 /
+ * 言語検出不可は 422、 block 関係なら 403。
+ */
+export async function translateTweet(
+	id: number | string,
+	client: AxiosInstance = api,
+): Promise<TweetTranslationResponse> {
+	await ensureCsrfToken(client);
+	const res = await client.post<TweetTranslationResponse>(
+		`/tweets/${id}/translate/`,
+	);
+	return res.data;
 }


### PR DESCRIPTION
## Summary

Phase 13 自動翻訳の **UI** 側 (X の auto-translate 相当)。 TweetCard 本文の下に「翻訳する」 button を出し、 \`/api/v1/tweets/<id>/translate/\` (#708) を叩いて結果に inline 差し替え。 翻訳済 state では「原文を表示」 link で revert。

### Behavior

- 表示条件 (spec §7.1): \`tweet.language && tweet.language !== viewer.preferred_language && author !== viewer\`
- 翻訳済 state は **per-card / per-session** (page reload で reset、 X と同じ)
- 翻訳中の本文は plain text を escape して表示 (HTML mention/hashtag は失われる、 X 同様)
- API 失敗時は role=alert で error メッセージ

### Files

| 変更 | 内容 |
|---|---|
| \`client/src/components/timeline/TranslateControl.tsx\` | 新規 — button / link / loading / error の小さな state machine |
| \`client/src/components/timeline/TweetCard.tsx\` | 翻訳 state を hold、 本文を翻訳テキストに差し替え、 \`<TranslateControl>\` を render |
| \`client/src/components/timeline/HomeFeed.tsx\` + \`TweetCardList.tsx\` | \`currentUserPreferredLanguage\` prop を pass-through |
| \`client/src/app/(template)/page.tsx\` | home page で \`user.preferred_language\` を HomeFeed に渡す |
| \`client/src/lib/api/tweets.ts\` | \`translateTweet()\` + \`TweetTranslationResponse\` 型、 \`TweetSummary.language\` / \`TweetMini.language\` 追加 |
| \`client/src/components/timeline/__tests__/TranslateControl.test.tsx\` | vitest 5 cases |

Closes: #701

## Test plan

- [x] \`vitest run src/components/timeline src/lib/api\` → 264 passed (25 files)
- [x] \`tsc --noEmit\` clean
- [ ] CI Frontend Next.js 緑
- [ ] stg deploy 後、 別言語の tweet で「翻訳する」 button が出て translate → 「原文を表示」 で戻ることを Playwright で確認