### PR TITLE
feat(agent): /agent route + AgentPanel + leftNavLinks (P14-05)

### DIFF
--- a/client/src/app/(template)/agent/page.tsx
+++ b/client/src/app/(template)/agent/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import AgentPanel from "@/components/agent/AgentPanel";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { AgentRunListPage, AgentRunResult } from "@/lib/api/agent";
+import type { CurrentUser } from "@/lib/api/users";
+
+export const metadata: Metadata = {
+	title: "Agent",
+	robots: { index: false },
+};
+
+async function loadCurrentUser(): Promise<CurrentUser | null> {
+	try {
+		return await serverFetch<CurrentUser>("/users/me/");
+	} catch (error) {
+		if (error instanceof ApiServerError && error.status === 401) return null;
+		throw error;
+	}
+}
+
+async function loadAgentHistory(): Promise<AgentRunResult[]> {
+	try {
+		const page = await serverFetch<AgentRunListPage>("/agent/runs/");
+		return page.results.slice(0, 10);
+	} catch {
+		// 履歴は補助情報なので fail しても UX を止めない
+		return [];
+	}
+}
+
+export default async function AgentPage() {
+	const currentUser = await loadCurrentUser();
+	if (!currentUser) redirect("/login");
+
+	const history = await loadAgentHistory();
+
+	return (
+		<>
+			<header
+				className="flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						Agent (β)
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						自然言語で指示 → tweet 下書き
+					</p>
+				</div>
+			</header>
+			<div className="p-5">
+				<AgentPanel initialHistory={history} />
+			</div>
+		</>
+	);
+}

