### PR TITLE
fix(agents): 空 draft でも Claude の text 返答を表示 (#732)

### DIFF
--- a/apps/agents/admin.py
+++ b/apps/agents/admin.py
@@ -32,6 +32,7 @@ class AgentRunAdmin(admin.ModelAdmin):
         "cache_creation_input_tokens",
         "cost_usd",
         "error",
+        "agent_message",
         "created_at",
     )
 

--- a/apps/agents/migrations/0002_agentrun_agent_message.py
+++ b/apps/agents/migrations/0002_agentrun_agent_message.py
@@ -1,0 +1,33 @@
+"""#732 follow-up: AgentRun.agent_message を追加。
+
+spec: docs/specs/claude-agent-spec.md §3.1 (P14 follow-up)
+
+Claude が `compose_tweet_draft` を呼ばずに `end_turn` した場合
+(= tool では解けない prompt) 、 Claude の text 返答を保存して frontend で
+「Claude より:」 として表示できるようにする。 draft_text が空のときの
+説明にあたる。
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("agents", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentrun",
+            name="agent_message",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text=(
+                    "compose_tweet_draft を呼ばずに end_turn したとき、"
+                    " Claude が返した text response。 draft_text が空の"
+                    "とき用の説明。"
+                ),
+            ),
+        ),
+    ]

--- a/apps/agents/models.py
+++ b/apps/agents/models.py
@@ -89,6 +89,18 @@ class AgentRun(models.Model):
             "user には generic message を返し、 詳細はここに保存。"
         ),
     )
+    # P14 follow-up (#732): Claude が compose_tweet_draft を呼ばずに end_turn
+    # した場合 (= tool では解けない prompt) 、 Claude の text 返答をここに
+    # 保存して frontend で「Claude より:」 として表示する。 draft_text が
+    # 空のときの説明にあたる。
+    agent_message = models.TextField(
+        blank=True,
+        default="",
+        help_text=(
+            "compose_tweet_draft を呼ばずに end_turn したとき、 Claude が"
+            " 返した text response。 draft_text が空のとき用の説明。"
+        ),
+    )
     created_at = models.DateTimeField(
         auto_now_add=True,
         db_index=False,  # composite index (user, -created_at) でカバー

--- a/apps/agents/runner.py
+++ b/apps/agents/runner.py
@@ -51,6 +51,14 @@ SYSTEM_PROMPT = (
     " ツールで 140 字以内の tweet 下書きを返してください。\n\n"
     "ルール:\n"
     "- 直接投稿はしません。 必ず compose_tweet_draft 経由で下書きを返してください。\n"
+    "- **`compose_tweet_draft` を呼ばずに会話を終えるのは禁止です**。 read 系ツールが"
+    "  空 / エラーを返した場合でも、 「データが無い旨を踏まえた 1 文の tweet 下書き」"
+    "  を user の prompt に沿って生成し、 必ず `compose_tweet_draft` で返してください"
+    "  (例: 「今日のニュース」 と聞かれて TL が空なら、 一般的な感想 / 質問 / 投げかけ"
+    "  形式の tweet を 1 つ作る)。\n"
+    "- どうしても tweet として成立しない (= ツールでは情報源が無く、 一般的な投稿も"
+    "  作りようがない) 場合のみ、 compose_tweet_draft を呼ばずに end_turn して、"
+    "  代わりに **なぜ draft を作れないかをユーザーに 1〜2 文の text で説明** してください。\n"
     "- 1 回の run でツールは最大 5 回まで。 同じツールを多用しないでください。\n"
     "- 出力言語は user の preferred_language (デフォルト 日本語) に合わせてください。\n"
     "- DM の本文は読めません (`read_my_notifications` の DM 種別は本文非表示)。\n"
@@ -287,7 +295,17 @@ class AgentRunner:
 
             if response.stop_reason != "tool_use":
                 # tool_use 以外で停止 (end_turn / max_tokens 等)。 compose
-                # まで届かなかったので draft_text は空のまま終わる。
+                # まで届かなかったので draft_text は空。 ただし Claude が
+                # 説明 text を返している場合があるので agent_message に保存し
+                # て frontend で「Claude より:」 として表示する (#732)。
+                texts: list[str] = []
+                for block in response.content:
+                    if getattr(block, "type", None) == "text":
+                        text = getattr(block, "text", "") or ""
+                        if text.strip():
+                            texts.append(text)
+                if texts:
+                    run.agent_message = "\n\n".join(texts).strip()
                 break
 
             # assistant の content (text + tool_use blocks) を messages に append
@@ -350,6 +368,7 @@ class AgentRunner:
                 "cache_creation_input_tokens",
                 "cost_usd",
                 "draft_text",
+                "agent_message",
             ]
         )
 

--- a/apps/agents/serializers.py
+++ b/apps/agents/serializers.py
@@ -44,6 +44,7 @@ class AgentRunSummarySerializer(serializers.ModelSerializer):
             "cache_creation_input_tokens",
             "cost_usd",
             "error",
+            "agent_message",
             "created_at",
         ]
         read_only_fields = fields

--- a/apps/agents/tests/test_runner.py
+++ b/apps/agents/tests/test_runner.py
@@ -330,3 +330,56 @@ class TestAgentRunnerErrors:
         assert run.tools_called == []
         assert run.input_tokens == 100
         assert run.error == ""
+        assert run.agent_message == ""
+
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_end_turn_with_text_response_saved_as_agent_message(self):
+        """#732: Claude が compose を呼ばず text で end_turn したケース。
+
+        text block を AgentRun.agent_message に保存して、 frontend で
+        「Claude より:」 として表示できるようにする。
+        """
+        user = _make_user("rh-msg@example.com", "rh_msg")
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "今日の TL に最近の投稿が無いため、 下書きを作れません。"
+        with patch("anthropic.Anthropic") as mock_anthropic_cls:
+            client = MagicMock()
+            mock_anthropic_cls.return_value = client
+            client.messages.create.return_value = _make_response(
+                "end_turn",
+                [text_block],
+                {"input_tokens": 120, "output_tokens": 40},
+            )
+
+            runner = AgentRunner()
+            run = runner.run(user, "今日のニュースで気になったものを書いて")
+
+        assert run.draft_text == ""
+        assert run.tools_called == []
+        assert run.error == ""
+        assert run.agent_message == "今日の TL に最近の投稿が無いため、 下書きを作れません。"
+
+    @override_settings(ANTHROPIC_API_KEY="sk-test")  # pragma: allowlist secret
+    def test_end_turn_with_multiple_text_blocks_joined(self):
+        """text block が複数ある場合は \\n\\n で連結して agent_message に保存。"""
+        user = _make_user("rh-msg2@example.com", "rh_msg2")
+        b1 = MagicMock(type="text")
+        b1.type = "text"
+        b1.text = "情報が見つかりませんでした。"
+        b2 = MagicMock(type="text")
+        b2.type = "text"
+        b2.text = "別の表現で試してください。"
+        with patch("anthropic.Anthropic") as mock_anthropic_cls:
+            client = MagicMock()
+            mock_anthropic_cls.return_value = client
+            client.messages.create.return_value = _make_response(
+                "end_turn",
+                [b1, b2],
+                {"input_tokens": 80, "output_tokens": 30},
+            )
+
+            runner = AgentRunner()
+            run = runner.run(user, "意味不明な prompt")
+
+        assert run.agent_message == ("情報が見つかりませんでした。\n\n別の表現で試してください。")

--- a/client/src/components/agent/AgentPanel.tsx
+++ b/client/src/components/agent/AgentPanel.tsx
@@ -208,43 +208,78 @@ export default function AgentPanel({ initialHistory = [] }: AgentPanelProps) {
 						</div>
 					) : null}
 
-					<Textarea
-						id="agent-draft"
-						rows={4}
-						value={draftEdit}
-						onChange={(e) => setDraftEdit(e.target.value)}
-						aria-describedby="agent-draft-counter"
-						aria-invalid={draftOver ? "true" : "false"}
-					/>
-					<p
-						id="agent-draft-counter"
-						className={
-							draftOver
-								? "text-sm text-destructive"
-								: "text-xs text-[color:var(--a-text-subtle)]"
-						}
-					>
-						{draftLen} / {DRAFT_MAX}
-					</p>
+					{result.draft_text ? (
+						<>
+							<Textarea
+								id="agent-draft"
+								rows={4}
+								value={draftEdit}
+								onChange={(e) => setDraftEdit(e.target.value)}
+								aria-describedby="agent-draft-counter"
+								aria-invalid={draftOver ? "true" : "false"}
+							/>
+							<p
+								id="agent-draft-counter"
+								className={
+									draftOver
+										? "text-sm text-destructive"
+										: "text-xs text-[color:var(--a-text-subtle)]"
+								}
+							>
+								{draftLen} / {DRAFT_MAX}
+							</p>
 
-					<div className="flex items-center justify-end gap-2">
-						<Button type="button" variant="secondary" onClick={onReset}>
-							リセット
-						</Button>
-						<Button
-							type="button"
-							onClick={onPostDraft}
-							disabled={isPosting || draftOver || !draftEdit.trim()}
-							className="inline-flex items-center gap-1.5"
+							<div className="flex items-center justify-end gap-2">
+								<Button type="button" variant="secondary" onClick={onReset}>
+									リセット
+								</Button>
+								<Button
+									type="button"
+									onClick={onPostDraft}
+									disabled={isPosting || draftOver || !draftEdit.trim()}
+									className="inline-flex items-center gap-1.5"
+								>
+									{isPosting ? (
+										<Loader2
+											className="size-4 animate-spin"
+											aria-hidden="true"
+										/>
+									) : (
+										<Send className="size-4" aria-hidden="true" />
+									)}
+									{isPosting ? "投稿中…" : "これを投稿"}
+								</Button>
+							</div>
+						</>
+					) : (
+						/* #732: draft が空のとき、 Claude の text 返答 (agent_message)
+						 * を「Claude より:」 として表示して、 user に「なぜ作れなかったか」
+						 * を伝える。 agent_message も空ならフォールバック文。 */
+						<div
+							role="note"
+							className="grid gap-2 rounded-md border border-dashed border-[color:var(--a-border)] bg-[color:var(--a-bg-muted)] p-3"
 						>
-							{isPosting ? (
-								<Loader2 className="size-4 animate-spin" aria-hidden="true" />
-							) : (
-								<Send className="size-4" aria-hidden="true" />
-							)}
-							{isPosting ? "投稿中…" : "これを投稿"}
-						</Button>
-					</div>
+							<div
+								className="font-medium"
+								style={{ fontSize: 12, color: "var(--a-text)" }}
+							>
+								Claude より:
+							</div>
+							<div
+								className="whitespace-pre-wrap text-[color:var(--a-text-muted)]"
+								style={{ fontSize: 13 }}
+							>
+								{result.agent_message
+									? result.agent_message
+									: "今回は tweet 下書きを作れませんでした。 prompt をもう少し具体的にして (例:「Python 3.13 の新機能を 1 tweet」) 再度お試しください。"}
+							</div>
+							<div className="flex items-center justify-end gap-2 pt-1">
+								<Button type="button" variant="secondary" onClick={onReset}>
+									閉じる
+								</Button>
+							</div>
+						</div>
+					)}
 				</section>
 			) : null}
 
@@ -270,6 +305,10 @@ export default function AgentPanel({ initialHistory = [] }: AgentPanelProps) {
 								{r.draft_text ? (
 									<div className="text-[color:var(--a-text-muted)]">
 										→ {r.draft_text}
+									</div>
+								) : r.agent_message ? (
+									<div className="text-[color:var(--a-text-muted)]">
+										→ (Claude より) {r.agent_message}
 									</div>
 								) : r.error ? (
 									<div className="text-destructive">→ エラー: {r.error}</div>

--- a/client/src/components/agent/__tests__/AgentPanel.test.tsx
+++ b/client/src/components/agent/__tests__/AgentPanel.test.tsx
@@ -69,6 +69,7 @@ const sampleRun = {
 	cache_creation_input_tokens: 0,
 	cost_usd: 0.0006,
 	error: "",
+	agent_message: "",
 	created_at: "2026-05-14T00:00:00Z",
 };
 
@@ -201,5 +202,52 @@ describe("AgentPanel (P14-05)", () => {
 		expect(
 			screen.getByRole("button", { name: /これを投稿|投稿中/ }),
 		).toBeDisabled();
+	});
+
+	it("shows 'Claude より:' message when draft_text empty and agent_message present (#732)", async () => {
+		runAgentMock.mockResolvedValueOnce({
+			...sampleRun,
+			draft_text: "",
+			agent_message: "今日の TL に最近の投稿が無いため、 下書きを作れません。",
+			tools_called: ["read_home_timeline"],
+		});
+		render(<AgentPanel />);
+		await userEvent.type(
+			screen.getByLabelText("やりたいことを自然言語で"),
+			"今日のニュースの感想",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Agent 起動" }));
+
+		await screen.findByText("Claude より:");
+		// 結果 panel + 履歴 panel の両方に出るので、 少なくとも 1 件出現を確認
+		expect(
+			screen.getAllByText(/今日の TL に最近の投稿が無いため/).length,
+		).toBeGreaterThan(0);
+		// 投稿 button は出てこない (draft 不在)
+		expect(
+			screen.queryByRole("button", { name: /これを投稿/ }),
+		).not.toBeInTheDocument();
+		// 代わりに「閉じる」 button が出る
+		expect(screen.getByRole("button", { name: "閉じる" })).toBeInTheDocument();
+	});
+
+	it("falls back to default copy when both draft_text and agent_message empty", async () => {
+		runAgentMock.mockResolvedValueOnce({
+			...sampleRun,
+			draft_text: "",
+			agent_message: "",
+			tools_called: [],
+		});
+		render(<AgentPanel />);
+		await userEvent.type(
+			screen.getByLabelText("やりたいことを自然言語で"),
+			"test",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Agent 起動" }));
+
+		await screen.findByText("Claude より:");
+		expect(
+			screen.getByText(/今回は tweet 下書きを作れませんでした/),
+		).toBeInTheDocument();
 	});
 });

--- a/client/src/lib/api/agent.ts
+++ b/client/src/lib/api/agent.ts
@@ -27,6 +27,12 @@ export interface AgentRunResult {
 	cache_creation_input_tokens: number;
 	cost_usd: number;
 	error: string;
+	/**
+	 * Claude が `compose_tweet_draft` を呼ばずに end_turn したとき返す text
+	 * 説明 (例: 「TL に最近の投稿が無くて下書きを作れません」)。 draft_text
+	 * が空のとき UI で「Claude より:」 として表示する (#732)。
+	 */
+	agent_message: string;
 	created_at: string;
 }
 

--- a/docs/specs/claude-agent-spec.md
+++ b/docs/specs/claude-agent-spec.md
@@ -79,6 +79,10 @@ class AgentRun(models.Model):
     cache_creation_input_tokens = models.IntegerField(default=0)
     cost_usd = models.DecimalField(max_digits=8, decimal_places=6, default=0)
     error = models.TextField(blank=True, default="")  # 失敗時の anthropic error message
+    # #732 follow-up: Claude が compose_tweet_draft を呼ばずに end_turn した
+    # 場合 (= tool では解けない prompt) 、 text 返答をここに保存。 draft_text
+    # が空のとき frontend で「Claude より:」 として表示する。
+    agent_message = models.TextField(blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:


### PR DESCRIPTION
## Summary

- ハルナさん stg 再現バグ修正 (#732): `/agent` で「今日の 1 日のニュースで気になったものの感想を書いて」 等の prompt を投入したとき、 Claude が `compose_tweet_draft` を呼ばずに `end_turn` してしまうと draft_text が空のまま画面に何も出ず、 user が「壊れた?」 と誤解する状況だった。
- 対処: AgentRun に `agent_message` field を追加して Claude の text 返答を保存し、 UI で「Claude より:」 callout として表示する。 同時に SYSTEM_PROMPT を強化して 「データが無くても 1 文 tweet を作るのが基本」 を明示。
- これで以下のどれかが必ず画面に出るようになる:
  - 成功: draft 表示 + 「これを投稿」 button (従来通り)
  - tool 不発: 「Claude より: ...」 callout + 「閉じる」 button
  - fallback: 「今回は tweet 下書きを作れませんでした。 prompt をもう少し具体的にして…」

## Changes

- `apps/agents/models.py`: `agent_message = TextField(blank=True, default="")` 追加
- `apps/agents/migrations/0002_agentrun_agent_message.py`: 新規
- `apps/agents/runner.py`:
  - `_execute` で `stop_reason != "tool_use"` のとき `response.content` の text block を抽出して `run.agent_message` にセット
  - `save(update_fields=...)` に `"agent_message"` を追加
  - `SYSTEM_PROMPT` を強化: read 系 tool が空でも compose_tweet_draft を呼ぶこと、 どうしても無理なときだけ text で説明
- `apps/agents/serializers.py`: `AgentRunSummarySerializer.Meta.fields` に `agent_message` 追加
- `apps/agents/admin.py`: readonly_fields に追加
- `client/src/lib/api/agent.ts`: `AgentRunResult` に `agent_message: string` 追加
- `client/src/components/agent/AgentPanel.tsx`:
  - draft_text が空のとき結果 panel で「Claude より:」 callout を表示 (agent_message の本文 or fallback copy)
  - 履歴行も「→ (Claude より) ...」 表示に対応
- `docs/specs/claude-agent-spec.md`: §3.1 に `agent_message` を追記

## Tests

- pytest 追加 (`apps/agents/tests/test_runner.py`):
  - `test_end_turn_with_text_response_saved_as_agent_message`: end_turn + 1 text block → agent_message に保存、 draft_text 空、 error 空
  - `test_end_turn_with_multiple_text_blocks_joined`: 複数 text block が `\n\n` で連結される
  - 既存の `test_stop_reason_end_turn_terminates_without_draft` に `agent_message == ""` の assert 追加
- vitest 追加 (`client/src/components/agent/__tests__/AgentPanel.test.tsx`):
  - `shows 'Claude より:' message when draft_text empty and agent_message present`: callout + 投稿 button 不在 + 閉じる button
  - `falls back to default copy when both draft_text and agent_message empty`: fallback 文表示

## Test plan

- [x] vitest ローカル green (7 / 7)
- [x] tsc --noEmit clean
- [x] eslint clean
- [ ] CI green (ruff / mypy / pytest / vitest / tsc / eslint)
- [ ] stg deploy 後、 main `/agent` で「今日の 1 日のニュースで気になったものの感想を書いて」 を再現 → 結果 panel に「Claude より:」 or 下書き が出る
- [ ] gan-evaluator agent で第三者目線 UX 採点

## Notes

- DB migration 0002: `AddField` で nullable な default="" 追加なので prod に対しても無停止で apply 可能 (table lock も最小限)
- Anthropic secret 変更なし → terraform apply 不要、 stg は main merge → CD で自動 deploy