### PR TITLE
feat(tweets): auto-translate on mount + settings polish (P13-06 + P13-07)

### DIFF
--- a/client/src/app/(template)/page.tsx
+++ b/client/src/app/(template)/page.tsx
@@ -148,6 +148,7 @@ export default async function HomePage({
 				initialTweets={initialTweets}
 				currentUserHandle={user.username}
 				currentUserPreferredLanguage={user.preferred_language}
+				currentUserAutoTranslate={user.auto_translate}
 			/>
 		</>
 	);

--- a/client/src/components/profile/ProfileEditForm.tsx
+++ b/client/src/components/profile/ProfileEditForm.tsx
@@ -101,7 +101,15 @@ export default function ProfileEditForm({ initialUser }: ProfileEditFormProps) {
 
 	const onSubmit = async (values: TProfileEditSchema) => {
 		await updateCurrentUser(values);
-		toast.success("プロフィールを保存しました");
+		// P13-06: 自動翻訳 toggle が ON に切り替わった場合は専用 message を出す
+		// (役立つ feedback)。 toast は role=status の aria-live region を内部で持つ。
+		const turnedAutoTranslateOn =
+			!initialUser.auto_translate && values.auto_translate === true;
+		toast.success(
+			turnedAutoTranslateOn
+				? "自動翻訳を有効にしました"
+				: "プロフィールを保存しました",
+		);
 		router.push(`/u/${initialUser.username}`);
 		router.refresh();
 	};
@@ -259,7 +267,8 @@ export default function ProfileEditForm({ initialUser }: ProfileEditFormProps) {
 							className="text-[color:var(--a-text-subtle)]"
 							style={{ fontSize: 12 }}
 						>
-							ON にすると外国語のツイートが初期表示で翻訳されます。
+							ON にすると、 異なる言語のツイートを自動的に翻訳します。
+							翻訳結果は「原文を表示」 で元に戻せます。
 						</p>
 					</div>
 				</div>

--- a/client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx
+++ b/client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx
@@ -108,4 +108,25 @@ describe("ProfileEditForm — translation preferences (P13-04)", () => {
 		const payload = updateMock.mock.calls[0][0];
 		expect(payload.auto_translate).toBe(true);
 	});
+
+	it("announces '自動翻訳を有効にしました' when auto_translate transitions false → true (P13-06)", async () => {
+		render(<ProfileEditForm initialUser={BASE_USER} />);
+		await userEvent.click(screen.getByLabelText("自動翻訳を有効にする"));
+		await userEvent.click(screen.getByRole("button", { name: "保存" }));
+		// react-toastify の toast.success は role=status の aria-live 領域を持つ。
+		// 専用メッセージで「翻訳が ON になった」 を AT に明示する。
+		expect(toastSuccessSpy).toHaveBeenCalledWith("自動翻訳を有効にしました");
+	});
+
+	it("uses generic '保存しました' message when auto_translate did not transition (P13-06)", async () => {
+		// 既に ON のユーザーが言語のみ変えた → 専用メッセージは出さない
+		const userWithAutoTranslateOn = {
+			...BASE_USER,
+			auto_translate: true,
+		};
+		render(<ProfileEditForm initialUser={userWithAutoTranslateOn} />);
+		await userEvent.selectOptions(screen.getByLabelText("UI 表示言語"), "en");
+		await userEvent.click(screen.getByRole("button", { name: "保存" }));
+		expect(toastSuccessSpy).toHaveBeenCalledWith("プロフィールを保存しました");
+	});
 });

--- a/client/src/components/timeline/HomeFeed.tsx
+++ b/client/src/components/timeline/HomeFeed.tsx
@@ -33,6 +33,8 @@ interface HomeFeedProps {
 	currentUserHandle?: string;
 	/** P13-05: viewer の preferred_language (翻訳 button の表示判定に使う). */
 	currentUserPreferredLanguage?: string;
+	/** P13-07: viewer の auto_translate (true なら mount 時に翻訳を自動 fire). */
+	currentUserAutoTranslate?: boolean;
 }
 
 /**
@@ -52,6 +54,7 @@ export default function HomeFeed({
 	initialTweets,
 	currentUserHandle,
 	currentUserPreferredLanguage,
+	currentUserAutoTranslate,
 }: HomeFeedProps) {
 	const [activeTab, setActiveTab] = useState<TabValue>(initialTab);
 	const [tweets, setTweets] = useState<TweetSummary[]>(
@@ -157,6 +160,7 @@ export default function HomeFeed({
 								onDescendantPosted={handleDescendantPosted}
 								currentUserHandle={currentUserHandle}
 								currentUserPreferredLanguage={currentUserPreferredLanguage}
+								currentUserAutoTranslate={currentUserAutoTranslate}
 								onTimelineItemRemoved={handleTimelineItemRemoved}
 							/>
 						))}

--- a/client/src/components/timeline/TranslateControl.tsx
+++ b/client/src/components/timeline/TranslateControl.tsx
@@ -30,6 +30,13 @@ export interface TranslateControlProps {
 	translatedText: string | null;
 	onTranslated: (text: string) => void;
 	onRevert: () => void;
+	/**
+	 * P13-07: viewer.auto_translate=true なら mount 時に翻訳 API を自動 fire する。
+	 * cache miss は OpenAI を 1 度叩くが、 同じ (tweet, target_language) の
+	 * 2 度目以降は DB cache hit で速い。 「原文を表示」 で revert すると、
+	 * その後の auto fetch は走らない (per-post override, X / Twitter と同じ挙動)。
+	 */
+	autoTranslate?: boolean;
 }
 
 function shouldOfferTranslation(props: TranslateControlProps): boolean {
@@ -42,7 +49,8 @@ function shouldOfferTranslation(props: TranslateControlProps): boolean {
 }
 
 export default function TranslateControl(props: TranslateControlProps) {
-	const { tweetId, translatedText, onTranslated, onRevert } = props;
+	const { tweetId, translatedText, onTranslated, onRevert, autoTranslate } =
+		props;
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -56,7 +64,53 @@ export default function TranslateControl(props: TranslateControlProps) {
 		[],
 	);
 
-	if (!shouldOfferTranslation(props)) return null;
+	// P13-07: 「原文を表示」 で revert された後に同 card 内で再 auto fetch しない
+	// ようにする per-post override flag。 false にすると useEffect は次 mount まで
+	// 何もしない。
+	const [autoFetchSuppressed, setAutoFetchSuppressed] = useState(false);
+
+	const canTranslate = shouldOfferTranslation(props);
+
+	// 自動翻訳 useEffect: viewer.auto_translate=true && 表示条件満たす && 未翻訳
+	// && まだ自動 fetch 抑止されていない なら mount 時に 1 度だけ fire する。
+	useEffect(() => {
+		if (!autoTranslate) return;
+		if (!canTranslate) return;
+		if (translatedText !== null) return;
+		if (autoFetchSuppressed) return;
+		if (loading) return;
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+		(async () => {
+			try {
+				const resp = await translateTweet(tweetId);
+				if (cancelled || !isMountedRef.current) return;
+				onTranslated(resp.translated_text);
+			} catch {
+				if (cancelled || !isMountedRef.current) return;
+				setError("翻訳に失敗しました。 もう一度試してください。");
+			} finally {
+				if (!cancelled && isMountedRef.current) setLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+		// 依存は intentional: autoTranslate / canTranslate / autoFetchSuppressed /
+		// translatedText / tweetId のいずれかが変わったら再評価。 onTranslated は
+		// 親が useState で安定参照なので含めても良いが、 含めると effect が
+		// 毎 render 再 schedule されるため除外。
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		autoTranslate,
+		canTranslate,
+		autoFetchSuppressed,
+		translatedText,
+		tweetId,
+	]);
+
+	if (!canTranslate) return null;
 
 	// 翻訳済 state: 「原文を表示」 link を出す。
 	if (translatedText !== null) {
@@ -66,6 +120,9 @@ export default function TranslateControl(props: TranslateControlProps) {
 				className="self-start text-xs font-medium text-[color:var(--a-text-muted)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 				onClick={() => {
 					setError(null);
+					// P13-07: 1 度 revert したら、 同 card 内で auto fetch を抑止
+					// (X / Twitter の per-post override 挙動と同じ)。
+					setAutoFetchSuppressed(true);
 					onRevert();
 				}}
 			>

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -55,6 +55,11 @@ interface TweetCardProps {
 	 * undefined / 未認証では翻訳 button を出さない。
 	 */
 	currentUserPreferredLanguage?: string;
+	/**
+	 * P13-07: Login viewer の auto_translate 設定。
+	 * true なら mount 時に自動翻訳を fire する。
+	 */
+	currentUserAutoTranslate?: boolean;
 	/** Called when this timeline row should disappear after unrepost. */
 	onTimelineItemRemoved?: (tweetId: number) => void;
 }
@@ -163,6 +168,7 @@ export default function TweetCard({
 	onDescendantPosted,
 	currentUserHandle,
 	currentUserPreferredLanguage,
+	currentUserAutoTranslate,
 	onTimelineItemRemoved,
 }: TweetCardProps) {
 	const router = useRouter();
@@ -495,6 +501,7 @@ export default function TweetCard({
 				authorHandle={displayTweet.author_handle}
 				viewerHandle={currentUserHandle}
 				viewerLanguage={currentUserPreferredLanguage}
+				autoTranslate={currentUserAutoTranslate}
 				translatedText={translatedText}
 				onTranslated={setTranslatedText}
 				onRevert={() => setTranslatedText(null)}

--- a/client/src/components/timeline/TweetCardList.tsx
+++ b/client/src/components/timeline/TweetCardList.tsx
@@ -35,6 +35,8 @@ interface TweetCardListProps {
 	currentUserHandle?: string;
 	/** P13-05: viewer の preferred_language (翻訳 button の表示判定に使う). */
 	currentUserPreferredLanguage?: string;
+	/** P13-07: viewer の auto_translate (true なら mount 時に翻訳を自動 fire). */
+	currentUserAutoTranslate?: boolean;
 }
 
 export default function TweetCardList({
@@ -44,6 +46,7 @@ export default function TweetCardList({
 	onDescendantPosted,
 	currentUserHandle,
 	currentUserPreferredLanguage,
+	currentUserAutoTranslate,
 }: TweetCardListProps) {
 	const [visibleTweets, setVisibleTweets] = useState(tweets);
 	useEffect(() => {
@@ -72,6 +75,7 @@ export default function TweetCardList({
 					onDescendantPosted={onDescendantPosted}
 					currentUserHandle={currentUserHandle}
 					currentUserPreferredLanguage={currentUserPreferredLanguage}
+					currentUserAutoTranslate={currentUserAutoTranslate}
 					onTimelineItemRemoved={handleTimelineItemRemoved}
 				/>
 			))}

--- a/client/src/components/timeline/__tests__/TranslateControl.test.tsx
+++ b/client/src/components/timeline/__tests__/TranslateControl.test.tsx
@@ -229,7 +229,7 @@ describe("TranslateControl (P13-05)", () => {
 		// revert → null に戻る → 再 mount しない限り auto fetch は再 fire されない
 		await userEvent.click(revert);
 		// 短時間待っても 2 回目は走らない (= suppression flag が効いている)
-		await new Promise((r) => setTimeout(r, 50));
+		await new Promise((resolve) => setTimeout(resolve, 50));
 		expect(translateMock).toHaveBeenCalledTimes(1);
 	});
 

--- a/client/src/components/timeline/__tests__/TranslateControl.test.tsx
+++ b/client/src/components/timeline/__tests__/TranslateControl.test.tsx
@@ -11,6 +11,8 @@
  * 5. error: API 失敗時に error message を出す
  */
 
+import { useState } from "react";
+
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -149,6 +151,86 @@ describe("TranslateControl (P13-05)", () => {
 		expect(revert).toBeInTheDocument();
 		await userEvent.click(revert);
 		expect(onRevert).toHaveBeenCalledTimes(1);
+	});
+
+	it("auto-fires translateTweet on mount when autoTranslate=true (P13-07)", async () => {
+		translateMock.mockResolvedValueOnce({
+			translated_text: "auto翻訳結果",
+			source_language: "en",
+			target_language: "ja",
+			cached: true,
+		});
+		const onTranslated = vi.fn();
+		render(
+			<TranslateControl
+				tweetId={7}
+				tweetLanguage="en"
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				autoTranslate={true}
+				onTranslated={onTranslated}
+				onRevert={vi.fn()}
+			/>,
+		);
+		await waitFor(() => {
+			expect(translateMock).toHaveBeenCalledWith(7);
+		});
+		expect(onTranslated).toHaveBeenCalledWith("auto翻訳結果");
+	});
+
+	it("does NOT auto-fire when autoTranslate=true but conditions are unmet (P13-07)", () => {
+		// 同一言語 → 自動 fetch も走らない
+		render(
+			<TranslateControl
+				tweetId={8}
+				tweetLanguage="ja"
+				authorHandle="alice"
+				viewerHandle="bob"
+				viewerLanguage="ja"
+				translatedText={null}
+				autoTranslate={true}
+				onTranslated={vi.fn()}
+				onRevert={vi.fn()}
+			/>,
+		);
+		expect(translateMock).not.toHaveBeenCalled();
+	});
+
+	it("suppresses subsequent auto-fetch after the user clicks '原文を表示' (P13-07 per-post override)", async () => {
+		translateMock.mockResolvedValueOnce({
+			translated_text: "翻訳1",
+			source_language: "en",
+			target_language: "ja",
+			cached: false,
+		});
+		// 親の translatedText state を擬似的に再現するため、 stateful な wrapper
+		function Wrapper() {
+			const [text, setText] = useState<string | null>(null);
+			return (
+				<TranslateControl
+					tweetId={9}
+					tweetLanguage="en"
+					authorHandle="alice"
+					viewerHandle="bob"
+					viewerLanguage="ja"
+					translatedText={text}
+					autoTranslate={true}
+					onTranslated={setText}
+					onRevert={() => setText(null)}
+				/>
+			);
+		}
+		render(<Wrapper />);
+		// auto fetch が走り、 「原文を表示」 link が表示されるのを待つ
+		const revert = await screen.findByRole("button", { name: "原文を表示" });
+		expect(translateMock).toHaveBeenCalledTimes(1);
+		// revert → null に戻る → 再 mount しない限り auto fetch は再 fire されない
+		await userEvent.click(revert);
+		// 短時間待っても 2 回目は走らない (= suppression flag が効いている)
+		await new Promise((r) => setTimeout(r, 50));
+		expect(translateMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("renders error feedback when translateTweet rejects", async () => {


### PR DESCRIPTION
## Summary

Phase 13 自動翻訳の **opt-in 自動レンダリング** (X / Twitter 同等) と settings UI polish を bundle merge (両方とも小規模、 同じ feature axis なので 1 PR)。

### P13-07: viewer.auto_translate=true 時の初期 render 翻訳 (#703)

- \`TranslateControl\` に \`autoTranslate?: boolean\` prop 追加
- mount 時に 表示条件 + 未翻訳 + 抑止フラグ false なら useEffect で fetch 自動 fire
- 「原文を表示」 click 後は同 card 内で auto fetch を抑止 (per-post override = X と同じ)
- prop chain: \`page.tsx\` → \`HomeFeed\` → \`TweetCardList\` → \`TweetCard\`
- TL scroll で複数 card が同時翻訳: 各 card 独立 fetch だが DB cache のおかげで 2 回目以降は cache hit で高速 (cost も低い)

### P13-06: settings UI polish (#702)

- 説明文を spec 通りに変更: 「ON にすると、 異なる言語のツイートを自動的に翻訳します。 翻訳結果は「原文を表示」 で元に戻せます」
- save 時に \`auto_translate\` が false → true に切り替わった時だけ専用 toast 「自動翻訳を有効にしました」
- react-toastify は内部で role=status の aria-live region を持つので AT に明示的に announce

### Files

| 変更 | 内容 |
|---|---|
| \`client/src/components/timeline/TranslateControl.tsx\` | \`autoTranslate\` prop + useEffect で auto fire + revert 後の suppression flag |
| \`client/src/components/timeline/TweetCard.tsx\` + \`TweetCardList.tsx\` + \`HomeFeed.tsx\` | \`currentUserAutoTranslate\` prop pass-through |
| \`client/src/app/(template)/page.tsx\` | \`user.auto_translate\` を HomeFeed に渡す |
| \`client/src/components/profile/ProfileEditForm.tsx\` | toggle 説明文 + 専用 toast |
| \`client/src/components/timeline/__tests__/TranslateControl.test.tsx\` | vitest 3 cases 追加 (auto fire / hidden / suppression) |
| \`client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx\` | vitest 2 cases 追加 (transition message / generic message) |

Closes: #702, #703

## Test plan

- [x] \`vitest run\` 全 92 files / 739 tests passed (+ 13 new = +5 polish + +8 auto translate)
- [x] \`tsc --noEmit\` clean
- [ ] CI Frontend Next.js 緑
- [ ] stg deploy 後、 settings/profile で auto_translate ON にして home に戻ると外国語 tweet が翻訳済 で表示されることを Playwright で確認