--- a/client/src/components/agent/AgentPanel.tsx
+++ b/client/src/components/agent/AgentPanel.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * Phase 14 P14-05: Agent panel — natural language → tweet draft。
+ *
+ * spec: docs/specs/claude-agent-spec.md §7.1
+ *
+ * UX flow:
+ * 1. user が prompt を textarea に入力 → 「Agent 起動」 button
+ * 2. loading 中 button disabled + Spinner
+ * 3. 結果 panel に tools_called + draft_text (editable Textarea)
+ * 4. 「これを投稿」 button → POST /tweets/ → success → toast + textarea reset
+ * 5. 「リセット」 button で next prompt に進む
+ *
+ * 完了シグナル (CLAUDE.md §4.5):
+ * - loading 中: Spinner + button disabled + role=status の aria-live region
+ * - 成功: result panel が出現 + tools 履歴表示 + draft が edit 可能に
+ * - 投稿後: toast「投稿しました」 + textarea クリア + 結果 panel reset
+ *
+ * Error 分岐 (HTTP code → user message):
+ *   400: prompt が短すぎ / 長すぎ
+ *   401: ログインしてください
+ *   422: draft が長すぎ / agent が compose まで届かなかった
+ *   429: 1 日 10 回上限、 明日また
+ *   500: 内部エラー、 再試行
+ *   503: Agent 機能が未設定 (= ハルナさんが ANTHROPIC_API_KEY を入れていない)
+ */
+
+import { useState } from "react";
+
+import { useRouter } from "next/navigation";
+import { AxiosError } from "axios";
+import { Loader2, Send, Sparkles, Wand2 } from "lucide-react";
+import { toast } from "react-toastify";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { fetchAgentRuns, runAgent, type AgentRunResult } from "@/lib/api/agent";
+import { createTweet } from "@/lib/api/tweets";
+
+const PROMPT_MAX = 2000;
+const DRAFT_MAX = 140;
+
+interface AgentPanelProps {
+	/** 履歴 panel の初期データ (SSR で fetchAgentRuns() 済の場合)。 省略時は client が fetch。 */
+	initialHistory?: AgentRunResult[];
+}
+
+function statusToMessage(status: number | undefined): string {
+	switch (status) {
+		case 400:
+			return "入力が空か長すぎます。 2000 字以内で入れてください。";
+		case 401:
+			return "ログインが必要です。";
+		case 422:
+			return "Agent が下書きを生成できませんでした (140 字超え / tool 上限)。";
+		case 429:
+			return "本日の Agent 起動上限 (10 回) に達しました。 明日また試してください。";
+		case 500:
+			return "Agent が一時的に応答できません。 少し時間を置いて再試行してください。";
+		case 503:
+			return "Agent 機能は現在無効です。 管理者にお問い合わせください。";
+		default:
+			return "通信に失敗しました。 通信状態を確認してください。";
+	}
+}
+
+export default function AgentPanel({ initialHistory = [] }: AgentPanelProps) {
+	const router = useRouter();
+	const [prompt, setPrompt] = useState("");
+	const [isRunning, setIsRunning] = useState(false);
+	const [isPosting, setIsPosting] = useState(false);
+	const [result, setResult] = useState<AgentRunResult | null>(null);
+	const [draftEdit, setDraftEdit] = useState("");
+	const [history, setHistory] = useState<AgentRunResult[]>(initialHistory);
+
+	const onSubmit = async () => {
+		const trimmed = prompt.trim();
+		if (!trimmed) return;
+		setIsRunning(true);
+		try {
+			const r = await runAgent({ prompt: trimmed });
+			setResult(r);
+			setDraftEdit(r.draft_text);
+			// 履歴をクライアント側で先頭に prepend (refetch しない)
+			setHistory((prev) => [r, ...prev].slice(0, 10));
+		} catch (e) {
+			const status = e instanceof AxiosError ? e.response?.status : undefined;
+			toast.error(statusToMessage(status));
+		} finally {
+			setIsRunning(false);
+		}
+	};
+
+	const onPostDraft = async () => {
+		const body = draftEdit.trim();
+		if (!body) {
+			toast.error("下書きが空です。");
+			return;
+		}
+		if (body.length > DRAFT_MAX) {
+			toast.error("下書きが 140 字を超えています。 編集してください。");
+			return;
+		}
+		setIsPosting(true);
+		try {
+			await createTweet({ body });
+			toast.success("ツイートを投稿しました。");
+			setResult(null);
+			setDraftEdit("");
+			setPrompt("");
+			router.refresh();
+		} catch (e) {
+			const status = e instanceof AxiosError ? e.response?.status : undefined;
+			toast.error(
+				status === 401
+					? "ログインが必要です。"
+					: "投稿に失敗しました。 再試行してください。",
+			);
+		} finally {
+			setIsPosting(false);
+		}
+	};
+
+	const onReset = () => {
+		setResult(null);
+		setDraftEdit("");
+		setPrompt("");
+	};
+
+	// 履歴を server から fresh fetch する (初回 / 投稿後 refresh 用)。
+	const onRefreshHistory = async () => {
+		try {
+			const page = await fetchAgentRuns();
+			setHistory(page.results.slice(0, 10));
+		} catch {
+			// silent (history は補助情報なので fail しても UX を止めない)
+		}
+	};
+
+	void onRefreshHistory; // 起動時 fetch は SSR か useEffect で行う想定。 ここでは未使用。
+
+	const draftLen = draftEdit.length;
+	const draftOver = draftLen > DRAFT_MAX;
+
+	return (
+		<div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 pb-12">
+			{/* role=status: AT に「現在何をしているか」 を伝える */}
+			<div role="status" aria-live="polite" className="sr-only">
+				{isRunning
+					? "Agent を実行中です"
+					: isPosting
+						? "ツイートを投稿中です"
+						: ""}
+			</div>
+
+			<section className="grid gap-3">
+				<label htmlFor="agent-prompt" className="text-sm font-medium">
+					やりたいことを自然言語で
+				</label>
+				<Textarea
+					id="agent-prompt"
+					rows={4}
+					maxLength={PROMPT_MAX}
+					value={prompt}
+					onChange={(e) => setPrompt(e.target.value)}
+					placeholder="例: 今日 TL で話題になったテックを 1 tweet にまとめて"
+					aria-describedby="agent-prompt-help"
+					disabled={isRunning}
+				/>
+				<p
+					id="agent-prompt-help"
+					className="text-[color:var(--a-text-subtle)]"
+					style={{ fontSize: 12 }}
+				>
+					Agent は TL / 通知 / 自分の投稿を読んで下書きを作ります。
+					投稿は別途「これを投稿」 button で確定します (Anthropic Claude 利用、
+					1 日 10 回まで)。
+				</p>
+				<div className="flex items-center justify-end gap-2">
+					<Button
+						type="button"
+						onClick={onSubmit}
+						disabled={isRunning || !prompt.trim()}
+						className="inline-flex items-center gap-1.5"
+					>
+						{isRunning ? (
+							<Loader2 className="size-4 animate-spin" aria-hidden="true" />
+						) : (
+							<Sparkles className="size-4" aria-hidden="true" />
+						)}
+						{isRunning ? "実行中…" : "Agent 起動"}
+					</Button>
+				</div>
+			</section>
+
+			{result ? (
+				<section
+					aria-label="Agent 結果"
+					className="flex flex-col gap-3 rounded-md border border-border p-4"
+				>
+					<div className="flex items-center gap-2">
+						<Wand2
+							className="size-4 text-[color:var(--a-accent)]"
+							aria-hidden="true"
+						/>
+						<h2 className="text-sm font-semibold">下書き</h2>
+					</div>
+
+					{result.tools_called.length > 0 ? (
+						<div
+							className="text-[color:var(--a-text-subtle)]"
+							style={{ fontSize: 11 }}
+						>
+							呼び出されたツール: {result.tools_called.join(" → ")}
+						</div>
+					) : null}
+
+					<Textarea
+						id="agent-draft"
+						rows={4}
+						value={draftEdit}
+						onChange={(e) => setDraftEdit(e.target.value)}
+						aria-describedby="agent-draft-counter"
+						aria-invalid={draftOver ? "true" : "false"}
+					/>
+					<p
+						id="agent-draft-counter"
+						className={
+							draftOver
+								? "text-sm text-destructive"
+								: "text-[color:var(--a-text-subtle)] text-xs"
+						}
+					>
+						{draftLen} / {DRAFT_MAX}
+					</p>
+
+					<div className="flex items-center justify-end gap-2">
+						<Button type="button" variant="secondary" onClick={onReset}>
+							リセット
+						</Button>
+						<Button
+							type="button"
+							onClick={onPostDraft}
+							disabled={isPosting || draftOver || !draftEdit.trim()}
+							className="inline-flex items-center gap-1.5"
+						>
+							{isPosting ? (
+								<Loader2 className="size-4 animate-spin" aria-hidden="true" />
+							) : (
+								<Send className="size-4" aria-hidden="true" />
+							)}
+							{isPosting ? "投稿中…" : "これを投稿"}
+						</Button>
+					</div>
+				</section>
+			) : null}
+
+			{history.length > 0 ? (
+				<section
+					aria-label="Agent 起動履歴"
+					className="grid gap-2 rounded-md border border-border p-4"
+				>
+					<h2 className="text-sm font-semibold">最近の Agent 履歴</h2>
+					<ul className="grid gap-2">
+						{history.map((r) => (
+							<li
+								key={r.run_id}
+								className="border-l-2 border-[color:var(--a-accent)] pl-3 text-xs"
+							>
+								<div
+									className="text-[color:var(--a-text-subtle)]"
+									style={{ fontSize: 11 }}
+								>
+									{new Date(r.created_at).toLocaleString("ja-JP")}
+								</div>
+								<div className="font-medium">{r.prompt}</div>
+								{r.draft_text ? (
+									<div className="text-[color:var(--a-text-muted)]">
+										→ {r.draft_text}
+									</div>
+								) : r.error ? (
+									<div className="text-destructive">→ エラー: {r.error}</div>
+								) : null}
+							</li>
+						))}
+					</ul>
+				</section>
+			) : null}
+		</div>
+	);
+}

