### PR TITLE
[bug][boards] /threads/<id> hydration mismatch (10 errors) を JST timezone 固定で修正 (#742)

### DIFF
--- a/client/e2e/threads-hydration.spec.ts
+++ b/client/e2e/threads-hydration.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * #742 /threads/<id> hydration mismatch fix E2E.
+ *
+ * Spec: docs/specs/threads-hydration-fix-spec.md §3.2
+ *
+ * 改修前 (stg 2026-05-17 実測): React #425 × 8 + #418 + #423 = 10 件
+ * 改修後 (本 PR merge 後 stg): 0 件
+ *
+ * 原因: ThreadPostItem.formatDateTime / ThreadRow.formatDateTime が
+ *       `new Date(iso).toLocaleString("ja-JP", ...)` を timezone 指定なしで
+ *       call していたため、 SSR (Docker UTC) と CSR (browser JST) で異なる
+ *       文字列が出ていた。
+ *
+ * 修正: lib/datetime.ts の formatJstDateTime に集約、 timeZone="Asia/Tokyo" 強制。
+ *
+ * 実行:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     npx playwright test e2e/threads-hydration.spec.ts --reporter=line
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+// React hydration / runtime errors のうち本 issue が対象とする 3 codes。
+// React production build は error code のみ表示 (full message なし)。
+// reactjs.org/docs/error-decoder.html?invariant=<n> を参照。
+const HYDRATION_ERROR_CODES = ["#425", "#418", "#423"];
+
+function isHydrationError(text: string): boolean {
+	return HYDRATION_ERROR_CODES.some((code) => text.includes(code));
+}
+
+test.describe("#742 /threads/<id> hydration fix", () => {
+	test("HYDRATION-1: /threads/1 で React hydration error が 0 件", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+
+		const hydrationErrors: string[] = [];
+		page.on("console", (msg) => {
+			if (msg.type() === "error" && isHydrationError(msg.text())) {
+				hydrationErrors.push(msg.text());
+			}
+		});
+
+		await page.goto(`${BASE}/threads/1`);
+		// ThreadView の post 描画 + hydration 完了を待つ
+		await page
+			.getByRole("heading", { level: 1 })
+			.first()
+			.waitFor({ timeout: 15000 });
+		// hydration error は client-side 描画途中に fire するので少し待つ
+		await page.waitForTimeout(2000);
+
+		expect(
+			hydrationErrors,
+			`Expected 0 hydration errors, got ${hydrationErrors.length}:\n${hydrationErrors.join("\n")}`,
+		).toHaveLength(0);
+
+		await ctx.close();
+	});
+
+	test("HYDRATION-2: /boards/django で ThreadRow render 中も hydration error 0 件", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+
+		const hydrationErrors: string[] = [];
+		page.on("console", (msg) => {
+			if (msg.type() === "error" && isHydrationError(msg.text())) {
+				hydrationErrors.push(msg.text());
+			}
+		});
+
+		await page.goto(`${BASE}/boards/django`);
+		await page
+			.getByRole("heading", { level: 1 })
+			.first()
+			.waitFor({ timeout: 15000 });
+		await page.waitForTimeout(2000);
+
+		expect(
+			hydrationErrors,
+			`Expected 0 hydration errors, got ${hydrationErrors.length}:\n${hydrationErrors.join("\n")}`,
+		).toHaveLength(0);
+
+		await ctx.close();
+	});
+});

--- a/client/e2e/threads-hydration.spec.ts
+++ b/client/e2e/threads-hydration.spec.ts
@@ -45,14 +45,22 @@ test.describe("#742 /threads/<id> hydration fix", () => {
 			}
 		});
 
-		await page.goto(`${BASE}/threads/1`);
-		// ThreadView の post 描画 + hydration 完了を待つ
+		// fixture thread (id=1)。 stg で削除されたら status check で fast-fail
+		// するので「 404 で hydration error 0 件 → vacuously green」 を防ぐ
+		// (code-reviewer MEDIUM 対応)。
+		const response = await page.goto(`${BASE}/threads/1`);
+		expect(
+			response?.status(),
+			"fixture thread /threads/1 が消えている可能性。 stg で id 再確認",
+		).toBeLessThan(400);
+		// ThreadView 描画 + hydration 完了を待つ。
+		// 固定 waitForTimeout だと slow stg cold start で race するので、
+		// network idle と heading 表示の AND で hydration step を確実に拾う。
 		await page
 			.getByRole("heading", { level: 1 })
 			.first()
 			.waitFor({ timeout: 15000 });
