### PR TITLE
fix(p13): pass currentUserPreferredLanguage to all TweetCardList sites

### DIFF
--- a/client/src/app/(template)/search/page.tsx
+++ b/client/src/app/(template)/search/page.tsx
@@ -17,6 +17,16 @@ import type { Metadata } from "next";
 import SearchBox from "@/components/search/SearchBox";
 import TweetCardList from "@/components/timeline/TweetCardList";
 import { fetchSearch } from "@/lib/api/search";
+import { serverFetch } from "@/lib/api/server";
+import type { CurrentUser } from "@/lib/api/users";
+
+async function loadCurrentUser(): Promise<CurrentUser | null> {
+	try {
+		return await serverFetch<CurrentUser>("/users/me/");
+	} catch {
+		return null;
+	}
+}
 
 interface SearchPageProps {
 	searchParams: { q?: string };
@@ -30,13 +40,16 @@ export const metadata: Metadata = {
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
 	const query = (searchParams.q ?? "").trim();
-	const data = query
-		? await fetchSearch(query).catch(() => ({
-				query,
-				results: [],
-				count: 0,
-			}))
-		: { query: "", results: [], count: 0 };
+	const [data, currentUser] = await Promise.all([
+		query
+			? fetchSearch(query).catch(() => ({
+					query,
+					results: [],
+					count: 0,
+				}))
+			: Promise.resolve({ query: "", results: [], count: 0 }),
+		loadCurrentUser(),
+	]);
 
 	return (
 		<>
@@ -83,6 +96,9 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 							tweets={data.results}
 							ariaLabel={`「${query}」の検索結果`}
 							emptyMessage="一致するツイートはありません。"
+							currentUserHandle={currentUser?.username}
+							currentUserPreferredLanguage={currentUser?.preferred_language}
+							currentUserAutoTranslate={currentUser?.auto_translate}
 						/>
 					</section>
 				)}

--- a/client/src/app/(template)/tag/[name]/page.tsx
+++ b/client/src/app/(template)/tag/[name]/page.tsx
@@ -4,6 +4,15 @@ import { notFound } from "next/navigation";
 import TweetCardList from "@/components/timeline/TweetCardList";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
+import type { CurrentUser } from "@/lib/api/users";
+
+async function loadCurrentUser(): Promise<CurrentUser | null> {
+	try {
+		return await serverFetch<CurrentUser>("/users/me/");
+	} catch {
+		return null;
+	}
+}
 
 interface TagDetail {
 	name: string;
@@ -65,7 +74,10 @@ export async function generateMetadata({
 export default async function TagPage({ params }: PageProps) {
 	const tag = await loadTag(params.name);
 	if (!tag) notFound();
-	const tweets = await loadTweets(tag.name);
+	const [tweets, currentUser] = await Promise.all([
+		loadTweets(tag.name),
+		loadCurrentUser(),
+	]);
 
 	return (
 		<>
@@ -133,6 +145,9 @@ export default async function TagPage({ params }: PageProps) {
 						tweets={tweets}
 						ariaLabel={`${tag.display_name} タグのツイート`}
 						emptyMessage="まだこのタグのツイートはありません。"
+						currentUserHandle={currentUser?.username}
+						currentUserPreferredLanguage={currentUser?.preferred_language}
+						currentUserAutoTranslate={currentUser?.auto_translate}
 					/>
 				</section>
 			</div>

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -227,6 +227,8 @@ export default async function TweetDetailPage({ params }: PageProps) {
 							tweets={ancestors}
 							ariaLabel="親ツイート"
 							currentUserHandle={currentUser?.username}
+							currentUserPreferredLanguage={currentUser?.preferred_language}
+							currentUserAutoTranslate={currentUser?.auto_translate}
 						/>
 					</section>
 				) : null}
@@ -237,6 +239,8 @@ export default async function TweetDetailPage({ params }: PageProps) {
 					focal={tweet}
 					initialReplies={replies}
 					currentUserHandle={currentUser?.username}
+					currentUserPreferredLanguage={currentUser?.preferred_language}
+					currentUserAutoTranslate={currentUser?.auto_translate}
 				/>
 			</article>
 		</>

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -443,6 +443,8 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 							ariaLabel={`@${profile.username} がいいねした投稿`}
 							emptyMessage="いいねした投稿がありません。"
 							currentUserHandle={currentUser?.username}
+							currentUserPreferredLanguage={currentUser?.preferred_language}
+							currentUserAutoTranslate={currentUser?.auto_translate}
 						/>
 					) : (
 						<TweetCardList
@@ -450,6 +452,8 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 							ariaLabel={`@${profile.username} のツイート`}
 							emptyMessage="まだツイートがありません。"
 							currentUserHandle={currentUser?.username}
+							currentUserPreferredLanguage={currentUser?.preferred_language}
+							currentUserAutoTranslate={currentUser?.auto_translate}
 						/>
 					)}
 				</section>

--- a/client/src/components/timeline/ConversationReplies.tsx
+++ b/client/src/components/timeline/ConversationReplies.tsx
@@ -21,6 +21,10 @@ interface ConversationRepliesProps {
 	focal: TweetSummary;
 	initialReplies: TweetSummary[];
 	currentUserHandle?: string;
+	/** P13-05: viewer の preferred_language (翻訳 button の表示判定に使う). */
+	currentUserPreferredLanguage?: string;
+	/** P13-07: viewer の auto_translate (true なら mount 時に翻訳を自動 fire). */
+	currentUserAutoTranslate?: boolean;
 }
 
 function dedupById(tweets: TweetSummary[]): TweetSummary[] {
@@ -36,6 +40,8 @@ export default function ConversationReplies({
 	focal,
 	initialReplies,
 	currentUserHandle,
+	currentUserPreferredLanguage,
+	currentUserAutoTranslate,
 }: ConversationRepliesProps) {
 	const [replies, setReplies] = useState<TweetSummary[]>(
 		dedupById(initialReplies),
@@ -73,6 +79,8 @@ export default function ConversationReplies({
 					ariaLabel="ツイート詳細"
 					onDescendantPosted={handleDescendantPosted}
 					currentUserHandle={currentUserHandle}
+					currentUserPreferredLanguage={currentUserPreferredLanguage}
+					currentUserAutoTranslate={currentUserAutoTranslate}
 				/>
 			</section>
 


### PR DESCRIPTION
## Summary

P13-05 で home page だけに currentUserPreferredLanguage / currentUserAutoTranslate を pass していたが、 stg で Playwright を回したら /u/<handle> プロフィールページで翻訳 button が出ないと判明 (TRANSLATE-1 fail)。

実機検証で見つかった bug。 横展開して全 TweetCardList 利用箇所を修正。

| 修正 | 内容 |
|---|---|
| /u/[handle]/page.tsx | 既存 currentUser を 2 prop で pass (2 箇所: tweets / liked tabs) |
| /tag/[name]/page.tsx | loadCurrentUser helper 追加 + 3 props |
| /search/page.tsx | loadCurrentUser helper 追加 + 3 props |
| /tweet/[id]/page.tsx | 既存 currentUser を 2 prop で pass (TweetCardList + ConversationReplies) |
| ConversationReplies.tsx | prop chain を継承 |

/explore は authenticated user を / に redirect する設計なので prop 不要 (skip)。

## Verification

- [x] tsc clean
- [ ] CI Frontend 緑
- [ ] stg deploy 後、 Playwright TRANSLATE-1〜4 全 pass を再確認