--- a/client/src/components/agent/AgentPanel.tsx
+++ b/client/src/components/agent/AgentPanel.tsx
@@ -35,7 +35,7 @@ import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { fetchAgentRuns, runAgent, type AgentRunResult } from "@/lib/api/agent";
+import { runAgent, type AgentRunResult } from "@/lib/api/agent";
 import { createTweet } from "@/lib/api/tweets";
 
 const PROMPT_MAX = 2000;
@@ -128,17 +128,9 @@ export default function AgentPanel({ initialHistory = [] }: AgentPanelProps) {
 		setPrompt("");
 	};
 
-	// 履歴を server から fresh fetch する (初回 / 投稿後 refresh 用)。
-	const onRefreshHistory = async () => {
-		try {
-			const page = await fetchAgentRuns();
-			setHistory(page.results.slice(0, 10));
-		} catch {
-			// silent (history は補助情報なので fail しても UX を止めない)
-		}
-	};
-
-	void onRefreshHistory; // 起動時 fetch は SSR か useEffect で行う想定。 ここでは未使用。
+	// 履歴 fetch は SSR (app/(template)/agent/page.tsx) で行うので、 client
+	// 側では runAgent 後に prepend するだけ。 client refetch が必要になったら
+	// fetchAgentRuns を import して useEffect で呼ぶ。
 
 	const draftLen = draftEdit.length;
 	const draftOver = draftLen > DRAFT_MAX;