-		// hydration error は client-side 描画途中に fire するので少し待つ
-		await page.waitForTimeout(2000);
+		await page.waitForLoadState("networkidle", { timeout: 15000 });
 
 		expect(
 			hydrationErrors,
@@ -75,12 +83,17 @@ test.describe("#742 /threads/<id> hydration fix", () => {
 			}
 		});
 
-		await page.goto(`${BASE}/boards/django`);
+		// fixture board "django"。 同様に status check で fast-fail。
+		const response = await page.goto(`${BASE}/boards/django`);
+		expect(
+			response?.status(),
+			"fixture board /boards/django が消えている可能性。 stg で slug 再確認",
+		).toBeLessThan(400);
 		await page
 			.getByRole("heading", { level: 1 })
 			.first()
 			.waitFor({ timeout: 15000 });
-		await page.waitForTimeout(2000);
+		await page.waitForLoadState("networkidle", { timeout: 15000 });
 
 		expect(
 			hydrationErrors,

--- a/client/src/components/boards/ThreadPostItem.tsx
+++ b/client/src/components/boards/ThreadPostItem.tsx
@@ -15,6 +15,7 @@ import { type ReactNode, useState } from "react";
 
 import type { ThreadPost } from "@/lib/api/boards";
 import { deleteThreadPost } from "@/lib/api/boards";
+import { formatJstDateTime } from "@/lib/datetime";
 
 interface ThreadPostItemProps {
 	post: ThreadPost;
@@ -52,19 +53,10 @@ function renderBody(body: string): ReactNode[] {
 	return parts;
 }
 
-function formatDateTime(iso: string): string {
-	try {
-		return new Date(iso).toLocaleString("ja-JP", {
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-		});
-	} catch {
-		return iso;
-	}
-}
+// #742: timezone を JST 固定にして SSR/CSR hydration mismatch (#425/#418/#423) を防ぐ。
+// 旧 inline toLocaleString は server (UTC) / client (browser TZ) で異なる
+// 文字列を出していたため React #425 が 1 post につき 1 件 fire していた。
+const formatDateTime = formatJstDateTime;
 
 export default function ThreadPostItem({
 	post,

--- a/client/src/components/boards/ThreadPostItem.tsx
+++ b/client/src/components/boards/ThreadPostItem.tsx
@@ -15,6 +15,9 @@ import { type ReactNode, useState } from "react";
 
 import type { ThreadPost } from "@/lib/api/boards";
 import { deleteThreadPost } from "@/lib/api/boards";
+// #742: timezone を JST 固定にして SSR/CSR hydration mismatch (#425/#418/#423) を防ぐ。
+// 旧 inline toLocaleString は server (UTC) / client (browser TZ) で異なる
+// 文字列を出していたため React #425 が 1 post につき 1 件 fire していた。
 import { formatJstDateTime } from "@/lib/datetime";
 
 interface ThreadPostItemProps {
@@ -52,11 +55,6 @@ function renderBody(body: string): ReactNode[] {
 	}
 	return parts;
 }
-
-// #742: timezone を JST 固定にして SSR/CSR hydration mismatch (#425/#418/#423) を防ぐ。
-// 旧 inline toLocaleString は server (UTC) / client (browser TZ) で異なる
-// 文字列を出していたため React #425 が 1 post につき 1 件 fire していた。
-const formatDateTime = formatJstDateTime;
 
 export default function ThreadPostItem({
 	post,
@@ -119,7 +117,7 @@ export default function ThreadPostItem({
 						dateTime={post.created_at}
 						className="shrink-0 text-xs text-gray-500 dark:text-gray-400"
 					>
-						{formatDateTime(post.created_at)}
+						{formatJstDateTime(post.created_at)}
 					</time>
 				</div>
 				{canDelete && (

--- a/client/src/components/boards/ThreadRow.tsx
+++ b/client/src/components/boards/ThreadRow.tsx
@@ -7,25 +7,15 @@
 import Link from "next/link";
 
 import type { ThreadSummary } from "@/lib/api/boards";
+import { formatJstDateTime } from "@/lib/datetime";
 
 interface ThreadRowProps {
 	thread: ThreadSummary;
 }
 
-function formatDateTime(iso: string): string {
-	try {
-		const d = new Date(iso);
-		return d.toLocaleString("ja-JP", {
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-		});
-	} catch {
-		return iso;
-	}
-}
+// #742: timezone を JST 固定にして SSR/CSR hydration mismatch を防ぐ。
+// 詳細は ThreadPostItem.tsx の同 const コメント / lib/datetime.ts 参照。
+const formatDateTime = formatJstDateTime;
 
 export default function ThreadRow({ thread }: ThreadRowProps) {
 	const authorLabel =

--- a/client/src/components/boards/ThreadRow.tsx
+++ b/client/src/components/boards/ThreadRow.tsx
@@ -14,8 +14,7 @@ interface ThreadRowProps {
 }
 
 // #742: timezone を JST 固定にして SSR/CSR hydration mismatch を防ぐ。
-// 詳細は ThreadPostItem.tsx の同 const コメント / lib/datetime.ts 参照。
-const formatDateTime = formatJstDateTime;
+// 詳細は lib/datetime.ts 参照。
 
 export default function ThreadRow({ thread }: ThreadRowProps) {
 	const authorLabel =
@@ -48,7 +47,7 @@ export default function ThreadRow({ thread }: ThreadRowProps) {
 				<div className="mt-1 flex items-center justify-between text-xs text-[color:var(--a-text-muted)]">
 					<span>{authorLabel}</span>
 					<time dateTime={thread.last_post_at}>
-						{formatDateTime(thread.last_post_at)}
+						{formatJstDateTime(thread.last_post_at)}
 					</time>
 				</div>
 			</Link>

--- a/client/src/lib/__tests__/datetime.test.ts
+++ b/client/src/lib/__tests__/datetime.test.ts
@@ -35,16 +35,23 @@ describe("formatJstDateTime", () => {
 		expect(result).toContain("5月");
 	});
 
-	it("ignores attempted timeZone override (hydration safety)", () => {
-		// timeZone を override しようとしても "Asia/Tokyo" が必ず勝つ
-		const result = formatJstDateTime("2026-05-17T06:00:00Z", {
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-			timeZone: "America/Los_Angeles", // 無視される
-		});
+	it("ignores attempted timeZone override (hydration safety, runtime guard)", () => {
+		// timeZone を override しようとしても "Asia/Tokyo" が必ず勝つ。
+		// type 上は Omit<..., "timeZone"> で弾いているが、 caller が any 経由で
+		// 渡してきても runtime で上書きされることを保証する (defensive)。
+		const overrideAttempt = {
+			year: "numeric" as const,
+			month: "2-digit" as const,
+			day: "2-digit" as const,
+			hour: "2-digit" as const,
+			minute: "2-digit" as const,
+			timeZone: "America/Los_Angeles",
+		};
+		// type 強制を回避して runtime 動作を verify
+		const result = formatJstDateTime(
+			"2026-05-17T06:00:00Z",
+			overrideAttempt as unknown as Parameters<typeof formatJstDateTime>[1],
+		);
 		// JST で 15:00 と出る (LA なら 前日 23:00 になるはず)
 		expect(result).toBe("2026/05/17 15:00");
 	});

--- a/client/src/lib/__tests__/datetime.test.ts
+++ b/client/src/lib/__tests__/datetime.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for datetime helper (#742).
+ *
+ * Spec: docs/specs/threads-hydration-fix-spec.md §3.1
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatJstDate, formatJstDateTime } from "@/lib/datetime";
+
+describe("formatJstDateTime", () => {
+	it("returns JST formatted string for valid UTC ISO", () => {
+		// 2026-05-17T06:00:00Z = 2026-05-17 15:00 JST (UTC+9)
+		const result = formatJstDateTime("2026-05-17T06:00:00Z");
+		expect(result).toBe("2026/05/17 15:00");
+	});
+
+	it("returns JST regardless of process timezone (hydration-safe)", () => {
+		// process.env.TZ を変えても結果不変 (timeZone option で強制)。
+		// vitest 環境で確認: 同じ input → 同じ output
+		const a = formatJstDateTime("2026-01-01T00:00:00Z");
+		const b = formatJstDateTime("2026-01-01T00:00:00Z");
+		expect(a).toBe(b);
+		// UTC midnight = JST 09:00
+		expect(a).toBe("2026/01/01 09:00");
+	});
+
+	it("respects custom options (other than timeZone)", () => {
+		const result = formatJstDateTime("2026-05-17T06:00:00Z", {
+			year: "numeric",
+			month: "long",
+		});
+		// "Asia/Tokyo" 強制なので JST。 month "long" だと「5月」
+		expect(result).toContain("2026");
+		expect(result).toContain("5月");
+	});
+
+	it("ignores attempted timeZone override (hydration safety)", () => {
+		// timeZone を override しようとしても "Asia/Tokyo" が必ず勝つ
+		const result = formatJstDateTime("2026-05-17T06:00:00Z", {
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			timeZone: "America/Los_Angeles", // 無視される
+		});
+		// JST で 15:00 と出る (LA なら 前日 23:00 になるはず)
+		expect(result).toBe("2026/05/17 15:00");
+	});
+
+	it("returns raw input for invalid ISO string", () => {
+		expect(formatJstDateTime("not-a-date")).toBe("not-a-date");
+		expect(formatJstDateTime("")).toBe("");
+	});
+
+	it("returns raw input for malformed string that throws", () => {
+		// 完全に破壊された input でも throw せず raw を返す
+		const weird = "2026-13-99T99:99:99Z";
+		expect(formatJstDateTime(weird)).toBe(weird);
+	});
+});
+
+describe("formatJstDate", () => {
+	it("returns date-only JST format", () => {
+		// UTC midnight = JST 09:00 → 日付は 2026/01/01
+		expect(formatJstDate("2026-01-01T00:00:00Z")).toBe("2026/01/01");
+	});
+
+	it("rolls over day at JST midnight", () => {
+		// 2026-05-17T15:00:00Z = JST 2026-05-18 00:00
+		expect(formatJstDate("2026-05-17T15:00:00Z")).toBe("2026/05/18");
+	});
+
+	it("returns raw for invalid input", () => {
+		expect(formatJstDate("invalid")).toBe("invalid");
+	});
+});

--- a/client/src/lib/datetime.ts
+++ b/client/src/lib/datetime.ts
@@ -1,0 +1,61 @@
+/**
+ * Datetime formatting helpers (#742).
+ *
+ * Spec: docs/specs/threads-hydration-fix-spec.md
+ *
+ * SSR (Docker container、 TZ=UTC) と CSR (browser、 TZ=JST 等) で
+ * `new Date(iso).toLocaleString("ja-JP", ...)` の出力が異なると
+ * React hydration mismatch (#425/#418/#423) を fire する。
+ *
+ * 日本語 SNS なので timezone は JST 固定で正しく、 `timeZone: "Asia/Tokyo"` を
+ * 渡せば SSR/CSR 両方が同じ文字列を出すため hydration が成立する。
+ *
+ * 本 module はこの「 JST 固定 + ja-JP locale」 の共通 helper を提供する。
+ */
+
+const JST_TIMEZONE = "Asia/Tokyo";
+
+const DEFAULT_OPTIONS: Intl.DateTimeFormatOptions = {
+	year: "numeric",
+	month: "2-digit",
+	day: "2-digit",
+	hour: "2-digit",
+	minute: "2-digit",
+};
+
+/**
+ * ISO 8601 string を「2026/05/17 15:00」 形式の JST 文字列に整形する。
+ *
+ * SSR と CSR で同じ出力になることを保証する (`timeZone: "Asia/Tokyo"` 強制)。
+ *
+ * @param iso ISO 8601 date string (e.g. "2026-05-17T06:00:00Z")
+ * @param options Intl.DateTimeFormatOptions を上書きできる。 `timeZone` は
+ *                常に "Asia/Tokyo" に強制される (override 不可、 hydration 保証)
+ * @returns 整形済み文字列。 `iso` が invalid な場合は raw string を返す
+ */
+export function formatJstDateTime(
+	iso: string,
+	options: Intl.DateTimeFormatOptions = DEFAULT_OPTIONS,
+): string {
+	try {
+		const date = new Date(iso);
+		if (Number.isNaN(date.getTime())) return iso;
+		return date.toLocaleString("ja-JP", {
+			...options,
+			timeZone: JST_TIMEZONE,
+		});
+	} catch {
+		return iso;
+	}
+}
+
+/**
+ * 「2026/05/17」 形式 (date only) で JST 整形。 `formatJstDateTime` の short alias。
+ */
+export function formatJstDate(iso: string): string {
+	return formatJstDateTime(iso, {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	});
+}

--- a/client/src/lib/datetime.ts
+++ b/client/src/lib/datetime.ts
@@ -15,7 +15,15 @@
 
 const JST_TIMEZONE = "Asia/Tokyo";
 
-const DEFAULT_OPTIONS: Intl.DateTimeFormatOptions = {
+/**
+ * `Intl.DateTimeFormatOptions` から `timeZone` を除いた型。
+ * #742: caller が timeZone を渡しても helper 内で必ず "Asia/Tokyo" に
+ * 上書きされるため、 type-level で「 timeZone は渡しても無意味」 と
+ * 明示する。 JSDoc だけだと caller が「 LA 指定で出せる」 と誤読する余地。
+ */
+type JstFormatOptions = Omit<Intl.DateTimeFormatOptions, "timeZone">;
+
+const DEFAULT_OPTIONS: JstFormatOptions = {
 	year: "numeric",
 	month: "2-digit",
 	day: "2-digit",
@@ -35,7 +43,7 @@ const DEFAULT_OPTIONS: Intl.DateTimeFormatOptions = {
  */
 export function formatJstDateTime(
 	iso: string,
-	options: Intl.DateTimeFormatOptions = DEFAULT_OPTIONS,
+	options: JstFormatOptions = DEFAULT_OPTIONS,
 ): string {
 	try {
 		const date = new Date(iso);

--- a/docs/specs/threads-hydration-fix-spec.md
+++ b/docs/specs/threads-hydration-fix-spec.md
@@ -1,0 +1,158 @@
+# /threads/<id> hydration mismatch fix 仕様 (#742)
+
+> Version: 0.1
+> 作成日: 2026-05-17
+> 関連 Issue: #742
+> 関連 audit: #741 ui-ux-tester M-3 (root cause 誤認識を Playwright MCP 実測で訂正)
+
+---
+
+## 0. 背景
+
+#741 の audit で「 /threads/<id> で /api/v1/timeline/recommended/ 404 → React hydration 10 件」 として #742 起票。 着手時に Playwright MCP で stg を実測したところ:
+
+- 該当 URL `/api/v1/timeline/recommended/` への request は **存在しない** (network log 404 = 0 件)
+- backend にも該当 endpoint なし、 client にも caller なし
+- ただし **hydration error 10 件は実在を再確認**:
+  - React #425 × 8 (text content does not match server-rendered HTML)
+  - React #418 × 1 (hydration failed)
+  - React #423 × 1 (text content does not match)
+
+audit の「404」 は URL 同定エラー。 真の root cause は別。
+
+---
+
+## 1. 真の root cause
+
+`client/src/components/boards/ThreadPostItem.tsx:55-67`:
+
+```ts
+function formatDateTime(iso: string): string {
+	try {
+		return new Date(iso).toLocaleString("ja-JP", {
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+		});
+	} catch {
+		return iso;
+	}
+}
+```
+
+SSR (Docker container、 TZ=UTC) と CSR (browser、 TZ=JST) で `toLocaleString` の出力が異なる:
+
+- SSR: `2026/05/17 06:00` (UTC で render)
+- CSR: `2026/05/17 15:00` (JST で render)
+
+post 数だけ #425 mismatch が累積。 8 posts なら 8 件、 これに overall hydration failed (#418) + text content (#423) で計 10 件。
+
+同 pattern が `ThreadRow.tsx:18` (boards スレ一覧) にもあり、 `/boards/<slug>` で同じバグの予備軍。
+
+---
+
+## 2. 修正方針
+
+**`timeZone: "Asia/Tokyo"` を toLocaleString options に追加** → SSR/CSR 両方が JST を出すので一致。 日本語 SNS なので機能的にも JST 固定が正しい (UTC で表示する意味はない)。
+
+### 2.1 helper 抽出
+
+15+ files で同 pattern が使われている。 単発修正だと将来同じバグを再生産するので、 共通 helper を抽出する:
+
+```ts
+// client/src/lib/datetime.ts
+const JST_TIMEZONE = "Asia/Tokyo";
+
+export function formatJstDateTime(
+	iso: string,
+	options: Intl.DateTimeFormatOptions = {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+	},
+): string {
+	try {
+		return new Date(iso).toLocaleString("ja-JP", {
+			...options,
+			timeZone: JST_TIMEZONE,
+		});
+	} catch {
+		return iso;
+	}
+}
+```
+
+### 2.2 本 PR scope (最小)
+
+- `client/src/lib/datetime.ts` 新規 (helper)
+- `client/src/lib/__tests__/datetime.test.ts` 新規 (timezone 固定 + invalid ISO の表)
+- `client/src/components/boards/ThreadPostItem.tsx` migration
+- `client/src/components/boards/ThreadRow.tsx` migration (同 family、 予備軍)
+- `client/e2e/threads-hydration.spec.ts` 新規 (`/threads/<id>` で console error 0 件を assertion)
+
+### 2.3 やらない (別 follow-up issue)
+
+同 pattern が以下 13 files にも存在。 体系的修正は別 PR で対応:
+
+- `app/(template)/mentor/wanted/page.tsx:154`
+- `app/(template)/mentor/contracts/me/page.tsx:165`
+- `app/(template)/tweet/[id]/page.tsx:153`
+- `app/(template)/mentors/[handle]/page.tsx:194,256`
+- `app/(template)/u/[handle]/page.tsx:354,363,563`
+- `app/(template)/articles/me/drafts/page.tsx:44-49`
+- `app/(template)/mentor/contracts/[id]/page.tsx:138,196`
+- `components/mentorship/MentorProposalList.tsx:81`
+- `components/follows/FollowRequestsPanel.tsx:34`
+- `components/drafts/DraftsPanel.tsx:32`
+- `components/agent/AgentPanel.tsx:302`
+- `components/timeline/TweetCard.tsx:315`
+
+注: `number.toLocaleString()` (千区切り) は timezone と無関係なので **対象外** (`/u/<handle>/page.tsx:354,363` 等)。
+
+---
+
+## 3. テスト
+
+### 3.1 unit (vitest)
+
+`client/src/lib/__tests__/datetime.test.ts`:
+
+- default options で固定 ISO を渡すと固定文字列 (timezone を environment で変えても結果不変)
+- override options が反映される
+- invalid ISO は raw string をそのまま返す
+- empty string は raw を返す (defensive)
+
+### 3.2 E2E (Playwright)
+
+`client/e2e/threads-hydration.spec.ts`:
+
+`PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/threads-hydration.spec.ts`
+
+- HYDRATION-1: `/threads/1` を navigate → console error 0 件 (#425/#418/#423 のいずれも fire しない)
+- HYDRATION-2: `/boards/<slug>` を navigate → ThreadRow 内の date が JST 表示で console error 0 件
+
+### 3.3 完了判定チェックリスト (CLAUDE.md §4.5 step 6)
+
+- [ ] vitest で datetime helper 全 case green
+- [ ] stg `/threads/1` で console.error 0 件 (改修前 10 件)
+- [ ] stg `/boards/<slug>` でも 0 件
+- [ ] 表示される time string が JST 表記 (改修前と同じ「2026/05/17 15:00」 形式)
+- [ ] frontend ルート追加なし → `gan-evaluator` 必須化対象外 (バグ修正のみ)
+
+---
+
+## 4. ロールバック
+
+- helper 1 ファイル + 2 component migration + 1 E2E + 1 spec doc。 PR revert 1 発で原状回復
+- DB / API / 設定変更なし、 完全に frontend-only
+
+---
+
+## 5. 関連
+
+- 親 audit: #741 (ui-ux-tester M-3、 root cause 誤認識は本 spec で訂正)
+- (起票予定) 体系的修正 follow-up issue: 残り 13 files の `toLocaleString("ja-JP")` を helper 化


### PR DESCRIPTION
Closes #742

## Summary

#741 audit が「`/api/v1/timeline/recommended/` 404 → hydration 10 件」 として起票していたが、 Playwright MCP で stg を実測したところ **404 は実在せず** (該当 URL への request なし、 backend にも endpoint なし)。 真の root cause は別:

`ThreadPostItem.tsx` と `ThreadRow.tsx` の `formatDateTime` が `new Date(iso).toLocaleString("ja-JP", ...)` を timezone 指定なしで call → SSR (Docker UTC) と CSR (browser JST) で異なる文字列を出して React #425 が fire。 8 posts × #425 + #418 + #423 = 10 件と完全一致。

修正: `timeZone: "Asia/Tokyo"` を強制する helper `formatJstDateTime` を `lib/datetime.ts` に新規追加、 2 component を移行。 日本語 SNS なので JST 固定が機能的にも正しい。

## 変更ファイル (6 files, +398 / -27)

| ファイル | 役割 |
|---|---|
| `client/src/lib/datetime.ts` | helper (新規、 Asia/Tokyo 強制) |
| `client/src/lib/__tests__/datetime.test.ts` | 9 case unit test (新規) |
| `client/src/components/boards/ThreadPostItem.tsx` | helper alias に置換 |
| `client/src/components/boards/ThreadRow.tsx` | 同上 (`/boards/<slug>` 予備軍) |
| `client/e2e/threads-hydration.spec.ts` | HYDRATION-1/2 (新規、 console error 0 件 assertion) |
| `docs/specs/threads-hydration-fix-spec.md` | 仕様 (新規、 root cause 修正経緯) |

## Test plan

### Unit / type / lint (local)
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx vitest run src/lib/__tests__/datetime.test.ts` → 9/9 pass
- [x] `npx vitest run` (full) → 101 files / 835 tests pass (前回 100 / 826 → +1 file +9 test)
- [x] `eslint` 変更ファイル → 0 errors

### E2E (stg、 merge → CD 反映後に Claude が踏む)
\`\`\`bash
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \\
  npx playwright test e2e/threads-hydration.spec.ts --reporter=line
\`\`\`

- [ ] HYDRATION-1 /threads/1: 改修前 10 件 → 改修後 0 件
- [ ] HYDRATION-2 /boards/django: 0 件継続

### Playwright MCP 直接 verify (本 PR merge 後)
- [ ] /threads/1 で `browser_console_messages` → 0 errors

### サブエージェントレビュー (CLAUDE.md §4.2 直列起動)
- [ ] `typescript-reviewer`
- [ ] `code-reviewer`
- [ ] `silent-failure-hunter` (catch で raw 返す pattern が silent failure に当たらないか)

a11y-architect / gan-evaluator / ui-ux-tester は呼ばない (UI/IA 変更なし、 timezone 固定のみ)

## Out of scope (別 follow-up issue 起票予定)

同 pattern が 13+ files に存在:
- `app/(template)/mentor/wanted/page.tsx:154`
- `app/(template)/tweet/[id]/page.tsx:153`
- `app/(template)/u/[handle]/page.tsx:354,363,563`
- `components/timeline/TweetCard.tsx:315`
- ...詳細は spec §2.3

体系的修正は別 PR (formatJstDateTime に一斉移行)。 本 PR は #742 直接原因 + 同 family の予備軍 (ThreadRow) のみ。

## Rollback

PR revert 1 発で原状回復可能。 DB / API / 設定変更なし、 frontend-only。