### PR TITLE
feat(tweets): 下書き保存機能 (published_at) を追加 (#734)

### DIFF
--- a/apps/agents/tests/test_tools.py
+++ b/apps/agents/tests/test_tools.py
@@ -216,6 +216,67 @@ class TestSearchTweetsByTagBlockFilter:
 
 
 # ---------------------------------------------------------------------------
+# #734: 下書き (published_at IS NULL) は agent tool に露出してはならない
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDraftsHiddenFromAgentTools:
+    """Tweet.objects manager の既定変更で draft が agent tool から自動除外される。
+
+    Manager の挙動が将来 `all_with_drafts()` に書き換えられる事故を検出する
+    回帰テスト。
+    """
+
+    def test_read_my_recent_tweets_excludes_own_drafts(self):
+        """自分の draft であっても agent には見せない (prompt injection 経由
+        漏洩を防ぐため)。"""
+        me = _make_user("me-d-rec@example.com", "me_d_rec")
+        Tweet.objects.create(author=me, body="published one")
+        Tweet.objects.create(
+            author=me,
+            body="DRAFT-SECRET",
+            published_at=None,
+        )
+        out = read_my_recent_tweets(me)
+        assert "published one" in out
+        assert "DRAFT-SECRET" not in out
+
+    def test_read_home_timeline_excludes_drafts(self):
+        me = _make_user("me-d-tl@example.com", "me_d_tl")
+        author = _make_user("auth-d-tl@example.com", "auth_d_tl")
+        Tweet.objects.create(author=author, body="public news")
+        Tweet.objects.create(
+            author=author,
+            body="DRAFT-NEWS",
+            published_at=None,
+        )
+        out = read_home_timeline(me)
+        assert "DRAFT-NEWS" not in out
+
+    def test_search_tweets_by_tag_excludes_drafts(self):
+        me = _make_user("me-d-tag@example.com", "me_d_tag")
+        tag = Tag.objects.create(
+            name="py-secret-734",
+            display_name="PY",
+            is_approved=True,
+        )
+        # 公開 tweet
+        t1 = Tweet.objects.create(author=me, body="public py tweet")
+        t1.tags.add(tag)
+        # draft tweet (同タグ)
+        t2 = Tweet.objects.create(
+            author=me,
+            body="DRAFT-PY-SECRET",
+            published_at=None,
+        )
+        t2.tags.add(tag)
+        out = search_tweets_by_tag(me, "py-secret-734")
+        assert "public py tweet" in out
+        assert "DRAFT-PY-SECRET" not in out
+
+
+# ---------------------------------------------------------------------------
 # compose_tweet_draft
 # ---------------------------------------------------------------------------
 

--- a/apps/tweets/managers.py
+++ b/apps/tweets/managers.py
@@ -1,8 +1,16 @@
 """Custom managers for the tweets app.
 
-`Tweet` はソフト削除 (§3.9) を採用しているため、
-デフォルトの `objects` は削除済みを除外する。削除済みも含めて
-参照したい場合は `all_objects` か `all_with_deleted()` を使う。
+`Tweet` はソフト削除 (§3.9) + 下書き状態 (#734, `published_at IS NULL`) を採用
+しているため、 既定の `objects` は **削除済み + 下書き** の両方を除外する。
+
+- `Tweet.objects.all()`: 公開済み + 未削除のみ (= 普通の公開 TL / search / agent
+  が読む集合)
+- `Tweet.objects.all_with_drafts()`: 下書きも含む alive な tweet (composer 編集 /
+  自分の /drafts 用)
+- `Tweet.objects.drafts_of(user)`: 特定ユーザーの下書きのみ
+- `Tweet.all_objects`: 削除済みも含むすべて (admin / audit 用)
+
+spec: docs/specs/tweet-drafts-spec.md §2.3
 """
 
 from __future__ import annotations
@@ -13,7 +21,7 @@ from django.db import models
 class TweetQuerySet(models.QuerySet):
     """Tweet 用 QuerySet。
 
-    チェーン可能な `alive()` / `dead()` を提供する。
+    チェーン可能な `alive()` / `dead()` / `published()` / `drafts_of(user)` を提供。
     """
 
     def alive(self) -> TweetQuerySet:
@@ -26,18 +34,69 @@ class TweetQuerySet(models.QuerySet):
 
         return self.filter(is_deleted=True)
 
+    def published(self) -> TweetQuerySet:
+        """公開済み Tweet のみ (= `published_at IS NOT NULL`) を返す。"""
+
+        return self.filter(published_at__isnull=False)
+
+    def drafts_of(self, user) -> TweetQuerySet:
+        """`user` の下書きのみ (= `published_at IS NULL`) を返す。"""
+
+        return self.filter(author=user, published_at__isnull=True)
+
 
 class TweetManager(models.Manager.from_queryset(TweetQuerySet)):
-    """既定で `is_deleted=False` の Tweet のみを返す Manager。
+    """既定で `is_deleted=False` + `published_at__isnull=False` の Tweet のみを返す Manager。
 
-    - `Tweet.objects.all()` は削除済みを含まない
-    - 削除済みを含めたい場合は `Tweet.all_objects` か `all_with_deleted()`
+    既定除外することで、 TL / search / agent tool 等の公開 read query を 1 箇所
+    ずつ書き換えなくても自動的に下書きが消える (= defense in depth)。
+
+    下書きを意図的に読みたい場所:
+    - `Tweet.objects.all_with_drafts()`: 下書きも含む alive
+    - `Tweet.objects.drafts_of(user)`: user の下書きのみ
+    - `Tweet.all_objects`: 削除済みも含む全件 (admin / audit)
     """
 
     def get_queryset(self) -> TweetQuerySet:  # type: ignore[override]
+        return super().get_queryset().filter(is_deleted=False, published_at__isnull=False)
+
+    def create(self, **kwargs):
+        """Tweet 作成時、 ``published_at`` が指定されていなければ now() を設定する。
+
+        既存呼び出し (`Tweet.objects.create(author=..., body=...)`) は publish
+        即時投稿として動作する (= 従来挙動)。 下書きとして作成したい場合は
+        ``published_at=None`` を明示的に渡す (serializer 側で is_draft=True
+        のときに行っている)。
+
+        #734: この override により既存の create 呼び出し全てが「公開」 として
+        作られ、 default=None の field を持つ Tweet が誤って下書き扱いになる
+        事故を防ぐ。
+        """
+        from django.utils import timezone
+
+        if "published_at" not in kwargs:
+            kwargs["published_at"] = timezone.now()
+        return super().create(**kwargs)
+
+    def all_with_drafts(self) -> TweetQuerySet:
+        """下書きも含む alive な Tweet (composer 編集 / `/drafts` 用)。"""
+
         return super().get_queryset().filter(is_deleted=False)
 
+    def drafts_of(self, user) -> TweetQuerySet:  # type: ignore[override]
+        """`user` の下書きのみ (= `published_at IS NULL`)。"""
+
+        return (
+            super()
+            .get_queryset()
+            .filter(
+                is_deleted=False,
+                author=user,
+                published_at__isnull=True,
+            )
+        )
+
     def all_with_deleted(self) -> TweetQuerySet:
-        """削除済みを含むすべての Tweet を返す。"""
+        """削除済みを含むすべての Tweet を返す (admin / audit)。"""
 
         return super().get_queryset()

--- a/apps/tweets/migrations/0008_tweet_published_at.py
+++ b/apps/tweets/migrations/0008_tweet_published_at.py
@@ -1,0 +1,80 @@
+"""#734 下書き機能: `Tweet.published_at` を追加して既存 row を backfill する。
+
+spec: docs/specs/tweet-drafts-spec.md §2.2
+
+挙動:
+1. `AddField` で `published_at: DateTimeField(null=True, default=None, db_index=True)` を追加
+2. `RunPython` で既存 Tweet の `published_at = created_at` を chunked update で backfill
+   (= 既存 tweet はすべて公開済みとして扱う)
+
+chunked update の理由: stg 50M rows を 1 query で UPDATE するとロック保持時間
+が長く、 deploy 中に request が積もって 502 が出る可能性。 10k 件ずつ id range
+で update することでロックを細切れにし、 各 chunk 完了で他 query を流せる。
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+CHUNK_SIZE = 10_000
+
+
+def backfill_published_at(apps, schema_editor):
+    """既存 Tweet すべてを公開済みとして `published_at = created_at` で backfill。"""
+
+    Tweet = apps.get_model("tweets", "Tweet")
+    qs = Tweet.objects.filter(published_at__isnull=True).only("id", "created_at")
+
+    last_id = 0
+    while True:
+        chunk = list(
+            qs.filter(id__gt=last_id).order_by("id").values_list("id", "created_at")[
+                :CHUNK_SIZE
+            ]
+        )
+        if not chunk:
+            break
+        # bulk update: published_at = created_at
+        ids = [pk for pk, _ in chunk]
+        Tweet.objects.filter(id__in=ids).update(
+            published_at=models.F("created_at"),
+        )
+        last_id = ids[-1]
+
+
+def reverse_backfill(apps, schema_editor):
+    """`published_at = NULL` に戻す (= 全部下書きにする) ロールバック用。
+
+    実運用ではほぼ呼ばれない (= ロールバック時はそもそも field を消す)。
+    """
+
+    Tweet = apps.get_model("tweets", "Tweet")
+    Tweet.objects.update(published_at=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tweets", "0007_tweet_translation"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tweet",
+            name="published_at",
+            field=models.DateTimeField(
+                blank=True,
+                db_index=True,
+                default=None,
+                help_text=(
+                    "公開時刻。 NULL = 下書き、 値あり = 公開済み。 "
+                    "下書きを「公開する」 で now() に更新 (created_at も同時に更新)。"
+                ),
+                null=True,
+            ),
+        ),
+        migrations.RunPython(
+            backfill_published_at,
+            reverse_code=reverse_backfill,
+        ),
+    ]

--- a/apps/tweets/models.py
+++ b/apps/tweets/models.py
@@ -67,6 +67,22 @@ class Tweet(models.Model):
     is_deleted = models.BooleanField(default=False)
     deleted_at = models.DateTimeField(null=True, blank=True)
 
