### PR TITLE
[refactor][explore] /explore 空 trending state の WhoToFollow inline fallback (#746)

### DIFF
--- a/client/e2e/explore-search-rail.spec.ts
+++ b/client/e2e/explore-search-rail.spec.ts
@@ -113,11 +113,15 @@ test.describe("#741 /explore + search + right rail IA refactor", () => {
 		// trending feed の現在の状態を判定 (stg は通常 empty だが populated でも
 		// 正しく動くよう conditional assertion):
 		//   - empty: 「今は表示できるツイートがありません。」 が見える
-		//             → 「代わりに、 おすすめユーザー」 fallback h2 が見える
-		//   - populated: tweet card が複数 → fallback h2 は **見えない** (regression 防止)
+		//             → 中央 column 内に WhoToFollow の「おすすめユーザー」 h2 が
+		//               (右 rail の同名 h2 とは独立に、 main 内で) 見える
+		//   - populated: tweet card が複数 → 中央 column 内に WhoToFollow なし
+		//     (右 rail には依然出るので 1 個は存在しうる、 main scope に限定して判定)
 		const emptyMessage = page.getByText("今は表示できるツイートがありません。");
-		const fallbackHeading = page.getByRole("heading", {
-			name: /代わりに、 おすすめユーザー/,
+		const mainColumn = page.getByRole("main", { name: /メインコンテンツ/ });
+		const fallbackHeading = mainColumn.getByRole("heading", {
+			name: /^おすすめユーザー$/,
+			level: 2,
 		});
 
 		await page
@@ -141,8 +145,10 @@ test.describe("#741 /explore + search + right rail IA refactor", () => {
 		await page.goto(`${BASE}/explore`);
 
 		const emptyMessage = page.getByText("今は表示できるツイートがありません。");
-		const fallbackHeading = page.getByRole("heading", {
-			name: /代わりに、 おすすめユーザー/,
+		const mainColumn = page.getByRole("main", { name: /メインコンテンツ/ });
+		const fallbackHeading = mainColumn.getByRole("heading", {
+			name: /^おすすめユーザー$/,
+			level: 2,
 		});
 
 		await page

--- a/client/e2e/explore-search-rail.spec.ts
+++ b/client/e2e/explore-search-rail.spec.ts
@@ -100,6 +100,64 @@ test.describe("#741 /explore + search + right rail IA refactor", () => {
 		await ctx.close();
 	});
 
+	// ───────────────────────────────────────────────── /explore empty fallback (#746)
+
+	test("EMPTY-1: trending 空のとき WhoToFollow が inline fallback として出る", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.goto(`${BASE}/explore`);
+
+		// trending feed の現在の状態を判定 (stg は通常 empty だが populated でも
+		// 正しく動くよう conditional assertion):
+		//   - empty: 「今は表示できるツイートがありません。」 が見える
+		//             → 「代わりに、 おすすめユーザー」 fallback h2 が見える
+		//   - populated: tweet card が複数 → fallback h2 は **見えない** (regression 防止)
+		const emptyMessage = page.getByText("今は表示できるツイートがありません。");
+		const fallbackHeading = page.getByRole("heading", {
+			name: /代わりに、 おすすめユーザー/,
+		});
+
+		await page
+			.getByRole("heading", { name: /トレンドツイート/, level: 2 })
+			.waitFor({ timeout: 15000 });
+
+		if (await emptyMessage.isVisible()) {
+			await expect(fallbackHeading).toBeVisible();
+		} else {
+			await expect(fallbackHeading).toHaveCount(0);
+		}
+
+		await ctx.close();
+	});
+
+	test("EMPTY-2: anon `/explore` でも空のときに WhoToFollow inline 出る", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/explore`);
+
+		const emptyMessage = page.getByText("今は表示できるツイートがありません。");
+		const fallbackHeading = page.getByRole("heading", {
+			name: /代わりに、 おすすめユーザー/,
+		});
+
+		await page
+			.getByRole("heading", { name: /トレンドツイート/, level: 2 })
+			.waitFor({ timeout: 15000 });
+
+		if (await emptyMessage.isVisible()) {
+			await expect(fallbackHeading).toBeVisible();
+		} else {
+			await expect(fallbackHeading).toHaveCount(0);
+		}
+
+		await ctx.close();
+	});
+
 	// ───────────────────────────────────────────────── /explore (anon)
 
 	test("EXP-3: /explore を logged-out で開く → Hero + Sticky + SearchBox", async ({

--- a/client/src/app/(template)/explore/page.tsx
+++ b/client/src/app/(template)/explore/page.tsx
@@ -62,6 +62,12 @@ const websiteJsonLd = {
 export default async function ExplorePage() {
 	const authed = await isAuthenticated();
 
+	// #746: fetchExploreTimeline が throw した (network / 5xx / timeout) 場合、
+	// 空 page を返して下流の empty-state branch に流す。 「trending tweets が
+	// 集計されてない」 と「 backend エラー」 は UI 上 区別せず、 どちらでも
+	// WhoToFollow fallback を出す (blank page よりは discovery surface を見せる
+	// 方が UX が良い)。 観測性は別途 Sentry / structlog が拾うので、 UI で
+	// distinguish しない方針。
 	const page = await fetchExploreTimeline(20).catch(() => ({
 		results: [],
 		count: 0,
@@ -147,20 +153,17 @@ export default async function ExplorePage() {
 				 * (mobile/tablet で消える)、 (b) 中央 column の inline 表示は
 				 * desktop でも「次の action はこれ」 として導線強化になる、 ので
 				 * 重複を許容。
+				 *
+				 * 見出しは WhoToFollow 内蔵 h2「おすすめユーザー」 をそのまま使う:
+				 * - 外側に「代わりに…」 のような追加 h2 を置くと nested heading 重複
+				 *   + 「primary content が壊れた」 と読ませる framing になる
+				 *   (code-reviewer 指摘)
+				 * - bare=false (default) で card style も維持
 				 */}
 				{page.results.length === 0 && (
-					<section
-						aria-labelledby="explore-fallback-heading"
-						className="mt-6 px-5"
-					>
-						<h2
-							id="explore-fallback-heading"
-							className="mb-4 px-2 text-lg font-semibold text-foreground"
-						>
-							代わりに、 おすすめユーザー
-						</h2>
+					<div className="mt-6 px-5">
 						<WhoToFollow isAuthenticated={authed} />
-					</section>
+					</div>
 				)}
 			</article>
 

--- a/client/src/app/(template)/explore/page.tsx
+++ b/client/src/app/(template)/explore/page.tsx
@@ -17,6 +17,7 @@ import type { Metadata } from "next";
 import HeroBanner from "@/components/explore/HeroBanner";
 import StickyLoginBanner from "@/components/explore/StickyLoginBanner";
 import SearchBox from "@/components/search/SearchBox";
+import WhoToFollow from "@/components/sidebar/WhoToFollow";
 import TweetCardList from "@/components/timeline/TweetCardList";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import { fetchExploreTimeline } from "@/lib/api/explore";
@@ -134,6 +135,33 @@ export default async function ExplorePage() {
 						emptyMessage="今は表示できるツイートがありません。"
 					/>
 				</section>
+
+				{/*
+				 * #746: trending tweets が空のとき (まだ集計されていない、
+				 * 一時的に backend がデータを返せない、 等)、 ページが「壊れて見える」
+				 * ほどスパースになるのを防ぐため、 既存 `WhoToFollow` を inline で
+				 * fallback render する。 logged-in なら personalised recommendations、
+				 * anon なら popular users (component 内で auth state 判定済)。
+				 *
+				 * 右 rail にも WhoToFollow があるが、 (a) 右 rail は lg+ のみ表示
+				 * (mobile/tablet で消える)、 (b) 中央 column の inline 表示は
+				 * desktop でも「次の action はこれ」 として導線強化になる、 ので
+				 * 重複を許容。
+				 */}
+				{page.results.length === 0 && (
+					<section
+						aria-labelledby="explore-fallback-heading"
+						className="mt-6 px-5"
+					>
+						<h2
+							id="explore-fallback-heading"
+							className="mb-4 px-2 text-lg font-semibold text-foreground"
+						>
+							代わりに、 おすすめユーザー
+						</h2>
+						<WhoToFollow isAuthenticated={authed} />
+					</section>
+				)}
 			</article>
 
 			{!authed && <StickyLoginBanner />}

--- a/docs/specs/explore-search-rightrail-spec.md
+++ b/docs/specs/explore-search-rightrail-spec.md
@@ -278,25 +278,30 @@ PLAYWRIGHT_USER1_HANDLE=test4 \
 
 ### 8.2 やる
 
-`client/src/app/(template)/explore/page.tsx` で trending が空 (`page.results.length === 0`) のとき、 既存 `WhoToFollow` component を **inline で fallback** として render する:
+`client/src/app/(template)/explore/page.tsx` で trending が空 (`page.results.length === 0`) のとき、 既存 `WhoToFollow` component を **inline で fallback** として render する。 既存の `TweetCardList` の `emptyMessage` はそのまま残し、 **その下に additive で** WhoToFollow セクションを足す pattern:
 
 ```tsx
-{page.results.length === 0 ? (
-  <>
-    <p className="...">今は表示できるツイートがありません。</p>
-    <div className="mt-6">
-      <h3 className="...">代わりに、 おすすめユーザー</h3>
-      <WhoToFollow isAuthenticated={authed} />
-    </div>
-  </>
-) : (
-  <TweetCardList tweets={page.results} ... />
+<section aria-labelledby="explore-feed-heading" ...>
+  <h2 id="explore-feed-heading">トレンドツイート</h2>
+  <TweetCardList
+    tweets={page.results}
+    ariaLabel="トレンドツイート"
+    emptyMessage="今は表示できるツイートがありません。"
+  />
+</section>
+
+{/* #746 fallback */}
+{page.results.length === 0 && (
+  <div className="mt-6 px-5">
+    <WhoToFollow isAuthenticated={authed} />
+  </div>
 )}
 ```
 
 - `WhoToFollow` は既存の sidebar component を流用 (`client/src/components/sidebar/WhoToFollow.tsx`)
 - logged-in なら personalised recommendations、 anon なら popular users (component が auth state で endpoint 分岐済)
-- card style を維持するため `bare` prop は **付けない** (sidebar 内では bare、 inline では fully styled `<section>`)
+- `bare` prop は **付けない** (default false) → WhoToFollow 内蔵の「おすすめユーザー」 h2 + card style がそのまま生きる
+- 外側にさらに「代わりに…」 のような h2 を足すと nested heading 重複 + 「primary content が壊れた」 と読ませる framing になるので避ける
 - desktop で右 rail がある場合は WhoToFollow が左右に重複表示されるが、 right rail 自体が trending tags + who-to-follow を出すので「両方候補が見える」 = discovery 強化として許容
 
 ### 8.3 やらない

--- a/docs/specs/explore-search-rightrail-spec.md
+++ b/docs/specs/explore-search-rightrail-spec.md
@@ -265,3 +265,56 @@ PLAYWRIGHT_USER1_HANDLE=test4 \
 - **(別 Issue)** 左 nav「メンター募集」 + 「メンターを探す」 重複 (L-2) — Phase 11 review 対象
 
 これら 3 件は priority:low / type:bug or type:feature で個別起票し、 後続の Phase で処理する。
+
+---
+
+## 8. follow-up: `/explore` empty trending state fallback (#746)
+
+### 8.1 背景
+
+#741 を merge して stg verify した際の `gan-evaluator` 採点で hierarchy/typography 6/10 (full SHIP-WITH-FOLLOWUP)。 主因は **logged-in `/explore` で trending tweets が空のときページが「壊れて見える」 ほどスパース** な状態。
+
+具体的: sticky bar (Explore + SearchBox + 検索 button) → "トレンドツイート" h2 → 「今は表示できるツイートがありません。」 だけが見えて、 ページ全体が機能していないように読める。
+
+### 8.2 やる
+
+`client/src/app/(template)/explore/page.tsx` で trending が空 (`page.results.length === 0`) のとき、 既存 `WhoToFollow` component を **inline で fallback** として render する:
+
+```tsx
+{page.results.length === 0 ? (
+  <>
+    <p className="...">今は表示できるツイートがありません。</p>
+    <div className="mt-6">
+      <h3 className="...">代わりに、 おすすめユーザー</h3>
+      <WhoToFollow isAuthenticated={authed} />
+    </div>
+  </>
+) : (
+  <TweetCardList tweets={page.results} ... />
+)}
+```
+
+- `WhoToFollow` は既存の sidebar component を流用 (`client/src/components/sidebar/WhoToFollow.tsx`)
+- logged-in なら personalised recommendations、 anon なら popular users (component が auth state で endpoint 分岐済)
+- card style を維持するため `bare` prop は **付けない** (sidebar 内では bare、 inline では fully styled `<section>`)
+- desktop で右 rail がある場合は WhoToFollow が左右に重複表示されるが、 right rail 自体が trending tags + who-to-follow を出すので「両方候補が見える」 = discovery 強化として許容
+
+### 8.3 やらない
+
+- trending tweets feed が空でないときの動作変更 (現状維持)
+- 右 rail 側の WhoToFollow の挙動変更
+- gan-evaluator finding #1 / #2 (`discover` eyebrow / 「TRENDING TAGS · 24H」 「WHO TO FOLLOW」 uppercase 英語) — A direction signature の design language として確定済 (ARightRail.tsx:34 既存、 #550)。 typography 議論は別 Phase で。
+- gan-evaluator finding #4 (mobile 375px SearchBox button 折り返し) — 私が直接 Playwright MCP で確認、 非該当 (button は wrap せず適切な touch target を保つ)。
+
+### 8.4 受け入れ基準
+
+- [ ] Playwright spec `client/e2e/explore-search-rail.spec.ts` に `EMPTY-1: logged-in 空 trending → WhoToFollow inline 表示` を追加
+- [ ] stg で `/explore` を logged-in で開き、 trending が空のときは中央 column 内に「おすすめユーザー」 section が visible
+- [ ] trending tweets がある場合は WhoToFollow inline 非表示 (現状の TweetCardList のみ)
+- [ ] anon `/explore` でも同じ挙動 (空のとき WhoToFollow inline) — anon は popular users が出る (既存 `fetchPopularUsers`)
+- [ ] `ui-ux-tester` 再 audit で hierarchy/typography 7+/10 に改善 (改修前 6/10)
+
+### 8.5 ロールバック
+
+- 単一 file の差分 (`client/src/app/(template)/explore/page.tsx`) を revert すれば原状回復
+- DB / API 触らず、 既存 component 流用のみ


### PR DESCRIPTION
Closes #746

## Summary

#741 / PR #745 を merge した直後の `gan-evaluator` 採点で「logged-in `/explore` で trending tweets が空のとき "broken" に見える」 と指摘 (hierarchy/typography 6/10)。

修正: `page.results.length === 0` のとき、 既存 `WhoToFollow` component を inline で fallback render する。 logged-in なら personalised recommendations、 anon なら popular users (component 内で auth 状態判定済)。

## 変更ファイル (3 files, +139 / -0)

| ファイル | 役割 |
|---|---|
| `client/src/app/(template)/explore/page.tsx` | 空 trending 時に WhoToFollow を inline render |
| `client/e2e/explore-search-rail.spec.ts` | EMPTY-1 / EMPTY-2 E2E シナリオ追加 (logged-in / anon) |
| `docs/specs/explore-search-rightrail-spec.md` | §8 follow-up section 追加 |

## Test plan

### Unit / type / lint (local)
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run lint` → 0 errors (既存 warning のみ)
- [x] `npx vitest run` → 100 files / 826 tests pass (本 PR で新規 unit test なし、 conditional render は E2E で検証)

### E2E (stg、 merge → CD 反映後に Claude が踏む)
\`\`\`bash
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \\
PLAYWRIGHT_USER1_EMAIL=test4@example.com \\
PLAYWRIGHT_USER1_PASSWORD=*** \\
PLAYWRIGHT_USER1_HANDLE=test4 \\
  npx playwright test e2e/explore-search-rail.spec.ts --reporter=line
\`\`\`

- [ ] EMPTY-1 logged-in /explore: trending 空なら「代わりに、 おすすめユーザー」 fallback 見える
- [ ] EMPTY-2 anon /explore: 同上、 popular users が出る
- 既存 EXP-1〜RAIL-FOOTER の 12 シナリオも全 pass を確認 (regression なし)

### サブエージェントレビュー (CLAUDE.md §4.2、 直列起動)
- [ ] `typescript-reviewer` + `code-reviewer`
- [ ] `a11y-architect` (UI 変更につき必須)
- [ ] post-merge: `ui-ux-tester` + `gan-evaluator` 再採点 (期待: hierarchy/typography が 6→7+ 改善)

## Rollback

単一 file の差分 (`client/src/app/(template)/explore/page.tsx`) を revert すれば原状回復。 既存 WhoToFollow component を import + 条件分岐で render するだけで、 既存挙動は破壊しない。