### PR TITLE
infra(p13-08): inject OPENAI_API_KEY into ECS django_secrets

### DIFF
--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -90,6 +90,11 @@ locals {
     { name = "SIGNING_KEY", valueFrom = var.secret_arns["django/jwt-signing-key"] },
     { name = "POSTGRES_PASSWORD", valueFrom = var.secret_arns["django/db-password"] },
     { name = "REDIS_AUTH_TOKEN", valueFrom = var.secret_arns["redis/auth-token"] },
+    # Phase 13 P13-08: OpenAI GPT-4o-mini (auto-translate)。 値はハルナさんが
+    # `aws secretsmanager put-secret-value --secret-id sns/stg/openai/api-key`
+    # で put 済。 万一空文字が secret に書かれていても apps.translation.services
+    # の `get_translator()` が NoopTranslator に fallback するので 500 にはならない。
+    { name = "OPENAI_API_KEY", valueFrom = var.secret_arns["openai/api-key"] },
   ]
 
   # Next.js (SSR) は public NEXT_PUBLIC_* のみ。Sentry DSN は build-time に build args


### PR DESCRIPTION
## Summary

Phase 13 自動翻訳の最終 piece。 ハルナさんが \`aws secretsmanager put-secret-value --secret-id sns/stg/openai/api-key\` で put 済の OpenAI key を ECS task env に注入。

- \`terraform/modules/services/main.tf\` の \`django_secrets\` に \`OPENAI_API_KEY\` 追加
- terraform plan / apply 済 (ハルナさん明示認可)
- ECS service の task_definition pointer は \`ignore_changes\` なので、 \`aws ecs update-service --force-new-deployment\` で 4 service (django / celery-worker / celery-beat / daphne) を新 task def に向け直し済

### Applied changes

| resource | result |
|---|---|
| \`module.services.aws_ecs_task_definition.django\` | revision 17 → 18 |
| \`module.services.aws_ecs_task_definition.django_migrate\` | revision 15 → 16 |
| \`module.services.aws_ecs_task_definition.celery_worker\` | revision 16 → 17 |
| \`module.services.aws_ecs_task_definition.celery_beat\` | revision 16 → 17 |
| \`module.services.aws_ecs_task_definition.daphne\` | revision 6 → 7 |
| \`module.observability.aws_sns_topic_subscription.alert_email\` | created (terraform drift cleanup) |
| \`module.edge.aws_cloudfront_distribution.this\` | in-place tweak (drift cleanup) |

### Safety

- 空文字 secret でも \`apps.translation.services.get_translator()\` が \`NoopTranslator\` に fallback するので 500 にならない
- ECS rollout は blue/green 風 (ALB health check) で no-downtime

Closes: #704

## Verify

- [x] \`terraform apply\` (stg) 成功
- [x] ECS task def 18 に OPENAI_API_KEY 含まれる (\`aws ecs describe-task-definition\` で確認済)
- [ ] ECS rollover 完了 (\`describe-services\` で deployments == 1)
- [ ] Playwright auto-translate spec 再実行 → cached=false の初回 translation が日本語訳で返る