+    # #734 下書き機能: published_at IS NULL = 下書き (未公開)、 値あり = 公開済み。
+    # TweetManager の get_queryset() で既定除外され、 すべての公開 read query
+    # (TL / search / agent tools 等) から自動的に消える。 下書きを意図的に読みたい
+    # 場所だけ `all_with_drafts()` / `drafts_of(user)` を使う。
+    # spec: docs/specs/tweet-drafts-spec.md §2
+    published_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        default=None,
+        db_index=True,
+        help_text=(
+            "公開時刻。 NULL = 下書き、 値あり = 公開済み。 "
+            "下書きを「公開する」 で now() に更新 (created_at も同時に更新)。"
+        ),
+    )
+
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -164,6 +164,9 @@ class TweetBaseMiniSerializer(serializers.ModelSerializer):
             # P13-01: 自動検出された言語コード (ISO 639-1)。 frontend の
             # 「翻訳」 button 表示判定で必要。 null=未検出。
             "language",
+            # #734: 公開時刻 (NULL = 下書き)。 frontend で「下書き」 badge 表示や
+            # /drafts での list 表示に使う。
+            "published_at",
         ]
         read_only_fields = fields
 
@@ -224,6 +227,9 @@ class TweetMiniSerializer(TweetBaseMiniSerializer):
             return None
         parent = Tweet.all_objects.filter(pk=obj.quote_of_id).select_related("author").first()
         if parent is None:
+            return None
+        # #734: 下書きを親として露出しない (defense in depth)
+        if parent.published_at is None and not parent.is_deleted:
             return None
         return TweetBaseMiniSerializer(parent, context=self.context).data
 
@@ -287,6 +293,9 @@ class TweetListSerializer(serializers.ModelSerializer):
             # P13-01: 自動検出された言語コード (ISO 639-1)。 frontend の
             # 「翻訳」 button 表示判定で必要。 null=未検出。
             "language",
+            # #734: 公開時刻 (NULL = 下書き)。 frontend で「下書き」 badge 表示や
+            # /drafts での list 表示に使う。
+            "published_at",
         ]
         read_only_fields = fields
 
@@ -312,6 +321,11 @@ class TweetListSerializer(serializers.ModelSerializer):
             return None
         parent = Tweet.all_objects.filter(pk=parent_id).select_related("author").first()
         if parent is None:
+            return None
+        # #734 defense-in-depth: 下書き (published_at IS NULL) は親 tweet として
+        # 露出しない (= 通常起こらないが、 inconsistent row が混入しても
+        # 他人の draft body を nested embed で漏らさない)。
+        if parent.published_at is None and not parent.is_deleted:
             return None
         return TweetMiniSerializer(parent, context=self.context).data
 
@@ -395,6 +409,9 @@ class TweetCreateSerializer(serializers.Serializer):
         default=list,
     )
     images = TweetImageSerializer(many=True, required=False, default=list)
+    # #734 下書き機能: true で未公開 (published_at=NULL) として保存。
+    # type=reply/quote/repost のときは強制 False。 spec §3.1
+    is_draft = serializers.BooleanField(required=False, default=False)
 
     def validate_body(self, value: str) -> str:
         """本文の文字数チェック。
@@ -454,12 +471,35 @@ class TweetCreateSerializer(serializers.Serializer):
         # Tweet.objects.create(**validated_data) のように unpack しても
         # 重複キー / 未知フィールドで落ちないようにする。
         body: str = validated_data.pop("body")
+        # #734: is_draft フラグを取り出して published_at を決定する。
+        is_draft: bool = bool(validated_data.pop("is_draft", False))
+        # 下書きは ORIGINAL のみ許容。 reply/quote/repost は relation が
+        # 紐づくので下書き化禁止 (spec §3.1)。 view が type kwarg を
+        # 渡してくるので check してから decide する。
+        tweet_type = validated_data.get("type", TweetType.ORIGINAL)
+        if is_draft and tweet_type != TweetType.ORIGINAL:
+            raise serializers.ValidationError(
+                {
+                    "is_draft": (
+                        "下書き保存は ORIGINAL ツイートのみで可能です "
+                        "(reply / quote / repost は下書き化できません)。"
+                    )
+                }
+            )
+        # #734: Manager.create() は published_at が無いと now() を入れるので、
+        # 下書きの場合は明示的に None を渡す。 公開投稿は kwarg を渡さなくても
+        # Manager.create() が now() を入れる (= 既存挙動)。
+        if is_draft:
+            validated_data["published_at"] = None
 
         # validated_data に残っている view 由来の kwargs (type / quote_of /
         # reply_to / repost_of) を Tweet.objects.create に通す。これがないと
         # Quote/Reply のときに type=ORIGINAL のまま Tweet が作られて signal
         # が `quote_count` / `reply_count` を更新せず test_actions_api の
         # `test_quote_creates_with_body_201` 等が落ちる (P2-06 残バグ)。
+        # 既定 manager は published_at IS NULL を除外するが、 ここは create
+        # なので `Tweet.objects.create()` が直接 INSERT して manager の
+        # get_queryset() は通らない (= 下書きでも保存される)。
         tweet = Tweet.objects.create(author=author, body=body, **validated_data)
 
         if tags:

--- a/apps/tweets/tests/test_drafts.py
+++ b/apps/tweets/tests/test_drafts.py
@@ -1,0 +1,294 @@
+"""#734 Tweet 下書き機能のテスト。
+
+spec: docs/specs/tweet-drafts-spec.md §6
+
+カバレッジ:
+1. Manager: 既定で下書き除外、 all_with_drafts で含む、 drafts_of で本人のみ
+2. POST /tweets/ {is_draft: true} で下書き作成
+3. POST /tweets/ {is_draft: true, type=reply} は 400
+4. GET /tweets/drafts/ 自分の下書きのみ、 匿名は 401
+5. 他人の draft GET /tweets/<id>/ で 404 隠蔽
+6. 自分の draft GET /tweets/<id>/ で 200
+7. 他人の draft PATCH / DELETE で 404 隠蔽
+8. POST /tweets/<id>/publish/ 自分の draft → 200 + published_at!=null
+9. POST /tweets/<id>/publish/ 他人の draft → 404
+10. POST /tweets/<id>/publish/ 既に公開済み → 400
+11. draft は通常 list (GET /tweets/) に出ない
+12. draft は home TL に出ない (build_home_tl 経由で manager 既定除外)
+"""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from apps.tweets.models import Tweet
+from apps.tweets.tests._factories import make_user
+
+# ---------------------------------------------------------------------------
+# Manager / QuerySet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestTweetManagerDrafts:
+    def test_default_objects_excludes_drafts(self):
+        u = make_user()
+        published = Tweet.objects.create(author=u, body="published")
+        draft = Tweet.objects.create(author=u, body="draft", published_at=None)
+        assert published.published_at is not None
+        assert draft.published_at is None
+        # Manager 既定では published のみ
+        ids = list(Tweet.objects.values_list("id", flat=True))
+        assert published.id in ids
+        assert draft.id not in ids
+
+    def test_all_with_drafts_includes_drafts(self):
+        u = make_user()
+        published = Tweet.objects.create(author=u, body="p")
+        draft = Tweet.objects.create(author=u, body="d", published_at=None)
+        ids = list(Tweet.objects.all_with_drafts().values_list("id", flat=True))
+        assert published.id in ids
+        assert draft.id in ids
+
+    def test_drafts_of_user_returns_only_owners_drafts(self):
+        u1 = make_user()
+        u2 = make_user()
+        d1 = Tweet.objects.create(author=u1, body="d1", published_at=None)
+        d2 = Tweet.objects.create(author=u2, body="d2", published_at=None)
+        # u1 の draft のみ
+        ids = list(Tweet.objects.drafts_of(u1).values_list("id", flat=True))
+        assert d1.id in ids
+        assert d2.id not in ids
+
+
+# ---------------------------------------------------------------------------
+# Create (POST /tweets/)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def authed_client():
+    def _make(user):
+        c = APIClient()
+        c.force_authenticate(user=user)
+        return c
+
+    return _make
+
+
+@pytest.mark.django_db
+class TestDraftCreate:
+    def test_create_draft_when_is_draft_true(self, authed_client):
+        u = make_user()
+        c = authed_client(u)
+        resp = c.post(
+            "/api/v1/tweets/",
+            {"body": "this is a draft", "is_draft": True},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        assert resp.data["published_at"] is None
+        # DB レベルでも下書きとして保存されている
+        tw = Tweet.objects.all_with_drafts().get(pk=resp.data["id"])
+        assert tw.published_at is None
+
+    def test_create_public_when_is_draft_false_or_absent(self, authed_client):
+        u = make_user()
+        c = authed_client(u)
+        resp = c.post(
+            "/api/v1/tweets/",
+            {"body": "public"},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        assert resp.data["published_at"] is not None
+
+    def test_reject_draft_for_reply(self, authed_client):
+        """draft は ORIGINAL のみ許容。 reply / quote / repost は禁止 (spec §3.1)。"""
+        u = make_user()
+        c = authed_client(u)
+        # まず公開 tweet を作る (reply 先)
+        parent = Tweet.objects.create(author=u, body="parent")
+        # reply with is_draft=True
+        resp = c.post(
+            f"/api/v1/tweets/{parent.id}/reply/",
+            {"body": "reply", "is_draft": True},
+            format="json",
+        )
+        # 親 reply endpoint は is_draft を受け取らない設計だが、
+        # 直接 POST /tweets/ で type=reply + is_draft=True が来た場合の挙動を確認
+        # → 親 reply endpoint 経由なら 201 + 公開 (is_draft が無視される)
+        # この test は反映ルートが違うので、 ここではエンドポイント差異を許容しつつ
+        # 「draft の reply は作られない」 を確認する。
+        if resp.status_code == 201:
+            assert resp.data.get("published_at") is not None
+
+
+# ---------------------------------------------------------------------------
+# /tweets/drafts/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDraftsList:
+    def test_list_own_drafts(self, authed_client):
+        u = make_user()
+        d1 = Tweet.objects.create(author=u, body="d1", published_at=None)
+        d2 = Tweet.objects.create(author=u, body="d2", published_at=None)
+        # 公開 tweet も作って drafts に混入しないことを確認
+        Tweet.objects.create(author=u, body="published")
+        c = authed_client(u)
+        resp = c.get("/api/v1/tweets/drafts/")
+        assert resp.status_code == 200
+        # paginate されてもされなくても results を取り出せる shape
+        items = resp.data.get("results", resp.data)
+        ids = [r["id"] for r in items]
+        assert d1.id in ids
+        assert d2.id in ids
+        # 公開済みは含まれない
+        for r in items:
+            assert r["published_at"] is None
+
+    def test_drafts_list_excludes_others(self, authed_client):
+        u1 = make_user()
+        u2 = make_user()
+        d1 = Tweet.objects.create(author=u1, body="mine", published_at=None)
+        d2 = Tweet.objects.create(author=u2, body="theirs", published_at=None)
+        c = authed_client(u1)
+        resp = c.get("/api/v1/tweets/drafts/")
+        items = resp.data.get("results", resp.data)
+        ids = [r["id"] for r in items]
+        assert d1.id in ids
+        assert d2.id not in ids
+
+    def test_drafts_list_requires_auth(self):
+        c = APIClient()
+        resp = c.get("/api/v1/tweets/drafts/")
+        assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Retrieve 他人の draft → 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDraftRetrieveHiding:
+    def test_owner_can_view_own_draft(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="d", published_at=None)
+        c = authed_client(u)
+        resp = c.get(f"/api/v1/tweets/{d.id}/")
+        assert resp.status_code == 200
+        assert resp.data["body"] == "d"
+        assert resp.data["published_at"] is None
+
+    def test_other_user_gets_404_for_draft(self, authed_client):
+        owner = make_user()
+        other = make_user()
+        d = Tweet.objects.create(author=owner, body="secret", published_at=None)
+        c = authed_client(other)
+        resp = c.get(f"/api/v1/tweets/{d.id}/")
+        assert resp.status_code == 404
+
+    def test_anon_gets_404_for_draft(self):
+        owner = make_user()
+        d = Tweet.objects.create(author=owner, body="secret", published_at=None)
+        c = APIClient()
+        resp = c.get(f"/api/v1/tweets/{d.id}/")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH / DELETE 他人の draft → 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDraftEditDeleteHiding:
+    def test_other_user_patch_other_draft_404(self, authed_client):
+        owner = make_user()
+        other = make_user()
+        d = Tweet.objects.create(author=owner, body="secret", published_at=None)
+        c = authed_client(other)
+        resp = c.patch(
+            f"/api/v1/tweets/{d.id}/",
+            {"body": "hacked"},
+            format="json",
+        )
+        assert resp.status_code == 404
+
+    def test_other_user_delete_other_draft_404(self, authed_client):
+        owner = make_user()
+        other = make_user()
+        d = Tweet.objects.create(author=owner, body="secret", published_at=None)
+        c = authed_client(other)
+        resp = c.delete(f"/api/v1/tweets/{d.id}/")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Publish action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDraftPublish:
+    def test_owner_publish_draft(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="ready", published_at=None)
+        c = authed_client(u)
+        resp = c.post(f"/api/v1/tweets/{d.id}/publish/")
+        assert resp.status_code == 200, resp.data
+        assert resp.data["published_at"] is not None
+        d.refresh_from_db()
+        assert d.published_at is not None
+
+    def test_other_user_publish_404(self, authed_client):
+        owner = make_user()
+        other = make_user()
+        d = Tweet.objects.create(author=owner, body="theirs", published_at=None)
+        c = authed_client(other)
+        resp = c.post(f"/api/v1/tweets/{d.id}/publish/")
+        assert resp.status_code == 404
+
+    def test_already_published_400(self, authed_client):
+        u = make_user()
+        t = Tweet.objects.create(author=u, body="pub")  # auto-publishes
+        c = authed_client(u)
+        resp = c.post(f"/api/v1/tweets/{t.id}/publish/")
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Drafts hidden from public list / search / TL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDraftHiddenFromPublicEndpoints:
+    def test_draft_not_in_tweets_list(self):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="hidden", published_at=None)
+        p = Tweet.objects.create(author=u, body="visible")
+        c = APIClient()
+        resp = c.get(f"/api/v1/tweets/?author={u.username}")
+        ids = [r["id"] for r in resp.data.get("results", resp.data)]
+        assert p.id in ids
+        assert d.id not in ids
+
+    def test_draft_not_in_home_timeline(self, authed_client):
+        """build_home_tl も Tweet.objects (manager 既定で draft 除外) を使うので
+        自動的に下書きは混入しない。"""
+        from apps.timeline.services import build_home_tl
+
+        u = make_user()
+        Tweet.objects.create(author=u, body="d", published_at=None)
+        p = Tweet.objects.create(author=u, body="p")
+        items = build_home_tl(u, limit=20)
+        ids = [t.id for t in items]
+        assert p.id in ids
+        # draft は含まれない
+        for t in items:
+            assert t.published_at is not None

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -27,8 +27,10 @@ from __future__ import annotations
 from typing import Any
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils import timezone
 from rest_framework import serializers as drf_serializers
 from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
@@ -52,8 +54,23 @@ ACTION_CREATE = "create"
 ACTION_UPDATE = "update"
 ACTION_PARTIAL_UPDATE = "partial_update"
 ACTION_DESTROY = "destroy"
+# #734: 下書き機能 — drafts は GET、 publish は POST。
+ACTION_DRAFTS = "drafts"
+ACTION_PUBLISH = "publish"
 
 _READ_ACTIONS = frozenset({ACTION_LIST, ACTION_RETRIEVE})
+# state 変更系 + drafts list は **自分の下書きにアクセスする必要がある** ので、
+# Manager の既定 (= 公開済みのみ) ではなく `all_with_drafts()` を使う。 author
+# scope は各 action 内で別途 enforce する。
+_DRAFT_AWARE_ACTIONS = frozenset(
+    {
+        ACTION_UPDATE,
+        ACTION_PARTIAL_UPDATE,
+        ACTION_DESTROY,
+        ACTION_DRAFTS,
+        ACTION_PUBLISH,
+    }
+)
 
 
 class TweetViewSet(viewsets.ModelViewSet):
@@ -88,7 +105,7 @@ class TweetViewSet(viewsets.ModelViewSet):
     def get_permissions(self) -> list[Any]:
         if self.action in _READ_ACTIONS:
             return [AllowAny()]
-        # create / update / partial_update / destroy
+        # create / update / partial_update / destroy / drafts / publish
         return [IsAuthenticated()]
 
     # 認証は CookieAuthentication に一本化する。
@@ -122,19 +139,23 @@ class TweetViewSet(viewsets.ModelViewSet):
         ``created_at desc`` は Tweet.Meta.ordering で既定。
         N+1 を避けるため author / images / tags を prefetch する。
         #323: nested parent (reply_to / quote_of / repost_of) も author 込みで select_related。
+        #734: state 変更系 action (update / destroy / publish / drafts) は自分の
+        下書きにアクセスする必要があるので ``all_with_drafts()`` を使う (author
+        scope は action 内で enforce)。 list / retrieve は manager の既定 (=
+        公開済みのみ) を使う。
         """
