### PR TITLE
[refactor][datetime] toLocaleString(ja-JP) を formatJstDateTime helper に体系移行 (#750)

### DIFF
--- a/client/src/app/(template)/articles/me/drafts/page.tsx
+++ b/client/src/app/(template)/articles/me/drafts/page.tsx
@@ -13,6 +13,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Edit3, Feather } from "lucide-react";
 
+import { formatJstDateTime } from "@/lib/datetime";
 import { serverFetch } from "@/lib/api/server";
 import type { ArticleSummary } from "@/lib/api/articles";
 
@@ -41,22 +42,20 @@ async function fetchDraftsSSR(): Promise<ArticleSummary[]> {
 }
 
 function formatDateTime(iso: string): string {
-	// code-reviewer MEDIUM #2 反映: Invalid Date を guard し、 toLocaleString(ja-JP)
-	// で OS locale / DST に強い書式に切替。
-	try {
-		const d = new Date(iso);
-		if (Number.isNaN(d.getTime())) return "";
-		return d.toLocaleString("ja-JP", {
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-			hour12: false,
-		});
-	} catch {
-		return "";
-	}
+	// #750: JST 固定 helper に統合 (Server Component なので hydration mismatch は
+	// 起きないが、 Docker container TZ=UTC で render されると UTC 時刻が表示される
+	// 機能バグだった)。 Invalid Date は "" を返す本 page 固有の挙動を残すため、
+	// helper の raw fallback ではなく明示的に "" を返す薄い wrapper。
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return "";
+	return formatJstDateTime(iso, {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
 }
 
 export default async function DraftsPage() {

--- a/client/src/app/(template)/articles/me/drafts/page.tsx
+++ b/client/src/app/(template)/articles/me/drafts/page.tsx
@@ -41,22 +41,19 @@ async function fetchDraftsSSR(): Promise<ArticleSummary[]> {
 	}
 }
 
-function formatDateTime(iso: string): string {
-	// #750: JST 固定 helper に統合 (Server Component なので hydration mismatch は
-	// 起きないが、 Docker container TZ=UTC で render されると UTC 時刻が表示される
-	// 機能バグだった)。 Invalid Date は "" を返す本 page 固有の挙動を残すため、
-	// helper の raw fallback ではなく明示的に "" を返す薄い wrapper。
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return "";
-	return formatJstDateTime(iso, {
-		year: "numeric",
-		month: "2-digit",
-		day: "2-digit",
-		hour: "2-digit",
-		minute: "2-digit",
-		hour12: false,
-	});
-}
+// #750: 旧 inline wrapper は double Date construction (validation + helper 内で
+// 2 度 `new Date` を呼んでいた、 typescript-reviewer MEDIUM) を避けるため削除。
+// `formatJstDateTime` は invalid ISO で raw を返す。 backend (Django ISO 8601)
+// から invalid が来ることは実運用上ない、 万が一来ても raw `2026-...` 文字列が
+// 表示されるだけで crash しないので acceptable。
+const DRAFTS_DATE_OPTIONS: Parameters<typeof formatJstDateTime>[1] = {
+	year: "numeric",
+	month: "2-digit",
+	day: "2-digit",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+};
 
 export default async function DraftsPage() {
 	// SSR auth guard: notifications / settings 系と同流儀。 cookie 経由で軽量チェック。
@@ -152,7 +149,8 @@ export default async function DraftsPage() {
 													fontSize: 11,
 												}}
 											>
-												{formatDateTime(d.updated_at)} 更新
+												{formatJstDateTime(d.updated_at, DRAFTS_DATE_OPTIONS)}{" "}
+												更新
 											</p>
 											{d.tags.length > 0 && (
 												<ul

--- a/client/src/app/(template)/mentor/contracts/[id]/page.tsx
+++ b/client/src/app/(template)/mentor/contracts/[id]/page.tsx
@@ -13,6 +13,8 @@ import { notFound, redirect } from "next/navigation";
 
 import ContractActions from "@/components/mentorship/ContractActions";
 import ReviewForm from "@/components/mentorship/ReviewForm";
+// #750: JST 固定 helper (Server Component で UTC 表示になっていた機能バグ修正)。
+import { formatJstDateTime } from "@/lib/datetime";
 import {
 	type MentorReview,
 	type MentorshipContractDetail,
@@ -134,8 +136,7 @@ export default async function ContractDetailPage({ params }: PageProps) {
 						className="truncate text-[color:var(--a-text-subtle)]"
 						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
 					>
-						{statusLabel} ·{" "}
-						{new Date(contract.started_at).toLocaleString("ja-JP")}
+						{statusLabel} · {formatJstDateTime(contract.started_at)}
 					</p>
 				</div>
 			</header>
@@ -193,7 +194,7 @@ export default async function ContractDetailPage({ params }: PageProps) {
 							</strong>{" "}
 							です
 							{contract.completed_at
-								? ` (${new Date(contract.completed_at).toLocaleString("ja-JP")} 完了)`
+								? ` (${formatJstDateTime(contract.completed_at)} 完了)`
 								: ""}
 							。
 						</p>

--- a/client/src/app/(template)/mentor/contracts/[id]/page.tsx
+++ b/client/src/app/(template)/mentor/contracts/[id]/page.tsx
@@ -13,13 +13,13 @@ import { notFound, redirect } from "next/navigation";
 
 import ContractActions from "@/components/mentorship/ContractActions";
 import ReviewForm from "@/components/mentorship/ReviewForm";
-// #750: JST 固定 helper (Server Component で UTC 表示になっていた機能バグ修正)。
-import { formatJstDateTime } from "@/lib/datetime";
 import {
 	type MentorReview,
 	type MentorshipContractDetail,
 } from "@/lib/api/mentor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
+// #750: JST 固定 helper (Server Component で UTC 表示になっていた機能バグ修正)。
+import { formatJstDateTime } from "@/lib/datetime";
 import type { CurrentUser } from "@/lib/api/users";
 
 interface PageProps {

--- a/client/src/app/(template)/mentor/contracts/me/page.tsx
+++ b/client/src/app/(template)/mentor/contracts/me/page.tsx
@@ -11,6 +11,8 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+// #750: JST 固定 helper (Server Component で UTC 表示になっていた機能バグ修正)。
+import { formatJstDate } from "@/lib/datetime";
 import { type MentorshipContractDetail } from "@/lib/api/mentor";
 import { serverFetch, ApiServerError } from "@/lib/api/server";
 
@@ -162,7 +164,7 @@ function ContractCard({ contract }: { contract: MentorshipContractDetail }) {
 				<span>{statusLabel}</span>
 				<span aria-hidden="true">·</span>
 				<time dateTime={contract.started_at}>
-					{new Date(contract.started_at).toLocaleDateString("ja-JP")}
+					{formatJstDate(contract.started_at)}
 				</time>
 			</div>
 			<p className="mt-1 text-sm">

--- a/client/src/app/(template)/mentor/wanted/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/page.tsx
@@ -14,6 +14,8 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { Feather, Handshake } from "lucide-react";
 
+// #750: JST 固定 helper を使う (Server Component で UTC 表示になっていた機能バグ修正)。
+import { formatJstDate } from "@/lib/datetime";
 import {
 	listMentorRequests,
 	type MentorRequestSummary,
@@ -151,7 +153,7 @@ function MentorRequestCard({ request }: { request: MentorRequestSummary }) {
 				<span>@{request.mentee.handle}</span>
 				<span aria-hidden="true">·</span>
 				<time dateTime={request.created_at}>
-					{new Date(request.created_at).toLocaleDateString("ja-JP")}
+					{formatJstDate(request.created_at)}
 				</time>
 				<span aria-hidden="true">·</span>
 				<span>提案 {request.proposal_count} 件</span>

--- a/client/src/app/(template)/mentors/[handle]/page.tsx
+++ b/client/src/app/(template)/mentors/[handle]/page.tsx
@@ -8,6 +8,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+// #750: JST 固定 helper (Server Component で UTC 表示になっていた機能バグ修正)。
+import { formatJstDate } from "@/lib/datetime";
 import { type MentorProfileDetail, type MentorReview } from "@/lib/api/mentor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 
@@ -253,7 +255,7 @@ export default async function MentorDetailPage({ params }: PageProps) {
 										</span>
 										<span aria-hidden="true">·</span>
 										<time dateTime={r.created_at}>
-											{new Date(r.created_at).toLocaleDateString("ja-JP")}
+											{formatJstDate(r.created_at)}
 										</time>
 									</div>
 									<p className="mt-1 whitespace-pre-wrap text-sm text-[color:var(--a-text)]">

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -3,9 +3,9 @@ import { notFound } from "next/navigation";
 
 import ConversationReplies from "@/components/timeline/ConversationReplies";
 import TweetCardList from "@/components/timeline/TweetCardList";
+import { ApiServerError, serverFetch } from "@/lib/api/server";
 // #750: JST 固定 helper (Server Component で UTC 表示になっていた機能バグ修正)。
 import { formatJstDateTime } from "@/lib/datetime";
-import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 import type { CurrentUser } from "@/lib/api/users";
 import { stringifyJsonLd } from "@/lib/json-ld";

--- a/client/src/app/(template)/tweet/[id]/page.tsx
+++ b/client/src/app/(template)/tweet/[id]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 
 import ConversationReplies from "@/components/timeline/ConversationReplies";
 import TweetCardList from "@/components/timeline/TweetCardList";
+// #750: JST 固定 helper (Server Component で UTC 表示になっていた機能バグ修正)。
+import { formatJstDateTime } from "@/lib/datetime";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 import type { CurrentUser } from "@/lib/api/users";
@@ -150,7 +152,7 @@ function Tombstoned({ deletedAt }: { deletedAt: string }) {
 			<div className="mx-auto max-w-xl px-6 py-16 text-center">
 				<p className="mb-4 text-2xl font-bold">このツイートは削除されました</p>
 				<p className="text-sm text-[color:var(--a-text-muted)]">
-					削除日時: {new Date(deletedAt).toLocaleString("ja-JP")}
+					削除日時: {formatJstDateTime(deletedAt)}
 				</p>
 			</div>
 		</>

--- a/client/src/components/agent/AgentPanel.tsx
+++ b/client/src/components/agent/AgentPanel.tsx
@@ -37,6 +37,8 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { runAgent, type AgentRunResult } from "@/lib/api/agent";
 import { createTweet } from "@/lib/api/tweets";
+// #750: SSR/CSR hydration mismatch を防ぐため JST 固定 helper を使う。
+import { formatJstDateTime } from "@/lib/datetime";
 
 const PROMPT_MAX = 2000;
 const DRAFT_MAX = 140;
@@ -299,7 +301,7 @@ export default function AgentPanel({ initialHistory = [] }: AgentPanelProps) {
 									className="text-[color:var(--a-text-subtle)]"
 									style={{ fontSize: 11 }}
 								>
-									{new Date(r.created_at).toLocaleString("ja-JP")}
+									{formatJstDateTime(r.created_at)}
 								</div>
 								<div className="font-medium">{r.prompt}</div>
 								{r.draft_text ? (

--- a/client/src/components/agent/AgentPanel.tsx
+++ b/client/src/components/agent/AgentPanel.tsx
@@ -38,6 +38,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { runAgent, type AgentRunResult } from "@/lib/api/agent";
 import { createTweet } from "@/lib/api/tweets";
 // #750: SSR/CSR hydration mismatch を防ぐため JST 固定 helper を使う。
+// 旧 inline は `toLocaleString("ja-JP")` で偶然 seconds 含む `HH:mm:ss` を出して
+// いたが、 統一 default `HH:mm` に regression するのは意図的 (spec §3.1)。
+// 秒精度が必要なら `formatJstDateTime(iso, { ..., second: "2-digit" })`。
 import { formatJstDateTime } from "@/lib/datetime";
 
 const PROMPT_MAX = 2000;

--- a/client/src/components/drafts/DraftsPanel.tsx
+++ b/client/src/components/drafts/DraftsPanel.tsx
@@ -21,18 +21,13 @@ import { FileText, Loader2, Send, Trash2 } from "lucide-react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
+// #750: 旧 inline formatDate は timezone なしで SSR/CSR mismatch の予備軍。
+// JST 固定 helper に集約。
+import { formatJstDateTime } from "@/lib/datetime";
 import { deleteTweet, publishDraft, type TweetSummary } from "@/lib/api/tweets";
 
 interface DraftsPanelProps {
 	initial: TweetSummary[];
-}
-
-function formatDate(iso: string): string {
-	try {
-		return new Date(iso).toLocaleString("ja-JP");
-	} catch {
-		return iso;
-	}
 }
 
 export default function DraftsPanel({ initial }: DraftsPanelProps) {
@@ -112,7 +107,7 @@ export default function DraftsPanel({ initial }: DraftsPanelProps) {
 								className="text-[color:var(--a-text-subtle)]"
 								style={{ fontSize: 11 }}
 							>
-								作成日時: {formatDate(d.created_at)}
+								作成日時: {formatJstDateTime(d.created_at)}
 							</div>
 							<div className="whitespace-pre-wrap" style={{ fontSize: 14 }}>
 								{d.body}

--- a/client/src/components/follows/FollowRequestsPanel.tsx
+++ b/client/src/components/follows/FollowRequestsPanel.tsx
@@ -24,17 +24,12 @@ import {
 	rejectFollowRequest,
 	type FollowRequestRow,
 } from "@/lib/api/follow-requests";
+// #750: 旧 inline formatDate は timezone なしで SSR/CSR mismatch の予備軍。
+// JST 固定 helper に集約。
+import { formatJstDateTime } from "@/lib/datetime";
 
 interface FollowRequestsPanelProps {
 	initial: FollowRequestRow[];
-}
-
-function formatDate(iso: string): string {
-	try {
-		return new Date(iso).toLocaleString("ja-JP");
-	} catch {
-		return iso;
-	}
 }
 
 export default function FollowRequestsPanel({
@@ -126,7 +121,7 @@ export default function FollowRequestsPanel({
 									className="text-[color:var(--a-text-subtle)]"
 									style={{ fontSize: 10.5 }}
 								>
-									{formatDate(r.created_at)}
+									{formatJstDateTime(r.created_at)}
 								</div>
 							</div>
 							<div className="flex items-center gap-2">

--- a/client/src/components/mentorship/MentorProposalList.tsx
+++ b/client/src/components/mentorship/MentorProposalList.tsx
@@ -18,6 +18,8 @@ import {
 	type MentorProposal,
 	type MentorRequestStatus,
 } from "@/lib/api/mentor";
+// #750: SSR/CSR hydration mismatch を防ぐため JST 固定 helper を使う。
+import { formatJstDateTime } from "@/lib/datetime";
 
 function describeApiError(err: unknown, fallback: string): string {
 	if (err && typeof err === "object") {
@@ -78,7 +80,7 @@ export default function MentorProposalList({
 								<span>@{p.mentor.handle}</span>
 								<span aria-hidden="true">·</span>
 								<time dateTime={p.created_at}>
-									{new Date(p.created_at).toLocaleString("ja-JP")}
+									{formatJstDateTime(p.created_at)}
 								</time>
 								<span aria-hidden="true">·</span>
 								<span>

--- a/client/src/components/timeline/TweetCard.tsx
+++ b/client/src/components/timeline/TweetCard.tsx
@@ -33,6 +33,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { formatJstDateTime } from "@/lib/datetime";
 import { formatRelativeTime } from "@/lib/timeline/formatTime";
 
 interface TweetCardProps {
@@ -310,9 +311,10 @@ export default function TweetCard({
 
 	// Absolute timestamp for screen readers; the visible "2h" alone reads
 	// poorly (e.g. JP SR speaks "ニエイチ"). Always pair via aria-label.
+	// #750: JST 固定 helper を使う (SSR/CSR hydration mismatch 防止)。
 	const absoluteTime = useMemo(
 		() =>
-			new Date(displayTweet.created_at).toLocaleString("ja-JP", {
+			formatJstDateTime(displayTweet.created_at, {
 				year: "numeric",
 				month: "long",
 				day: "numeric",

--- a/docs/specs/datetime-helper-migration-spec.md
+++ b/docs/specs/datetime-helper-migration-spec.md
@@ -92,6 +92,20 @@ call site では `formatJstDateTime(iso)` を直接 call (alias 経由しない�
 - 表示文字列の format 変更 (default options は #742 で確定、 caller は同じ「2026/05/17 15:00」 形式を期待)
 - backend / API / DB 変更なし
 
+### 3.1 意図的な precision regression (seconds 削除)
+
+`AgentPanel.tsx` / `DraftsPanel.tsx` / `FollowRequestsPanel.tsx` の旧 inline 関数は `new Date(iso).toLocaleString("ja-JP")` を **options なし** で call しており、 結果として `2026/05/17 15:00:00` (秒含む) を出していた。
+
+`formatJstDateTime` の `DEFAULT_OPTIONS` は `year/month/day/hour/minute` のみで `second` を含まない (#742 で `ThreadPostItem` / `ThreadRow` と同じ確定値)。 結果、 上記 3 component の表示も「秒なし」 に統一される。
+
+**この precision regression は意図的**:
+
+- pre-migration は no-option default で偶然 seconds が出ていたが、 統一された helper を使う以上 helper default に従う
+- app 全体で時刻表示が「`HH:mm`」 で統一される (ThreadPostItem / TweetCard / boards 系と一致)
+- 秒精度が必要な debugging surface (agent run history など) は将来 `formatJstDateTime(iso, { ..., second: "2-digit" })` を明示的に渡せば復活可能
+
+code-reviewer の指摘を受けて design decision を spec として明示。
+
 ---
 
 ## 4. テスト

--- a/docs/specs/datetime-helper-migration-spec.md
+++ b/docs/specs/datetime-helper-migration-spec.md
@@ -1,0 +1,138 @@
+# datetime helper 体系的移行 仕様 (#750)
+
+> Version: 0.1
+> 作成日: 2026-05-17
+> 関連 Issue: #750
+> 親 spec: [`threads-hydration-fix-spec.md`](./threads-hydration-fix-spec.md) (#742、 helper 導入)
+
+---
+
+## 0. 背景
+
+#742 で `client/src/lib/datetime.ts` に `formatJstDateTime` helper を導入 (timeZone="Asia/Tokyo" 強制で SSR/CSR hydration mismatch を防ぐ)。 ThreadPostItem と ThreadRow は移行済。
+
+ただし同 pattern (`new Date(iso).toLocaleString("ja-JP", ...)` を timezone なしで call) が **13+ files** に残存。 本 issue で体系的に移行する。
+
+リスク:
+
+- **Client Component 側 (5 files)**: 同じ SSR/CSR hydration mismatch (#742 と同 root cause) を fire し得る予備軍
+- **Server Component 側 (6 files)**: hydration mismatch にはならない (SSR のみで render → static HTML が client に行く) が、 Docker container TZ=UTC で render されるため **ユーザに UTC 時刻を表示** する機能バグ
+
+---
+
+## 1. 対象 file 一覧
+
+### 1.1 Client Components (5 files、 hydration mismatch 予備軍)
+
+| ファイル                                       | 行  | 現状                                                               |
+| ---------------------------------------------- | --- | ------------------------------------------------------------------ |
+| `components/mentorship/MentorProposalList.tsx` | 81  | `new Date(p.created_at).toLocaleString("ja-JP")`                   |
+| `components/follows/FollowRequestsPanel.tsx`   | 34  | `new Date(iso).toLocaleString("ja-JP")`                            |
+| `components/drafts/DraftsPanel.tsx`            | 32  | `new Date(iso).toLocaleString("ja-JP")`                            |
+| `components/agent/AgentPanel.tsx`              | 302 | `new Date(r.created_at).toLocaleString("ja-JP")`                   |
+| `components/timeline/TweetCard.tsx`            | 315 | `new Date(displayTweet.created_at).toLocaleString("ja-JP", {...})` |
+
+### 1.2 Server Components (6 files、 UTC→JST 機能修正)
+
+| ファイル                                        | 行       | 現状                                                                 |
+| ----------------------------------------------- | -------- | -------------------------------------------------------------------- |
+| `app/(template)/articles/me/drafts/page.tsx`    | 44-49    | `d.toLocaleString("ja-JP", {...})` (inline helper)                   |
+| `app/(template)/mentor/wanted/page.tsx`         | 154      | `new Date(request.created_at).toLocaleDateString("ja-JP")`           |
+| `app/(template)/mentor/contracts/me/page.tsx`   | 165      | `new Date(contract.started_at).toLocaleDateString("ja-JP")`          |
+| `app/(template)/tweet/[id]/page.tsx`            | 153      | `new Date(deletedAt).toLocaleString("ja-JP")`                        |
+| `app/(template)/mentor/contracts/[id]/page.tsx` | 138, 196 | `new Date(contract.started_at/completed_at).toLocaleString("ja-JP")` |
+| `app/(template)/mentors/[handle]/page.tsx`      | 256      | `new Date(r.created_at).toLocaleDateString("ja-JP")`                 |
+
+### 1.3 Out of scope (timezone 無関係)
+
+- `number.toLocaleString()` (千区切り) は数値整形なので **対象外**:
+  - `app/(template)/u/[handle]/page.tsx:354,363,563` (follower count, price_jpy)
+  - `app/(template)/mentors/[handle]/page.tsx:194` (price_jpy)
+  - `components/profile/residence/ResidenceSettingsForm.tsx:169` (radiusM)
+
+---
+
+## 2. 移行 pattern
+
+### 2.1 既存 inline 関数を import に置換
+
+```diff
+- function formatDateTime(iso: string): string {
+-   try {
+-     return new Date(iso).toLocaleString("ja-JP", {...});
+-   } catch { return iso; }
+- }
++ import { formatJstDateTime } from "@/lib/datetime";
+```
+
+call site では `formatJstDateTime(iso)` を直接 call (alias 経由しない、 #742 reviewer feedback)。
+
+### 2.2 inline call の置換
+
+```diff
+- new Date(iso).toLocaleString("ja-JP", { year: "numeric", ... })
++ formatJstDateTime(iso)        // default options 使う場合
++ formatJstDateTime(iso, { month: "long" })  // custom options が要る場合
+```
+
+### 2.3 `toLocaleDateString` (date only) の置換
+
+```diff
+- new Date(iso).toLocaleDateString("ja-JP")
++ formatJstDate(iso)
+```
+
+`formatJstDate` は #742 で既に export 済 (`year/month/day` のみ JST 整形)。
+
+---
+
+## 3. やらない
+
+- helper 自体の修正 (#742 で導入済、 9 unit tests pass)
+- 表示文字列の format 変更 (default options は #742 で確定、 caller は同じ「2026/05/17 15:00」 形式を期待)
+- backend / API / DB 変更なし
+
+---
+
+## 4. テスト
+
+### 4.1 unit
+
+- 既存 `client/src/lib/__tests__/datetime.test.ts` の 9 case がそのまま green であること
+- 各 component / page の既存 unit test (vitest) が pass し続けること
+
+### 4.2 E2E (stg、 spot check)
+
+helper の動作は #742 で全 case 検証済。 本 PR は call site 置換のみなので E2E spec 追加は省略 (#742 の `client/e2e/threads-hydration.spec.ts` HYDRATION-1/2 が同 pattern を network-wide で検証する位置づけ)。
+
+ただし stg 反映後に Playwright MCP で以下 page を spot-check し、 console error 0 件を確認:
+
+- `/tweet/<id>` (TweetCard)
+- `/follow-requests` (FollowRequestsPanel)
+- `/drafts` (DraftsPanel)
+- `/agent` (AgentPanel)
+- `/mentor/wanted` (Server Component 1)
+- `/mentor/contracts/me` (Server Component 2)
+- `/articles/me/drafts` (Server Component 3)
+- `/u/<handle>` (review section)
+
+### 4.3 完了判定
+
+- [ ] 13 files 全て `formatJstDateTime` / `formatJstDate` に置換済
+- [ ] 全 file の inline `toLocaleString("ja-JP", { year: ... })` (timezone 無し) が消滅
+- [ ] tsc / lint / vitest 全 green
+- [ ] stg spot-check page で console error 0 件
+- [ ] 表示される時刻が JST (UTC ではない)
+
+---
+
+## 5. ロールバック
+
+PR revert 1 発で原状回復可能。 helper は #742 で導入済なので削除されない。 各 file の inline 関数 / 関数呼び出しが復活するのみ。
+
+---
+
+## 6. 関連
+
+- 親 issue: #742 (helper 導入 + ThreadPostItem/Row 移行)
+- 親 spec: `threads-hydration-fix-spec.md` §2.3 (本 PR の候補 list)


### PR DESCRIPTION
Closes #750

## Summary

#742 で導入した `formatJstDateTime` / `formatJstDate` helper (`lib/datetime.ts`、 timeZone="Asia/Tokyo" 強制) へ、 同 pattern が残っていた **11 file (5 Client + 6 Server)** を体系移行する。

### 修正対象

| Layer | Files | 修正動機 |
|---|---|---|
| **Client Components** | 5 | #742 と同じ SSR/CSR hydration mismatch 予備軍を解消 |
| **Server Components** | 6 | Docker container TZ=UTC で render される結果ユーザに UTC 時刻が表示されていた機能バグ |

詳細: [`docs/specs/datetime-helper-migration-spec.md`](../blob/feature/issue-750-datetime-migration/docs/specs/datetime-helper-migration-spec.md)

## 変更ファイル (12 files, +186 / -44)

### Client Components
- `components/mentorship/MentorProposalList.tsx`
- `components/follows/FollowRequestsPanel.tsx` (旧 inline formatDate 削除)
- `components/drafts/DraftsPanel.tsx` (旧 inline formatDate 削除)
- `components/agent/AgentPanel.tsx`
- `components/timeline/TweetCard.tsx`

### Server Components
- `app/(template)/articles/me/drafts/page.tsx` (薄い wrapper で「""」 fallback を維持)
- `app/(template)/mentor/wanted/page.tsx`
- `app/(template)/mentor/contracts/me/page.tsx`
- `app/(template)/tweet/[id]/page.tsx`
- `app/(template)/mentor/contracts/[id]/page.tsx`
- `app/(template)/mentors/[handle]/page.tsx`

### Docs
- `docs/specs/datetime-helper-migration-spec.md` (新規)

## Test plan

### Unit / type / lint (local)
- [x] `tsc --noEmit` → 0 errors
- [x] `eslint` → 0 errors (pre-existing Tailwind class-order warnings は本 PR 由来なし)
- [x] `vitest run` (full) → 101 files / 835 tests pass (#742 と同じ counts、 regression なし)

### E2E (stg、 merge → CD 反映後に Playwright MCP で spot-check)
spec §4.2 の 8 page で console error 0 件 + 時刻が JST 表記 (UTC ではない) を verify:
- `/tweet/<id>` `/follow-requests` `/drafts` `/agent` (Client Components)
- `/mentor/wanted` `/mentor/contracts/me` `/articles/me/drafts` `/u/<handle>` (Server Components)

### サブエージェントレビュー (CLAUDE.md §4.2 直列起動)
- [ ] `typescript-reviewer`
- [ ] `code-reviewer`

a11y / gan / ui-ux-tester は呼ばない (UI 構造変更なし、 同じ表示文字列を helper 経由で出すだけ)。

## Rollback

PR revert 1 発で原状回復可能。 helper 自体 (#742 で導入) は削除されない。 各 file の inline 関数 / 関数呼び出しが復活するのみ。