@@ -229,7 +221,7 @@ export default function AgentPanel({ initialHistory = [] }: AgentPanelProps) {
 						className={
 							draftOver
 								? "text-sm text-destructive"
-								: "text-[color:var(--a-text-subtle)] text-xs"
+								: "text-xs text-[color:var(--a-text-subtle)]"
 						}
 					>
 						{draftLen} / {DRAFT_MAX}

--- a/client/src/components/agent/__tests__/AgentPanel.test.tsx
+++ b/client/src/components/agent/__tests__/AgentPanel.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * P14-05: AgentPanel vitest 4+ cases.
+ *
+ * spec: docs/specs/claude-agent-spec.md §7.1 §8.2
+ *
+ * カバレッジ:
+ * 1. submit → runAgent が呼ばれて draft が表示される
+ * 2. 「これを投稿」 で createTweet が呼ばれて textarea reset
+ * 3. 429 → toast error「本日の Agent 起動上限」
+ * 4. 503 → toast error「Agent 機能は現在無効」
+ * 5. draft が 141 字 → 「これを投稿」 button が disabled
+ */
+
+import { AxiosError, AxiosHeaders } from "axios";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AgentPanel from "@/components/agent/AgentPanel";
+
+const {
+	runAgentMock,
+	createTweetMock,
+	pushMock,
+	refreshMock,
+	toastSuccessSpy,
+	toastErrorSpy,
+} = vi.hoisted(() => ({
+	runAgentMock: vi.fn(),
+	createTweetMock: vi.fn(),
+	pushMock: vi.fn(),
+	refreshMock: vi.fn(),
+	toastSuccessSpy: vi.fn(),
+	toastErrorSpy: vi.fn(),
+}));
+
+vi.mock("@/lib/api/agent", () => ({
+	runAgent: runAgentMock,
+	fetchAgentRuns: vi.fn().mockResolvedValue({ results: [] }),
+}));
+
+vi.mock("@/lib/api/tweets", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/tweets")>(
+			"@/lib/api/tweets",
+		);
+	return {
+		...actual,
+		createTweet: createTweetMock,
+	};
+});
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+const sampleRun = {
+	run_id: "run-1",
+	prompt: "TL を要約",
+	draft_text: "今日は良い天気です",
+	tools_called: ["read_home_timeline", "compose_tweet_draft"],
+	input_tokens: 200,
+	output_tokens: 80,
+	cache_read_input_tokens: 0,
+	cache_creation_input_tokens: 0,
+	cost_usd: 0.0006,
+	error: "",
+	created_at: "2026-05-14T00:00:00Z",
+};
+
+describe("AgentPanel (P14-05)", () => {
+	beforeEach(() => {
+		runAgentMock.mockReset();
+		createTweetMock.mockReset();
+		pushMock.mockReset();
+		refreshMock.mockReset();
+		toastSuccessSpy.mockReset();
+		toastErrorSpy.mockReset();
+	});
+
+	it("submits prompt and displays draft on success", async () => {
+		runAgentMock.mockResolvedValueOnce(sampleRun);
+		render(<AgentPanel />);
+
+		const textarea = screen.getByLabelText("やりたいことを自然言語で");
+		await userEvent.type(textarea, "TL を要約");
+		await userEvent.click(screen.getByRole("button", { name: "Agent 起動" }));
+
+		// draft が出る
+		await screen.findByText(/呼び出されたツール/);
+		expect(runAgentMock).toHaveBeenCalledWith({ prompt: "TL を要約" });
+
+		// draft textarea は 2 つ目の textarea (prompt が 1 つ目)
+		const textareas = screen.getAllByRole("textbox");
+		const draftField = textareas[1] as HTMLTextAreaElement;
+		expect(draftField.value).toContain("今日は良い天気");
+	});
+
+	it("posts draft via createTweet and resets textarea", async () => {
+		runAgentMock.mockResolvedValueOnce(sampleRun);
+		createTweetMock.mockResolvedValueOnce({});
+		render(<AgentPanel />);
+
+		await userEvent.type(
+			screen.getByLabelText("やりたいことを自然言語で"),
+			"TL を要約",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Agent 起動" }));
+		await screen.findByText(/呼び出されたツール/);
+
+		await userEvent.click(screen.getByRole("button", { name: "これを投稿" }));
+		await waitFor(() => {
+			expect(createTweetMock).toHaveBeenCalledWith({
+				body: "今日は良い天気です",
+			});
+		});
+		expect(toastSuccessSpy).toHaveBeenCalledWith(
+			expect.stringContaining("投稿しました"),
+		);
+		expect(refreshMock).toHaveBeenCalled();
+	});
+
+	it("shows '本日の上限' error toast on 429", async () => {
+		const err = new AxiosError("rate limit");
+		err.response = {
+			status: 429,
+			statusText: "Too Many Requests",
+			data: {},
+			headers: {},
+			config: { headers: new AxiosHeaders() },
+		};
+		runAgentMock.mockRejectedValueOnce(err);
+		render(<AgentPanel />);
+
+		await userEvent.type(
+			screen.getByLabelText("やりたいことを自然言語で"),
+			"TL を要約",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Agent 起動" }));
+
+		await waitFor(() => {
+			expect(toastErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("本日の Agent 起動上限"),
+			);
+		});
+	});
+
+	it("shows 'Agent 機能は現在無効' error toast on 503", async () => {
+		const err = new AxiosError("disabled");
+		err.response = {
+			status: 503,
+			statusText: "Service Unavailable",
+			data: {},
+			headers: {},
+			config: { headers: new AxiosHeaders() },
+		};
+		runAgentMock.mockRejectedValueOnce(err);
+		render(<AgentPanel />);
+
+		await userEvent.type(
+			screen.getByLabelText("やりたいことを自然言語で"),
+			"test",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Agent 起動" }));
+
+		await waitFor(() => {
+			expect(toastErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("無効"),
+			);
+		});
+	});
+
+	it("disables '投稿' button when draft exceeds 140 chars", async () => {
+		runAgentMock.mockResolvedValueOnce({
+			...sampleRun,
+			draft_text: "あ".repeat(120), // initial < 140
+		});
+		render(<AgentPanel />);
+		await userEvent.type(
+			screen.getByLabelText("やりたいことを自然言語で"),
+			"test",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Agent 起動" }));
+		await screen.findByText(/呼び出されたツール/);
+
+		// draft textarea を 141 字に編集
+		const counter = await screen.findByText(/120 \/ 140/);
+		expect(counter).toBeInTheDocument();
+
+		// find the draft textarea (the second textarea, since prompt is first)
+		const textareas = screen.getAllByRole("textbox");
+		const draft = textareas[1] as HTMLTextAreaElement;
+		// add 30 more chars: 120 + 30 = 150 > 140
+		await userEvent.type(draft, "い".repeat(30));
+
+		await screen.findByText(/150 \/ 140/);
+		expect(
+			screen.getByRole("button", { name: /これを投稿|投稿中/ }),
+		).toBeDisabled();
+	});
+});

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -20,6 +20,7 @@ import {
 	MessagesSquare,
 	Plus,
 	Search,
+	Sparkles,
 	User,
 	UserSearch,
 } from "lucide-react";
@@ -42,6 +43,7 @@ const ICON_MAP: Record<
 	MessagesSquare,
 	FileText,
 	Handshake,
+	Sparkles,
 };
 
 /** isProfile link は self handle を埋めて返す。handle 未取得時は null。 */

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -21,6 +21,7 @@ import {
 	MessageSquare,
 	MessagesSquare,
 	Search,
+	Sparkles,
 	User,
 	UserSearch,
 } from "lucide-react";
@@ -43,6 +44,7 @@ const ICON_MAP: Record<
 	MessagesSquare,
 	FileText,
 	Handshake,
+	Sparkles,
 };
 
 function resolveLinkPath(

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -67,6 +67,14 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "Handshake",
 	},
 	{
+		// Phase 14 (P14-05): Claude Agent。 ログイン必須 (Anthropic 課金で
+		// per-user 10/day 制限。 spec: docs/specs/claude-agent-spec.md)。
+		path: "/agent",
+		label: "Agent",
+		iconName: "Sparkles",
+		requiresAuth: true,
+	},
+	{
 		// path は LeftNavbar 側で `/u/<self.handle>` に動的に組み替える
 		path: "",
 		label: "プロフィール",

--- a/client/src/lib/api/agent.ts
+++ b/client/src/lib/api/agent.ts
@@ -1,0 +1,66 @@
+/**
+ * Phase 14 P14-05: Claude Agent API client helpers.
+ *
+ * spec: docs/specs/claude-agent-spec.md §6
+ *
+ * 2 endpoint しかないので薄く wrap。 422/429/503 のような特殊系は呼び元
+ * (AgentPanel) で `error.response?.status` を見て分岐する。
+ */
+
+import type { AxiosInstance } from "axios";
+import { api, ensureCsrfToken } from "@/lib/api/client";
+
+/** POST /api/v1/agent/run の入力。 */
+export interface AgentRunInput {
+	prompt: string;
+}
+
+/** AgentRun の応答 (GET /agent/runs/ 各 row も同形)。 */
+export interface AgentRunResult {
+	run_id: string;
+	prompt: string;
+	draft_text: string;
+	tools_called: string[];
+	input_tokens: number;
+	output_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	cost_usd: number;
+	error: string;
+	created_at: string;
+}
+
+export interface AgentRunListPage {
+	count: number;
+	next: string | null;
+	previous: string | null;
+	results: AgentRunResult[];
+}
+
+/**
+ * POST /api/v1/agent/run
+ *
+ * Agent を起動して tweet 下書きを取得する。 throttle / API key 未設定 /
+ * draft 長すぎ 等は AxiosError として throw されるので、 呼び元で
+ * `e.response?.status` を見て user に分岐 message を出す。
+ */
+export async function runAgent(
+	input: AgentRunInput,
+	client: AxiosInstance = api,
+): Promise<AgentRunResult> {
+	await ensureCsrfToken(client);
+	const res = await client.post<AgentRunResult>("/agent/run", input);
+	return res.data;
+}
+
+/**
+ * GET /api/v1/agent/runs/
+ *
+ * 自分の AgentRun 履歴を新しい順 paginate で取得。
+ */
+export async function fetchAgentRuns(
+	client: AxiosInstance = api,
+): Promise<AgentRunListPage> {
+	const res = await client.get<AgentRunListPage>("/agent/runs/");
+	return res.data;
+}

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -10,7 +10,8 @@ export type LeftNavIconName =
 	| "Bell"
 	| "MessagesSquare"
 	| "FileText"
-	| "Handshake";
+	| "Handshake"
+	| "Sparkles";
 
 export interface LeftNavLink {
 	/** 静的 path。`isProfile=true` の時は無視され self handle を組み立てる。 */


### PR DESCRIPTION
## Summary

Phase 14 Claude Agent **frontend MVP**。 自然言語 prompt → tweet 下書きの UI。

### 新規

| File | 内容 |
|---|---|
| \`client/src/app/(template)/agent/page.tsx\` | /agent route (auth 必須、 SSR で /users/me/ と /agent/runs/ を fetch) |
| \`client/src/components/agent/AgentPanel.tsx\` | prompt textarea + result panel + 履歴 + post button |
| \`client/src/lib/api/agent.ts\` | runAgent / fetchAgentRuns + 型定義 |
| \`client/src/constants/index.ts\` | leftNavLinks に Agent 行追加 (requiresAuth=true, Sparkles icon) |
| \`client/src/components/shared/navbar/LeftNavbar.tsx\` + \`MobileNavbar.tsx\` | ICON_MAP に Sparkles 登録 |
| \`client/src/types/index.d.ts\` | LeftNavIconName に 'Sparkles' を追加 |
| \`client/src/components/agent/__tests__/AgentPanel.test.tsx\` | vitest 5 cases |

### UX

- loading 中: Loader2 spinner + button disabled + \`role=status\` aria-live
- 成功: result panel に \`tools_called\` 履歴 + draft (editable textarea)
- draft 140 字超: counter が destructive + 投稿 button disabled
- 投稿後: \`toast.success\`「ツイートを投稿しました。」 + textarea reset + \`router.refresh()\`
- error: HTTP status → 日本語 user メッセージ (429「本日の Agent 起動上限」/ 503「Agent 機能は現在無効」/ 422 / 500 / etc.)
- 履歴: 最近 10 件を SSR で fetch、 client で push prepend (refetch しない)

### CLAUDE.md §4.5 完了判定

- ✅ ナビ導線 OK (ホーム → 左サイドバー「Agent」 で 1 click)
- ✅ 未ログインで /agent → /login redirect (SSR で 401 を catch)
- ✅ 完了シグナル: role=status aria-live + 投稿後 toast
- ✅ vitest 5 cases (submit → draft / post → reset / 429 toast / 503 toast / draft 141 字 disabled)
- ⏳ Playwright spec は P14-06 (#722) で別 issue
- ⏳ gan-evaluator は stg 反映後に呼ぶ

Closes: #721

## Test plan

- [x] \`vitest run src/components/agent\` → 5 passed
- [x] \`vitest run src/components/shared/navbar\` regression → 25 passed
- [x] \`tsc --noEmit\` clean
- [ ] CI Frontend Next.js 緑
- [ ] stg deploy 後 Playwright MCP で動作確認 (P14-06 で別 issue)