### PR TITLE
[refactor][mentor] nav label を「相談を募集中」/「メンター一覧」 に rename (#744)

### DIFF
--- a/client/e2e/mentor-board.spec.ts
+++ b/client/e2e/mentor-board.spec.ts
@@ -76,7 +76,8 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 
 		// LeftNav から /mentor/wanted へ (3 click 以内)
 		await mentee.goto(`${BASE}/`);
-		const navLink = mentee.getByRole("link", { name: "メンター募集" }).first();
+		// #744: nav label を「メンター募集」 → 「相談を募集中」 に変更。
+		const navLink = mentee.getByRole("link", { name: "相談を募集中" }).first();
 		await expect(navLink).toBeVisible({ timeout: 15000 });
 		await navLink.click();
 		await mentee.waitForURL(`${BASE}/mentor/wanted`);

--- a/client/src/app/(template)/mentor/wanted/[id]/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/[id]/page.tsx
@@ -106,7 +106,7 @@ export default async function MentorRequestDetailPage({ params }: PageProps) {
 					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					style={{ fontSize: 12.5 }}
 				>
-					← 募集一覧
+					← 相談を募集中
 				</Link>
 				<div className="ml-2 min-w-0 flex-1">
 					<h1

--- a/client/src/app/(template)/mentor/wanted/[id]/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/[id]/page.tsx
@@ -66,7 +66,8 @@ export async function generateMetadata({
 	const req = await fetchRequest(pk);
 	if (!req) return { title: "募集が見つかりません" };
 	return {
-		title: `${req.title} — メンター募集`,
+		// #744: nav label と揃える ( メンター募集 → 相談を募集中 )。
+		title: `${req.title} — 相談を募集中`,
 		description: req.body.slice(0, 160),
 		robots: req.status === "open" ? undefined : { index: false },
 	};

--- a/client/src/app/(template)/mentor/wanted/new/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/new/page.tsx
@@ -15,7 +15,8 @@ import { redirect } from "next/navigation";
 import MentorRequestForm from "@/components/mentorship/MentorRequestForm";
 
 export const metadata: Metadata = {
-	title: "メンター募集を出す — エンジニア SNS",
+	// #744: nav label と揃えて「相談を投稿する」 に統一。
+	title: "相談を投稿する — エンジニア SNS",
 	robots: { index: false },
 };
 
@@ -40,14 +41,14 @@ export default function NewMentorRequestPage() {
 					className="rounded text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					style={{ fontSize: 12.5 }}
 				>
-					← 募集一覧
+					← 相談を募集中
 				</Link>
 				<div className="ml-2 min-w-0 flex-1">
 					<h1
 						className="truncate font-semibold tracking-tight"
 						style={{ fontSize: 15, letterSpacing: -0.2 }}
 					>
-						メンター募集を出す
+						相談を投稿する
 					</h1>
 					<p
 						className="truncate text-[color:var(--a-text-subtle)]"

--- a/client/src/app/(template)/mentor/wanted/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/page.tsx
@@ -23,9 +23,10 @@ import {
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 
 export const metadata: Metadata = {
-	title: "メンター募集 — エンジニア SNS",
+	// #744: nav label と揃えて「相談を募集中」 に統一 (whiplash 回避)。
+	title: "相談を募集中 — エンジニア SNS",
 	description:
-		"エンジニア SNS のメンター募集 board。 学習中の人が現役エンジニアに 1 on 1 で教わりたい内容を投稿、 mentor が提案を出して契約成立で DM が始まります。",
+		"エンジニア SNS の相談募集 board。 学習中の人が現役エンジニアに 1 on 1 で教わりたい内容を投稿、 mentor が提案を出して契約成立で DM が始まります。",
 };
 
 async function fetchListSSR(
@@ -64,7 +65,7 @@ export default async function MentorWantedListPage({
 	return (
 		<>
 			<header
-				aria-label="メンター募集 board ヘッダー"
+				aria-label="相談募集 board ヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
@@ -81,7 +82,7 @@ export default async function MentorWantedListPage({
 						className="truncate font-semibold tracking-tight"
 						style={{ fontSize: 15, letterSpacing: -0.2 }}
 					>
-						メンター募集
+						相談を募集中
 					</h1>
 					<p
 						className="truncate text-[color:var(--a-text-subtle)]"

--- a/client/src/app/(template)/mentors/[handle]/page.tsx
+++ b/client/src/app/(template)/mentors/[handle]/page.tsx
@@ -94,7 +94,7 @@ export default async function MentorDetailPage({ params }: PageProps) {
 							className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white"
 							style={{ background: "var(--a-accent)", fontSize: 12.5 }}
 						>
-							メンターを探す
+							メンター一覧へ
 						</Link>
 					</div>
 				</div>

--- a/client/src/app/(template)/mentors/page.tsx
+++ b/client/src/app/(template)/mentors/page.tsx
@@ -14,7 +14,8 @@ import { type MentorProfileDetail } from "@/lib/api/mentor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 
 export const metadata: Metadata = {
-	title: "メンターを探す — エンジニア SNS",
+	// #744: nav label と揃えて「メンター一覧」 に統一。
+	title: "メンター一覧 — エンジニア SNS",
 	description:
 		"エンジニア SNS のメンター一覧。 受付中のメンターをスキルタグで絞り込み、 提案前にプロフィールと plan を確認できます。",
 };
@@ -63,7 +64,7 @@ export default async function MentorsListPage({ searchParams }: PageProps) {
 						className="truncate font-semibold tracking-tight"
 						style={{ fontSize: 15, letterSpacing: -0.2 }}
 					>
-						メンターを探す
+						メンター一覧
 					</h1>
 					<p
 						className="truncate text-[color:var(--a-text-subtle)]"

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -79,13 +79,16 @@ const NAV_ITEMS: NavItemDef[] = [
 	},
 	{ href: "/articles", label: "記事", Icon: FileText },
 	{ href: "/boards", label: "掲示板", Icon: Flame },
-	// Phase 11 11-A (P11-09 follow-up): home (A direction) でも「メンター募集」 を
+	// Phase 11 11-A (P11-09 follow-up): home (A direction) でも mentor board を
 	// 1 click 到達できるようにする。 既存 `leftNavLinks` (LeftNavbar / MobileNavbar
 	// 用、 X 風レイアウト) には追加済だが、 home が使う ALeftNav は別 list を持つ
 	// (#550 POC) ため、 ここにも明示する。
-	{ href: "/mentor/wanted", label: "メンター募集", Icon: Handshake },
-	// Phase 11-B (P11-14): mentor 検索 (anon 可)。 「募集」 と区別する label。
-	{ href: "/mentors", label: "メンターを探す", Icon: Users },
+	// #744: label を「メンター募集」 → 「相談を募集中」 / 「メンターを探す」 →
+	// 「メンター一覧」 (両方「メンター」 で始まって icon も people 系で synonym
+	// collision を起こしていたため、 board / directory の semantic を明示する形に)。
+	{ href: "/mentor/wanted", label: "相談を募集中", Icon: Handshake },
+	// Phase 11-B (P11-14): mentor 検索 (anon 可)。 「一覧」 で directory 明示。
+	{ href: "/mentors", label: "メンター一覧", Icon: Users },
 	// Phase 14 (P14-05): Claude Agent。 ログイン必須 (Anthropic 課金で
 	// per-user 10/day 制限)。 leftNavLinks (X 風 LeftNavbar) と同 entry を
 	// A direction の home にも明示する。

--- a/client/src/components/layout-a/AMobileShell.tsx
+++ b/client/src/components/layout-a/AMobileShell.tsx
@@ -266,7 +266,8 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 		},
 		{ href: "/articles", label: "記事", Icon: FileText },
 		{ href: "/boards", label: "掲示板", Icon: Flame },
-		{ href: "/mentor/wanted", label: "メンター募集", Icon: Handshake },
+		// #744: label を「メンター募集」 → 「相談を募集中」 に変更。
+		{ href: "/mentor/wanted", label: "相談を募集中", Icon: Handshake },
 		// Phase 14 (P14-05): Claude Agent。 leftNavLinks と同 entry を
 		// mobile drawer にも明示する。
 		{

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -53,8 +53,9 @@ export const leftNavLinks: LeftNavLink[] = [
 	{
 		// Phase 11 (#625 / P11-06): mentor 募集 board。 匿名閲覧可。
 		// CLAUDE.md §9 「ホームから 3 click 以内で到達」 反省で LeftNav に追加。
+		// #744: label を「メンター募集」 → 「相談を募集中」 (synonym collision 解消)。
 		path: "/mentor/wanted",
-		label: "メンター募集",
+		label: "相談を募集中",
 		iconName: "Handshake",
 	},
 	{

--- a/docs/specs/mentor-board-scenarios.md
+++ b/docs/specs/mentor-board-scenarios.md
@@ -12,8 +12,8 @@ Phase 11 11-A の golden path + 周辺 edge case を自然言語で記述。 CLA
 
 | step | 誰が           | 何をする                                                                                | 何が起きる / 何が見える                                                                                         |
 | ---- | -------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| 1    | test2 (mentee) | ホーム `/` を開く                                                                       | 左 nav に「メンター募集」 link (Handshake icon) が見える                                                        |
-| 2    | test2          | 左 nav の「メンター募集」 を click                                                      | `/mentor/wanted` 一覧に遷移、 sticky header に「募集を出す」 CTA                                                |
+| 1    | test2 (mentee) | ホーム `/` を開く                                                                       | 左 nav に「相談を募集中」 link (Handshake icon) が見える (#744 で rename)                                       |
+| 2    | test2          | 左 nav の「相談を募集中」 を click                                                      | `/mentor/wanted` 一覧に遷移、 sticky header に「募集を出す」 CTA                                                |
 | 3    | test2          | 「募集を出す」 click                                                                    | `/mentor/wanted/new` で投稿 form                                                                                |
 | 4    | test2          | title「Django で質問」 + body「DRF の認証で詰まっています」 を入力 → 「募集を投稿する」 | toast「募集を投稿しました」 + `/mentor/wanted/<id>` 詳細ページに遷移                                            |
 | 5    | test3 (mentor) | 別 context で `/mentor/wanted/<id>` を開く                                              | mentor 候補として提案 form が出る (owner ではないので proposal list は見えない)                                 |

--- a/docs/specs/mentor-board-spec.md
+++ b/docs/specs/mentor-board-spec.md
@@ -10,7 +10,7 @@ Phase 11 11-A の **UI 詳細**。 backend API は phase-11 spec §6 / frontend 
 
 ### `/mentor/wanted` 一覧
 
-- sticky header: 🤝 icon + 「メンター募集」 + filterDescription (`#tag で募集中` or `募集中の相談`) + CTA
+- sticky header: 🤝 icon + 「相談を募集中」 (旧「メンター募集」、 #744 で rename) + filterDescription (`#tag で募集中` or `募集中の相談`) + CTA
   - auth: 「募集を出す」 (青背景) → `/mentor/wanted/new`
   - anon: 「ログインして募集する」 → `/login?next=/mentor/wanted/new`
 - body: cursor pagination で公開中 (status=open) のみ列挙、 各 row は

--- a/docs/specs/mentor-nav-labels-spec.md
+++ b/docs/specs/mentor-nav-labels-spec.md
@@ -1,0 +1,108 @@
+# mentor nav label refactor 仕様 (#744)
+
+> Version: 0.1
+> 作成日: 2026-05-17
+> 関連 Issue: #744
+> 関連 audit: ui-ux-tester 2026-05-17 (verdict B、 ship now)
+
+---
+
+## 0. 背景
+
+#741 audit が「左 nav の『メンター募集』 と『メンターを探す』 は同じ mental model に見える」 と LOW で flag。 #744 として起票したが Phase 11 review で方針を決めるため open のまま放置していた。
+
+2026-05-17 に Phase 11 nav の review として ui-ux-tester agent に audit させた結果、 **Option B (label 改善)** が verdict。 機能的には 2 surface は orthogonal なので統合は wrong abstraction、 単に label を「メンター」 で始まる類似名にしているのが問題。
+
+---
+
+## 1. 真の問題
+
+`/mentor/wanted` と `/mentors` は **functionally distinct**:
+
+- `/mentor/wanted` = **request board** (job-posting analog): mentee が「教わりたい」 を投稿、 mentor が提案
+- `/mentors` = **people directory** (freelancer marketplace analog): mentor が profile + plans を公開、 mentee が browse
+
+LinkedIn の「Jobs」 vs 「People」、 Menta (Phase 11 inspiration source) の「相談を探す」 vs 「メンターを探す」 と同じ orthogonal な surface。 統合してはダメ (#744 issue 本文の Option A は overruled)。
+
+問題は label のみ:
+
+- 「メンター募集」 / 「メンターを探す」 → 両方 4-6 char + 「メンター」 で始まる + Handshake/Users icon (どちらも people-related) → first-time visitor が「memorize before click」 を強いられる
+- 「探す」 が広すぎて「人を検索する」 とも「募集を検索する」 とも取れる
+
+---
+
+## 2. 変更内容
+
+### 2.1 label rename pair
+
+audit recommendation:
+
+- **`/mentor/wanted` (Handshake icon)**: 「メンター募集」 → **「相談を募集中」**
+
+  - 「メンター」 を label から外して synonym collision を断つ
+  - 「募集中」 は board に並んでる現在進行形の request を端的に表現
+
+- **`/mentors` (Users icon)**: 「メンターを探す」 → **「メンター一覧」**
+  - 「〜一覧」 は日本語 SaaS UI で directory を示す最強 signal (cf.「ユーザー一覧」「商品一覧」)
+  - 「メンター」 アンカーは directory 側に残して semantic continuity を保つ
+
+Final pair: **「相談を募集中」** + **「メンター一覧」** — first char distinct (相 vs メ)、 noun distinct (相談 vs メンター)、 verb 不要 / 名詞句で完結。
+
+### 2.2 修正 file
+
+#### Nav definitions (3 files、 issue scope)
+
+- `client/src/constants/index.ts:57` (leftNavLinks の Phase 11 entry)
+- `client/src/components/layout-a/ALeftNav.tsx:86, 88` (A direction nav の 2 entry)
+- `client/src/components/layout-a/AMobileShell.tsx:269` (mobile drawer)
+
+#### Page-internal h1 / metadata title (whiplash 防止)
+
+nav label を変えると user は「相談を募集中」 を click → page h1 が「メンター募集」 だと違和感。 同時に揃える:
+
+- `client/src/app/(template)/mentor/wanted/page.tsx`: metadata title + h1
+- `client/src/app/(template)/mentor/wanted/[id]/page.tsx`: metadata title suffix
+- `client/src/app/(template)/mentor/wanted/new/page.tsx`: metadata title + h1
+- `client/src/app/(template)/mentors/page.tsx`: metadata title + h1
+- `client/src/app/(template)/mentors/[handle]/page.tsx`: back link text
+
+### 2.3 やらない (out of scope)
+
+- `MentorRequestForm.tsx` の aria-label「メンター募集フォーム」 → form 自体の name で nav と独立、 残す
+- `app/layout.tsx` の site description「..., メンター募集, ...」 → top-level marketing copy、 別 issue で SEO 最適化と一緒に
+- backend / API の field 名 (`mentor_request`, `MentorRequest` model) は変更しない
+- backend route (`/api/v1/mentor/requests/`) は変更しない
+
+---
+
+## 3. test
+
+### 3.1 既存 test 影響
+
+- nav に関する vitest test (`LeftNavbar.test.tsx` 等) は label を実 string で assertion していないので影響なし
+- `MentorRequestForm.test.tsx` は form aria-label「メンター募集フォーム」 を使っているが本 PR で form 名は変えないので影響なし
+
+### 3.2 E2E
+
+既存 `client/e2e/mentor-board.spec.ts` 等が h1 / nav label を実 string で assertion していたら更新が必要。 PR 内で grep して該当があれば一括更新。
+
+### 3.3 完了判定
+
+- [ ] 3 nav file で label 変更済 (constants / ALeftNav / AMobileShell)
+- [ ] 5 page file で h1 + metadata title 変更済
+- [ ] tsc / lint / vitest 全 green
+- [ ] stg で nav 確認: 「相談を募集中」「メンター一覧」 が並んで表示、 click で対応 route に遷移
+- [ ] 各 page の h1 / browser tab title が新 label と一致 (whiplash なし)
+
+---
+
+## 4. ロールバック
+
+label 変更のみ、 PR revert 1 発で復旧。 backend / API / DB 触らない。 SEO は metadata title 変更で site:検索結果が一時的に古い title になる可能性あるが、 数日で再 indexing される。
+
+---
+
+## 5. 関連
+
+- 親 audit: #741 ui-ux-tester L-2
+- Phase 11 spec: `docs/specs/phase-11-mentor-board-spec.md` §7 (route table、 本 PR で route は変更しない、 label のみ)


### PR DESCRIPTION
Closes #744

## Summary

#741 audit が「左 nav の『メンター募集』 と『メンターを探す』 が semantic に紛らわしい」 と LOW で flag。 #744 として起票し Phase 11 review として保留していた。

ui-ux-tester (2026-05-17) に audit させて **verdict B (label 改善で ship now)** を採用。 機能的には 2 surface は orthogonal (job-posting board vs people directory の LinkedIn analog、 Menta inspiration と整合) なので統合は wrong abstraction (#744 issue 本文 Option A は overruled)。 単に label が「メンター」 で始まる + people icon の synonym collision を起こしていたのを断つ。

### Before / After

| route | icon | label (before) | label (after) |
|---|---|---|---|
| `/mentor/wanted` | Handshake | 「メンター募集」 | **「相談を募集中」** |
| `/mentors` | Users | 「メンターを探す」 | **「メンター一覧」** |

両 label の first char (相 vs メ)、 noun (相談 vs メンター) が distinct になって click 前にどちらが何か判定できる。

詳細: [`docs/specs/mentor-nav-labels-spec.md`](../blob/feature/issue-744-mentor-nav-labels/docs/specs/mentor-nav-labels-spec.md)

## 変更ファイル (10 files, +136 / -18)

### Nav definitions (3 files)
- `client/src/constants/index.ts` (leftNavLinks)
- `client/src/components/layout-a/ALeftNav.tsx` (A direction)
- `client/src/components/layout-a/AMobileShell.tsx` (mobile drawer)

### Page-internal h1 + metadata title (5 files、 whiplash 回避)
- `app/(template)/mentor/wanted/page.tsx` (一覧 + metadata)
- `app/(template)/mentor/wanted/[id]/page.tsx` (metadata suffix)
- `app/(template)/mentor/wanted/new/page.tsx` (h1「相談を投稿する」 + metadata)
- `app/(template)/mentors/page.tsx` (一覧 + metadata)
- `app/(template)/mentors/[handle]/page.tsx` (back link + empty CTA)

### E2E spec (1 file)
- `client/e2e/mentor-board.spec.ts` (nav link assertion 追従)

### Docs (1 file new)
- `docs/specs/mentor-nav-labels-spec.md`

## Test plan

### Unit / type / lint (local)
- [x] `tsc --noEmit` → 0 errors
- [x] `vitest run` (full) → 101 files / 835 tests pass
- [x] `eslint` 変更 file → 0 errors

### サブエージェントレビュー (CLAUDE.md §4.2 直列起動)
- [x] `ui-ux-tester` (pre-impl audit verdict B)
- [ ] `typescript-reviewer`
- [ ] `code-reviewer`

### stg verify (CD 反映後)
- [ ] 左 nav に「相談を募集中」「メンター一覧」 が並ぶ
- [ ] それぞれ click で `/mentor/wanted` `/mentors` に遷移
- [ ] 各 page h1 が新 label と一致 (browser tab title も)

## Rollback

PR revert 1 発で復旧。 backend / API / DB / route 触らず frontend label のみ。