### PR TITLE
feat(users): 鍵アカ + フォロー承認制 (#735)

### DIFF
--- a/apps/agents/tests/test_tools.py
+++ b/apps/agents/tests/test_tools.py
@@ -277,6 +277,57 @@ class TestDraftsHiddenFromAgentTools:
 
 
 # ---------------------------------------------------------------------------
+# #735: 鍵アカ user の tweet は agent tool に露出してはならない
+# (viewer が approved follower 関係で無いとき)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPrivateAccountHiddenFromAgentTools:
+    def test_home_timeline_excludes_private_non_follower(self):
+        from apps.timeline.services import build_home_tl
+
+        me = _make_user("me-priv-tl@example.com", "me_priv_tl")
+        private_author = _make_user("priv-author-tl@example.com", "priv_author_tl")
+        private_author.is_private = True
+        private_author.save()
+        Tweet.objects.create(author=private_author, body="PRIVATE-TL-SECRET")
+        items = build_home_tl(me, limit=20)
+        for t in items:
+            assert "PRIVATE-TL-SECRET" not in t.body
+
+    def test_search_excludes_private_non_follower(self):
+        """non-follower の agent から鍵アカの tag tweet が見えないこと。
+
+        `_query_global` で `author__is_private=False` filter が効いて、
+        search_tweets_by_tag は `Tweet.objects.filter(tags__name=...)` で
+        manager 既定経由なので、 個別 view 層の visible_to を介さない。
+        現状の `search_tweets_by_tag` は manager 既定だけで draft は除外して
+        いるが、 **private filter は未統合**。 ここでは将来 search 側にも
+        visibility filter を入れる前提で、 manager の `visible_to()` で
+        フィルタした queryset でも同じ結果が出ることを確認する。
+        """
+        me = _make_user("me-priv-tag@example.com", "me_priv_tag")
+        private_author = _make_user("priv-author-tag@example.com", "priv_author_tag")
+        private_author.is_private = True
+        private_author.save()
+        tag = Tag.objects.create(
+            name="priv-secret-735",
+            display_name="PS",
+            is_approved=True,
+        )
+        t = Tweet.objects.create(author=private_author, body="PRIVATE-TAG-SECRET")
+        t.tags.add(tag)
+        # manager の visible_to で me から見たら鍵アカ tweet は出ないこと
+        visible_ids = list(
+            Tweet.objects.filter(tags__name="priv-secret-735")
+            .visible_to(me)
+            .values_list("id", flat=True)
+        )
+        assert t.id not in visible_ids
+
+
+# ---------------------------------------------------------------------------
 # compose_tweet_draft
 # ---------------------------------------------------------------------------
 

--- a/apps/agents/tools.py
+++ b/apps/agents/tools.py
@@ -214,6 +214,9 @@ def search_tweets_by_tag(
             is_deleted=False,
             type=TweetType.ORIGINAL,
         )
+        # #735: 鍵アカ author の tweet は viewer (= agent 起動者) が approved
+        # follower でない場合は除外。 ``visible_to(user)`` で 1 行 filter で済む。
+        .visible_to(user)
         .order_by("-created_at")
         .select_related("author")
         .distinct()[: n * 3]  # block filter 後に件数が減る前提で余分に取得

--- a/apps/follows/migrations/0002_follow_status_approved_at.py
+++ b/apps/follows/migrations/0002_follow_status_approved_at.py
@@ -1,0 +1,82 @@
+"""#735 鍵アカ機能: ``Follow.status`` + ``Follow.approved_at`` を追加。
+
+spec: docs/specs/private-account-spec.md §2.2
+
+既存 Follow はすべて ``status=approved, approved_at=created_at`` で backfill
+(= 公開アカ宛 follow は即承認済として動作、 既存挙動維持)。
+
+chunked update: 5,000 件ずつ id range で update してロック時間を最小化する。
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+CHUNK_SIZE = 5_000
+
+
+def backfill_status_and_approved_at(apps, schema_editor):
+    """既存 Follow すべてを ``status='approved', approved_at=created_at`` で backfill。"""
+
+    Follow = apps.get_model("follows", "Follow")
+    # 既に status を持っている (= AddField default で全行に approved が入っている)
+    # ので、 approved_at だけ chunked で created_at にコピーする。
+    qs = Follow.objects.filter(approved_at__isnull=True).only("id", "created_at")
+
+    last_id = 0
+    while True:
+        chunk = list(
+            qs.filter(id__gt=last_id).order_by("id").values_list("id", "created_at")[
+                :CHUNK_SIZE
+            ]
+        )
+        if not chunk:
+            break
+        ids = [pk for pk, _ in chunk]
+        Follow.objects.filter(id__in=ids).update(approved_at=models.F("created_at"))
+        last_id = ids[-1]
+
+
+def reverse_backfill(apps, schema_editor):
+    """approved_at を全部 NULL に戻す ロールバック用。"""
+
+    Follow = apps.get_model("follows", "Follow")
+    Follow.objects.update(approved_at=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("follows", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="follow",
+            name="status",
+            field=models.CharField(
+                choices=[("pending", "承認待ち"), ("approved", "承認済み")],
+                default="approved",
+                help_text=(
+                    "公開アカへの follow は即 approved、 鍵アカへの follow は "
+                    "pending → 承認 / 拒否で確定する。"
+                ),
+                max_length=10,
+            ),
+        ),
+        migrations.AddField(
+            model_name="follow",
+            name="approved_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text=(
+                    "承認時刻 (status=approved になった時刻)。 pending 中は NULL。"
+                ),
+                null=True,
+            ),
+        ),
+        migrations.RunPython(
+            backfill_status_and_approved_at,
+            reverse_code=reverse_backfill,
+        ),
+    ]

--- a/apps/follows/models.py
+++ b/apps/follows/models.py
@@ -21,7 +21,17 @@ class Follow(models.Model):
 
     フォロー方向は ``follower → followee`` (follower が followee を follow している)。
     削除時は signals で User.followers_count / following_count を ``F-1`` でデクリメント。
+
+    #735 鍵アカ機能:
+    - 公開アカへの follow は即 ``status=approved`` (= 既存挙動)
+    - 鍵アカへの follow は ``status=pending`` (= 承認待ち)
+    - 承認 → ``status=approved`` + ``approved_at=now()`` + counters +1
+    - 拒否 → 行を物理削除 (= もう一度 follow 可能、 X 仕様準拠)
     """
+
+    class Status(models.TextChoices):
+        PENDING = "pending", "承認待ち"
+        APPROVED = "approved", "承認済み"
 
     follower = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -34,6 +44,24 @@ class Follow(models.Model):
         on_delete=models.CASCADE,
         related_name="follower_set",
         help_text="The user being followed.",
+    )
+    # #735: 鍵アカ承認制。 公開アカへの follow は即 approved、 鍵アカへの follow
+    # は pending → 承認 / 拒否で確定する。 既存 Follow は migration で全て
+    # approved に backfill (= 後方互換)。
+    # spec: docs/specs/private-account-spec.md §2.2
+    status = models.CharField(
+        max_length=10,
+        choices=Status.choices,
+        default=Status.APPROVED,
+        help_text=(
+            "公開アカへの follow は即 approved、 鍵アカへの follow は pending → "
+            "承認 / 拒否で確定する。"
+        ),
+    )
+    approved_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="承認時刻 (status=approved になった時刻)。 pending 中は NULL。",
     )
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/apps/follows/serializers.py
+++ b/apps/follows/serializers.py
@@ -43,8 +43,14 @@ class PublicUserMiniSerializer(serializers.ModelSerializer):
 
 
 class FollowResponseSerializer(serializers.Serializer):
-    """POST /follow/ の戻り値 (idempotent: created or existing)."""
+    """POST /follow/ の戻り値 (idempotent: created or existing)。
+
+    #735: ``status`` を含める (= 公開アカなら ``"approved"``、 鍵アカなら
+    ``"pending"``)。 frontend FollowButton が 3 状態 (承認待ち / フォロー中 /
+    フォローする) を切り替えるために使う。
+    """
 
     follower = serializers.UUIDField(read_only=True)
     followee = serializers.UUIDField(read_only=True)
     created = serializers.BooleanField(read_only=True)
+    status = serializers.CharField(read_only=True)

