### PR TITLE
feat(agents): agent API endpoints (POST /agent/run + GET /agent/runs/, P14-04)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 584
+        "line_number": 588
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T06:42:06Z"
+  "generated_at": "2026-05-14T07:28:51Z"
 }

--- a/apps/agents/serializers.py
+++ b/apps/agents/serializers.py
@@ -1,0 +1,49 @@
+"""Phase 14 P14-04: Agent API serializers."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from apps.agents.models import AgentRun
+
+
+class AgentRunRequestSerializer(serializers.Serializer):
+    """POST /api/v1/agent/run の入力 (prompt のみ)。
+
+    Note: 2000 字制限を validate (spec §6.1)。
+    """
+
+    prompt = serializers.CharField(
+        min_length=1,
+        max_length=2000,
+        trim_whitespace=True,
+        allow_blank=False,
+    )
+
+
+class AgentRunSummarySerializer(serializers.ModelSerializer):
+    """GET /api/v1/agent/runs/ 履歴一覧の各行に使う serializer。
+
+    cost_usd は float に変換 (frontend 表示用)。 prompt / draft_text は
+    snippet として返さない (全文 retrieve は将来 GET /agent/runs/<id>/ で)。
+    """
+
+    run_id = serializers.UUIDField(source="id", read_only=True)
+    cost_usd = serializers.FloatField()
+
+    class Meta:
+        model = AgentRun
+        fields = [
+            "run_id",
+            "prompt",
+            "draft_text",
+            "tools_called",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+            "cost_usd",
+            "error",
+            "created_at",
+        ]
+        read_only_fields = fields

--- a/apps/agents/tests/test_agent_run_view.py
+++ b/apps/agents/tests/test_agent_run_view.py
@@ -1,0 +1,275 @@
+"""
+P14-04: POST /api/v1/agent/run + GET /api/v1/agent/runs/ のテスト。
+
+spec: docs/specs/claude-agent-spec.md §6 §8.1
+
+カバレッジ:
+1. 401 未認証
+2. 400 prompt 空 / 2000 字超
+3. 200 happy path (AgentRunner mock)
+4. 503 ANTHROPIC_API_KEY 未設定
+5. 422 DraftTooLongError
+6. 422 AgentMaxIterationsError
+7. 500 一般 anthropic 例外
+8. 429 rate limit (agent_run scope 2/day で patch)
+9. GET /agent/runs/ 自分の履歴のみ + 新しい順
+10. GET /agent/runs/ 他人の AgentRun は見えない
+11. GET /agent/runs/ 401 未認証
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.agents.models import AgentRun
+from apps.agents.runner import AgentMaxIterationsError
+from apps.agents.tools import DraftTooLongError
+
+User = get_user_model()
+
+
+def _make_user(email: str, username: str) -> User:
+    return User.objects.create_user(
+        email=email,
+        username=username,
+        first_name="F",
+        last_name="L",
+        password="StrongPass!1",  # pragma: allowlist secret
+    )
+
+
+def _make_run_mock(user, prompt: str, draft_text: str = "今日は良い天気") -> AgentRun:
+    """AgentRunner.run() の戻り値 stub: AgentRun を実際に DB に作る。"""
+    return AgentRun.objects.create(
+        user=user,
+        prompt=prompt,
+        draft_text=draft_text,
+        tools_called=["compose_tweet_draft"],
+        input_tokens=200,
+        output_tokens=80,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cost_usd=Decimal("0.000600"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /agent/run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAgentRunViewAuth:
+    def test_401_unauthenticated(self):
+        client = APIClient()
+        resp = client.post(reverse("agent-run"), {"prompt": "test"}, format="json")
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+class TestAgentRunViewValidation:
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_400_empty_prompt(self):
+        user = _make_user("av-empty@example.com", "av_empty")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        resp = client.post(reverse("agent-run"), {"prompt": ""}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_400_prompt_too_long(self):
+        user = _make_user("av-long@example.com", "av_long")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        # 2001 chars
+        resp = client.post(
+            reverse("agent-run"),
+            {"prompt": "あ" * 2001},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+class TestAgentRunViewHappyPath:
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_200_returns_draft(self):
+        user = _make_user("av-200@example.com", "av_200")
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        # AgentRunner.run() を stub。 AgentRunner 自体は init 通過させる。
+        with patch("apps.agents.views.AgentRunner") as MockRunner:
+            instance = MagicMock()
+            MockRunner.return_value = instance
+            instance.run.return_value = _make_run_mock(user, "TL を要約")
+
+            resp = client.post(
+                reverse("agent-run"),
+                {"prompt": "TL を要約"},
+                format="json",
+            )
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["draft_text"] == "今日は良い天気"
+        assert resp.data["tools_called"] == ["compose_tweet_draft"]
+        assert "run_id" in resp.data
+        assert "cost_usd" in resp.data
+
+
+@pytest.mark.django_db
+class TestAgentRunViewErrors:
+    @override_settings(ANTHROPIC_API_KEY="")
+    def test_503_when_anthropic_disabled(self):
+        user = _make_user("av-disabled@example.com", "av_disabled")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        # AgentRunner() 自体が AgentDisabledError を raise する
+        resp = client.post(
+            reverse("agent-run"),
+            {"prompt": "test"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "not configured" in resp.data["detail"].lower()
+
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_422_when_draft_too_long(self):
+        user = _make_user("av-too-long@example.com", "av_too_long")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        with patch("apps.agents.views.AgentRunner") as MockRunner:
+            instance = MagicMock()
+            MockRunner.return_value = instance
+            instance.run.side_effect = DraftTooLongError("141 chars")
+
+            resp = client.post(
+                reverse("agent-run"),
+                {"prompt": "test"},
+                format="json",
+            )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "140" in resp.data["detail"]
+
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_422_when_max_iterations_exceeded(self):
+        user = _make_user("av-max@example.com", "av_max")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        with patch("apps.agents.views.AgentRunner") as MockRunner:
+            instance = MagicMock()
+            MockRunner.return_value = instance
+            instance.run.side_effect = AgentMaxIterationsError("loop > 5")
+
+            resp = client.post(
+                reverse("agent-run"),
+                {"prompt": "test"},
+                format="json",
+            )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "tool iteration" in resp.data["detail"].lower()
+
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_500_on_unexpected_runtime_error(self):
+        user = _make_user("av-500@example.com", "av_500")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        with patch("apps.agents.views.AgentRunner") as MockRunner:
+            instance = MagicMock()
+            MockRunner.return_value = instance
+            instance.run.side_effect = RuntimeError("anthropic 503 down")
+
+            resp = client.post(
+                reverse("agent-run"),
+                {"prompt": "test"},
+                format="json",
+            )
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        # generic message (内部詳細を user に漏らさない)
+        assert "Agent failed" in resp.data["detail"]
+
+
+@pytest.mark.django_db
+class TestAgentRunViewThrottle:
+    """ScopedRateThrottle.THROTTLE_RATES はクラス属性として import 時に
+    凍結されるので、 settings override では効かない (test_crud_api / translate_endpoint
+    の同種テスト参照)。 monkeypatch で class attr を上書きする。"""
+
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_429_after_exceeding_agent_run_scope(self, monkeypatch):
+        from django.core.cache import cache
+        from rest_framework.throttling import ScopedRateThrottle
+
+        monkeypatch.setattr(
+            ScopedRateThrottle,
+            "THROTTLE_RATES",
+            {**ScopedRateThrottle.THROTTLE_RATES, "agent_run": "2/day"},
+        )
+        cache.clear()
+
+        user = _make_user("av-rl@example.com", "av_rl")
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        with patch("apps.agents.views.AgentRunner") as MockRunner:
+            instance = MagicMock()
+            MockRunner.return_value = instance
+            instance.run.return_value = _make_run_mock(user, "first")
+
+            for i in range(2):
+                r = client.post(
+                    reverse("agent-run"),
+                    {"prompt": f"prompt {i}"},
+                    format="json",
+                )
+                assert (
+                    r.status_code == status.HTTP_200_OK
+                ), f"call {i + 1} should pass (got {r.status_code})"
+
+            r = client.post(
+                reverse("agent-run"),
+                {"prompt": "over the limit"},
+                format="json",
+            )
+            assert r.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/runs/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAgentRunListView:
+    def test_401_unauthenticated(self):
+        client = APIClient()
+        resp = client.get(reverse("agent-runs"))
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_own_runs_newest_first(self):
+        user = _make_user("av-list@example.com", "av_list")
+        other = _make_user("av-other@example.com", "av_other")
+        r1 = AgentRun.objects.create(user=user, prompt="第 1", draft_text="d1")
+        r2 = AgentRun.objects.create(user=user, prompt="第 2", draft_text="d2")
+        # 他人の run は見えない
+        AgentRun.objects.create(user=other, prompt="他人", draft_text="x")
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        resp = client.get(reverse("agent-runs"))
+        assert resp.status_code == status.HTTP_200_OK
+        results = resp.data.get("results", resp.data)
+        run_ids = [str(row["run_id"]) for row in results]
+        # 新しい順
+        assert run_ids == [str(r2.id), str(r1.id)]
+        # 他人の run prompt が含まれない
+        prompts = [row["prompt"] for row in results]
+        assert "他人" not in prompts

--- a/apps/agents/urls.py
+++ b/apps/agents/urls.py
@@ -1,0 +1,19 @@
+"""P14-04: Agent app URLs。
+
+config/urls.py の ``path('api/v1/agent/', include('apps.agents.urls'))`` から
+マウントされる。
+
+- POST /api/v1/agent/run
+- GET  /api/v1/agent/runs/
+"""
+
+from __future__ import annotations
+
+from django.urls import path
+
+from apps.agents.views import AgentRunListView, AgentRunView
+
+urlpatterns = [
+    path("run", AgentRunView.as_view(), name="agent-run"),
+    path("runs/", AgentRunListView.as_view(), name="agent-runs"),
+]

--- a/apps/agents/views.py
+++ b/apps/agents/views.py
@@ -1,0 +1,103 @@
+"""Phase 14 P14-04: Agent API views.
+
+spec: docs/specs/claude-agent-spec.md §6
+
+- POST /api/v1/agent/run     — agent を起動し、 draft_text を返す
+- GET  /api/v1/agent/runs/   — 自分の AgentRun 履歴を新しい順に paginate
+
+throttle scope ``agent_run`` は per-user 10/day (stg 100/day) で
+``config/settings/base.py`` の DEFAULT_THROTTLE_RATES に登録される。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rest_framework import generics, status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.views import APIView
+
+from apps.agents.models import AgentRun
+from apps.agents.runner import (
+    AgentDisabledError,
+    AgentMaxIterationsError,
+    AgentRunner,
+)
+from apps.agents.serializers import (
+    AgentRunRequestSerializer,
+    AgentRunSummarySerializer,
+)
+from apps.agents.tools import DraftTooLongError
+from apps.common.cookie_auth import CookieAuthentication
+
+logger = logging.getLogger(__name__)
+
+
+class AgentRunView(APIView):
+    """POST /api/v1/agent/run
+
+    Cookie JWT + IsAuthenticated。 throttle scope ``agent_run`` で per-user
+    日次制限 (10/day)。
+    """
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [CookieAuthentication]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "agent_run"
+
+    def post(self, request: Request) -> Response:
+        serializer = AgentRunRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        prompt: str = serializer.validated_data["prompt"]
+
+        try:
+            runner = AgentRunner()
+        except AgentDisabledError as e:
+            # spec §6.1: ANTHROPIC_API_KEY 未設定 → 503
+            logger.warning("agent.disabled %s", e)
+            return Response(
+                {"detail": "Claude Agent is not configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        try:
+            run = runner.run(request.user, prompt)
+        except DraftTooLongError:
+            # spec §6.1: compose で 140 字超 → 422 (user の指示が悪かった、
+            # generic 500 ではない)
+            return Response(
+                {"detail": "Generated draft exceeded 140 characters."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+        except AgentMaxIterationsError:
+            # spec §6.1: tool loop 上限超 → 422 (LLM が compose に到達できない)
+            return Response(
+                {"detail": "Agent exceeded the tool iteration limit."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+        except Exception:
+            logger.exception("agent.run failed for user=%s", request.user.pk)
+            return Response(
+                {"detail": "Agent failed; please try again later."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        out = AgentRunSummarySerializer(run).data
+        return Response(out, status=status.HTTP_200_OK)
+
+
+class AgentRunListView(generics.ListAPIView):
+    """GET /api/v1/agent/runs/
+
+    Cookie JWT + IsAuthenticated。 自分の AgentRun のみ新しい順、 PageNumberPagination。
+    """
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [CookieAuthentication]
+    serializer_class = AgentRunSummarySerializer
+
+    def get_queryset(self):
+        return AgentRun.objects.filter(user=self.request.user).order_by("-created_at")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -494,6 +494,10 @@ _THROTTLE_RATES_BASE = {
     # TL を眺めながら数件押す通常 UX に十分な余裕、 cache hit は OpenAI を叩かないので
     # 同一ツイートを繰り返し押しても枠は消費しない (cache miss だけがコスト要因)。
     "translate": "60/hour" if not _IS_STG else "600/hour",
+    # Phase 14 P14-04 (claude-agent-spec §6):
+    # POST /api/v1/agent/run は Anthropic 課金が発生するので per-user 10/day。
+    # stg は 100/day に緩和して E2E 動作確認しやすくする。
+    "agent_run": "10/day" if not _IS_STG else "100/day",
 }
 
 REST_FRAMEWORK = {

--- a/config/urls.py
+++ b/config/urls.py
@@ -91,6 +91,9 @@ urlpatterns = [
     # /mentors/me/ + /mentors/me/plans/[<id>/] を提供。 /mentors/<handle>/ (公開
     # profile) は P11-13 検索 API で追加。
     path("api/v1/mentors/", include("apps.mentorship.urls_mentors")),
+    # Phase 14 P14-04: Claude Agent (Read+Compose MVP)。 POST /agent/run と
+    # GET /agent/runs/ を提供する。
+    path("api/v1/agent/", include("apps.agents.urls")),
 ]
 
 # Sentry smoke test endpoint (P0-06). DEBUG=True の環境だけ URL 登録すること自体を


### PR DESCRIPTION
## Summary

Phase 14 Claude Agent の **API 層**。 これで backend は完成 (model + tools + runner + view)。 残るは frontend (P14-05/06) と infra (P14-07)。

### Endpoints

| Endpoint | 内容 |
|---|---|
| \`POST /api/v1/agent/run\` | prompt を投げて draft_text を返す。 Cookie auth + ScopedRateThrottle(\`agent_run\` 10/day) |
| \`GET /api/v1/agent/runs/\` | 自分の AgentRun 履歴を新しい順 paginate |

### Status code matrix

| code | trigger |
|---|---|
| 200 | run 成功 |
| 400 | prompt 空 / 2001 字超 |
| 401 | 未認証 |
| 422 | DraftTooLongError / AgentMaxIterationsError |
| 429 | rate limit (agent_run 10/day) |
| 500 | 内部例外 (anthropic 系含む、 generic message を user に返す) |
| 503 | \`ANTHROPIC_API_KEY\` 未設定 |

### 設定変更

- \`config/urls.py\`: \`path('api/v1/agent/', include('apps.agents.urls'))\`
- \`config/settings/base.py\`: throttle scope \`agent_run\` を \`10/day\` (stg \`100/day\`) で追加

### Tests (11 cases)

- POST 401 unauthenticated
- POST 400 empty / too long prompt
- POST 200 happy path (AgentRunner stub)
- POST 503 API key missing
- POST 422 DraftTooLong / MaxIter
- POST 500 generic anthropic error
- POST 429 rate limit (monkeypatch ScopedRateThrottle.THROTTLE_RATES で 2/day に)
- GET 401 unauthenticated
- GET own runs only + newest first

Closes: #720

## Test plan

- [ ] CI Backend Django (pytest) 緑 — 11 cases pass
- [ ] CI pre-commit 緑