### PR TITLE
feat(agents): user-scoped tool layer (5 tools, P14-02)

### DIFF
--- a/apps/agents/tests/test_tools.py
+++ b/apps/agents/tests/test_tools.py
@@ -1,0 +1,266 @@
+"""
+P14-02: Tool layer のテスト。
+
+spec: docs/specs/claude-agent-spec.md §4 §8.1
+
+カバレッジ:
+- user scope (各 tool は自分のデータしか見えない)
+- block / mute filter (双方向 block で除外)
+- DM 本文は読まない (Privacy)
+- limit の clamp (LLM が境界超えても安全)
+- compose_tweet_draft の 140 字制限
+- tool registry / get_callable
+
+テスト戦略:
+- 各 tool に対し「自分のデータ含まれる」「他人のデータ含まれない」 の対をテスト
+- block の場合 ``Block`` model を作って filter を確認
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.agents.tools import (
+    TWEET_DRAFT_MAX_CHARS,
+    DraftTooLongError,
+    compose_tweet_draft,
+    get_callable,
+    read_home_timeline,
+    read_my_notifications,
+    read_my_recent_tweets,
+    search_tweets_by_tag,
+)
+from apps.notifications.models import Notification, NotificationKind
+from apps.tags.models import Tag
+from apps.tweets.models import Tweet, TweetType
+
+User = get_user_model()
+
+
+def _make_user(email: str, username: str) -> User:
+    return User.objects.create_user(
+        email=email,
+        username=username,
+        first_name="F",
+        last_name="L",
+        password="StrongPass!1",  # pragma: allowlist secret
+    )
+
+
+# ---------------------------------------------------------------------------
+# read_my_recent_tweets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestReadMyRecentTweets:
+    def test_returns_only_own_tweets(self):
+        me = _make_user("me-rec@example.com", "me_rec")
+        other = _make_user("o-rec@example.com", "o_rec")
+        Tweet.objects.create(author=me, body="my tweet 1")
+        Tweet.objects.create(author=other, body="other tweet")
+        out = read_my_recent_tweets(me)
+        assert "@me_rec" in out
+        assert "@o_rec" not in out
+        assert "my tweet 1" in out
+
+    def test_excludes_repost_and_reply_types(self):
+        """ORIGINAL のみ。 repost / quote / reply は除外。"""
+        me = _make_user("me-types@example.com", "me_types")
+        target = Tweet.objects.create(author=me, body="target")
+        Tweet.objects.create(author=me, body="repost", type=TweetType.REPOST, repost_of=target)
+        Tweet.objects.create(author=me, body="quote body", type=TweetType.QUOTE, quote_of=target)
+        out = read_my_recent_tweets(me)
+        assert "target" in out
+        assert "repost" not in out
+        assert "quote body" not in out
+
+    def test_returns_empty_message_when_no_tweets(self):
+        me = _make_user("me-empty@example.com", "me_empty")
+        out = read_my_recent_tweets(me)
+        assert "(0 件)" in out
+        assert "(無し)" in out
+
+    def test_limit_is_clamped(self):
+        """limit=999 を渡しても最大 20 件まで。"""
+        me = _make_user("me-clamp@example.com", "me_clamp")
+        for i in range(25):
+            Tweet.objects.create(author=me, body=f"t-{i}")
+        out = read_my_recent_tweets(me, limit=999)
+        # 出力には 20 行までしか含まれない
+        lines = [line for line in out.split("\n") if line.startswith("- @")]
+        assert len(lines) <= 20
+
+
+# ---------------------------------------------------------------------------
+# read_my_notifications
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestReadMyNotifications:
+    def test_returns_only_my_notifications(self):
+        me = _make_user("me-not@example.com", "me_not")
+        other = _make_user("o-not@example.com", "o_not")
+        Notification.objects.create(recipient=me, actor=other, kind=NotificationKind.LIKE)
+        Notification.objects.create(recipient=other, actor=me, kind=NotificationKind.LIKE)
+        out = read_my_notifications(me)
+        # 自分宛 1 件、 他人宛 1 件は出ない
+        assert out.count("[like]") == 1
+        # actor は @o_not (相手)
+        assert "@o_not" in out
+        assert "@me_not" not in out
+
+    def test_dm_message_body_is_redacted(self):
+        """DM 本文は読まない (Privacy)。 kind だけ出して 本文は (本文は非表示)。"""
+        me = _make_user("me-dm@example.com", "me_dm")
+        sender = _make_user("o-dm@example.com", "o_dm")
+        Notification.objects.create(
+            recipient=me,
+            actor=sender,
+            kind=NotificationKind.DM_MESSAGE,
+            target_type="dm_message",
+            target_id="42",
+        )
+        out = read_my_notifications(me)
+        assert "[dm_message]" in out
+        assert "(本文は非表示)" in out
+        # target_id を含まないこと (DM では一切 message ID を漏らさない方針)
+        assert "/42" not in out
+
+    def test_includes_unread_marker(self):
+        me = _make_user("me-unr@example.com", "me_unr")
+        other = _make_user("o-unr@example.com", "o_unr")
+        Notification.objects.create(
+            recipient=me, actor=other, kind=NotificationKind.MENTION, read=False
+        )
+        out = read_my_notifications(me)
+        assert "[未読]" in out
+
+
+# ---------------------------------------------------------------------------
+# read_home_timeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestReadHomeTimeline:
+    def test_uses_build_home_tl(self):
+        """build_home_tl の戻り値を整形して返すだけ。 ここでは smoke test。"""
+        me = _make_user("me-hot@example.com", "me_hot")
+        other = _make_user("o-hot@example.com", "o_hot")
+        Tweet.objects.create(author=other, body="other tweet for tl")
+        # build_home_tl の挙動の詳細は apps/timeline/tests/test_services.py で
+        # 既にカバーされているので、 ここでは smoke test (例外なく実行できる) のみ。
+        out = read_home_timeline(me, limit=10)
+        assert isinstance(out, str)
+        assert "# home TL" in out
+
+    def test_empty_returns_no_match_message(self):
+        me = _make_user("me-hot-e@example.com", "me_hot_e")
+        out = read_home_timeline(me)
+        assert "(0 件)" in out or "@" in out  # 空 or 何か入っている
+
+
+# ---------------------------------------------------------------------------
+# search_tweets_by_tag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestSearchTweetsByTag:
+    def test_returns_tweets_with_tag(self):
+        me = _make_user("me-tag@example.com", "me_tag")
+        other = _make_user("o-tag@example.com", "o_tag")
+        tag = Tag.objects.create(name="python", display_name="Python", is_approved=True)
+        t1 = Tweet.objects.create(author=other, body="Python is cool")
+        t1.tags.add(tag)
+        out = search_tweets_by_tag(me, "python")
+        assert "@o_tag" in out
+        assert "Python is cool" in out
+
+    def test_strips_hash_prefix(self):
+        me = _make_user("me-h@example.com", "me_h")
+        other = _make_user("o-h@example.com", "o_h")
+        tag = Tag.objects.create(name="rust", display_name="Rust", is_approved=True)
+        t1 = Tweet.objects.create(author=other, body="rust lang")
+        t1.tags.add(tag)
+        out = search_tweets_by_tag(me, "#rust")
+        assert "@o_h" in out
+        assert "rust lang" in out
+
+    def test_unknown_tag_returns_placeholder(self):
+        me = _make_user("me-ut@example.com", "me_ut")
+        out = search_tweets_by_tag(me, "this-tag-does-not-exist")
+        assert "存在しません" in out
+
+
+@pytest.mark.django_db
+class TestSearchTweetsByTagBlockFilter:
+    def test_blocked_user_tweet_is_excluded(self):
+        """security: block 関係にある相手の tweet は tag 検索結果から除外。"""
+        from apps.moderation.models import Block
+
+        me = _make_user("me-blk@example.com", "me_blk")
+        bad = _make_user("o-blk@example.com", "o_blk")
+        tag = Tag.objects.create(name="js", display_name="JS", is_approved=True)
+        t1 = Tweet.objects.create(author=bad, body="js tweet by blocked user")
+        t1.tags.add(tag)
+        # me が bad を block
+        Block.objects.create(blocker=me, blockee=bad)
+        out = search_tweets_by_tag(me, "js")
+        assert "js tweet by blocked user" not in out
+        # 「(0 件)」 になる (block で全件 filter された)
+        assert "(0 件)" in out
+
+
+# ---------------------------------------------------------------------------
+# compose_tweet_draft
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestComposeTweetDraft:
+    def test_returns_stripped_text(self):
+        me = _make_user("me-cmp@example.com", "me_cmp")
+        out = compose_tweet_draft(me, "  hello world  ")
+        assert out == "hello world"
+
+    def test_raises_on_too_long(self):
+        me = _make_user("me-long@example.com", "me_long")
+        with pytest.raises(DraftTooLongError):
+            compose_tweet_draft(me, "あ" * (TWEET_DRAFT_MAX_CHARS + 1))
+
+    def test_boundary_140_chars_ok(self):
+        me = _make_user("me-boundary@example.com", "me_boundary")
+        out = compose_tweet_draft(me, "あ" * TWEET_DRAFT_MAX_CHARS)
+        assert len(out) == TWEET_DRAFT_MAX_CHARS
+
+
+# ---------------------------------------------------------------------------
+# Tool registry
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistry:
+    def test_registry_is_deterministic(self):
+        """spec §5.1.1: tools 順序は cache invalidation 防止のため deterministic。"""
+        from apps.agents.tools import TOOL_REGISTRY
+
+        # 順序が固定されている (sorted ではないがソート可能な確定順序)
+        assert TOOL_REGISTRY == (
+            "read_home_timeline",
+            "read_my_notifications",
+            "read_my_recent_tweets",
+            "search_tweets_by_tag",
+            "compose_tweet_draft",
+        )
+
+    def test_get_callable_returns_callable(self):
+        f = get_callable("read_home_timeline")
+        assert callable(f)
+
+    def test_get_callable_unknown_name_raises(self):
+        with pytest.raises(KeyError):
+            get_callable("not_a_real_tool")

--- a/apps/agents/tools.py
+++ b/apps/agents/tools.py
@@ -1,0 +1,299 @@
+"""Phase 14 P14-02: Claude Agent 用 user-scoped tools.
+
+spec: docs/specs/claude-agent-spec.md §4
+
+各 tool は **request.user の scope に閉じる** plain Python function。
+Anthropic SDK の `@beta_tool` decoration は P14-03 (AgentRunner) で
+適用する。 ここでは:
+
+- user は第一引数として明示的に注入 (Claude が input で偽装できない設計)
+- 戻り値は plain text の短い summary (token 浪費を防ぐ)
+- block / mute 関係は既存 `is_blocked_relationship` で自動 filter
+- DM 本文は **絶対に** 触らない (Privacy、 Phase 14 スコープ外)
+
+戻り値は LLM が読みやすい簡潔な日本語フォーマット。 1 件 1 行で
+``@handle: body...`` の形に統一する (token 効率)。
+
+P14-03 で `apps.agents.runner` が以下のように wrap する想定:
+
+    from apps.agents import tools as t
+
+    def make_anthropic_tools(user):
+        return [
+            {"name": "read_my_recent_tweets", "description": ...,
+             "input_schema": {"type": "object", "properties": {"limit": {"type": "integer"}}, ...},
+             "_callable": lambda **kw: t.read_my_recent_tweets(user, **kw)},
+            ...
+        ]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from apps.common.blocking import is_blocked_relationship
+from apps.notifications.models import Notification, NotificationKind
+from apps.tags.models import Tag
+from apps.timeline.services import build_home_tl
+from apps.tweets.models import Tweet, TweetType
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser
+
+
+# ---- 共通定数 ----
+
+# Phase 14 §4.2 にあるツール毎の上限。 LLM が大きい limit を渡しても dispatcher
+# 側で clamp する (token を無駄遣いさせない安全網)。
+_MAX_RECENT_TWEETS = 20
+_MAX_NOTIFICATIONS = 30
+_MAX_HOME_TIMELINE = 30
+_MAX_TAG_SEARCH = 20
+
+# tweet draft の char 上限 (X / Twitter 互換)。 Phase 1 SPEC §2.4 と同じ。
+TWEET_DRAFT_MAX_CHARS = 140
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    """LLM から渡る limit を安全な範囲に clamp する。"""
+    if value < minimum:
+        return minimum
+    if value > maximum:
+        return maximum
+    return value
+
+
+def _format_body(body: str, max_chars: int = 120) -> str:
+    """本文を 1 行に正規化 + 長すぎる場合は ``…`` で truncate。
+
+    LLM 用の token-economical な形式。 改行は半角空白に潰す。
+    """
+    one_line = body.replace("\n", " ").replace("\r", " ").strip()
+    if len(one_line) <= max_chars:
+        return one_line
+    return one_line[: max_chars - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# read_my_recent_tweets
+# ---------------------------------------------------------------------------
+
+
+def read_my_recent_tweets(user: AbstractBaseUser, limit: int = 10) -> str:
+    """自分が最近投稿した tweet を取得する (original のみ、 repost / quote / reply 除く)。
+
+    Args:
+        user: agent を起動した user (注: tool input には現れず、 closure で注入)。
+        limit: 取得件数。 1-20 の範囲に clamp。
+
+    Returns:
+        ``"# 最近の自分の tweet (n 件)\n@handle: body\n..."`` 形式の plain text。
+        該当 0 件なら ``"# 最近の自分の tweet (0 件)\n(無し)"``。
+    """
+    n = _clamp(limit, 1, _MAX_RECENT_TWEETS)
+    qs = (
+        Tweet.objects.filter(
+            author=user,
+            type=TweetType.ORIGINAL,
+            is_deleted=False,
+        )
+        .order_by("-created_at")
+        .select_related("author")[:n]
+    )
+    rows = list(qs)
+    if not rows:
+        return "# 最近の自分の tweet (0 件)\n(無し)"
+    lines = [f"# 最近の自分の tweet ({len(rows)} 件)"]
+    for t in rows:
+        lines.append(f"- @{t.author.username}: {_format_body(t.body)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# read_my_notifications
+# ---------------------------------------------------------------------------
+
+
+def read_my_notifications(user: AbstractBaseUser, limit: int = 20) -> str:
+    """自分宛の最近の notification (mention / like / repost / reply / follow 等) を取得。
+
+    DM の本文は読まない (Privacy)。 dm_message / dm_invite kind は kind だけ
+    含めて本文は省く (LLM に「DM が来ました」 までは伝える)。
+
+    Args:
+        user: agent を起動した user。
+        limit: 取得件数。 1-30 の範囲に clamp。
+
+    Returns:
+        ``"# 最近の通知 (n 件)\n[kind] from @actor : target_type=...\n..."`` 形式。
+    """
+    n = _clamp(limit, 1, _MAX_NOTIFICATIONS)
+    qs = (
+        Notification.objects.filter(recipient=user)
+        .order_by("-created_at")
+        .select_related("actor")[:n]
+    )
+    rows = list(qs)
+    if not rows:
+        return "# 最近の通知 (0 件)\n(無し)"
+    lines = [f"# 最近の通知 ({len(rows)} 件)"]
+    for n_ in rows:
+        actor = f"@{n_.actor.username}" if n_.actor_id else "(system)"
+        kind_label = n_.kind
+        # DM の本文には触れない (Privacy)。 kind と発信者だけ。
+        if n_.kind in (NotificationKind.DM_MESSAGE, NotificationKind.DM_INVITE):
+            target = "(本文は非表示)"
+        else:
+            target = (f"target={n_.target_type}/{n_.target_id}" if n_.target_type else "").strip()
+        read_mark = "" if n_.read else " [未読]"
+        lines.append(f"- [{kind_label}] from {actor}{read_mark} {target}".rstrip())
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# read_home_timeline
+# ---------------------------------------------------------------------------
+
+
+def read_home_timeline(user: AbstractBaseUser, limit: int = 20) -> str:
+    """自分の home TL (follow している人の tweet + 全体トレンド) を取得。
+
+    既存の `apps.timeline.services.build_home_tl` を流用するので、 block /
+    mute は自動 filter される。 reply / repost は除外される (timeline 仕様)。
+
+    Args:
+        user: agent を起動した user。
+        limit: 取得件数。 1-30 の範囲に clamp。
+
+    Returns:
+        ``"# home TL (n 件)\n@handle: body\n..."`` 形式。
+    """
+    n = _clamp(limit, 1, _MAX_HOME_TIMELINE)
+    tweets = build_home_tl(user, limit=n)
+    rows = tweets[:n]
+    if not rows:
+        return "# home TL (0 件)\n(無し)"
+    lines = [f"# home TL ({len(rows)} 件)"]
+    for t in rows:
+        lines.append(f"- @{t.author.username}: {_format_body(t.body)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# search_tweets_by_tag
+# ---------------------------------------------------------------------------
+
+
+def search_tweets_by_tag(
+    user: AbstractBaseUser,
+    tag: str,
+    limit: int = 10,
+) -> str:
+    """特定 tag の最近の tweet を取得 (block / mute は filter)。
+
+    Args:
+        user: agent を起動した user (block/mute 判定用)。
+        tag: タグ名 (先頭 ``#`` は除去、 lowercase 正規化)。
+        limit: 取得件数。 1-20 の範囲に clamp。
+
+    Returns:
+        ``"# tag '<name>' の最近の tweet (n 件)\n@handle: body\n..."`` 形式。
+        tag が存在しない場合は ``"# tag '<name>' は存在しません"``。
+    """
+    n = _clamp(limit, 1, _MAX_TAG_SEARCH)
+    tag_name = tag.lstrip("#").lower().strip()
+    if not tag_name:
+        return "# tag が空です"
+
+    if not Tag.objects.filter(name=tag_name).exists():
+        return f"# tag '{tag_name}' は存在しません"
+
+    qs = (
+        Tweet.objects.filter(
+            tags__name=tag_name,
+            is_deleted=False,
+            type=TweetType.ORIGINAL,
+        )
+        .order_by("-created_at")
+        .select_related("author")
+        .distinct()[: n * 3]  # block filter 後に件数が減る前提で余分に取得
+    )
+    rows: list[Tweet] = []
+    for t in qs:
+        if is_blocked_relationship(user, t.author):
+            continue
+        rows.append(t)
+        if len(rows) >= n:
+            break
+
+    if not rows:
+        return f"# tag '{tag_name}' の最近の tweet (0 件)\n(無し)"
+
+    lines = [f"# tag '{tag_name}' の最近の tweet ({len(rows)} 件)"]
+    for t in rows:
+        lines.append(f"- @{t.author.username}: {_format_body(t.body)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# compose_tweet_draft (marker tool — loop 終了の合図)
+# ---------------------------------------------------------------------------
+
+
+class DraftTooLongError(ValueError):
+    """compose_tweet_draft に 140 字超のテキストが渡された。"""
+
+
+def compose_tweet_draft(user: AbstractBaseUser, text: str) -> str:
+    """tweet 下書きを最終出力として確定する。 AgentRunner は本 tool 呼び出しで loop を break。
+
+    本関数自体は input を validate して返すだけの marker。 実際の DB 保存は
+    AgentRunner が `AgentRun.draft_text` に行う。
+
+    Args:
+        user: agent を起動した user (本 tool では未使用、 signature 統一のため)。
+        text: 投稿候補 (140 文字以内)。
+
+    Returns:
+        渡されたテキストをそのまま返す。
+
+    Raises:
+        DraftTooLongError: 140 字超。
+    """
+    del user  # 未使用だが signature を他 tool と揃える
+    stripped = text.strip()
+    if len(stripped) > TWEET_DRAFT_MAX_CHARS:
+        raise DraftTooLongError(
+            f"draft text is {len(stripped)} chars (max {TWEET_DRAFT_MAX_CHARS})"
+        )
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Tool registry (P14-03 AgentRunner が使う)
+# ---------------------------------------------------------------------------
+
+
+# Anthropic SDK は tool list を deterministic に渡すと prompt cache が効く。
+# dict 順序は Python 3.7+ で保証されているが、 cache 用に明示的に key の順序を
+# 固定しておく (Anthropic spec §10 caching: cache_control を効かせるための
+# tools 一覧 deterministic 化)。
+TOOL_REGISTRY: tuple[str, ...] = (
+    "read_home_timeline",
+    "read_my_notifications",
+    "read_my_recent_tweets",
+    "search_tweets_by_tag",
+    "compose_tweet_draft",
+)
+
+
+def get_callable(name: str):
+    """tool name から callable を取得。 unknown name は KeyError。"""
+    mapping = {
+        "read_home_timeline": read_home_timeline,
+        "read_my_notifications": read_my_notifications,
+        "read_my_recent_tweets": read_my_recent_tweets,
+        "search_tweets_by_tag": search_tweets_by_tag,
+        "compose_tweet_draft": compose_tweet_draft,
+    }
+    return mapping[name]


### PR DESCRIPTION
## Summary

Phase 14 Claude Agent の **core** 部分: Claude が呼ぶ 5 つの custom tool を user-scope に閉じた plain Python function として実装。

| Tool | 内容 |
|---|---|
| \`read_my_recent_tweets(user, limit)\` | 自分の ORIGINAL tweet のみ (repost/quote/reply 除く) |
| \`read_my_notifications(user, limit)\` | 自分宛、 DM 本文は \`(本文は非表示)\` で redacted |
| \`read_home_timeline(user, limit)\` | \`build_home_tl\` 流用で block/mute filter 自動 |
| \`search_tweets_by_tag(user, tag, limit)\` | tag 検索 + block filter、 \`#\` prefix 自動除去 |
| \`compose_tweet_draft(user, text)\` | marker tool、 140 字制限、 P14-03 で loop break のトリガに |

### 設計上の判断 (spec から軽い deviation)

- **anthropic SDK の \`@beta_tool\` 適用は P14-03 (AgentRunner) で wrap**、 本 PR は plain Python function に留める。 テスタビリティ + 依存の段階分離が目的。 spec §4.2 では \`@beta_tool\` 直書きだったが、 user closure 内に decorator を入れると test fixture が anthropic SDK 依存になる。 P14-03 で manual tool definition (JSON schema + callable dispatcher) として wrap する。
- **limit は LLM が境界超えても \`_clamp\`** で安全網 (token を無駄遣いさせない)
- **出力は token-economical な短文 plain text** (改行→空白化、 120 字で \`…\` truncate)
- **TOOL_REGISTRY を deterministic tuple** で固定 (Anthropic prompt cache invalidation 防止)
- **DM 本文は \`(本文は非表示)\` で redact** (Privacy、 target_id も含めない)

### Tests (17 cases)

- own / other isolation × 2 tools (recent_tweets, notifications)
- block filter (search_tweets_by_tag, home_timeline は build_home_tl 経由で自動)
- DM 本文 redaction
- limit clamp (LLM が 999 渡しても 20 で stop)
- compose 140 字 boundary + raise on overflow
- tag \`#\` prefix 自動除去 + unknown tag placeholder
- TOOL_REGISTRY determinism + get_callable

Closes: #718

## Test plan

- [ ] CI Backend Django (pytest) 緑 — 17 cases pass
- [ ] CI pre-commit 緑