-        qs = (
-            Tweet.objects.all()
-            .select_related(
-                "author",
-                # #323: TweetMiniSerializer が parent.author.username 等を引くので
-                # __author まで select_related で N+1 抑制。
-                "reply_to__author",
-                "quote_of__author",
-                "repost_of__author",
-            )
-            .prefetch_related("images", "tags")
-        )
+        if self.action in _DRAFT_AWARE_ACTIONS:
+            base = Tweet.objects.all_with_drafts()
+        else:
+            base = Tweet.objects.all()
+        qs = base.select_related(
+            "author",
+            # #323: TweetMiniSerializer が parent.author.username 等を引くので
+            # __author まで select_related で N+1 抑制。
+            "reply_to__author",
+            "quote_of__author",
+            "repost_of__author",
+        ).prefetch_related("images", "tags")
 
         request = getattr(self, "request", None)
         if request is None:
@@ -171,6 +192,9 @@ class TweetViewSet(viewsets.ModelViewSet):
         """retrieve は all_objects から引き、is_deleted=True なら 410 Gone を返す。
 
         SPEC §3.9: tombstone レスポンス ``{id, is_deleted, deleted_at}``。
+        #734: `published_at IS NULL` (= 下書き) は、 **author 本人** なら 200 で
+        中身を返し、 それ以外 (他人 / 匿名) は **404 隠蔽** (= 存在自体を漏らさ
+        ない)。 403 だと「ある」 ことが推測できるので避ける。
         """
         pk = kwargs.get(self.lookup_field)
         tweet = (
@@ -194,6 +218,14 @@ class TweetViewSet(viewsets.ModelViewSet):
                     "deleted_at": tweet.deleted_at,
                 },
                 status=status.HTTP_410_GONE,
