### PR TITLE
infra(p14-07): inject ANTHROPIC_API_KEY into ECS django_secrets

### DIFF
--- a/terraform/modules/services/main.tf
+++ b/terraform/modules/services/main.tf
@@ -95,6 +95,14 @@ locals {
     # で put 済。 万一空文字が secret に書かれていても apps.translation.services
     # の `get_translator()` が NoopTranslator に fallback するので 500 にはならない。
     { name = "OPENAI_API_KEY", valueFrom = var.secret_arns["openai/api-key"] },
+    # Phase 14 P14-07: Anthropic Claude (Read+Compose Agent MVP)。 値は
+    # ハルナさんが console.anthropic.com で取得 + put-secret-value する運用:
+    # `aws secretsmanager put-secret-value --secret-id sns/stg/anthropic/api-key`
+    # placeholder のままだと apps.agents.runner の AgentRunner.__init__ は
+    # 通るが (key 文字列が空でないため) 実 API call が 401 になる。 view は
+    # 500 generic を返すので user に内部詳細は漏れない。 ANTHROPIC_API_KEY が
+    # 完全に空文字なら AgentDisabledError → 503 で kill switch として動く。
+    { name = "ANTHROPIC_API_KEY", valueFrom = var.secret_arns["anthropic/api-key"] },
   ]
 
   # Next.js (SSR) は public NEXT_PUBLIC_* のみ。Sentry DSN は build-time に build args


### PR DESCRIPTION
## Summary

Phase 14 Claude Agent の最終 piece。 P13-08 (OpenAI) と同型運用。

### Plan summary (terraform plan 済)

\`\`\`
Plan: 5 to add, 1 to change, 5 to destroy

module.services.aws_ecs_task_definition.django: delete,create
module.services.aws_ecs_task_definition.django_migrate: delete,create
module.services.aws_ecs_task_definition.celery_worker: delete,create
module.services.aws_ecs_task_definition.celery_beat: delete,create
module.services.aws_ecs_task_definition.daphne: delete,create
module.edge.aws_cloudfront_distribution.this: update    # 既存 drift
\`\`\`

5 ECS task def に \`ANTHROPIC_API_KEY\` 環境変数 (Secrets Manager 経由) を注入する。 secret \`sns/stg/anthropic/api-key\` は P0-04 secrets module で既に作成済の placeholder。

### ⚠️ Apply 前提

**ハルナさんが先に実 key を put してください**:

\`\`\`bash
# 1. https://console.anthropic.com/ で API key 取得 (sk-ant-...)
# 2. terminal で put-secret-value
aws secretsmanager put-secret-value \\
  --secret-id sns/stg/anthropic/api-key \\
  --secret-string 'sk-ant-...'
\`\`\`

理由: placeholder のまま apply すると AgentRunner init は通るが、 実 API call で 401 になり user に 500 が返ります。 kill switch (503) は **secret が完全に空文字** のときのみ効きます。

### Apply 順序 (key put 後に Claude が実行)

1. \`terraform apply p14-07-anthropic.tfplan\` (ハルナさん明示認可済)
2. \`aws ecs update-service --force-new-deployment\` で 4 service (django / celery-worker / celery-beat / daphne) を新 task def に rollover
3. ECS deploys stable まで待機
4. curl で \`POST /api/v1/agent/run\` smoke test

Closes: #723

## Verify

- [x] terraform plan 完走 (5 add / 1 change / 5 destroy)
- [ ] ハルナさん: \`aws secretsmanager put-secret-value\` 実行済確認
- [ ] CI Terraform 緑
- [ ] terraform apply (Claude)
- [ ] ECS rollover (Claude)
- [ ] stg smoke test (Playwright MCP)