### PR TITLE
docs(p13): auto-translate Playwright spec + test commands

### DIFF
--- a/client/e2e/auto-translate.spec.ts
+++ b/client/e2e/auto-translate.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Phase 13 自動翻訳 機能 E2E (P13-05 / P13-07).
+ *
+ * spec: docs/specs/auto-translate-spec.md §7 §8.3
+ *
+ * シナリオ:
+ *   1. USER2 が API で英文 tweet を投稿
+ *   2. USER1 (preferred_language=ja) が /u/<USER2 handle> を開く
+ *   3. 英文 tweet に「翻訳する」 button が出ていることを assert
+ *   4. button click → POST /tweets/<id>/translate/ が fire され、 翻訳結果に
+ *      切り替わる + 「原文を表示」 link が出る
+ *   5. 「原文を表示」 click → 元 body に戻る + 「翻訳する」 button 再表示
+ *
+ * NOTE: stg に OPENAI_API_KEY が未注入の段階では NoopTranslator が原文を返すので
+ *   `translated_text === original body` になる。 button / link の visible/state
+ *   切り替えはそれでも検証できる。 P13-08 (terraform で key 注入) が済んで
+ *   real translation を確認したい場合は別 spec を追加すること。
+ *
+ * 実行手順:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+ *   PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+ *   PLAYWRIGHT_USER1_HANDLE=test2 \
+ *   PLAYWRIGHT_USER2_EMAIL=test3@gmail.com \
+ *   PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
+ *   PLAYWRIGHT_USER2_HANDLE=test3 \
+ *     npx playwright test e2e/auto-translate.spec.ts --reporter=line
+ */
+
+import {
+	expect,
+	request,
+	test,
+	type APIRequestContext,
+	type Page,
+} from "@playwright/test";
+
+const API_BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "alice@example.com",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "supersecret12", // pragma: allowlist secret
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "alice",
+};
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "bob@example.com",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "supersecret12", // pragma: allowlist secret
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "bob",
+};
+
+interface AuthedApi {
+	api: APIRequestContext;
+	csrf: string;
+}
+
+async function apiAuthed(email: string, password: string): Promise<AuthedApi> {
+	const api = await request.newContext({ baseURL: API_BASE });
+	await api.get("/api/v1/auth/csrf/");
+	const cookies = await api.storageState();
+	const csrf = cookies.cookies.find((c) => c.name === "csrftoken")?.value ?? "";
+	const loginRes = await api.post("/api/v1/auth/cookie/create/", {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${API_BASE}/login`,
+		},
+		data: { email, password },
+	});
+	expect(loginRes.status(), `login failed for ${email}`).toBe(200);
+	const cookies2 = await api.storageState();
+	const csrf2 =
+		cookies2.cookies.find((c) => c.name === "csrftoken")?.value ?? csrf;
+	return { api, csrf: csrf2 };
+}
+
+async function apiPostTweet(authed: AuthedApi, body: string): Promise<number> {
+	const res = await authed.api.post("/api/v1/tweets/", {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": authed.csrf,
+			Referer: `${API_BASE}/`,
+		},
+		data: { body },
+	});
+	expect(res.status(), "tweet post").toBeLessThan(300);
+	const json = await res.json();
+	return json.id as number;
+}
+
+async function apiDeleteTweet(authed: AuthedApi, id: number): Promise<void> {
+	await authed.api.delete(`/api/v1/tweets/${id}/`, {
+		headers: {
+			"X-CSRFToken": authed.csrf,
+			Referer: `${API_BASE}/`,
+		},
+	});
+}
+
+async function uiLogin(page: Page, email: string, password: string) {
+	await page.goto("/login");
+	await page.getByLabel("Email Address").fill(email);
+	await page.getByPlaceholder("Password").fill(password);
+	await page.getByRole("button", { name: /Sign In/i }).click();
+	await page.waitForURL(/\/onboarding|\/$/);
+}
+
+test.describe("Phase 13 自動翻訳 (P13-05 / P13-07)", () => {
+	let user2: AuthedApi;
+	let englishTweetId: number;
+
+	test.beforeAll(async () => {
+		user2 = await apiAuthed(USER2.email, USER2.password);
+		englishTweetId = await apiPostTweet(
+			user2,
+			"Hello, world. This is an English test tweet for the translate feature.",
+		);
+	});
+
+	test.afterAll(async () => {
+		// 後片付け: 投稿した tweet を消す
+		await apiDeleteTweet(user2, englishTweetId);
+	});
+
+	test("TRANSLATE-1/2: button toggles between original and translated body", async ({
+		page,
+	}) => {
+		await uiLogin(page, USER1.email, USER1.password);
+
+		// USER2 のプロフィールに行って英文 tweet を見つける
+		await page.goto(`/u/${USER2.handle}`);
+		const tweetCard = page
+			.getByRole("article")
+			.filter({ hasText: "English test tweet" })
+			.first();
+		await expect(tweetCard).toBeVisible({ timeout: 15_000 });
+
+		// TRANSLATE-1: 翻訳 button が visible (USER1 default lang=ja !== tweet.language=en)
+		const translateBtn = tweetCard.getByRole("button", { name: "翻訳する" });
+		await expect(translateBtn).toBeVisible();
+
+		// click → API fire → 「原文を表示」 link が出る
+		await translateBtn.click();
+		const revertBtn = tweetCard.getByRole("button", { name: "原文を表示" });
+		await expect(revertBtn).toBeVisible({ timeout: 15_000 });
+		// 翻訳 button は消える
+		await expect(translateBtn).toBeHidden();
+
+		// TRANSLATE-2: revert → 翻訳 button 再表示 / 「原文を表示」 消える
+		await revertBtn.click();
+		await expect(
+			tweetCard.getByRole("button", { name: "翻訳する" }),
+		).toBeVisible();
+		await expect(revertBtn).toBeHidden();
+	});
+
+	test("TRANSLATE-3: same-language tweet has no translate button", async ({
+		page,
+	}) => {
+		// USER2 が日本語 tweet を投稿 (USER1 default lang も ja → button 出ない)
+		const jaTweetId = await apiPostTweet(
+			user2,
+			"こんにちは、 これは日本語のテストツイートです。",
+		);
+		try {
+			await uiLogin(page, USER1.email, USER1.password);
+			await page.goto(`/u/${USER2.handle}`);
+			const jaCard = page
+				.getByRole("article")
+				.filter({ hasText: "日本語のテストツイート" })
+				.first();
+			await expect(jaCard).toBeVisible({ timeout: 15_000 });
+			// 翻訳 button は出ない
+			await expect(
+				jaCard.getByRole("button", { name: "翻訳する" }),
+			).toHaveCount(0);
+		} finally {
+			await apiDeleteTweet(user2, jaTweetId);
+		}
+	});
+
+	test("TRANSLATE-4: own tweet has no translate button", async ({ page }) => {
+		// USER1 (= viewer 自身) が英文 tweet を投稿 → 自分の TL / 自分の page では
+		// 翻訳 button が出ない (per spec §7.1: author !== viewer 条件)
+		const user1Api = await apiAuthed(USER1.email, USER1.password);
+		const ownTweetId = await apiPostTweet(
+			user1Api,
+			"Hello, this is my own English tweet that should not show a translate button.",
+		);
+		try {
+			await uiLogin(page, USER1.email, USER1.password);
+			await page.goto(`/u/${USER1.handle}`);
+			const ownCard = page
+				.getByRole("article")
+				.filter({ hasText: "my own English tweet" })
+				.first();
+			await expect(ownCard).toBeVisible({ timeout: 15_000 });
+			await expect(
+				ownCard.getByRole("button", { name: "翻訳する" }),
+			).toHaveCount(0);
+		} finally {
+			await apiDeleteTweet(user1Api, ownTweetId);
+		}
+	});
+});

--- a/docs/specs/auto-translate-spec.md
+++ b/docs/specs/auto-translate-spec.md
@@ -263,12 +263,28 @@ state は client-side `useState`、 page reload で reset (X と同じ per-sessi
 
 ### 8.3 E2E (Playwright, stg)
 
-`client/e2e/auto-translate.spec.ts`:
+`client/e2e/auto-translate.spec.ts` (実装済):
 
-- TRANSLATE-1: test2 (ja user) で英語投稿が見える tweet card に「翻訳する」 button → 翻訳済 + 「原文を表示」 確認
-- TRANSLATE-2: 翻訳済から「原文を表示」 click → 元の英語に戻る、 「翻訳する」 が再表示
+- TRANSLATE-1/2: test2 (ja user) で英語投稿の tweet card に「翻訳する」 button → 翻訳済 + 「原文を表示」 → revert で原文戻り + 「翻訳する」 再表示
 - TRANSLATE-3: 同一言語 (test2 = ja で日本語投稿) は button が出ない
 - TRANSLATE-4: 自分の投稿には button が出ない
+
+実行コマンド (env は [docs/local/e2e-stg.md](../local/e2e-stg.md) 参照):
+
+```bash
+cd /workspace/client
+
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+PLAYWRIGHT_USER2_EMAIL=test3@gmail.com \
+PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER2_HANDLE=test3 \
+  npx playwright test e2e/auto-translate.spec.ts --reporter=line
+```
+
+**注意 (P13-08 未完時)**: stg env に `OPENAI_API_KEY` が注入されるまでは `get_translator()` が `NoopTranslator` を返すので、 endpoint の `translated_text` は原文と同じ文字列になる。 「翻訳済 state への遷移」 と「revert」 の UX 検証は NoopTranslator でも通るので問題ないが、 **実際の翻訳品質確認は P13-08 完了後** に行う必要がある。
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 13 自動翻訳の Playwright e2e spec を新設、 spec doc §8.3 に実行コマンドを記載。

- \`client/e2e/auto-translate.spec.ts\`: stg 用 spec (3 test cases: button toggle / same-lang hidden / own tweet hidden)
- \`docs/specs/auto-translate-spec.md\` §8.3: 実行コマンドテンプレ + P13-08 未完時の挙動 (NoopTranslator 原文返却) を注記

NOTE: 本 PR は spec / doc のみ、 production code 変更なし。

## Test plan

- [ ] CI lint / type 緑
- [ ] stg deploy 確認後、 \`PLAYWRIGHT_BASE_URL=https://stg.codeplace.me\` で実行して 3 test 通過