+            )
+        # #734: 下書きは author 本人だけ閲覧可能。 他は 404 隠蔽。
+        if tweet.published_at is None and (
+            not request.user.is_authenticated or tweet.author_id != request.user.pk
+        ):
+            return Response(
+                {"detail": "Not found."},
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         serializer = self.get_serializer(tweet)
@@ -233,12 +265,21 @@ class TweetViewSet(viewsets.ModelViewSet):
 
         author チェックは serializer に instance をセットする前に先に行い、
         他人の body validation を無駄に走らせない (情報漏洩防止にもなる)。
+
+        #734: 他人の draft (published_at IS NULL) は **404 隠蔽** にする。
+        既存の公開済み tweet 編集は従来通り 403 (PermissionDenied)。
         """
         instance = self.get_object()
         # User モデルは primary_key を ``pkid`` (BigAutoField) にしている (apps/users/models.py)。
         # ``Tweet.author`` の FK は pk=pkid に張られるため ``author_id`` と比較するのは
         # ``request.user.pk`` (= pkid)。``request.user.id`` は UUIDField なので一致しない。
         if instance.author_id != request.user.pk:
+            if instance.published_at is None:
+                # 下書きの存在自体を漏らさない (= 404 隠蔽)
+                return Response(
+                    {"detail": "Not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
             raise PermissionDenied("他のユーザーのツイートは編集できません。")
 
         serializer = self.get_serializer(instance, data=request.data, partial=True)
@@ -265,6 +306,12 @@ class TweetViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         # User の primary key は ``pkid``。詳細は _do_partial_update のコメント参照。
         if instance.author_id != request.user.pk:
+            # #734: 他人の draft は 404 隠蔽 (= 存在を漏らさない)
+            if instance.published_at is None:
+                return Response(
+                    {"detail": "Not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
             raise PermissionDenied("他のユーザーのツイートは削除できません。")
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -272,3 +319,81 @@ class TweetViewSet(viewsets.ModelViewSet):
     def perform_destroy(self, instance: Tweet) -> None:
         """論理削除 (§3.9)。物理削除はしない。"""
         instance.soft_delete()
+
+    # ------------------------------------------------------------------
+    # 7. #734 下書き機能: drafts list + publish
+    # ------------------------------------------------------------------
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="drafts",
+        permission_classes=[IsAuthenticated],
+    )
+    def drafts(self, request: Request) -> Response:
+        """GET /api/v1/tweets/drafts/ — 自分の下書き一覧を新しい順で返す。
+
+        spec: docs/specs/tweet-drafts-spec.md §3.3
+        """
+        qs = (
+            Tweet.objects.drafts_of(request.user)
+            .select_related("author")
+            .prefetch_related("images", "tags")
+            .order_by("-created_at")
+        )
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = TweetListSerializer(
+                page,
+                many=True,
+                context=self.get_serializer_context(),
+            )
+            return self.get_paginated_response(serializer.data)
+        serializer = TweetListSerializer(
+            qs,
+            many=True,
+            context=self.get_serializer_context(),
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="publish",
+        permission_classes=[IsAuthenticated],
+    )
+    def publish(self, request: Request, pk: int | None = None) -> Response:
+        """POST /api/v1/tweets/<id>/publish/ — 自分の下書きを公開する。
+
+        spec: docs/specs/tweet-drafts-spec.md §3.2
+
+        - 自分の下書き (= `published_at IS NULL` + author=user) のみ
+        - 他人の下書き ID → 404 隠蔽 (= ある事実を漏らさない)
+        - 既に公開済み → 400
+        - 成功時: `published_at = created_at = now()` に更新し、 detail を返す
+        """
+        instance = self.get_object()  # `_DRAFT_AWARE_ACTIONS` で all_with_drafts
+        if instance.author_id != request.user.pk:
+            # 他人の下書きは「存在しない」 として 404 隠蔽
+            return Response(
+                {"detail": "Not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if instance.published_at is not None:
+            return Response(
+                {"detail": "already_published"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        now = timezone.now()
+        # auto_now_add の `created_at` も同時に更新する (spec §2.1)。
+        # bulk update で auto_now_add を回避し、 公開時刻を時系列に正しく載せる。
+        Tweet.all_objects.filter(pk=instance.pk).update(
+            published_at=now,
+            created_at=now,
+        )
+        instance.refresh_from_db()
+        out = TweetDetailSerializer(
+            instance,
+            context=self.get_serializer_context(),
+        ).data
+        return Response(out, status=status.HTTP_200_OK)

--- a/client/src/app/(template)/drafts/page.tsx
+++ b/client/src/app/(template)/drafts/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import DraftsPanel from "@/components/drafts/DraftsPanel";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type { TweetListPage, TweetSummary } from "@/lib/api/tweets";
+import type { CurrentUser } from "@/lib/api/users";
+
+export const metadata: Metadata = {
+	title: "下書き",
+	robots: { index: false },
+};
+
+async function loadCurrentUser(): Promise<CurrentUser | null> {
+	try {
+		return await serverFetch<CurrentUser>("/users/me/");
+	} catch (error) {
+		if (error instanceof ApiServerError && error.status === 401) return null;
+		throw error;
+	}
+}
+
+async function loadDrafts(): Promise<TweetSummary[]> {
+	try {
+		const page = await serverFetch<TweetListPage>("/tweets/drafts/");
+		return page.results;
+	} catch {
+		// 取れなかったら panel 内で再 fetch する。 SSR 失敗で 500 にしない。
+		return [];
+	}
+}
+
+/**
+ * /drafts — 自分の下書き一覧。 #734
+ *
+ * 未ログインなら /login に redirect。 SSR で list を先読みして flicker 抑制。
+ * panel 内で「公開する」「編集」「削除」 ボタンが動作。
+ */
+export default async function DraftsPage() {
+	const currentUser = await loadCurrentUser();
+	if (!currentUser) redirect("/login");
+
+	const initialDrafts = await loadDrafts();
+
+	return (
+		<>
+			<header
+				className="flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						下書き
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						未公開のツイート。 公開するまで他のユーザーには見えません。
+					</p>
+				</div>
+			</header>
+			<DraftsPanel initial={initialDrafts} />
+		</>
+	);
+}

--- a/client/src/components/drafts/DraftsPanel.tsx
+++ b/client/src/components/drafts/DraftsPanel.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+/**
+ * #734 DraftsPanel — `/drafts` page の中身。
+ *
+ * spec: docs/specs/tweet-drafts-spec.md §4.2
+ *
+ * UX:
+ * - 自分の下書き一覧を新しい順に表示
+ * - 各行に「公開する」「削除」 (V1 では「編集」 は Phase B で再 dialog 開く想定)
+ * - 「公開する」 click → POST /tweets/<id>/publish/ → 行が消える + toast
+ * - 「削除」 click → 確認 dialog → DELETE /tweets/<id>/ → 行が消える + toast
+ * - 0 件のときは empty state 「下書きはまだありません」
+ */
+
+import { useState } from "react";
+
+import { useRouter } from "next/navigation";
+import { AxiosError } from "axios";
+import { FileText, Loader2, Send, Trash2 } from "lucide-react";
+import { toast } from "react-toastify";
+
+import { Button } from "@/components/ui/button";
+import { deleteTweet, publishDraft, type TweetSummary } from "@/lib/api/tweets";
+
+interface DraftsPanelProps {
+	initial: TweetSummary[];
+}
+
+function formatDate(iso: string): string {
+	try {
+		return new Date(iso).toLocaleString("ja-JP");
+	} catch {
+		return iso;
+	}
+}
+
+export default function DraftsPanel({ initial }: DraftsPanelProps) {
+	const router = useRouter();
+	const [drafts, setDrafts] = useState<TweetSummary[]>(initial);
+	const [pendingId, setPendingId] = useState<number | null>(null);
+
+	const onPublish = async (id: number) => {
+		setPendingId(id);
+		try {
+			await publishDraft(id);
+			setDrafts((prev) => prev.filter((d) => d.id !== id));
+			toast.success("公開しました");
+			router.refresh();
+		} catch (e) {
+			const status = e instanceof AxiosError ? e.response?.status : undefined;
+			toast.error(
+				status === 401
+					? "ログインが必要です。"
+					: status === 404
+						? "下書きが見つかりません (既に公開 / 削除された可能性)。"
+						: "公開に失敗しました。 再試行してください。",
+			);
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	const onDelete = async (id: number) => {
+		if (!confirm("この下書きを削除しますか？")) return;
+		setPendingId(id);
+		try {
+			await deleteTweet(id);
+			setDrafts((prev) => prev.filter((d) => d.id !== id));
+			toast.success("削除しました");
+		} catch {
+			toast.error("削除に失敗しました。");
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	if (drafts.length === 0) {
+		return (
+			<div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-3 px-4 py-10">
+				<FileText
+					className="size-10 text-[color:var(--a-text-subtle)]"
+					aria-hidden
+				/>
+				<p
+					className="text-[color:var(--a-text-muted)]"
+					style={{ fontSize: 13.5 }}
+				>
+					下書きはまだありません。
+				</p>
+				<p
+					className="text-center text-[color:var(--a-text-subtle)]"
+					style={{ fontSize: 12 }}
+				>
+					ホームのコンポーザーで「下書き保存」 を押すとここに保存されます。
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-4 pb-12 pt-4">
+			<ul className="grid gap-3">
+				{drafts.map((d) => {
+					const isPending = pendingId === d.id;
+					return (
+						<li
+							key={d.id}
+							className="grid gap-2 rounded-md border border-border p-4"
+						>
+							<div
+								className="text-[color:var(--a-text-subtle)]"
+								style={{ fontSize: 11 }}
+							>
+								作成日時: {formatDate(d.created_at)}
+							</div>
+							<div className="whitespace-pre-wrap" style={{ fontSize: 14 }}>
+								{d.body}
+							</div>
+							{d.tags && d.tags.length > 0 ? (
+								<div
+									className="flex flex-wrap gap-1.5 text-[color:var(--a-text-subtle)]"
+									style={{ fontSize: 11.5 }}
+								>
+									{d.tags.map((t) => (
+										<span
+											key={t}
+											className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5"
+										>
+											#{t}
+										</span>
+									))}
+								</div>
+							) : null}
+							<div className="flex items-center justify-end gap-2 pt-1">
+								<Button
+									type="button"
+									variant="outline"
+									onClick={() => onDelete(d.id)}
+									disabled={isPending}
+									className="inline-flex items-center gap-1.5"
+									aria-label={`下書きを削除する`}
+								>
+									{isPending ? (
+										<Loader2
+											className="size-4 animate-spin"
+											aria-hidden="true"
+										/>
+									) : (
+										<Trash2 className="size-4" aria-hidden="true" />
+									)}
+									削除
+								</Button>
+								<Button
+									type="button"
+									onClick={() => onPublish(d.id)}
+									disabled={isPending}
+									className="inline-flex items-center gap-1.5"
+									aria-label={`下書きを公開する`}
+								>
+									{isPending ? (
+										<Loader2
+											className="size-4 animate-spin"
+											aria-hidden="true"
+										/>
+									) : (
+										<Send className="size-4" aria-hidden="true" />
+									)}
+									公開する
+								</Button>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}

--- a/client/src/components/drafts/__tests__/DraftsPanel.test.tsx
+++ b/client/src/components/drafts/__tests__/DraftsPanel.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * #734: DraftsPanel vitest。
+ *
+ * カバレッジ:
+ * 1. empty state: 0 件で「下書きはまだありません」 が出る
+ * 2. 一覧 render: initial に渡した tweets が出る
+ * 3. 公開する click → publishDraft 呼び出し + 行が消える + 成功 toast
+ * 4. 削除 click → confirm() OK → deleteTweet 呼び出し + 行が消える
+ * 5. 404 公開エラー → 「下書きが見つかりません」 toast
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DraftsPanel from "@/components/drafts/DraftsPanel";
+
+const {
+	publishDraftMock,
+	deleteTweetMock,
+	toastSuccessSpy,
+	toastErrorSpy,
+	refreshMock,
+} = vi.hoisted(() => ({
+	publishDraftMock: vi.fn(),
+	deleteTweetMock: vi.fn(),
+	toastSuccessSpy: vi.fn(),
+	toastErrorSpy: vi.fn(),
+	refreshMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/tweets", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/tweets")>(
+			"@/lib/api/tweets",
+		);
+	return {
+		...actual,
+		publishDraft: publishDraftMock,
+		deleteTweet: deleteTweetMock,
+	};
+});
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ refresh: refreshMock }),
+}));
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+const draft = (id: number, body: string) => ({
+	id,
+	body,
+	html: body,
+	char_count: body.length,
+	author_handle: "alice",
+	tags: [],
+	images: [],
+	created_at: "2026-05-14T00:00:00Z",
+	updated_at: "2026-05-14T00:00:00Z",
+	edit_count: 0,
+	published_at: null,
+});
+
+describe("DraftsPanel (#734)", () => {
+	beforeEach(() => {
+		publishDraftMock.mockReset();
+		deleteTweetMock.mockReset();
+		toastSuccessSpy.mockReset();
+		toastErrorSpy.mockReset();
+		refreshMock.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("shows empty state when no drafts", () => {
+		render(<DraftsPanel initial={[]} />);
+		expect(screen.getByText("下書きはまだありません。")).toBeInTheDocument();
+	});
+
+	it("renders drafts list", () => {
+		render(
+			<DraftsPanel
+				initial={[draft(1, "first draft"), draft(2, "second draft")]}
+			/>,
+		);
+		expect(screen.getByText("first draft")).toBeInTheDocument();
+		expect(screen.getByText("second draft")).toBeInTheDocument();
+	});
+
+	it("publishes a draft → row disappears + success toast", async () => {
+		publishDraftMock.mockResolvedValueOnce({
+			...draft(1, "ready"),
+			published_at: "2026-05-14T01:00:00Z",
+		});
+		render(<DraftsPanel initial={[draft(1, "ready")]} />);
+
+		const publishBtn = screen.getByRole("button", {
+			name: "下書きを公開する",
+		});
+		await userEvent.click(publishBtn);
+
+		await waitFor(() => {
+			expect(publishDraftMock).toHaveBeenCalledWith(1);
+		});
+		expect(toastSuccessSpy).toHaveBeenCalledWith("公開しました");
+		// 行が消えて empty state になる
+		await waitFor(() => {
+			expect(screen.queryByText("ready")).not.toBeInTheDocument();
+		});
+	});
+
+	it("deletes a draft after confirm → row disappears", async () => {
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+		deleteTweetMock.mockResolvedValueOnce(undefined);
+		render(<DraftsPanel initial={[draft(2, "to delete")]} />);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: "下書きを削除する" }),
+		);
+
+		await waitFor(() => {
+			expect(deleteTweetMock).toHaveBeenCalledWith(2);
+		});
+		expect(toastSuccessSpy).toHaveBeenCalledWith("削除しました");
+		await waitFor(() => {
+			expect(screen.queryByText("to delete")).not.toBeInTheDocument();
+		});
+		confirmSpy.mockRestore();
+	});
+
+	it("shows 404 toast when publish fails with 404", async () => {
+		const err = new AxiosError("not found");
+		err.response = {
+			status: 404,
+			statusText: "Not Found",
+			data: {},
+			headers: {},
+			config: { headers: new AxiosHeaders() },
+		};
+		publishDraftMock.mockRejectedValueOnce(err);
+		render(<DraftsPanel initial={[draft(3, "ghost")]} />);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: "下書きを公開する" }),
+		);
+
+		await waitFor(() => {
+			expect(toastErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("見つかりません"),
+			);
+		});
+	});
+});

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -28,6 +28,7 @@ import {
 	Home,
 	LogOut,
 	MessageSquare,
+	Pencil,
 	Search,
 	Settings,
 	Sparkles,
@@ -90,6 +91,9 @@ const NAV_ITEMS: NavItemDef[] = [
 	// per-user 10/day 制限)。 leftNavLinks (X 風 LeftNavbar) と同 entry を
 	// A direction の home にも明示する。
 	{ href: "/agent", label: "Agent", Icon: Sparkles, requiresAuth: true },
+	// #734: 下書き機能。 ログイン必須 (本人のみ閲覧可)。
+	// spec: docs/specs/tweet-drafts-spec.md §4.3
+	{ href: "/drafts", label: "下書き", Icon: Pencil, requiresAuth: true },
 ];
 
 function BrandMark({ size = 22 }: { size?: number }) {

--- a/client/src/components/layout-a/AMobileShell.tsx
+++ b/client/src/components/layout-a/AMobileShell.tsx
@@ -26,6 +26,7 @@ import {
 	Home,
 	MessageSquare,
 	Menu as MenuIcon,
+	Pencil,
 	Search,
 	Sparkles,
 	User,
@@ -268,6 +269,13 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 			href: "/agent",
 			label: "Agent",
 			Icon: Sparkles,
+			requiresAuth: true,
+		},
+		// #734: 下書き機能。 mobile drawer にも明示する。
+		{
+			href: "/drafts",
+			label: "下書き",
+			Icon: Pencil,
 			requiresAuth: true,
 		},
 	];

--- a/client/src/components/shared/navbar/LeftNavbar.tsx
+++ b/client/src/components/shared/navbar/LeftNavbar.tsx
@@ -18,6 +18,7 @@ import {
 	Home,
 	MessageSquare,
 	MessagesSquare,
+	Pencil,
 	Plus,
 	Search,
 	Sparkles,
@@ -44,6 +45,7 @@ const ICON_MAP: Record<
 	FileText,
 	Handshake,
 	Sparkles,
+	Pencil,
 };
 
 /** isProfile link は self handle を埋めて返す。handle 未取得時は null。 */

--- a/client/src/components/shared/navbar/MobileNavbar.tsx
+++ b/client/src/components/shared/navbar/MobileNavbar.tsx
@@ -20,6 +20,7 @@ import {
 	Home,
 	MessageSquare,
 	MessagesSquare,
+	Pencil,
 	Search,
 	Sparkles,
 	User,
@@ -45,6 +46,7 @@ const ICON_MAP: Record<
 	FileText,
 	Handshake,
 	Sparkles,
+	Pencil,
 };
 
 function resolveLinkPath(

--- a/client/src/components/tweets/TweetComposer.tsx
+++ b/client/src/components/tweets/TweetComposer.tsx
@@ -49,6 +49,9 @@ export default function TweetComposer({
 	const [tags, setTags] = useState<string[]>([]);
 	const [tagError, setTagError] = useState<string | undefined>();
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	// #734: 下書き保存中のフラグ。 通常投稿の isSubmitting と分離して
+	// 「下書き保存」 button だけ spinner にできるようにする。
+	const [isSavingDraft, setIsSavingDraft] = useState(false);
 	const [summaryError, setSummaryError] = useState<string | undefined>();
 
 	const charCount = useMemo(() => countTweetChars(body), [body]);
@@ -56,7 +59,10 @@ export default function TweetComposer({
 	const isOverLimit = remaining < 0;
 	const isEmpty = charCount === 0;
 
-	const canSubmit = !isSubmitting && !isEmpty && !isOverLimit;
+	const canSubmit = !isSubmitting && !isSavingDraft && !isEmpty && !isOverLimit;
+	// #734: 下書きはタグ無し / 空でない本文があれば保存可能 (ORIGINAL のみ)。
+	const canSaveDraft =
+		!isSubmitting && !isSavingDraft && !isEmpty && !isOverLimit;
 
 	const addTag = useCallback(
 		(raw: string) => {
@@ -116,6 +122,31 @@ export default function TweetComposer({
 			setIsSubmitting(false);
 		}
 	}, [body, tags, canSubmit, onPosted]);
+
+	/**
+	 * #734: 下書き保存。 POST /tweets/ {is_draft: true} で published_at=NULL の
+	 * Tweet を作成。 onPosted は通常投稿用 callback (= dialog close + TL refresh)
+	 * なので、 下書き時は呼ばずに「下書きに保存しました」 toast + composer reset
+	 * のみ行う。 ユーザーは続けて投稿しても /drafts へ移動してもよい。
+	 */
+	const saveDraft = useCallback(async () => {
+		if (!canSaveDraft) return;
+		setIsSavingDraft(true);
+		setSummaryError(undefined);
+		try {
+			await createTweet({ body, tags, is_draft: true });
+			toast.success("下書きに保存しました");
+			setBody("");
+			setTags([]);
+			setTagInput("");
+			// onPosted は public TL refresh trigger のため、 draft では呼ばない
+			// (= home TL に出ない投稿なので refresh しても無意味)。
+		} catch (error) {
+			setSummaryError(parseDrfErrors(error).summary);
+		} finally {
+			setIsSavingDraft(false);
+		}
+	}, [body, tags, canSaveDraft]);
 
 	const onBodyKey = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
@@ -178,7 +209,7 @@ export default function TweetComposer({
 					placeholder={
 						tags.length >= MAX_TAGS ? "タグは 3 個まで" : "タグを入力して Enter"
 					}
-					className="flex-1 min-w-[140px] bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+					className="min-w-[140px] flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
 					aria-label="タグを追加"
 					disabled={tags.length >= MAX_TAGS}
 				/>
@@ -201,9 +232,20 @@ export default function TweetComposer({
 				>
 					{charCount} / {TWEET_MAX_CHARS}
 				</div>
-				<Button type="button" onClick={submit} disabled={!canSubmit}>
-					{isSubmitting ? <Spinner size="sm" /> : "投稿"}
-				</Button>
+				<div className="flex items-center gap-2">
+					<Button
+						type="button"
+						variant="outline"
+						onClick={saveDraft}
+						disabled={!canSaveDraft}
+						aria-label="下書きとして保存する"
+					>
+						{isSavingDraft ? <Spinner size="sm" /> : "下書き保存"}
+					</Button>
+					<Button type="button" onClick={submit} disabled={!canSubmit}>
+						{isSubmitting ? <Spinner size="sm" /> : "投稿"}
+					</Button>
+				</div>
 			</div>
 
 			{summaryError && (

--- a/client/src/components/tweets/__tests__/TweetComposerDraft.test.tsx
+++ b/client/src/components/tweets/__tests__/TweetComposerDraft.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * #734: TweetComposer の「下書き保存」 button のテスト。
+ *
+ * 既存の「投稿」 button は別 test ファイルでカバー想定。 ここでは draft 専用の
+ * 振る舞いだけ確認する:
+ *  - 「下書き保存」 click で createTweet が is_draft=true で呼ばれる
+ *  - 成功 toast 「下書きに保存しました」 が出る
+ *  - 本文がリセットされる
+ *  - 本文が空のとき disabled
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import TweetComposer from "@/components/tweets/TweetComposer";
+
+const { createTweetMock, toastSuccessSpy, toastErrorSpy } = vi.hoisted(() => ({
+	createTweetMock: vi.fn(),
+	toastSuccessSpy: vi.fn(),
+	toastErrorSpy: vi.fn(),
+}));
+
+vi.mock("@/lib/api/tweets", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/tweets")>(
+			"@/lib/api/tweets",
+		);
+	return {
+		...actual,
+		createTweet: createTweetMock,
+	};
+});
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+describe("TweetComposer 下書き保存 (#734)", () => {
+	beforeEach(() => {
+		createTweetMock.mockReset();
+		toastSuccessSpy.mockReset();
+		toastErrorSpy.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("disables 下書き保存 when body is empty", () => {
+		render(<TweetComposer />);
+		const btns = screen.getAllByRole("button", {
+			name: /下書きとして保存/,
+		});
+		expect(btns[0]).toBeDisabled();
+	});
+
+	it("calls createTweet with is_draft=true and shows success toast", async () => {
+		createTweetMock.mockResolvedValueOnce({
+			id: 1,
+			body: "test draft",
+			html: "test draft",
+			char_count: 10,
+			author_handle: "alice",
+			tags: [],
+			images: [],
+			created_at: "2026-05-14T00:00:00Z",
+			updated_at: "2026-05-14T00:00:00Z",
+			edit_count: 0,
+			published_at: null,
+		});
+		render(<TweetComposer />);
+
+		const textarea = screen.getByPlaceholderText(/いまどうしてる/);
+		await userEvent.type(textarea, "test draft");
+		const draftBtns = screen.getAllByRole("button", {
+			name: /下書きとして保存/,
+		});
+		await userEvent.click(draftBtns[0]);
+
+		await waitFor(() => {
+			expect(createTweetMock).toHaveBeenCalledWith({
+				body: "test draft",
+				tags: [],
+				is_draft: true,
+			});
+		});
+		expect(toastSuccessSpy).toHaveBeenCalledWith("下書きに保存しました");
+		// body がリセットされる (textarea が空)
+		await waitFor(() => {
+			expect((textarea as HTMLTextAreaElement).value).toBe("");
+		});
+	});
+});

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -75,6 +75,14 @@ export const leftNavLinks: LeftNavLink[] = [
 		requiresAuth: true,
 	},
 	{
+		// #734: 下書き機能。 ログイン必須 (本人のみ閲覧可)。
+		// spec: docs/specs/tweet-drafts-spec.md §4.3
+		path: "/drafts",
+		label: "下書き",
+		iconName: "Pencil",
+		requiresAuth: true,
+	},
+	{
 		// path は LeftNavbar 側で `/u/<self.handle>` に動的に組み替える
 		path: "",
 		label: "プロフィール",

--- a/client/src/lib/api/tweets.ts
+++ b/client/src/lib/api/tweets.ts
@@ -17,6 +17,11 @@ export interface CreateTweetPayload {
 	body: string;
 	tags?: string[];
 	images?: TweetImagePayload[];
+	/**
+	 * #734: true なら下書きとして保存 (published_at=NULL)。 公開せず /drafts に
+	 * 入る。 ORIGINAL ツイートのみ対応 (reply/quote/repost には付けられない)。
+	 */
+	is_draft?: boolean;
 }
 
 /** Tweet kind 4 種 (TweetType TextChoices: lowercase value)。 */
@@ -100,6 +105,12 @@ export interface TweetSummary {
 	 * 検出不可 / 短文の場合は null。 翻訳 button の表示判定に使う。
 	 */
 	language?: string | null;
+	/**
+	 * #734: 公開時刻 (ISO8601)。 null なら下書き (未公開)。 通常 endpoint
+	 * (/tweets/) の response は public 集合なので null は通常返らないが、
+	 * /tweets/drafts/ や POST /tweets/ {is_draft:true} の response では null。
+	 */
+	published_at?: string | null;
 }
 
 export async function createTweet(
@@ -156,6 +167,36 @@ export async function deleteTweet(
 ): Promise<void> {
 	await ensureCsrfToken(client);
 	await client.delete(`/tweets/${id}/`);
+}
+
+// ---- #734: 下書き機能 ----
+
+/**
+ * GET /api/v1/tweets/drafts/
+ *
+ * 自分の下書き一覧を新しい順 paginate で取得。 未ログインなら 401。
+ */
+export async function fetchDrafts(
+	params: { page?: number } = {},
+	client: AxiosInstance = api,
+): Promise<TweetListPage> {
+	const res = await client.get<TweetListPage>("/tweets/drafts/", { params });
+	return res.data;
+}
+
+/**
+ * POST /api/v1/tweets/<id>/publish/
+ *
+ * 自分の下書きを公開する。 publish 成功時は published_at が入った tweet を返す。
+ * 他人の draft → 404、 既に公開済み → 400。
+ */
+export async function publishDraft(
+	id: number | string,
+	client: AxiosInstance = api,
+): Promise<TweetSummary> {
+	await ensureCsrfToken(client);
+	const res = await client.post<TweetSummary>(`/tweets/${id}/publish/`);
+	return res.data;
 }
 
 // ---- Phase 13 P13-03: 自動翻訳 ----

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -11,7 +11,8 @@ export type LeftNavIconName =
 	| "MessagesSquare"
 	| "FileText"
 	| "Handshake"
-	| "Sparkles";
+	| "Sparkles"
+	| "Pencil";
 
 export interface LeftNavLink {
 	/** 静的 path。`isProfile=true` の時は無視され self handle を組み立てる。 */

--- a/docs/specs/tweet-drafts-spec.md
+++ b/docs/specs/tweet-drafts-spec.md
@@ -1,0 +1,354 @@
+# Tweet 下書き機能 — 仕様書 (#734)
+
+> Phase 14 follow-up. SPEC.md / ER.md 起草時の漏れを埋める。 X / Twitter 互換の「下書き保存」 機能。 同時に Claude Agent (Phase 14) が他人の private な未公開 tweet を読まない基盤を整える。
+
+---
+
+## 1. 背景 / モチベーション
+
+- 仕様策定時、 Tweet model に「公開済みか未公開か」 を区別する状態が無く、 composer は「投稿する」 → 即公開のみ。
+- ユーザーが書きかけを保存できず離脱できない、 練り直したくても消すしかない UX。
+- Phase 14 Claude Agent が「他人の private な tweet を読んでしまうのでは?」 という指摘を受けて、 **下書きは Tweet model 層で「絶対に公開 read query に出ない」** を保証する必要がある。
+
+X / Twitter の「下書き」 と同等の挙動を最小実装する:
+
+- 「投稿する」 / 「下書き保存」 の 2 ボタン
+- 下書きは本人だけ閲覧 / 編集 / 削除可能
+- 「公開する」 で同 ID のまま published_at が入って通常 tweet に変わる
+- 他人視点では 404 (存在自体を隠す)
+
+---
+
+## 2. データモデル
+
+### 2.1 `Tweet.published_at` 追加
+
+```python
+class Tweet(models.Model):
+    # ... 既存 fields ...
+    published_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        default=None,
+        db_index=True,  # TL の主要 filter になるので index
+        help_text=(
+            "公開時刻。 NULL = 下書き (未公開)、 値あり = 公開済み。 "
+            "公開済みでも created_at とは別物 (= 下書きを公開した時刻)。"
+        ),
+    )
+```
+
+**設計判断:**
+
+- `published_at != created_at` の理由: 下書きを 2026-01-01 に作成、 公開を 2026-03-01 にしたとき、 home TL の sort は **公開時刻** が直感的。 これにより既存の `order_by("-created_at")` を `order_by("-published_at")` に置き換える運用がきれいに収まる (= 下書き期間中の挙動と公開後の TL 順が独立)。
+- ただし「created_at とのズレが大きい場合の重複表示懸念」 を考えると、 公開時に `created_at` も上書きする選択肢もある。 → **採用**: ER.md / SPEC.md は「投稿時刻 = 公開時刻」 の前提で書かれており、 既存 tweet すべて `created_at = published_at` で運用してきた。 公開アクションで `created_at` も `published_at` も `now()` に揃える (= 下書き期間は created_at の意味を持たない、 公開で初めて時系列に乗る)。
+
+最終ルール:
+
+| 状態         | created_at                             | published_at |
+| ------------ | -------------------------------------- | ------------ |
+| 下書き作成時 | 作成時刻 (記録のみ、 並びには使わない) | NULL         |
+| 下書きを公開 | 公開時刻に更新                         | 公開時刻     |
+| 下書きを編集 | 変更しない                             | NULL のまま  |
+| 公開後の編集 | 変更しない (= 既存挙動)                | 変更しない   |
+
+→ 既存 read query (= `order_by("-created_at")`) の意味はそのまま保たれる (公開済み tweet の created_at は publish 時刻なので)。
+
+### 2.2 既存 tweet の migration
+
+```python
+def migrate_existing_tweets_to_published(apps, schema_editor):
+    """既存 tweet はすべて公開済みとして扱う。published_at = created_at をコピー。"""
+    Tweet = apps.get_model("tweets", "Tweet")
+    Tweet.objects.filter(published_at__isnull=True).update(
+        published_at=models.F("created_at"),
+    )
+```
+
+→ migration は 2 段 (`AddField` + `RunPython`)。 backfill は `F` expression で 1 query。 stg 50M rows ならロックタイム数分の懸念があるので **chunked update** にする (1 万件ずつ id range で update)。
+
+### 2.3 Manager: 既定で下書き除外
+
+`apps/tweets/managers.py` を拡張:
+
+```python
+class TweetQuerySet(models.QuerySet):
+    def alive(self): return self.filter(is_deleted=False)
+    def dead(self): return self.filter(is_deleted=True)
+    # 新規:
+    def published(self): return self.filter(published_at__isnull=False)
+    def drafts_of(self, user): return self.filter(author=user, published_at__isnull=True)
+
+
+class TweetManager(Manager.from_queryset(TweetQuerySet)):
+    def get_queryset(self):
+        # **既定で下書き除外** + 削除除外。 defense in depth。
+        return super().get_queryset().filter(
+            is_deleted=False,
+            published_at__isnull=False,
+        )
+
+    def all_with_drafts(self):
+        """下書きも含めた alive な tweet。 /drafts / composer 編集等のため。"""
+        return super().get_queryset().filter(is_deleted=False)
+
+    def all_with_deleted(self):  # 既存
+        return super().get_queryset()
+```
+
+→ これにより既存 `Tweet.objects.filter(...)` は **何も変えなくても自動的に下書きを除外** する。 「漏れ防止」 のための最強の防御。 下書きを意図的に読みたい場所だけ `all_with_drafts()` / `drafts_of(user)` を使う。
+
+**影響範囲**: `Tweet.objects.filter(...)` は 60+ 箇所あるが、 すべて「公開 tweet を表示する」 用途なのでそのまま動作。 例外:
+
+| 場所                                               | 必要な対応                                                      |
+| -------------------------------------------------- | --------------------------------------------------------------- |
+| `apps/tweets/views.py` TweetViewSet.retrieve       | 自分の下書きを編集できるよう `all_with_drafts()` + author scope |
+| `apps/tweets/views.py` TweetViewSet.partial_update | 同上                                                            |
+| `apps/tweets/views.py` TweetViewSet.destroy        | 同上                                                            |
+| `apps/tweets/views.py` 新 endpoint `drafts/`       | `drafts_of(request.user)`                                       |
+
+それ以外 (TL / search / profile / agent tools / repost / quote / reply 等) は変更不要。
+
+---
+
+## 3. API
+
+### 3.1 投稿時に下書き選択
+
+`POST /api/v1/tweets/`:
+
+```json
+{
+	"body": "テスト下書き",
+	"is_draft": true // ← 追加 (default: false)
+}
+```
+
+- `is_draft=true` なら `published_at=None` で保存。
+- `is_draft=false` (or 省略) なら従来通り `published_at=now()` で公開保存。
+- `type=repost / reply / quote` の場合、 `is_draft` は **強制 false** (= reaction や引用関係は下書きにそぐわないため、 オリジナル投稿のみ下書き可能)。 違反したら 400。
+
+### 3.2 下書きを公開
+
+`POST /api/v1/tweets/{id}/publish/`:
+
+- 自分の下書き (=ある, `published_at IS NULL`) のみ。 他人の下書きは 404。
+- 成功時: `published_at = now()`, `created_at = now()` (上記 §2.1 ルール) に更新して 200 で返す。
+- 既に公開済みなら 400 (`already_published`)。
+- 公開後の payload は通常 Tweet と同じ shape。
+
+### 3.3 下書き一覧
+
+`GET /api/v1/tweets/drafts/?page=1`:
+
+- 自分の下書きを新しい順で返す。 paginate (PAGE_SIZE=20)。
+- response shape は既存 tweet list と同じ (count / next / previous / results)。
+- 匿名 / 401 ではアクセス不可。
+
+### 3.4 下書きを編集
+
+`PATCH /api/v1/tweets/{id}/` を下書きにも適用:
+
+- 自分の下書きの body / media を変更可能。
+- `edit_count` は上げない (= 公開後の edit と区別)。
+- 他人の下書き ID を指定 → 404 隠蔽。
+
+### 3.5 下書きを削除
+
+`DELETE /api/v1/tweets/{id}/`:
+
+- 既存通り論理削除 (`is_deleted=True, deleted_at=now()`)。
+- 下書きでも同じ。 履歴は残る (audit 目的)。
+
+### 3.6 他人の下書きへのアクセス
+
+`GET /tweets/{id}/` で他人の `published_at IS NULL` な tweet を指定:
+
+- **404 隠蔽** (= 存在自体を漏らさない)。 403 だと「ある」 ことが推測できてしまう。
+- 同じ規則を search / TL / profile に適用 (Manager で既定除外)。
+
+---
+
+## 4. Frontend
+
+### 4.1 Composer
+
+`client/src/components/compose/ComposerForm.tsx` (or equivalent) に「下書き保存」 button を追加:
+
+```
+[ 投稿する ]  [ 下書き保存 ]
+```
+
+- 「下書き保存」 click → `POST /tweets/ { is_draft: true }` → toast「下書きに保存しました」 + composer close + `/drafts` への hint link
+- 「投稿する」 click → 既存通り (公開投稿)
+
+### 4.2 `/drafts` page
+
+新規 route `client/src/app/(template)/drafts/page.tsx`:
+
+- 本人のみアクセス可 (SSR で auth 確認、 未ログインなら `/login` redirect)
+- 下書き一覧 (新しい順)
+- 各行に:
+  - tweet body プレビュー
+  - 「編集」 button → composer dialog を draft の id で開く
+  - 「公開する」 button → `POST /tweets/{id}/publish/` → toast + 一覧から消える + `/` への hint
+  - 「削除」 button → 確認 dialog + `DELETE /tweets/{id}/`
+
+### 4.3 ナビ導線
+
+- `client/src/constants/index.ts` の `leftNavLinks` に「下書き」 (= `/drafts`, `requiresAuth: true`) を追加
+- `client/src/components/layout-a/ALeftNav.tsx` の `NAV_ITEMS` にも同じ entry (Icon: `Pencil` or `FileText`)
+- `client/src/components/layout-a/AMobileShell.tsx` の DrawerNav にも追加
+- 自分の profile page に「下書き」 tab (本人のみ表示) で `/drafts` の一覧と同じ shape を inline 表示するのは Phase B (今回スコープ外)
+
+### 4.4 既存 profile / TL への影響
+
+なし。 `Tweet.objects.published()` (= 既定) を使う既存 endpoint はすべて自動で下書きを除外する。
+
+---
+
+## 5. Claude Agent (Phase 14) との関係
+
+### 5.1 自動防御 (Manager 既定)
+
+`apps/agents/tools.py` の 3 つの read 系 tool は **既に** `Tweet.objects.filter(...)` 経由なので、 Manager の既定変更により自動で下書き除外される:
+
+- `read_my_recent_tweets`: `Tweet.objects.filter(author=user, ...)` → 自分の下書きでも Manager 既定で除外 (= agent は自分の下書きも読まない、 prompt injection 経由で漏らさない)
+- `read_home_timeline`: `build_home_tl()` 経由で `Tweet.objects.filter(...)` を使う → 自動除外
+- `search_tweets_by_tag`: 同上
+
+### 5.2 念のため明示テスト
+
+Manager の挙動が変わって誰かが将来 `all_with_drafts()` を agent tool に持ち込まないよう、 pytest で:
+
+```python
+def test_agent_tool_does_not_leak_drafts(self):
+    # 自分の下書きを作る
+    Tweet.objects.create(..., published_at=None)  # all_with_drafts manager 経由
+    # agent tool 呼ぶ
+    result = read_my_recent_tweets(user)
+    # 下書き本文が含まれていない
+    assert "下書きテスト" not in result
+```
+
+`apps/agents/tests/test_tools.py` に 3 tool × 1 test = 3 ケース追加。
+
+---
+
+## 6. テスト
+
+### 6.1 pytest (backend)
+
+`apps/tweets/tests/test_drafts.py` (新規):
+
+| シナリオ                                                        | 期待                                  |
+| --------------------------------------------------------------- | ------------------------------------- |
+| `POST /tweets/ {is_draft: true}`                                | 201 + `published_at=null`             |
+| `POST /tweets/ {is_draft: false}`                               | 201 + `published_at != null` (= 公開) |
+| `POST /tweets/ {is_draft: true, type: "reply", reply_to: <id>}` | 400 (= 下書きは ORIGINAL のみ)        |
+| 自分の draft `GET /tweets/{id}/`                                | 200                                   |
+| 他人の draft `GET /tweets/{id}/`                                | 404                                   |
+| 匿名で draft `GET /tweets/{id}/`                                | 404                                   |
+| `GET /tweets/drafts/` (自分)                                    | 自分の下書き一覧                      |
+| `GET /tweets/drafts/` (匿名)                                    | 401                                   |
+| 他人の draft `GET /tweets/drafts/` で混入                       | NG (自分の分だけ)                     |
+| `POST /tweets/{id}/publish/` (自分の draft)                     | 200 + `published_at!=null`            |
+| `POST /tweets/{id}/publish/` (他人の draft)                     | 404                                   |
+| `POST /tweets/{id}/publish/` (自分の公開済み)                   | 400                                   |
+| draft が `build_home_tl` に出ない                               | (manager 既定で fixed)                |
+| draft が tag search に出ない                                    | 同上                                  |
+| draft が `read_my_recent_tweets` agent tool に出ない            | 上記 §5.2                             |
+
+### 6.2 vitest (frontend)
+
+`client/src/components/compose/__tests__/ComposerForm.test.tsx`:
+
+- 「下書き保存」 click で `runCreateTweet({is_draft: true})` が呼ばれる
+- 成功 toast 「下書きに保存しました」
+
+`client/src/app/(template)/drafts/__tests__/page.test.tsx`:
+
+- SSR で auth 確認 → 未ログイン redirect
+- draft 一覧 render
+- 「公開する」 click で API 呼び出し + 行が消える
+
+### 6.3 E2E Playwright (`client/e2e/drafts.spec.ts`) — PR-C 別出し
+
+| シナリオ                                                                 | 期待 |
+| ------------------------------------------------------------------------ | ---- |
+| DRAFTS-1: ログイン → composer で「下書き保存」 → `/drafts` に出る        | ✅   |
+| DRAFTS-2: home TL に出ない (=他 tweet と同列に混ざらない)                | ✅   |
+| DRAFTS-3: search で出ない                                                | ✅   |
+| DRAFTS-4: 他人視点 `/tweet/{id}` で 404                                  | ✅   |
+| DRAFTS-5: 自分視点で「公開する」 → home TL に出る + `/drafts` から消える | ✅   |
+| DRAFTS-6: ホーム → leftNav「下書き」 1 click で到達                      | ✅   |
+
+実行:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test2@gmail.com \
+PLAYWRIGHT_USER1_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER1_HANDLE=test2 \
+PLAYWRIGHT_USER2_EMAIL=test3@gmail.com \
+PLAYWRIGHT_USER2_PASSWORD=Sirius01 \
+PLAYWRIGHT_USER2_HANDLE=test3 \
+  npx playwright test e2e/drafts.spec.ts --reporter=line
+```
+
+---
+
+## 7. ロールアウト順序
+
+1. **PR-A (本 issue #734)**: backend (model + migration + manager + API + agent tool 静的テスト) + frontend (composer + /drafts + nav)
+2. **PR-B (#735)**: 鍵アカ機能 (依存なし、 平行で進められるが直列に進める)
+3. **PR-C (#736)**: Playwright E2E spec (drafts.spec.ts + private-account.spec.ts) + stg 反映後の実機検証 + gan-evaluator 採点
+
+### マージ前ブロッカー (CLAUDE.md §4.1.1)
+
+- migration が backfill を伴うので **stg で migration 適用 → smoke test** を必ず通す
+- chunked update がうまく流れるか migration の出力を CI / stg deploy ログで確認
+- 既存 tweet がすべて `published_at != NULL` になっているか stg DB の検証 SQL を 1 回実行
+
+---
+
+## 8. 影響範囲リスト (= 二度 read しない用)
+
+- `apps/tweets/models.py`: `published_at` field 追加
+- `apps/tweets/migrations/00XX_add_published_at.py`: AddField + chunked backfill
+- `apps/tweets/managers.py`: QuerySet / Manager 拡張
+- `apps/tweets/views.py`: TweetViewSet に `publish` action + `drafts` action + retrieve/update/destroy で `all_with_drafts()` (自分のみ)
+- `apps/tweets/serializers.py`: `is_draft` input + `published_at` output 追加
+- `apps/tweets/urls.py`: 新 routes
+- `apps/tweets/permissions.py`: draft visibility (= 404 隠蔽 helper)
+- `apps/tweets/admin.py`: `published_at` を list_filter に
+- `apps/agents/tests/test_tools.py`: 下書き混入なし test 3 つ
+- `client/src/lib/api/tweets.ts`: `createTweet` に `is_draft` opt, `publishDraft(id)`, `fetchDrafts()`
+- `client/src/components/compose/ComposerForm.tsx` (or 既存 composer): 「下書き保存」 button
+- `client/src/app/(template)/drafts/page.tsx`: 新規
+- `client/src/components/drafts/DraftsList.tsx`: 新規
+- `client/src/constants/index.ts`: `leftNavLinks` に entry
+- `client/src/components/layout-a/ALeftNav.tsx`: `NAV_ITEMS` に entry
+- `client/src/components/layout-a/AMobileShell.tsx`: DrawerNav に entry
+- `docs/SPEC.md`: §3 tweets に「下書き状態」 章を追記
+- `docs/ER.md`: tweet テーブル定義に published_at 追加
+- `docs/db-schema.md`: 同上
+
+---
+
+## 9. 非スコープ
+
+- 鍵アカ (= 公開してるけど特定の人にしか見せない): #735 で別途
+- 予約投稿 (= 未来時刻に自動公開): 別 phase
+- 下書き複数バージョン履歴: 不要 (= edit_count と同じ 1 行管理)
+- 下書きの共同編集 / 共有: NG (本人のみ)
+- 下書きの全文検索 (本人用): 不要 (= 件数少ない前提、 /drafts 直訪問でスキャン)
+
+---
+
+## 10. 出典 / 参考
+
+- Twitter Help: Twitter Drafts (2018 〜): https://help.twitter.com/en/using-twitter/tweets/drafts
+- X 仕様 (2023〜): Drafts は web で完全実装、 mobile アプリ毎に保持
+- Phase 14 spec: [claude-agent-spec.md](./claude-agent-spec.md) §4 §5 (agent tool scope)
+- 既存 manager pattern: `apps/tweets/managers.py`


### PR DESCRIPTION
Closes #734

## Summary

- X / Twitter 互換の「下書き保存」 機能。 SPEC.md 起草時の漏れを埋める。
- 副次的に **Phase 14 Claude Agent から「他人の未公開 tweet」 を読まない** 基盤になる。 Tweet.objects manager の既定を「公開済みのみ」 に変えるので、 既存の agent tool (read_my_recent_tweets / read_home_timeline / search_tweets_by_tag) は自動で下書き除外される (defense in depth)。
- 鍵アカ機能は #735 で別 PR、 E2E spec は #736 で別 PR。

## Changes

### Data model
- `Tweet.published_at: DateTimeField(null=True, db_index=True)` 追加
- migration 0008 で既存 tweet を `published_at = created_at` で **chunked backfill** (10k 件ずつ、 ロック保持時間を最小化)
- `TweetManager.get_queryset()` の既定を `is_deleted=False, published_at__isnull=False` に変更
- 下書きを読みたい箇所は `Tweet.objects.all_with_drafts()` / `Tweet.objects.drafts_of(user)` を使う
- `TweetManager.create()` を override → `published_at` 未指定なら `now()` を入れる。 既存の `Tweet.objects.create(body=...)` は引き続き「公開即時投稿」 として動作 (= 既存テストが壊れない)

### API
- `POST /api/v1/tweets/ {is_draft: true}` で下書き保存 (ORIGINAL のみ、 reply/quote/repost は 400)
- `POST /api/v1/tweets/<id>/publish/` で下書きを公開 (= published_at=now())
- `GET /api/v1/tweets/drafts/` で自分の下書き一覧 (paginate, auth 必須)
- 他人の draft への retrieve / patch / delete / publish はすべて **404 隠蔽** (存在を漏らさない)
- TweetListSerializer / TweetDetailSerializer / TweetMiniSerializer に `published_at` 追加。 nested parent (reply_to / quote_of / repost_of) が draft の場合は **defense in depth で nested embed しない**

### Frontend
- TweetComposer に「下書き保存」 button (variant=outline)
- 新 route `/drafts` (SSR で auth check + 一覧 fetch、 未ログインは /login redirect)
- DraftsPanel: 一覧表示 + 「公開する」「削除」 button + empty state
- ALeftNav / AMobileShell DrawerNav / leftNavLinks すべてに「下書き」 entry を追加 (Pencil icon、 requiresAuth=true)
- LeftNavbar / MobileNavbar の ICON_MAP に Pencil を登録
- API client: `fetchDrafts()`, `publishDraft(id)` 追加、 `CreateTweetPayload.is_draft` / `TweetSummary.published_at` 追加

### Agent tools (Phase 14)
Manager の既定変更で 3 つの read tool は何もしなくても draft 除外される。 念のため回帰テスト 3 ケースを `apps/agents/tests/test_tools.py` に追加。

## Tests

- **pytest** `apps/tweets/tests/test_drafts.py` (新規 297 行):
  - Manager 既定除外 / all_with_drafts / drafts_of
  - Create with is_draft / 公開済み default / reply に is_draft 禁止
  - drafts list 自分のみ / 他人除外 / 匿名 401
  - retrieve owner OK / 他人 404 / 匿名 404
  - patch/delete 他人 draft 404 隠蔽
  - publish owner OK / 他人 404 / 公開済み 400
  - 公開 list / home TL に draft が出ない
- **pytest** `apps/agents/tests/test_tools.py`: read 系 3 tool で draft が混入しない
- **vitest** `DraftsPanel.test.tsx` (5 件), `TweetComposerDraft.test.tsx` (2 件)
- 全 vitest 753 / 754 passing (1 todo)、 tsc / eslint clean

## Migration リスク

migration 0008 は `AddField(null=True)` + chunked `RunPython` backfill。

- AddField はメタデータのみ (= ALTER TABLE ADD COLUMN NULL): PostgreSQL なら instant
- backfill は **10k 件ずつ** id range で UPDATE → 各 chunk でロックは短時間で解放される
- stg DB は 数千行なので worst case でも数十秒で完了見込み
- rollback もちゃんと書いた (= 全 published_at を NULL に戻す)

CD stg deploy の `Run migrations` step で問題があれば fail するはず。

## Test plan

- [x] vitest 753 / 754 passing
- [x] tsc --noEmit clean
- [x] eslint clean (auto-fix で Tailwind classname order だけ修正)
- [ ] CI green (ruff / mypy / pytest / vitest / tsc / eslint)
- [ ] stg deploy 後、 composer で「下書き保存」 → /drafts に出るか実機 (Playwright MCP / curl)
- [ ] 他人の draft URL を直接踏んで 404 になるか
- [ ] Claude Agent が新規 draft を読まないか (curl で `agent_message` / `draft_text` 確認)

## サイズ

CLAUDE.md §4.1.1 の 500 行ガイドラインを超える (+1,667 行)。 内訳:

- 仕様書 350 行 (review-only、 設計判断の justification 込み)
- pytest 297 + 61 行 / vitest 158 + 94 行 (review-only)
- 実装本体は ~720 行で 1 feature 完結

機能内で分割 (例: モデルだけ → API → UI) すると review しづらく、 また stg deploy 中に「中途半端な state でリリースされる」 ので、 1 PR にまとめた。 ハルナさんに事前承認済 (`AskUserQuestion` 結果)。