--- a/apps/follows/signals.py
+++ b/apps/follows/signals.py
@@ -50,8 +50,15 @@ def on_follow_created(sender: type[Follow], instance: Follow, created: bool, **k
 
     P2-08: 自分の home TL キャッシュを invalidate (follow 直後に新しいフォロイーの
     ツイートが TL に反映されるよう)。
+
+    #735: 鍵アカ機能で ``status=pending`` で作成された Follow は **counter 更新
+    しない** (= 承認時に approve view 側で counters を +1 する)。 通知も「フォロー
+    申請」 として別 kind で送る (本 signal は status=approved 限定)。
     """
     if not created:
+        return
+    # #735: pending な follow は counter / 通知の対象外
+    if instance.status != Follow.Status.APPROVED:
         return
     follower_pk = instance.follower_id
     followee_pk = instance.followee_id
@@ -92,7 +99,13 @@ def on_follow_created(sender: type[Follow], instance: Follow, created: bool, **k
 
 @receiver(post_delete, sender=Follow)
 def on_follow_deleted(sender: type[Follow], instance: Follow, **kwargs: Any) -> None:
-    """Follow 削除時に followers_count / following_count を -1 (0 で clip)."""
+    """Follow 削除時に followers_count / following_count を -1 (0 で clip).
+
+    #735: pending な follow 削除 (= follow request reject) は counter 不変。
+    """
+    # #735: pending Follow は counter に算入されていない → 削除しても変動なし
+    if instance.status != Follow.Status.APPROVED:
+        return
     follower_pk = instance.follower_id
     followee_pk = instance.followee_id
     follower_obj = instance.follower

--- a/apps/follows/tests/test_follow_requests.py
+++ b/apps/follows/tests/test_follow_requests.py
@@ -30,7 +30,7 @@ def authed_client():
     return _make
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestFollowOnPublicAccount:
     def test_follow_public_is_immediately_approved(self, authed_client):
         a = make_user()  # follower
@@ -49,7 +49,7 @@ class TestFollowOnPublicAccount:
         assert a.following_count == 1
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestFollowOnPrivateAccount:
     def test_follow_private_creates_pending(self, authed_client):
         a = make_user()  # follower
@@ -68,7 +68,7 @@ class TestFollowOnPrivateAccount:
         assert a.following_count == 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestFollowRequestsList:
     def test_list_own_pending_requests(self, authed_client):
         owner = make_user(is_private=True)
@@ -93,7 +93,7 @@ class TestFollowRequestsList:
         assert resp.status_code in (401, 403)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestApproveReject:
     def test_approve_promotes_status_and_bumps_counters(self, authed_client):
         owner = make_user(is_private=True)
@@ -145,7 +145,7 @@ class TestApproveReject:
         assert resp.status_code == 400
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestUnprivateAutoApproves:
     def test_setting_is_private_false_auto_approves_pending(self, authed_client):
         owner = make_user(is_private=True)

--- a/apps/follows/tests/test_follow_requests.py
+++ b/apps/follows/tests/test_follow_requests.py
@@ -1,0 +1,163 @@
+"""#735 鍵アカ機能: フォロー承認制 API のテスト。
+
+spec: docs/specs/private-account-spec.md §6.1
+
+カバレッジ:
+1. 公開アカへの follow → 即 approved
+2. 鍵アカへの follow → pending
+3. GET /follows/requests/ で自分宛 pending 一覧
+4. approve → status=approved + counters +1
+5. reject → 行物理削除 + counters 不変
+6. 他人の request を approve/reject → 404
+"""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from apps.follows.models import Follow
+from apps.tweets.tests._factories import make_user
+
+
+@pytest.fixture
+def authed_client():
+    def _make(user):
+        c = APIClient()
+        c.force_authenticate(user=user)
+        return c
+
+    return _make
+
+
+@pytest.mark.django_db
+class TestFollowOnPublicAccount:
+    def test_follow_public_is_immediately_approved(self, authed_client):
+        a = make_user()  # follower
+        b = make_user()  # followee (公開)
+        c = authed_client(a)
+        resp = c.post(f"/api/v1/users/{b.username}/follow/")
+        assert resp.status_code == 201, resp.data
+        assert resp.data["status"] == Follow.Status.APPROVED
+        f = Follow.objects.get(follower=a, followee=b)
+        assert f.status == Follow.Status.APPROVED
+        assert f.approved_at is not None
+        # counter は signal で +1
+        b.refresh_from_db()
+        a.refresh_from_db()
+        assert b.followers_count == 1
+        assert a.following_count == 1
+
+
+@pytest.mark.django_db
+class TestFollowOnPrivateAccount:
+    def test_follow_private_creates_pending(self, authed_client):
+        a = make_user()  # follower
+        b = make_user(is_private=True)  # 鍵アカ
+        c = authed_client(a)
+        resp = c.post(f"/api/v1/users/{b.username}/follow/")
+        assert resp.status_code == 201, resp.data
+        assert resp.data["status"] == Follow.Status.PENDING
+        f = Follow.objects.get(follower=a, followee=b)
+        assert f.status == Follow.Status.PENDING
+        assert f.approved_at is None
+        # counter は更新されない (signal で skip)
+        b.refresh_from_db()
+        a.refresh_from_db()
+        assert b.followers_count == 0
+        assert a.following_count == 0
+
+
+@pytest.mark.django_db
+class TestFollowRequestsList:
+    def test_list_own_pending_requests(self, authed_client):
+        owner = make_user(is_private=True)
+        u1 = make_user()
+        u2 = make_user()
+        Follow.objects.create(follower=u1, followee=owner, status=Follow.Status.PENDING)
+        Follow.objects.create(follower=u2, followee=owner, status=Follow.Status.PENDING)
+        # 他人宛 pending (= 関係ない)
+        other_owner = make_user(is_private=True)
+        Follow.objects.create(follower=u1, followee=other_owner, status=Follow.Status.PENDING)
+
+        c = authed_client(owner)
+        resp = c.get("/api/v1/follows/requests/")
+        assert resp.status_code == 200
+        items = resp.data.get("results", resp.data)
+        handles = {row["follower"]["handle"] for row in items}
+        assert handles == {u1.username, u2.username}
+
+    def test_anon_cannot_list(self):
+        c = APIClient()
+        resp = c.get("/api/v1/follows/requests/")
+        assert resp.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+class TestApproveReject:
+    def test_approve_promotes_status_and_bumps_counters(self, authed_client):
+        owner = make_user(is_private=True)
+        u = make_user()
+        f = Follow.objects.create(follower=u, followee=owner, status=Follow.Status.PENDING)
+        c = authed_client(owner)
+        resp = c.post(f"/api/v1/follows/requests/{f.id}/approve/")
+        assert resp.status_code == 200, resp.data
+        f.refresh_from_db()
+        assert f.status == Follow.Status.APPROVED
+        assert f.approved_at is not None
+        owner.refresh_from_db()
+        u.refresh_from_db()
+        assert owner.followers_count == 1
+        assert u.following_count == 1
+
+    def test_reject_deletes_row_and_no_counter_change(self, authed_client):
+        owner = make_user(is_private=True)
+        u = make_user()
+        f = Follow.objects.create(follower=u, followee=owner, status=Follow.Status.PENDING)
+        c = authed_client(owner)
+        resp = c.post(f"/api/v1/follows/requests/{f.id}/reject/")
+        assert resp.status_code == 204
+        assert not Follow.objects.filter(pk=f.id).exists()
+        owner.refresh_from_db()
+        u.refresh_from_db()
+        assert owner.followers_count == 0
+        assert u.following_count == 0
+
+    def test_approve_others_request_404(self, authed_client):
+        owner = make_user(is_private=True)
+        attacker = make_user()
+        u = make_user()
+        f = Follow.objects.create(follower=u, followee=owner, status=Follow.Status.PENDING)
+        c = authed_client(attacker)
+        resp = c.post(f"/api/v1/follows/requests/{f.id}/approve/")
+        assert resp.status_code == 404
+
+    def test_approve_already_approved_returns_400(self, authed_client):
+        owner = make_user(is_private=True)
+        u = make_user()
+        f = Follow.objects.create(
+            follower=u,
+            followee=owner,
+            status=Follow.Status.APPROVED,
+        )
+        c = authed_client(owner)
+        resp = c.post(f"/api/v1/follows/requests/{f.id}/approve/")
+        assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+class TestUnprivateAutoApproves:
+    def test_setting_is_private_false_auto_approves_pending(self, authed_client):
+        owner = make_user(is_private=True)
+        u1 = make_user()
+        u2 = make_user()
+        Follow.objects.create(follower=u1, followee=owner, status=Follow.Status.PENDING)
+        Follow.objects.create(follower=u2, followee=owner, status=Follow.Status.PENDING)
+        c = authed_client(owner)
+        resp = c.patch("/api/v1/users/me/", {"is_private": False}, format="json")
+        assert resp.status_code == 200, resp.data
+        # 全 pending が approved になる
+        assert Follow.objects.filter(followee=owner, status=Follow.Status.PENDING).count() == 0
+        assert Follow.objects.filter(followee=owner, status=Follow.Status.APPROVED).count() == 2
+        owner.refresh_from_db()
+        assert owner.followers_count == 2

--- a/apps/follows/urls_requests.py
+++ b/apps/follows/urls_requests.py
@@ -1,0 +1,38 @@
+"""#735 フォロー申請承認 API.
+
+mounted at ``/api/v1/follows/`` in ``config/urls.py``:
+
+- GET  /api/v1/follows/requests/                  → 自分宛 pending 一覧
+- POST /api/v1/follows/requests/<follow_id>/approve/ → 承認
+- POST /api/v1/follows/requests/<follow_id>/reject/  → 拒否 (物理削除)
+
+spec: docs/specs/private-account-spec.md §3.3 §3.4
+"""
+
+from __future__ import annotations
+
+from django.urls import path
+
+from apps.follows.views import (
+    FollowApproveView,
+    FollowRejectView,
+    FollowRequestsListView,
+)
+
+urlpatterns = [
+    path(
+        "requests/",
+        FollowRequestsListView.as_view(),
+        name="follows-requests-list",
+    ),
+    path(
+        "requests/<int:follow_id>/approve/",
+        FollowApproveView.as_view(),
+        name="follows-requests-approve",
+    ),
+    path(
+        "requests/<int:follow_id>/reject/",
+        FollowRejectView.as_view(),
+        name="follows-requests-reject",
+    ),
+]

--- a/apps/follows/views.py
+++ b/apps/follows/views.py
@@ -18,8 +18,9 @@ import logging
 
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
-from django.db.models import QuerySet
+from django.db.models import F, QuerySet
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import CursorPagination
@@ -81,19 +82,36 @@ class FollowView(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        # #735: 鍵アカ宛なら pending、 公開アカなら approved で作成。
+        # spec: docs/specs/private-account-spec.md §3.2
+        if followee.is_private:
+            initial_status = Follow.Status.PENDING
+            initial_approved_at = None
+        else:
+            initial_status = Follow.Status.APPROVED
+            initial_approved_at = timezone.now()
+
         try:
             with transaction.atomic():
-                follow, created = Follow.objects.get_or_create(follower=follower, followee=followee)
+                follow, created = Follow.objects.get_or_create(
+                    follower=follower,
+                    followee=followee,
+                    defaults={
+                        "status": initial_status,
+                        "approved_at": initial_approved_at,
+                    },
+                )
         except IntegrityError:
             # 万一の同時作成 race を idempotent 化 (UniqueConstraint で発生)。
-            # follow オブジェクト自体は payload で参照しないので fetch 不要。
             created = False
+            follow = Follow.objects.get(follower=follower, followee=followee)
 
         payload = FollowResponseSerializer(
             {
                 "follower": follower.id,
                 "followee": followee.id,
                 "created": created,
+                "status": follow.status,
             }
         ).data
         return Response(
@@ -199,3 +217,123 @@ class PopularUsersView(APIView):
         else:
             rows = get_popular_users(limit=limit)
         return Response({"results": rows})
+
+
+# ---------------------------------------------------------------------------
+# #735 鍵アカ / フォロー承認制
+# ---------------------------------------------------------------------------
+
+
+class FollowRequestsListView(ListAPIView):
+    """GET /api/v1/follows/requests/
+
+    自分宛の pending フォロー申請一覧 (鍵アカ user 用)。 新しい順で paginate。
+    spec: docs/specs/private-account-spec.md §3.3
+    """
+
+    permission_classes = [IsAuthenticated]
+    pagination_class = FollowCursorPagination
+
+    def get_queryset(self) -> QuerySet[Follow]:
+        return (
+            Follow.objects.filter(
+                followee=self.request.user,
+                status=Follow.Status.PENDING,
+            )
+            .select_related("follower")
+            .order_by("-created_at")
+        )
+
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        qs = self.get_queryset()
+        page = self.paginate_queryset(qs)
+        rows = page if page is not None else list(qs)
+        results = [
+            {
+                "follow_id": f.id,
+                "follower": {
+                    "id": str(f.follower.id),
+                    "handle": f.follower.username,
+                    "display_name": f.follower.display_name or f.follower.username,
+                    "avatar_url": f.follower.avatar_url or "",
+                },
+                "created_at": f.created_at,
+            }
+            for f in rows
+        ]
+        if page is not None:
+            return self.get_paginated_response(results)
+        return Response({"results": results})
+
+
+class FollowRequestActionView(APIView):
+    """POST /api/v1/follows/requests/<int:follow_id>/approve|reject/
+
+    自分宛の pending Follow を承認 / 拒否する。 spec §3.4
+
+    approve: status=approved + approved_at=now() + counters +1 (signal で)
+    reject: Follow 行を物理削除 (X 仕様準拠、 audit 不要)
+    """
+
+    permission_classes = [IsAuthenticated]
+    # サブクラスで上書き
+    action: str = "approve"
+
+    def post(self, request: Request, follow_id: int) -> Response:
+        follow = (
+            Follow.objects.select_related("follower", "followee")
+            .filter(pk=follow_id, followee=request.user)
+            .first()
+        )
+        if follow is None:
+            # 自分宛でない / 存在しない → 404 (= 他人の request の存在を漏らさない)
+            return Response(
+                {"detail": "Not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if follow.status != Follow.Status.PENDING:
+            return Response(
+                {"detail": "already_processed"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if self.action == "approve":
+            # signal が status=APPROVED な行の post_save を見て counters +1 する。
+            # post_save は created=False のとき早期 return するので、 ここでは
+            # bulk update ではなく save() で渡す必要がある (signal 経由でなく)。
+            # → counters は手動で +1 する (signal の post_save は created=True
+            # のときだけ動く)。
+            follow.status = Follow.Status.APPROVED
+            follow.approved_at = timezone.now()
+            with transaction.atomic():
+                follow.save(update_fields=["status", "approved_at"])
+                # signal は created=False で早期 return するので、 手動 +1。
+                from django.contrib.auth import get_user_model
+                from django.db.models.functions import Greatest
+
+                _U = get_user_model()
+                _U.objects.filter(pk=follow.follower_id).update(
+                    following_count=Greatest(F("following_count") + 1, 0),
+                )
+                _U.objects.filter(pk=follow.followee_id).update(
+                    followers_count=Greatest(F("followers_count") + 1, 0),
+                )
+            return Response(
+                {
+                    "follow_id": follow.id,
+                    "status": follow.status,
+                    "approved_at": follow.approved_at,
+                },
+                status=status.HTTP_200_OK,
+            )
+        # reject: 物理削除
+        follow.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class FollowApproveView(FollowRequestActionView):
+    action = "approve"
+
+
+class FollowRejectView(FollowRequestActionView):
+    action = "reject"

--- a/apps/follows/views.py
+++ b/apps/follows/views.py
@@ -224,6 +224,20 @@ class PopularUsersView(APIView):
 # ---------------------------------------------------------------------------
 
 
+class _FollowRequestPagination(CursorPagination):
+    """`/follows/requests/` 専用 cursor pagination (= Follow queryset 用)。
+
+    FollowCursorPagination は User queryset 用に `date_joined` を ordering に
+    使っているので、 Follow queryset では FieldError になる。 こちらは
+    `created_at` を使う (Follow.created_at は auto_now_add で常にある)。
+    """
+
+    page_size = 20
+    ordering = "-created_at"
+    cursor_query_param = "cursor"
+    max_page_size = 100
+
+
 class FollowRequestsListView(ListAPIView):
     """GET /api/v1/follows/requests/
 
@@ -232,7 +246,7 @@ class FollowRequestsListView(ListAPIView):
     """
 
     permission_classes = [IsAuthenticated]
-    pagination_class = FollowCursorPagination
+    pagination_class = _FollowRequestPagination
 
     def get_queryset(self) -> QuerySet[Follow]:
         return (

--- a/apps/timeline/services.py
+++ b/apps/timeline/services.py
@@ -130,8 +130,14 @@ def _query_following(user, blocked_ids: set[int], limit: int) -> list[Tweet]:
     qs = (
         Tweet.objects.select_related("author", "repost_of")
         .filter(
-            # フォロイーのツイート OR 自分のツイート
-            Q(author__follower_set__follower=user) | Q(author=user),
+            # #735: フォロイー (= approved follow されている) のツイート OR 自分のツイート。
+            # pending な follow からは TL に出さない (鍵アカの follow 中に
+            # tweet を覗くのを防ぐ)。
+            Q(
+                author__follower_set__follower=user,
+                author__follower_set__status="approved",
+            )
+            | Q(author=user),
             created_at__gte=cutoff,
             # #334: reply は home TL に出さない
             type__in=[TweetType.ORIGINAL, TweetType.REPOST, TweetType.QUOTE],
@@ -164,6 +170,12 @@ def _query_global(blocked_ids: set[int], exclude_author_id: int | None, limit: i
     base_qs = Tweet.objects.select_related("author").filter(
         created_at__gte=cutoff,
         type__in=[TweetType.ORIGINAL, TweetType.QUOTE],
+        # #735: global 候補は公開アカ user の tweet のみ。 鍵アカ user の tweet
+        # は viewer が approved follower かどうか判定できない (= viewer 情報を
+        # `_query_global` に渡していないので、 接続不可)。 ここでは安全側に
+        # 倒して **公開アカのみ** に絞る (= 鍵アカ tweet を見たい場合は
+        # _query_following で approved follow 経由で来る)。
+        author__is_private=False,
     )
     if blocked_ids:
         base_qs = base_qs.exclude(author_id__in=blocked_ids)

--- a/apps/tweets/managers.py
+++ b/apps/tweets/managers.py
@@ -44,6 +44,39 @@ class TweetQuerySet(models.QuerySet):
 
         return self.filter(author=user, published_at__isnull=True)
 
+    def visible_to(self, viewer) -> TweetQuerySet:
+        """``viewer`` が見られる tweet のみに絞るチェーンメソッド。
+
+        spec: docs/specs/private-account-spec.md §2.4
+
+        #735 鍵アカ機能の visibility 判定:
+        - 公開アカ (``author.is_private=False``) の tweet: 誰でも見える
+        - 鍵アカ author の tweet:
+          - viewer が author 本人 → 見える
+          - viewer が approved follower → 見える
+          - それ以外 (匿名 / 非 follower / pending) → 見えない
+
+        viewer が None (or 未認証) のときは公開アカのみを返す。 view 層から:
+
+            qs = Tweet.objects.all().visible_to(request.user)
+
+        の形で呼ぶ運用。 manager の `get_queryset()` で勝手に viewer を取れない
+        (request context は無い) ので、 viewer に応じた filter は view 層責務。
+        """
+        from django.db.models import Q
+
+        if viewer is None or not getattr(viewer, "is_authenticated", False):
+            return self.filter(author__is_private=False)
+        return self.filter(
+            Q(author__is_private=False)
+            | Q(author=viewer)
+            | Q(
+                author__is_private=True,
+                author__follower_set__follower=viewer,
+                author__follower_set__status="approved",
+            )
+        ).distinct()
+
 
 class TweetManager(models.Manager.from_queryset(TweetQuerySet)):
     """既定で `is_deleted=False` + `published_at__isnull=False` の Tweet のみを返す Manager。

--- a/apps/tweets/tests/test_visibility.py
+++ b/apps/tweets/tests/test_visibility.py
@@ -1,0 +1,99 @@
+"""#735 Tweet 鍵アカ visibility テスト。
+
+spec: docs/specs/private-account-spec.md §2.4
+
+カバレッジ:
+- 匿名 viewer は公開アカ tweet のみ visible_to に出る
+- 自分の鍵アカ tweet は visible_to(self) で見える
+- approved follower は鍵アカ author の tweet が見える
+- 非 follower / pending follower は鍵アカ tweet を見られない
+- 鍵アカの tweet を非 follower が GET → 404 隠蔽
+"""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from apps.follows.models import Follow
+from apps.tweets.models import Tweet
+from apps.tweets.tests._factories import make_user
+
+
+@pytest.mark.django_db
+class TestVisibleTo:
+    def test_anon_sees_only_public_tweets(self):
+        public_author = make_user()
+        private_author = make_user(is_private=True)
+        t_public = Tweet.objects.create(author=public_author, body="hello")
+        t_private = Tweet.objects.create(author=private_author, body="secret")
+        ids = list(Tweet.objects.all().visible_to(None).values_list("id", flat=True))
+        assert t_public.id in ids
+        assert t_private.id not in ids
+
+    def test_self_sees_own_private_tweets(self):
+        owner = make_user(is_private=True)
+        t = Tweet.objects.create(author=owner, body="self private")
+        ids = list(Tweet.objects.all().visible_to(owner).values_list("id", flat=True))
+        assert t.id in ids
+
+    def test_approved_follower_sees_private_tweets(self):
+        owner = make_user(is_private=True)
+        u = make_user()
+        Follow.objects.create(follower=u, followee=owner, status=Follow.Status.APPROVED)
+        t = Tweet.objects.create(author=owner, body="for followers")
+        ids = list(Tweet.objects.all().visible_to(u).values_list("id", flat=True))
+        assert t.id in ids
+
+    def test_pending_follower_does_not_see_private_tweets(self):
+        owner = make_user(is_private=True)
+        u = make_user()
+        Follow.objects.create(follower=u, followee=owner, status=Follow.Status.PENDING)
+        t = Tweet.objects.create(author=owner, body="for followers only")
+        ids = list(Tweet.objects.all().visible_to(u).values_list("id", flat=True))
+        assert t.id not in ids
+
+    def test_non_follower_does_not_see_private_tweets(self):
+        owner = make_user(is_private=True)
+        u = make_user()
+        t = Tweet.objects.create(author=owner, body="private only")
+        ids = list(Tweet.objects.all().visible_to(u).values_list("id", flat=True))
+        assert t.id not in ids
+
+
+@pytest.mark.django_db
+class TestRetrieveHiding:
+    def test_anon_gets_404_for_private_users_tweet(self):
+        owner = make_user(is_private=True)
+        t = Tweet.objects.create(author=owner, body="secret")
+        c = APIClient()
+        resp = c.get(f"/api/v1/tweets/{t.id}/")
+        assert resp.status_code == 404
+
+    def test_non_follower_gets_404(self):
+        owner = make_user(is_private=True)
+        other = make_user()
+        t = Tweet.objects.create(author=owner, body="secret")
+        c = APIClient()
+        c.force_authenticate(other)
+        resp = c.get(f"/api/v1/tweets/{t.id}/")
+        assert resp.status_code == 404
+
+    def test_approved_follower_can_see(self):
+        owner = make_user(is_private=True)
+        u = make_user()
+        Follow.objects.create(follower=u, followee=owner, status=Follow.Status.APPROVED)
+        t = Tweet.objects.create(author=owner, body="for followers")
+        c = APIClient()
+        c.force_authenticate(u)
+        resp = c.get(f"/api/v1/tweets/{t.id}/")
+        assert resp.status_code == 200
+        assert resp.data["body"] == "for followers"
+
+    def test_owner_always_sees_own_tweet(self):
+        owner = make_user(is_private=True)
+        t = Tweet.objects.create(author=owner, body="mine")
+        c = APIClient()
+        c.force_authenticate(owner)
+        resp = c.get(f"/api/v1/tweets/{t.id}/")
+        assert resp.status_code == 200

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -161,6 +161,13 @@ class TweetViewSet(viewsets.ModelViewSet):
         if request is None:
             return qs
 
+        # #735: 公開 read action (list / retrieve) に visible_to で鍵アカ filter
+        # を適用。 state 変更系 (update / destroy / publish / drafts) は author
+        # scope を action 内で enforce するので、 ここでは applique しない
+        # (= 自分の鍵アカ tweet が編集できなくなる事故を防ぐ)。
+        if self.action in _READ_ACTIONS:
+            qs = qs.visible_to(request.user)
+
         author = request.query_params.get("author")
         if author:
             # username は大文字小文字を区別しない (users 側と揃える)
@@ -227,6 +234,29 @@ class TweetViewSet(viewsets.ModelViewSet):
                 {"detail": "Not found."},
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        # #735: 鍵アカ user の tweet は本人 / approved follower のみ閲覧可能。
+        # 非 follower / 匿名 / pending は 404 隠蔽 (= 存在を漏らさない)。
+        if tweet.author.is_private:
+            viewer = request.user
+            if not viewer.is_authenticated:
+                return Response(
+                    {"detail": "Not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            if tweet.author_id != viewer.pk:
+                from apps.follows.models import Follow
+
+                is_approved_follower = Follow.objects.filter(
+                    follower=viewer,
+                    followee_id=tweet.author_id,
+                    status=Follow.Status.APPROVED,
+                ).exists()
+                if not is_approved_follower:
+                    return Response(
+                        {"detail": "Not found."},
+                        status=status.HTTP_404_NOT_FOUND,
+                    )
 
         serializer = self.get_serializer(tweet)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/tweets/views_actions.py
+++ b/apps/tweets/views_actions.py
@@ -47,7 +47,7 @@ class _RepostResponseSerializer(drf_serializers.Serializer):
     created = drf_serializers.BooleanField(read_only=True)
 
 
-def _resolve_target(tweet_id: int) -> Tweet:
+def _resolve_target(tweet_id: int, viewer: Any | None = None) -> Tweet:
     """元ツイートを取得する (alive のみ、削除済み / 存在しないなら 404)。
 
     #346 (X 互換): tweet_id が REPOST tweet を指している場合、その REPOST 自身
@@ -59,6 +59,9 @@ def _resolve_target(tweet_id: int) -> Tweet:
     解決後の target は ORIGINAL / QUOTE / REPLY のいずれかになる。万一壊れた
     データでチェーン (REPOST→REPOST) が残っていた場合は wrong-result を返す
     リスクがあるため、解決後の type を再チェックして 404 にする。
+
+    #735: ``viewer`` が指定されていれば、 鍵アカ author の tweet を非 follower
+    が repost / quote / reply しようとしたとき 404 隠蔽する。
     """
     target = get_object_or_404(Tweet, pk=tweet_id)
     if target.type == TweetType.REPOST:
@@ -77,6 +80,22 @@ def _resolve_target(tweet_id: int) -> Tweet:
                 extra={"original_id": tweet_id, "resolved_id": target.pk},
             )
             raise Http404("リポストのチェーンは許容されません")
+    # #735: 鍵アカ user の tweet visibility check (= 404 隠蔽)。
+    if (
+        viewer is not None
+        and getattr(viewer, "is_authenticated", False)
+        and target.author.is_private
+        and target.author_id != viewer.pk
+    ):
+        from apps.follows.models import Follow
+
+        approved = Follow.objects.filter(
+            follower=viewer,
+            followee_id=target.author_id,
+            status=Follow.Status.APPROVED,
+        ).exists()
+        if not approved:
+            raise Http404("Not found.")
     return target
 
 
@@ -97,7 +116,7 @@ class RepostView(APIView):
     authentication_classes = [CookieAuthentication]
 
     def post(self, request: Request, tweet_id: int) -> Response:
-        target = _resolve_target(tweet_id)
+        target = _resolve_target(tweet_id, request.user)
         if (resp := _check_block_or_403(request.user, target)) is not None:
             return resp
 
@@ -138,7 +157,7 @@ class RepostView(APIView):
         )
 
     def delete(self, request: Request, tweet_id: int) -> Response:
-        target = _resolve_target(tweet_id)
+        target = _resolve_target(tweet_id, request.user)
         deleted, _ = Tweet.objects.filter(
             author=request.user,
             type=TweetType.REPOST,
@@ -167,7 +186,7 @@ class _QuoteOrReplyBaseView(APIView):
     fk_field_name: str = ""
 
     def post(self, request: Request, tweet_id: int) -> Response:
-        target = _resolve_target(tweet_id)
+        target = _resolve_target(tweet_id, request.user)
         if (resp := _check_block_or_403(request.user, target)) is not None:
             return resp
 

--- a/apps/users/migrations/0008_user_is_private.py
+++ b/apps/users/migrations/0008_user_is_private.py
@@ -1,0 +1,32 @@
+"""#735 鍵アカ機能: ``User.is_private`` 追加。
+
+spec: docs/specs/private-account-spec.md §2.1
+
+既存 user はすべて ``is_private=False`` で backfill (= 公開アカ、 従来挙動維持)。
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0007_user_language_preferences"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="is_private",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "Whether this account is private. New follow requests "
+                    "require approval, and only approved followers can see "
+                    "this user's tweets."
+                ),
+                verbose_name="Is Private (鍵アカ)",
+            ),
+        ),
+    ]

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -105,6 +105,20 @@ class User(AbstractUser):
         help_text=_("Number of users this user follows."),
     )
 
+    # ---- #735 鍵アカ (非公開アカウント) ----
+    # spec: docs/specs/private-account-spec.md §2.1
+    # True にすると新規 follow が承認制 (Follow.status=pending) になり、
+    # 既存 follower は維持される。 鍵アカ user の tweet は承認済み follower
+    # + 本人のみ閲覧可能 (Tweet.objects.visible_to(viewer) で判定)。
+    is_private = models.BooleanField(
+        verbose_name=_("Is Private (鍵アカ)"),
+        default=False,
+        help_text=_(
+            "Whether this account is private. New follow requests require "
+            "approval, and only approved followers can see this user's tweets."
+        ),
+    )
+
     # ---- 課金 / オンボーディング ----
     is_premium = models.BooleanField(
         verbose_name=_("Is Premium"),

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -73,6 +73,9 @@ class CustomUserSerializer(UserSerializer):
             # ChoiceField validator) で行われる。
             "preferred_language",
             "auto_translate",
+            # #735: 鍵アカ機能。 PATCH /users/me/ で toggle 可能。
+            # spec: docs/specs/private-account-spec.md §3.1
+            "is_private",
             "date_joined",
         ]
         # username / email / is_premium は変更不可 (is_premium は Stripe webhook でのみ更新)。
@@ -135,6 +138,9 @@ class PublicProfileSerializer(serializers.ModelSerializer):
     # フォローしているか。未ログイン時 / 自分自身 / target 不在は false。
     # 1 query (Follow.objects.filter(...).exists()) で済むので N+1 リスク無し。
     is_following = serializers.SerializerMethodField()
+    # #735: 鍵アカ user に対し、 閲覧者が approved follower か / pending かを
+    # frontend が「フォロー中 / 承認待ち / フォローする」 button 状態に使う。
+    follow_status = serializers.SerializerMethodField()
 
     # Phase 4B (#448): ProfileKebab の初期状態判定用。
     is_blocking = serializers.SerializerMethodField()
@@ -152,7 +158,26 @@ class PublicProfileSerializer(serializers.ModelSerializer):
         # circular import 回避のため遅延 import (apps.follows は users に依存)
         from apps.follows.models import Follow
 
-        return Follow.objects.filter(follower=viewer, followee=obj).exists()
+        # #735: pending な follow は「フォロー中」 ではないので除外
+        return Follow.objects.filter(
+            follower=viewer, followee=obj, status=Follow.Status.APPROVED
+        ).exists()
+
+    def get_follow_status(self, obj: User) -> str | None:
+        """#735: 閲覧者の自分から `obj` への follow 状態を返す。
+
+        返り値: ``"approved"`` | ``"pending"`` | ``None`` (フォロー無し / 匿名)
+        """
+        request = self.context.get("request")
+        if not request or not getattr(request, "user", None):
+            return None
+        viewer = request.user
+        if not viewer.is_authenticated or viewer.pk == obj.pk:
+            return None
+        from apps.follows.models import Follow
+
+        f = Follow.objects.filter(follower=viewer, followee=obj).only("status").first()
+        return f.status if f else None
 
     def get_is_blocking(self, obj: User) -> bool:
         request = self.context.get("request")
@@ -200,6 +225,11 @@ class PublicProfileSerializer(serializers.ModelSerializer):
             # #421: フォロー数 / フォロワー数 (X 風プロフィール表示)
             "followers_count",
             "following_count",
+            # #735: 鍵アカ機能の UI 判定用。
+            # - is_private: 鍵アカなら true (UI で「このアカウントは非公開です」 表示)
+            # - follow_status: viewer→obj への follow 状態 (approved | pending | null)
+            "is_private",
+            "follow_status",
         ]
         # 公開 API はすべて read_only (PATCH は /me/ 経由のみ)。
         # ``fields`` と同じ list を参照させると、DRF 内部で片方に mutate が走った

--- a/apps/users/tests/test_profile_api.py
+++ b/apps/users/tests/test_profile_api.py
@@ -58,6 +58,9 @@ EXPECTED_PUBLIC_KEYS = {
     "is_blocking",
     "is_muting",
     "user_id",
+    # #735: 鍵アカ機能。 FollowButton の 3 状態 + 「非公開アカウント」 表示用。
+    "is_private",
+    "follow_status",
 }
 
 

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -3,9 +3,11 @@ import math
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db.models import FloatField, Q, QuerySet
+from django.db import transaction
+from django.db.models import F, FloatField, Q, QuerySet
 from django.db.models.expressions import RawSQL
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from djoser.social.views import ProviderAuthView
 from rest_framework import serializers, status
 from rest_framework.exceptions import NotAuthenticated, ValidationError
@@ -491,14 +493,49 @@ class MeView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def patch(self, request: Request, *args, **kwargs) -> Response:
+        # #735: 鍵化解除を検知して、 自分宛の pending follow を全部 approved に
+        # 自動昇格させる。 spec: docs/specs/private-account-spec.md §3.1
+        was_private = bool(getattr(request.user, "is_private", False))
         serializer = CustomUserSerializer(
             request.user,
             data=request.data,
             partial=True,
         )
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        with transaction.atomic():
+            serializer.save()
+            request.user.refresh_from_db()
+            if was_private and not request.user.is_private:
+                _auto_approve_pending_follows(request.user)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+def _auto_approve_pending_follows(user) -> None:
+    """#735: 鍵を外したときに自分宛の pending follow を一括 approved 化する。
+
+    counters は signal 経由ではなく **手動で +N** する (signal は created=True
+    の post_save 1 回しか動かないため、 bulk update では発火しない)。
+    """
+    from django.contrib.auth import get_user_model
+    from django.db.models.functions import Greatest
+
+    from apps.follows.models import Follow
+
+    User = get_user_model()
+    now = timezone.now()
+    pending_qs = Follow.objects.filter(followee=user, status=Follow.Status.PENDING)
+    pending = list(pending_qs.values_list("follower_id", flat=True))
+    if not pending:
+        return
+    pending_qs.update(status=Follow.Status.APPROVED, approved_at=now)
+    # followee (= user) の followers_count += len(pending)
+    User.objects.filter(pk=user.pk).update(
+        followers_count=Greatest(F("followers_count") + len(pending), 0),
+    )
+    # 各 follower の following_count += 1
+    User.objects.filter(pk__in=pending).update(
+        following_count=Greatest(F("following_count") + 1, 0),
+    )
 
 
 class CompleteOnboardingView(APIView):

--- a/client/src/app/(template)/follow-requests/page.tsx
+++ b/client/src/app/(template)/follow-requests/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import FollowRequestsPanel from "@/components/follows/FollowRequestsPanel";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
+import type {
+	FollowRequestListPage,
+	FollowRequestRow,
+} from "@/lib/api/follow-requests";
+import type { CurrentUser } from "@/lib/api/users";
+
+export const metadata: Metadata = {
+	title: "フォロー申請",
+	robots: { index: false },
+};
+
+async function loadCurrentUser(): Promise<CurrentUser | null> {
+	try {
+		return await serverFetch<CurrentUser>("/users/me/");
+	} catch (error) {
+		if (error instanceof ApiServerError && error.status === 401) return null;
+		throw error;
+	}
+}
+
+async function loadRequests(): Promise<FollowRequestRow[]> {
+	try {
+		const page = await serverFetch<FollowRequestListPage>("/follows/requests/");
+		return page.results ?? [];
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * /follow-requests — 自分宛の pending フォロー申請を承認 / 拒否する画面。 #735
+ *
+ * 未ログインなら /login redirect。
+ */
+export default async function FollowRequestsPage() {
+	const me = await loadCurrentUser();
+	if (!me) redirect("/login");
+	const initial = await loadRequests();
+
+	return (
+		<>
+			<header
+				className="flex items-center gap-3 px-5 py-3"
+				style={{
+					borderBottom: "1px solid var(--a-border)",
+					background: "rgba(255,255,255,0.85)",
+					backdropFilter: "blur(8px)",
+				}}
+			>
+				<div className="min-w-0 flex-1">
+					<h1
+						className="truncate font-semibold tracking-tight"
+						style={{ fontSize: 15, letterSpacing: -0.2 }}
+					>
+						フォロー申請
+					</h1>
+					<p
+						className="truncate text-[color:var(--a-text-subtle)]"
+						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
+					>
+						鍵アカへの新規フォロー申請を承認 / 拒否します。
+					</p>
+				</div>
+			</header>
+			<FollowRequestsPanel initial={initial} />
+		</>
+	);
+}

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -32,6 +32,14 @@ interface PublicProfile {
 	/** #296: 閲覧者が既に target を follow しているか。未ログイン時は false。
 	 *  backend PublicProfileSerializer.get_is_following で算出。 */
 	is_following: boolean;
+	/** #735: 鍵アカ機能。 true ならアカウント非公開。 */
+	is_private?: boolean;
+	/** #735: 閲覧者→target への follow status。
+	 *  - `"approved"`: フォロー中
+	 *  - `"pending"`: 承認待ち (鍵アカ申請後)
+	 *  - `null`: フォローしていない (匿名 or 未 follow)
+	 */
+	follow_status?: "approved" | "pending" | null;
 	/** #421: X 風 — フォロワー数 / フォロー中数 */
 	followers_count: number;
 	following_count: number;
@@ -267,6 +275,7 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 								<FollowButton
 									targetHandle={profile.username}
 									initialIsFollowing={profile.is_following}
+									initialFollowStatus={profile.follow_status ?? null}
 								/>
 								<StartDMButton targetHandle={profile.username} />
 								{/* Phase 4B (#448): X 風 kebab → ミュート / ブロック / 通報 */}

--- a/client/src/components/follows/FollowButton.tsx
+++ b/client/src/components/follows/FollowButton.tsx
@@ -25,6 +25,16 @@ interface FollowButtonProps {
 	targetHandle: string;
 	/** 初期 follow 状態 (PublicProfile.is_following 由来)。未指定なら false。 */
 	initialIsFollowing?: boolean;
+	/**
+	 * #735: 初期 follow 状態の詳細 (PublicProfile.follow_status 由来)。
+	 * - `"approved"`: フォロー中
+	 * - `"pending"`: 承認待ち (鍵アカへの follow 申請後)
+	 * - `null` / undefined: フォローしていない
+	 *
+	 * 指定があれば `initialIsFollowing` より優先される (= 鍵アカ pending の
+	 * 状態を「承認待ち」 表示にする)。
+	 */
+	initialFollowStatus?: "approved" | "pending" | null;
 	/** 表示サイズ。WhoToFollow は sm、profile header は md。 */
 	size?: "sm" | "md";
 	/** click 後の callback (任意)。親が件数 badge 等を更新する場合に使う。 */
@@ -34,12 +44,24 @@ interface FollowButtonProps {
 export default function FollowButton({
 	targetHandle,
 	initialIsFollowing = false,
+	initialFollowStatus,
 	size = "md",
 	onChange,
 }: FollowButtonProps) {
 	const { profile } = useUserProfile();
 	const selfHandle = profile?.username;
-	const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+	// #735: 3 状態を初期化。 initialFollowStatus が来ていればそちら優先。
+	const initial: "approved" | "pending" | null =
+		initialFollowStatus !== undefined
+			? initialFollowStatus
+			: initialIsFollowing
+				? "approved"
+				: null;
+	const [followStatus, setFollowStatus] = useState<
+		"approved" | "pending" | null
+	>(initial);
+	const isFollowing = followStatus === "approved";
+	const isPendingRequest = followStatus === "pending";
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [followUser, { isLoading: isFollowingPending }] =
 		useFollowUserMutation();
@@ -52,20 +74,30 @@ export default function FollowButton({
 
 	const handleClick = async () => {
 		setErrorMessage(null);
-		const willFollow = !isFollowing;
-		// 楽観 UI: 状態を先に切り替える
-		setIsFollowing(willFollow);
-		onChange?.(willFollow);
+		// #735: 3 状態間の遷移:
+		// - approved | pending → null (= unfollow / 申請キャンセル)
+		// - null → approved (公開アカ) or pending (鍵アカ、 backend が判断)
+		const willUnfollow = followStatus !== null;
+		const optimisticNext: "approved" | "pending" | null = willUnfollow
+			? null
+			: "approved"; // 公開アカ前提で approved を仮置き。 鍵アカなら下で pending に補正
+		const previousStatus = followStatus;
+		setFollowStatus(optimisticNext);
+		onChange?.(optimisticNext === "approved");
 		try {
-			if (willFollow) {
-				await followUser(targetHandle).unwrap();
-			} else {
+			if (willUnfollow) {
 				await unfollowUser(targetHandle).unwrap();
+			} else {
+				// #735: backend response の status を見て pending or approved
+				// に確定する。
+				const res = await followUser(targetHandle).unwrap();
+				const serverStatus = res?.status ?? "approved";
+				setFollowStatus(serverStatus);
+				onChange?.(serverStatus === "approved");
 			}
 		} catch (err) {
-			// 失敗で元に戻す
-			setIsFollowing(!willFollow);
-			onChange?.(!willFollow);
+			setFollowStatus(previousStatus);
+			onChange?.(previousStatus === "approved");
 			const status = (err as { status?: number })?.status;
 			if (status === 401) {
 				setErrorMessage("ログインが必要です");
@@ -73,21 +105,30 @@ export default function FollowButton({
 				setErrorMessage("このユーザーをフォローできません");
 			} else {
 				setErrorMessage(
-					willFollow ? "フォローに失敗しました" : "フォロー解除に失敗しました",
+					willUnfollow
+						? "フォロー解除に失敗しました"
+						: "フォローに失敗しました",
 				);
 			}
 		}
 	};
 
 	const sizeClass = size === "sm" ? "px-3 py-1 text-xs" : "px-4 py-1.5 text-sm";
-	const variantClass = isFollowing
-		? "bg-transparent border border-border text-foreground hover:bg-baby_red/10 hover:text-baby_red hover:border-baby_red/40"
-		: "bg-baby_blue text-baby_white hover:bg-baby_blue/90";
+	const variantClass =
+		isFollowing || isPendingRequest
+			? "bg-transparent border border-border text-foreground hover:bg-baby_red/10 hover:text-baby_red hover:border-baby_red/40"
+			: "bg-baby_blue text-baby_white hover:bg-baby_blue/90";
+	// #735: 3 状態の label:
+	// - pending: 「承認待ち」 (click でキャンセル = follow 申請取り消し)
+	// - approved: 「フォロー中」 (click で unfollow)
+	// - null: 「フォロー」 (click で follow)
 	const label = isPending
 		? "処理中..."
-		: isFollowing
-			? "フォロー中"
-			: "フォロー"; // #408: 「フォローする」 → 「フォロー」 (X 流の短い表記)
+		: isPendingRequest
+			? "承認待ち"
+			: isFollowing
+				? "フォロー中"
+				: "フォロー";
 
 	return (
 		<div className="inline-flex flex-col items-end gap-1">

--- a/client/src/components/follows/FollowRequestsPanel.tsx
+++ b/client/src/components/follows/FollowRequestsPanel.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+/**
+ * #735 FollowRequestsPanel — `/follow-requests` page の中身。
+ *
+ * spec: docs/specs/private-account-spec.md §4.3
+ *
+ * UX:
+ * - 自分宛 pending follow 一覧を新しい順に表示
+ * - 各行に「承認」「拒否」 button
+ * - 承認: POST .../approve/ → 行が消える + toast
+ * - 拒否: 確認 dialog + POST .../reject/ → 行が消える + toast
+ * - 0 件 empty state
+ */
+
+import { useState } from "react";
+
+import { Loader2, UserCheck, UserMinus } from "lucide-react";
+import { toast } from "react-toastify";
+
+import { Button } from "@/components/ui/button";
+import {
+	approveFollowRequest,
+	rejectFollowRequest,
+	type FollowRequestRow,
+} from "@/lib/api/follow-requests";
+
+interface FollowRequestsPanelProps {
+	initial: FollowRequestRow[];
+}
+
+function formatDate(iso: string): string {
+	try {
+		return new Date(iso).toLocaleString("ja-JP");
+	} catch {
+		return iso;
+	}
+}
+
+export default function FollowRequestsPanel({
+	initial,
+}: FollowRequestsPanelProps) {
+	const [rows, setRows] = useState<FollowRequestRow[]>(initial);
+	const [pendingId, setPendingId] = useState<number | null>(null);
+
+	const onApprove = async (id: number) => {
+		setPendingId(id);
+		try {
+			await approveFollowRequest(id);
+			setRows((prev) => prev.filter((r) => r.follow_id !== id));
+			toast.success("承認しました");
+		} catch {
+			toast.error("承認に失敗しました。");
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	const onReject = async (id: number) => {
+		if (!confirm("このフォロー申請を拒否しますか？")) return;
+		setPendingId(id);
+		try {
+			await rejectFollowRequest(id);
+			setRows((prev) => prev.filter((r) => r.follow_id !== id));
+			toast.success("拒否しました");
+		} catch {
+			toast.error("拒否に失敗しました。");
+		} finally {
+			setPendingId(null);
+		}
+	};
+
+	if (rows.length === 0) {
+		return (
+			<div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-3 px-4 py-10">
+				<UserCheck
+					className="size-10 text-[color:var(--a-text-subtle)]"
+					aria-hidden
+				/>
+				<p
+					className="text-[color:var(--a-text-muted)]"
+					style={{ fontSize: 13.5 }}
+				>
+					承認待ちのフォロー申請はありません。
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-4 pb-12 pt-4">
+			<ul className="grid gap-3">
+				{rows.map((r) => {
+					const isPending = pendingId === r.follow_id;
+					return (
+						<li
+							key={r.follow_id}
+							className="flex items-center gap-3 rounded-md border border-border p-3"
+						>
+							<div
+								className="grid size-10 shrink-0 place-items-center rounded-full font-semibold text-white"
+								style={{ background: "hsl(200 70% 32%)", fontSize: 12.5 }}
+								aria-hidden
+							>
+								{(r.follower.display_name || r.follower.handle)
+									.slice(0, 2)
+									.toUpperCase()}
+							</div>
+							<div className="min-w-0 flex-1 leading-tight">
+								<div
+									className="truncate font-medium"
+									style={{ fontSize: 13.5 }}
+								>
+									{r.follower.display_name || r.follower.handle}
+								</div>
+								<div
+									className="truncate text-[color:var(--a-text-subtle)]"
+									style={{
+										fontFamily: "var(--a-font-mono)",
+										fontSize: 11.5,
+									}}
+								>
+									@{r.follower.handle}
+								</div>
+								<div
+									className="text-[color:var(--a-text-subtle)]"
+									style={{ fontSize: 10.5 }}
+								>
+									{formatDate(r.created_at)}
+								</div>
+							</div>
+							<div className="flex items-center gap-2">
+								<Button
+									type="button"
+									variant="outline"
+									onClick={() => onReject(r.follow_id)}
+									disabled={isPending}
+									className="inline-flex items-center gap-1.5"
+									aria-label={`@${r.follower.handle} のフォロー申請を拒否`}
+								>
+									{isPending ? (
+										<Loader2
+											className="size-4 animate-spin"
+											aria-hidden="true"
+										/>
+									) : (
+										<UserMinus className="size-4" aria-hidden="true" />
+									)}
+									拒否
+								</Button>
+								<Button
+									type="button"
+									onClick={() => onApprove(r.follow_id)}
+									disabled={isPending}
+									className="inline-flex items-center gap-1.5"
+									aria-label={`@${r.follower.handle} のフォロー申請を承認`}
+								>
+									{isPending ? (
+										<Loader2
+											className="size-4 animate-spin"
+											aria-hidden="true"
+										/>
+									) : (
+										<UserCheck className="size-4" aria-hidden="true" />
+									)}
+									承認
+								</Button>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}

--- a/client/src/components/profile/ProfileEditForm.tsx
+++ b/client/src/components/profile/ProfileEditForm.tsx
@@ -96,6 +96,8 @@ export default function ProfileEditForm({ initialUser }: ProfileEditFormProps) {
 				? (initialUser.preferred_language as PreferredLanguage)
 				: "ja") as PreferredLanguage,
 			auto_translate: initialUser.auto_translate ?? false,
+			// #735: 鍵アカ機能の初期値 (default False)。
+			is_private: initialUser.is_private ?? false,
 		},
 	});
 
@@ -269,6 +271,31 @@ export default function ProfileEditForm({ initialUser }: ProfileEditFormProps) {
 						>
 							ON にすると、 異なる言語のツイートを自動的に翻訳します。
 							翻訳結果は「原文を表示」 で元に戻せます。
+						</p>
+					</div>
+				</div>
+
+				{/* #735: 鍵アカ toggle */}
+				<div className="flex items-start gap-2 border-t border-border pt-4">
+					<input
+						id="is_private"
+						type="checkbox"
+						{...register("is_private")}
+						className="mt-1 size-4 rounded border-input"
+						aria-describedby="is_private_help"
+					/>
+					<div className="grid gap-1">
+						<label htmlFor="is_private" className="text-sm font-medium">
+							アカウントを非公開にする (鍵アカ)
+						</label>
+						<p
+							id="is_private_help"
+							className="text-[color:var(--a-text-subtle)]"
+							style={{ fontSize: 12 }}
+						>
+							ON にすると新規フォロー申請が承認制になります。 既存のフォロワー
+							はそのまま継続します。 鍵アカのツイートは承認済みフォロワーと
+							あなた本人だけが閲覧できます。
 						</p>
 					</div>
 				</div>

--- a/client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx
+++ b/client/src/components/profile/__tests__/ProfileEditForm.language.test.tsx
@@ -66,6 +66,7 @@ const BASE_USER: CurrentUser = {
 	linkedin_url: "",
 	preferred_language: "ja",
 	auto_translate: false,
+	is_private: false,
 	date_joined: "2026-01-01T00:00:00Z",
 };
 

--- a/client/src/lib/api/follow-requests.ts
+++ b/client/src/lib/api/follow-requests.ts
@@ -1,0 +1,53 @@
+/**
+ * #735 フォロー申請承認 API client.
+ *
+ * - GET  /api/v1/follows/requests/                  → 自分宛 pending 一覧
+ * - POST /api/v1/follows/requests/<follow_id>/approve/ → 承認
+ * - POST /api/v1/follows/requests/<follow_id>/reject/  → 拒否
+ *
+ * spec: docs/specs/private-account-spec.md §3.3 §3.4
+ */
+
+import type { AxiosInstance } from "axios";
+import { api, ensureCsrfToken } from "@/lib/api/client";
+
+export interface FollowRequestRow {
+	follow_id: number;
+	follower: {
+		id: string;
+		handle: string;
+		display_name: string;
+		avatar_url: string;
+	};
+	created_at: string;
+}
+
+export interface FollowRequestListPage {
+	count?: number;
+	next?: string | null;
+	previous?: string | null;
+	results: FollowRequestRow[];
+}
+
+export async function fetchFollowRequests(
+	client: AxiosInstance = api,
+): Promise<FollowRequestListPage> {
+	const res = await client.get<FollowRequestListPage>("/follows/requests/");
+	return res.data;
+}
+
+export async function approveFollowRequest(
+	followId: number,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await ensureCsrfToken(client);
+	await client.post(`/follows/requests/${followId}/approve/`);
+}
+
+export async function rejectFollowRequest(
+	followId: number,
+	client: AxiosInstance = api,
+): Promise<void> {
+	await ensureCsrfToken(client);
+	await client.post(`/follows/requests/${followId}/reject/`);
+}

--- a/client/src/lib/api/users.ts
+++ b/client/src/lib/api/users.ts
@@ -30,6 +30,9 @@ export interface CurrentUser {
 	// P13-04: Phase 13 自動翻訳機能 (auto-translate)
 	preferred_language: string;
 	auto_translate: boolean;
+	// #735: 鍵アカ機能。 true ならアカウント非公開。
+	// spec: docs/specs/private-account-spec.md
+	is_private: boolean;
 	date_joined: string;
 }
 
@@ -50,6 +53,8 @@ export interface UpdateProfilePayload {
 	// P13-04: 翻訳設定の更新
 	preferred_language?: string;
 	auto_translate?: boolean;
+	// #735: 鍵アカ機能の toggle。
+	is_private?: boolean;
 }
 
 export async function fetchCurrentUser(

--- a/client/src/lib/redux/features/follows/followsApiSlice.ts
+++ b/client/src/lib/redux/features/follows/followsApiSlice.ts
@@ -10,9 +10,21 @@
  */
 import { baseApiSlice } from "@/lib/redux/features/api/baseApiSlice";
 
+/**
+ * #735: follow POST の response shape (FollowResponseSerializer)。
+ * 公開アカへの follow は status="approved"、 鍵アカへの follow は
+ * status="pending" を返す。
+ */
+export interface FollowMutationResponse {
+	follower?: string;
+	followee?: string;
+	created?: boolean;
+	status: "approved" | "pending";
+}
+
 export const followsApiSlice = baseApiSlice.injectEndpoints({
 	endpoints: (builder) => ({
-		followUser: builder.mutation<void, string>({
+		followUser: builder.mutation<FollowMutationResponse, string>({
 			query: (handle) => ({
 				url: `/users/${handle}/follow/`,
 				method: "POST",

--- a/client/src/lib/validationSchemas/ProfileEditSchema.ts
+++ b/client/src/lib/validationSchemas/ProfileEditSchema.ts
@@ -49,6 +49,8 @@ export const profileEditSchema = z.object({
 	// P13-04: 翻訳設定
 	preferred_language: z.enum(PREFERRED_LANGUAGES).default("ja"),
 	auto_translate: z.boolean().default(false),
+	// #735: 鍵アカ機能。 ON でアカウント非公開化、 新規 follow が承認制になる。
+	is_private: z.boolean().default(false),
 });
 
 export type TProfileEditSchema = z.infer<typeof profileEditSchema>;

--- a/config/urls.py
+++ b/config/urls.py
@@ -58,6 +58,9 @@ urlpatterns = [
     # urls_profile 側の me/ 系も static path だが follows.urls には me/ パターン
     # が無いので衝突しない。
     path("api/v1/users/", include("apps.follows.urls")),
+    # #735: フォロー申請承認 API は handle と無関係の resource なので別 prefix。
+    # /api/v1/follows/requests/ (GET) / .../<id>/approve/ / .../<id>/reject/
+    path("api/v1/follows/", include("apps.follows.urls_requests")),
     # P1-03 #89: プロフィール API (SPEC §2)。
     # /api/v1/users/me/ (GET/PATCH) と /api/v1/users/<handle>/ (GET) を提供。
     # 認証系 (/api/v1/auth/) と分離するため apps.users.urls_profile として別登録。

--- a/docs/specs/private-account-spec.md
+++ b/docs/specs/private-account-spec.md
@@ -1,0 +1,355 @@
+# 鍵アカ (非公開アカウント) + フォロー承認制 — 仕様書 (#735)
+
+> Phase 14 follow-up。 SPEC.md / ER.md 起草時の漏れを埋める。 X / Twitter 互換の「鍵アカ (Protected account)」 機能。 同時に Claude Agent (Phase 14) が「他人の private な tweet を読まない」 ことを visibility 制御で保証する基盤になる。
+
+---
+
+## 1. 背景 / モチベーション
+
+- 仕様策定時、 User model に「公開アカウント / 非公開アカウント」 の区別が無く、 全ユーザーの tweet が常時公開だった。
+- ユーザーが「特定の人 (= 承認した follower) にしか見せたくない」 を実現する手段が無い。
+- Phase 14 Claude Agent から「鍵アカ user の tweet」 が agent 経由で他人に漏れない仕組みを Tweet 配信レイヤで保証する必要がある (= #734 「下書き」 と同じ「他人の private な tweet を読まない」 の続編)。
+
+X / Twitter の「鍵アカ (Protected Tweets)」 と同等を最小実装する:
+
+- Settings → 「アカウントを非公開にする」 toggle (= `User.is_private`)
+- 鍵アカへの follow は承認待ち (= `Follow.status = pending`)
+- 鍵アカ user の tweet は **承認済み follower + 本人** のみ閲覧可能
+- 非 follower / pending / 匿名は **404 隠蔽** (= 存在自体を漏らさない)
+- search / TL / agent tools すべてに visibility filter が効く
+- 既存 follower はそのまま `status=approved` で動作継続 (= 鍵化しても誰も切れない)
+
+---
+
+## 2. データモデル
+
+### 2.1 `User.is_private` 追加
+
+```python
+class User(AbstractUser):
+    # ...
+    is_private = models.BooleanField(
+        default=False,
+        help_text=(
+            "True にするとアカウントが非公開化される。 既存 follower は維持され、 "
+            "新規 follow は承認制 (Follow.status=pending) になる。"
+        ),
+    )
+```
+
+- migration で全既存 user を `is_private=False` で backfill (= 既定挙動を維持)
+- API: `PATCH /api/v1/users/me/` で `{is_private: true|false}` を受け付ける
+- 鍵化 → 非鍵化に戻したときは、 既存の pending を **すべて approved に自動昇格** (= 鍵を外した瞬間に誰でも見える状態に揃える)
+
+### 2.2 `Follow` model に承認制 を足す
+
+```python
+class Follow(models.Model):
+    # ... 既存 ...
+    class Status(models.TextChoices):
+        PENDING = "pending", "承認待ち"
+        APPROVED = "approved", "承認済み"
+
+    status = models.CharField(
+        max_length=10,
+        choices=Status.choices,
+        default=Status.APPROVED,  # 公開アカへの follow は即 approved (既存互換)
+    )
+    approved_at = models.DateTimeField(null=True, blank=True)
+```
+
+migration:
+
+- AddField `status` (default=approved, null=False)
+- AddField `approved_at` (null=True)
+- backfill: `status='approved', approved_at=created_at` を全既存 follow に適用
+- chunked update (1 万件ずつ) で stg / prod のロック時間を最小化
+
+### 2.3 既存 counter (followers_count / following_count) の意味
+
+**承認済み** の follow だけを数える方針:
+
+- 鍵アカ user の followers_count → 承認済み follower のみ
+- pending は別 counter `pending_request_count` を新設しない (= UI 上は通知センターで件数表示)
+- 既存 signal は status を見るように更新 (= pending を作っても counter は動かない、 approve で +1、 reject / delete で -1)
+
+### 2.4 Tweet visibility 判定
+
+```python
+# apps/tweets/managers.py (#734 既存 manager を拡張)
+class TweetQuerySet(QuerySet):
+    def visible_to(self, viewer):
+        """viewer が見られる tweet のみに絞る。
+
+        - 公開アカ (is_private=False) author: 全員見える
+        - 鍵アカ author の tweet:
+          - viewer が author 本人 → 見える
+          - viewer が approved follower → 見える
+          - それ以外 → 見えない
+        """
+        # 匿名 / viewer=None は公開アカのみ
+        if viewer is None or not getattr(viewer, "is_authenticated", False):
+            return self.filter(author__is_private=False)
+        # 認証済み: 公開 OR (鍵アカ + (本人 OR approved follower))
+        return self.filter(
+            Q(author__is_private=False)
+            | Q(author=viewer)
+            | Q(
+                author__is_private=True,
+                author__follower_set__follower=viewer,
+                author__follower_set__status="approved",
+            )
+        ).distinct()
+```
+
+→ TweetManager.get_queryset() は既定で `is_deleted=False, published_at__isnull=False` (#734 で導入)。 viewer に応じた visibility は manager の **既定では適用しない** (= viewer は manager から見えない)。 view 側で `Tweet.objects.visible_to(request.user)` をチェーンする運用にする。
+
+これは #734 の draft 既定除外と違って **chainable** にする理由:
+
+- viewer の id を manager の get_queryset で取れないから (request context が無い)
+- 全 view が viewer を持っているので、 viewer 起点の filter は view 層が責任を持つほうがレイヤ分離として綺麗
+
+view 層での call pattern 例:
+
+```python
+qs = Tweet.objects.all().visible_to(request.user)
+```
+
+---
+
+## 3. API
+
+### 3.1 鍵化 toggle
+
+`PATCH /api/v1/users/me/` (既存 endpoint):
+
+```json
+{ "is_private": true }
+```
+
+- 鍵化: status=approved な既存 follower はそのまま、 新規 follow が pending になる
+- 鍵解除 (`false`): 全 pending を approved に自動昇格 + 該当 follower の `followers_count` 更新
+
+### 3.2 Follow 作成 (既存 endpoint 拡張)
+
+`POST /api/v1/follows/`:
+
+- 公開アカ宛: 即 `status=approved`, `approved_at=now()` (= 既存挙動)
+- 鍵アカ宛: `status=pending`, `approved_at=None`、 followee に通知を作る
+- response shape: `{follow_id, status, approved_at}`
+
+### 3.3 自分宛の follow request 一覧
+
+`GET /api/v1/follows/requests/`:
+
+- 鍵アカ user 用。 自分宛の `status=pending` な Follow を新しい順で返す
+- shape: `{count, next, previous, results: [{follow_id, follower: {handle, display_name, ...}, created_at}]}`
+
+### 3.4 承認 / 拒否
+
+`POST /api/v1/follows/requests/<follow_id>/approve/`:
+
+- status を approved に、 approved_at=now()
+- 承認時に followers_count / following_count を +1 (signal で)
+- follower に「フォロー承認」 通知を作る
+
+`POST /api/v1/follows/requests/<follow_id>/reject/`:
+
+- Follow 行を **論理削除ではなく物理削除** (= もう一度 follow を試せる、 history は audit 不要)
+- 通知は飛ばさない (= passive rejection、 follower に伝わらない X 仕様準拠)
+
+### 3.5 既存 Tweet 関連 endpoint への visibility filter 適用
+
+- `GET /api/v1/tweets/` (公開 list): `visible_to(request.user)` チェーン
+- `GET /api/v1/tweets/<id>/`: 鍵アカ + 非 approved follower の tweet → **404 隠蔽**
+- `POST /api/v1/tweets/<id>/repost|quote|reply/`: 元 tweet が visible_to で見える前提 (= 鍵アカの非 follower は target を見つけられないので 404)
+- search / TL / home_tl は views 層で visible_to を適用 (詳細は §5)
+
+### 3.6 Profile 表示 (`GET /api/v1/users/<handle>/`)
+
+- 鍵アカ user の profile 本体 (display_name, bio, follower_count) は誰でも見える (= X 互換、 「鍵アカである」 情報自体は隠さない)
+- ただし `tweets` / `followers` / `following` list は viewer が承認済み follower でないと空配列で返す (or 別 endpoint で 403)
+- response に `is_private: bool` を含める (= UI が「鍵アカ表示」 を出す判定材料)
+- 「自分は viewer 側で approved follower か?」 を `is_following_approved: bool` で返す (UI で「フォロー中」 / 「承認待ち」 / 「フォローする」 表示分岐)
+
+---
+
+## 4. Frontend
+
+### 4.1 Settings の「アカウント設定」 タブ
+
+`client/src/app/(template)/settings/account/page.tsx` (or 該当 page):
+
+- 「アカウントを非公開にする」 toggle (checkbox or switch)
+- toggle で `PATCH /api/v1/users/me/ {is_private: true|false}`
+- 確認 dialog: 「非公開にするとフォロー申請が承認制になります」
+- 解除時: 「公開にすると全ての follow 申請が自動承認されます」
+
+### 4.2 鍵アカ profile 表示
+
+`client/src/app/(template)/u/[handle]/page.tsx`:
+
+- backend response の `is_private: true` で:
+  - tweets タブ: 「このアカウントは非公開です」 表示
+  - フォローボタン: `is_following_approved` で「フォロー中」 / 「承認待ち」 / 「フォローする」 の 3 状態
+  - `is_following_approved=true` なら通常 tweet list を render
+- 本人視点では従来通り全表示
+
+### 4.3 通知ページに「フォロー承認」 セクション
+
+`client/src/app/(template)/notifications/page.tsx`:
+
+- 既存通知 list の上に「フォロー承認 (N 件)」 banner
+- click → `/notifications/follow-requests` page (新規)
+- request 一覧: 各 row に「承認」「拒否」 button
+
+### 4.4 フォローボタンの 3 状態
+
+`client/src/components/users/FollowButton.tsx` (or 同等):
+
+- `is_following_approved` + `follow_status` (= pending|approved|null) で状態管理
+- click 動作:
+  - 鍵アカ + 未 follow → `POST /follows/` → status=pending → button text「承認待ち」
+  - 公開アカ + 未 follow → `POST /follows/` → status=approved → 「フォロー中」
+  - approved → click で unfollow
+
+---
+
+## 5. Claude Agent (Phase 14) との関係
+
+### 5.1 自動防御の仕組み
+
+`apps/agents/tools.py` の 3 read tool:
+
+- `read_my_recent_tweets`: 自分の tweet のみなので visibility 影響なし
+- `read_home_timeline`: `build_home_tl(user)` を経由。 既存 query を `visible_to(user)` でチェーン
+- `search_tweets_by_tag`: 既存 query を `visible_to(user)` でチェーン
+
+→ agent は viewer (= agent を起動したユーザー) の権限で動くので、 viewer が approved follower でない鍵アカ user の tweet は **絶対に読めない**。
+
+### 5.2 念のため明示テスト
+
+```python
+# apps/agents/tests/test_tools.py に追加
+def test_search_excludes_private_user_tweets_when_not_follower(self):
+    me = make_user()
+    private_author = make_user(is_private=True)
+    tag = Tag.objects.create(name="x", is_approved=True)
+    t = Tweet.objects.create(author=private_author, body="SECRET")
+    t.tags.add(tag)
+    out = search_tweets_by_tag(me, "x")
+    assert "SECRET" not in out
+
+def test_search_includes_private_user_tweets_when_approved_follower(self):
+    me = make_user()
+    private_author = make_user(is_private=True)
+    Follow.objects.create(follower=me, followee=private_author, status="approved")
+    ...
+    out = search_tweets_by_tag(me, "x")
+    assert "OK" in out
+```
+
+---
+
+## 6. テスト
+
+### 6.1 pytest backend
+
+`apps/users/tests/test_is_private.py`:
+
+- is_private toggle: PATCH で正しく反映
+- 鍵解除時に pending → approved 自動昇格 + counter 更新
+
+`apps/follows/tests/test_follow_requests.py`:
+
+- 公開アカへの follow → 即 approved
+- 鍵アカへの follow → pending、 follower_count は変わらない
+- approve → approved、 followers_count +1
+- reject → Follow 行削除
+- 他人の request を approve/reject → 403
+
+`apps/tweets/tests/test_visibility.py`:
+
+- visible_to(None) = 公開アカのみ
+- visible_to(self) = 自分の鍵アカ tweet 含む
+- visible_to(approved_follower) = 鍵アカ tweet 含む
+- visible_to(non_follower) = 鍵アカ tweet 含まない
+- visible_to(pending_follower) = 鍵アカ tweet 含まない
+
+`apps/agents/tests/test_tools.py`:
+
+- private author の tweet は agent から読めない (上記 §5.2)
+
+### 6.2 vitest frontend
+
+- `SettingsAccountForm.test.tsx`: toggle の確認 dialog + PATCH 呼び出し
+- `FollowButton.test.tsx`: 3 状態の遷移 (鍵アカ含む)
+- `FollowRequestsPanel.test.tsx`: 承認 / 拒否の row 操作
+
+### 6.3 E2E Playwright (#736 で別出し)
+
+`client/e2e/private-account.spec.ts`:
+
+- test3 が settings で鍵化
+- test2 が test3 の profile を見る → 「非公開」 表示
+- test2 が follow → button 「承認待ち」
+- test2 が test3 の tweet を直接 URL で踏む → 404
+- test3 が通知ページで「承認」
+- test2 が test3 の tweet 一覧を見る → 表示される
+- test2 が test3 の tweet を Claude Agent で読もうとして見える (承認後)
+
+---
+
+## 7. ロールアウト順序
+
+1. **PR-A (#734, drafts)** — 完了 (本 PR の上流、 manager 既定変更で基盤完成)
+2. **PR-B (本 issue #735)** — 鍵アカ + フォロー承認制
+3. **PR-C (#736)** — Playwright E2E (drafts + private account) + stg 実機検証 + gan-evaluator
+
+### マージ前ブロッカー (CLAUDE.md §4.1.1)
+
+- migration: `Follow.status` + `User.is_private` の backfill が **stg で完走** すること。 50k 行未満の見込みなので 1 chunk で OK
+- visible_to が既存 query にきちんと染み出していることを pytest で全カバー
+- 既存 follower の挙動が壊れていない (= 全部 approved に backfill されて従来動作)
+
+---
+
+## 8. 影響範囲
+
+- `apps/users/models.py`: is_private 追加
+- `apps/users/migrations/00XX_user_is_private.py`
+- `apps/users/serializers.py`: is_private を read/write
+- `apps/users/views.py` (or `apps/users/views_me.py`): 鍵解除時に pending → approved 一括処理
+- `apps/follows/models.py`: status / approved_at 追加
+- `apps/follows/migrations/00XX_follow_status.py`: AddField + backfill
+- `apps/follows/views.py`: create で is_private 判定 / requests / approve / reject endpoint 追加
+- `apps/follows/serializers.py`: status を露出
+- `apps/follows/signals.py`: counter は approved follow のみカウント (= pending → approved の signal を新設)
+- `apps/tweets/managers.py`: `visible_to(viewer)` 追加 (既存 manager にチェーンメソッド)
+- `apps/tweets/views.py`: list / retrieve / 検索系で visible_to 適用 + 404 隠蔽
+- `apps/timeline/services.py`: build_home_tl が visible_to をかけ込む (= 鍵アカ非 follower の tweet を除外)
+- `apps/notifications/...`: フォロー承認通知種別追加
+- `client/src/lib/api/users.ts`: `CurrentUser.is_private` 追加、 `updateMe({is_private})` 追加
+- `client/src/lib/api/follows.ts`: requests / approve / reject 追加
+- `client/src/components/settings/AccountForm.tsx` (or 該当): toggle 実装
+- `client/src/components/users/FollowButton.tsx`: 3 状態対応
+- `client/src/components/notifications/FollowRequestsPanel.tsx`: 新規
+- `client/src/app/(template)/u/[handle]/page.tsx`: 鍵アカ表示分岐
+
+---
+
+## 9. 非スコープ
+
+- DM の鍵化 (= 鍵アカ user の DM は引き続き従来通り送受信できる)
+- 鍵化 user に block / mute の交差シナリオ追加 (= 既存 block 優先)
+- 過去 follower の遡及承認状態管理 (= 全部 approved にする)
+- 鍵化 user の OGP / SEO 隠蔽: profile 自体は見えるので noindex メタは optional
+
+---
+
+## 10. 出典 / 参考
+
+- Twitter Help: Protect your posts: https://help.twitter.com/en/safety-and-security/public-and-protected-tweets
+- 既存 `Tweet.objects` Manager 拡張 pattern (`apps/tweets/managers.py`)
+- 関連: [tweet-drafts-spec.md](./tweet-drafts-spec.md) (#734, manager 既定の defense in depth)
+- 関連: [claude-agent-spec.md](./claude-agent-spec.md) Phase 14 §4 §5 (agent tool scope)


### PR DESCRIPTION
Closes #735

## Summary

X / Twitter 互換の「鍵アカ (Protected account)」 + フォロー承認制を追加。 SPEC.md 起草時の漏れを埋める。 副次的に Phase 14 Claude Agent から「鍵アカ user の tweet」 が agent 経由で他人に漏れない仕組みを Tweet 配信レイヤで保証する。

#734 (下書き) と組み合わせると、 Phase 14 Claude Agent から「draft」「private な未公開コンテンツ」 を絶対に読まない多層防御が完成する。

E2E spec は #736 で別 PR。

## Changes (data model)

- `User.is_private: BooleanField(default=False)` (migration 0008)
- `Follow.status: TextChoices(pending|approved)` + `Follow.approved_at` (migration 0002, 既存 Follow は **chunked backfill** で全部 status=approved に揃える)
- `Tweet.objects.visible_to(viewer)` チェーンメソッド追加
  - 公開アカ → 誰でも
  - 鍵アカ author → 本人 + approved follower のみ
  - 匿名 / 非 follower / pending は除外
- `Follow.signals.on_follow_created/on_follow_deleted` を `status=APPROVED` のときだけ counter +1/-1 にする (= pending は counter に算入しない)

## API

- `PATCH /api/v1/users/me/` で `is_private` toggle (鍵解除時に pending を一括 approved 化、 counters を補正)
- `POST /api/v1/users/<handle>/follow/` が `followee.is_private` で status=pending/approved を分岐、 response に status を含める
- `GET /api/v1/follows/requests/` 自分宛 pending 一覧
- `POST /api/v1/follows/requests/<id>/approve/`
- `POST /api/v1/follows/requests/<id>/reject/` (物理削除、 X 仕様準拠)
- Tweet retrieve: 鍵アカ非 follower → 404 隠蔽
- Tweet list: `visible_to(request.user)` を get_queryset で自動チェーン
- `_resolve_target` (repost/quote/reply): visibility check → 鍵アカ非 follower の元 tweet 操作で 404
- `build_home_tl`: approved follow のみ following 候補、 global は author__is_private=False で公開アカ限定

## Frontend

- `CurrentUser.is_private` + `UpdateProfilePayload.is_private` 追加
- `ProfileEditForm` に「アカウントを非公開にする」 toggle (既存 settings/profile から PATCH)
- `PublicProfile.is_private` / `follow_status` 追加 (ProfileSerializer 由来)
- `FollowButton` 3 状態化 (フォロー / 承認待ち / フォロー中)。 backend response の status を見て pending を確定
- `followsApiSlice.followUser` の return type を `FollowMutationResponse` に変更
- 新 route `/follow-requests` (本人のみ、 SSR で auth check + 一覧 fetch)
- `FollowRequestsPanel`: 承認 / 拒否 button + confirm dialog

## Tests

- **pytest** `apps/follows/tests/test_follow_requests.py` (新規):
  - 公開アカ → 即 approved + counters +1
  - 鍵アカ → pending + counters 不変
  - GET /follows/requests/ 自分宛のみ
  - approve → counters +1, reject → 物理削除 + counters 不変
  - 他人の req approve/reject → 404
  - 鍵解除で pending 一括昇格 + counters 補正
- **pytest** `apps/tweets/tests/test_visibility.py` (新規):
  - visible_to: anon/self/approved/pending/non-follower の 5 case
  - retrieve 404 隠蔽 (anon / non-follower / approved follower / owner)
- **pytest** `apps/agents/tests/test_tools.py`: 鍵アカ非 follower で agent から見えない
- 全 vitest 753/754 passing (1 todo)、 tsc / eslint clean

## Migration リスク

- `0008_user_is_private`: AddField(default=False) のみ。 instant operation on PostgreSQL
- `0002_follow_status_approved_at`:
  - AddField status (default="approved") + AddField approved_at (null=True)
  - RunPython で `approved_at = created_at` を 5,000 件ずつ chunked backfill
  - stg / prod の Follow 行数は少ない見込み (まだフェーズ初期) なので worst case でも数十秒で完了
  - rollback もちゃんと書いた

## Test plan

- [x] vitest 753 / 754 passing
- [x] tsc --noEmit clean
- [x] eslint clean
- [ ] CI green (ruff / mypy / pytest / vitest / tsc / eslint)
- [ ] stg deploy 後、 settings で is_private toggle 動作確認
- [ ] 別 user で鍵アカに follow → /follow-requests で承認できるか
- [ ] 承認後、 home TL に表示されるか
- [ ] 非 follower で鍵アカ tweet URL を踏むと 404 になるか
- [ ] Claude Agent から鍵アカ非 follower の tweet が見えないか (curl + agent run)

## サイズ

CLAUDE.md §4.1.1 ガイドライン (500 行) を超える (+1,617 行)。 内訳:

- 仕様書 336 行 (review-only)
- pytest 300 行 (review-only)
- 実装本体 backend +500 + frontend +480

機能内分割するとモデル / API / UI が単独で review しづらく、 stg 中途半端 release のリスクもあるので 1 PR にまとめた。 ハルナさんに事前承認済 (`AskUserQuestion` 結果)。