### PR TITLE
fix(p13): expose Tweet.language in API serializers (P13-01 oversight)

### DIFF
--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -161,6 +161,9 @@ class TweetBaseMiniSerializer(serializers.ModelSerializer):
             "reaction_count",
             "reposted_by_me",
             "reaction_summary",
+            # P13-01: 自動検出された言語コード (ISO 639-1)。 frontend の
+            # 「翻訳」 button 表示判定で必要。 null=未検出。
+            "language",
         ]
         read_only_fields = fields
 
@@ -281,6 +284,9 @@ class TweetListSerializer(serializers.ModelSerializer):
             "reposted_by_me",
             # #383
             "reaction_summary",
+            # P13-01: 自動検出された言語コード (ISO 639-1)。 frontend の
+            # 「翻訳」 button 表示判定で必要。 null=未検出。
+            "language",
         ]
         read_only_fields = fields
 

--- a/apps/tweets/tests/test_tweet_language.py
+++ b/apps/tweets/tests/test_tweet_language.py
@@ -75,6 +75,27 @@ class TestTweetLanguageDetection:
         tweet.refresh_from_db()
         assert tweet.language == "en"
 
+    def test_api_response_includes_language_field(self, author):
+        """P13-01 follow-up: GET /api/v1/tweets/<id>/ の response に
+        "language" key が含まれること。 stg Playwright で frontend が
+        button 表示判定できなかった bug (= serializer fields 漏れ) の regression guard。
+        """
+        from rest_framework.test import APIClient
+
+        tweet = Tweet.objects.create(
+            author=author,
+            body="It was a beautiful day today. I took a walk in the park.",
+        )
+        client = APIClient()
+        client.force_authenticate(user=author)
+        resp = client.get(f"/api/v1/tweets/{tweet.pk}/")
+        assert resp.status_code == 200
+        assert "language" in resp.data, (
+            "TweetDetailSerializer must expose 'language' field "
+            "for frontend translate button to work"
+        )
+        assert resp.data["language"] == "en"
+
     def test_edit_re_detects_language(self, author):
         """本文を変更したら language も再検出。"""
         tweet = Tweet.objects.create(author=author, body="Hello world, this is English text")


### PR DESCRIPTION
## Summary

stg Playwright で発見した bug の修正。 TweetCard の翻訳 button が表示されない原因は、 backend serializer の Meta.fields に \`language\` が漏れていたため。

### 症状

- DB / 検出 signal は正常 (Tweet.language 列に値は書かれる)
- API response に \`language\` key が含まれず frontend が表示判定できない
- TranslateControl の \`shouldOfferTranslation\` が false → button 描画されない

### 修正

- \`TweetBaseMiniSerializer.fields\` に \`\"language\"\` 追加
- \`TweetListSerializer.fields\` に \`\"language\"\` 追加
- \`TweetDetailSerializer\` は継承で自動反映
- pytest regression test 追加 (GET /tweets/<id>/ response に key が含まれることを assert)

## Test plan

- [x] pytest local 確認は api container 落ちているので skip → CI で確認
- [ ] CI Backend Django 緑
- [ ] stg deploy 後、 \`curl /api/v1/tweets/<id>/\` で \`language: \"en\"\` が返ることを確認
- [ ] Playwright auto-translate.spec.ts 全 3 cases pass