### PR TITLE
[refactor][mentor] form aria-label + CTA を「相談」 terminology に統一 (#753 + #754)

### DIFF
--- a/client/e2e/mentor-board.spec.ts
+++ b/client/e2e/mentor-board.spec.ts
@@ -82,14 +82,15 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 		await navLink.click();
 		await mentee.waitForURL(`${BASE}/mentor/wanted`);
 
-		// 「募集を出す」 CTA から /new
-		await mentee.getByRole("link", { name: "募集を出す" }).click();
+		// #754: CTA を「募集を出す」 → 「相談を投稿する」 に変更。
+		await mentee.getByRole("link", { name: "相談を投稿する" }).click();
 		await mentee.waitForURL(`${BASE}/mentor/wanted/new`);
 
 		const title = `E2E mentor-board ${Date.now()}`;
 		await mentee.getByLabel("タイトル").fill(title);
 		await mentee.getByLabel(/^本文/).fill("E2E でメンターを募集しています。");
-		await mentee.getByRole("button", { name: "募集を投稿する" }).click();
+		// #753: submit button「募集を投稿する」 → 「相談を投稿する」 (form aria-label 統一の続き)。
+		await mentee.getByRole("button", { name: "相談を投稿する" }).click();
 
 		// 詳細ページに遷移
 		await mentee.waitForURL(/\/mentor\/wanted\/\d+/, { timeout: 15000 });
@@ -137,9 +138,9 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 		const list = await ctx.request.get(`${BASE}/mentor/wanted`);
 		expect(list.status()).toBe(200);
 		await page.goto(`${BASE}/mentor/wanted`);
-		// anon のときは「ログインして募集する」 が出る
+		// #754: anon CTA を「ログインして募集する」 → 「ログインして相談する」 に変更。
 		await expect(
-			page.getByRole("link", { name: "ログインして募集する" }),
+			page.getByRole("link", { name: "ログインして相談する" }),
 		).toBeVisible({ timeout: 15000 });
 		await ctx.close();
 	});

--- a/client/src/app/(template)/mentor/wanted/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/page.tsx
@@ -2,9 +2,9 @@
  * /mentor/wanted — メンター募集 board 一覧 (P11-06 / Phase 11 11-A).
  *
  * 匿名閲覧可。 SSR で公開募集 (status=open) 一覧を fetch。 sticky header に
- * 「募集を出す」 CTA を auth のみで表示、 anon は「ログインして募集する」 で
+ * 「相談を投稿する」 CTA を auth のみで表示、 anon は「ログインして相談する」 で
  * /login?next=/mentor/wanted/new に誘導 (PR #608 ALeftNav 「投稿する」 CTA と
- * 同流儀)。
+ * 同流儀。 #754 で「募集」 → 「相談」 terminology に統一)。
  *
  * spec: docs/specs/phase-11-mentor-board-spec.md §7
  */
@@ -101,7 +101,7 @@ export default async function MentorWantedListPage({
 					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
 				>
 					<Feather className="size-3.5" aria-hidden="true" />
-					{isAuthenticated ? "募集を出す" : "ログインして募集する"}
+					{isAuthenticated ? "相談を投稿する" : "ログインして相談する"}
 				</Link>
 			</header>
 

--- a/client/src/app/(template)/mentor/wanted/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/page.tsx
@@ -59,7 +59,7 @@ export default async function MentorWantedListPage({
 	const isAuthenticated = cookies().get("logged_in")?.value === "true";
 
 	const filterDescription = searchParams?.tag
-		? `#${searchParams.tag} で募集中`
+		? `#${searchParams.tag} の相談`
 		: "募集中の相談";
 
 	return (
@@ -126,8 +126,8 @@ export default async function MentorWantedListPage({
 				{items.length === 0 ? (
 					<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
 						{searchParams?.tag
-							? `#${searchParams.tag} の募集はまだありません。`
-							: "まだ募集がありません。 最初の募集を投稿してみませんか?"}
+							? `#${searchParams.tag} の相談はまだありません。`
+							: "まだ相談がありません。 最初の相談を投稿してみませんか?"}
 					</p>
 				) : (
 					<ul role="list" className="grid gap-3">
@@ -147,7 +147,7 @@ function MentorRequestCard({ request }: { request: MentorRequestSummary }) {
 	return (
 		<Link
 			href={`/mentor/wanted/${request.id}`}
-			aria-label={`募集 ${request.title} を開く`}
+			aria-label={`相談「${request.title}」 を開く`}
 			className="block rounded-lg border border-[color:var(--a-border)] p-4 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 		>
 			<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">

--- a/client/src/components/mentorship/MentorRequestForm.tsx
+++ b/client/src/components/mentorship/MentorRequestForm.tsx
@@ -81,7 +81,7 @@ export default function MentorRequestForm() {
 		<form
 			onSubmit={handleSubmit}
 			className="space-y-4"
-			aria-label="メンター募集フォーム"
+			aria-label="相談募集フォーム"
 		>
 			{error && (
 				<p
@@ -153,7 +153,7 @@ export default function MentorRequestForm() {
 				disabled={submitting}
 				className="rounded-full bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
 			>
-				{submitting ? "投稿中…" : "募集を投稿する"}
+				{submitting ? "投稿中…" : "相談を投稿する"}
 			</button>
 		</form>
 	);

--- a/client/src/components/mentorship/MentorRequestForm.tsx
+++ b/client/src/components/mentorship/MentorRequestForm.tsx
@@ -69,7 +69,7 @@ export default function MentorRequestForm() {
 				body: trimmedBody,
 				target_skill_tag_names: tags,
 			});
-			toast.success("募集を投稿しました");
+			toast.success("相談を投稿しました");
 			router.push(`/mentor/wanted/${created.id}`);
 		} catch (err) {
 			setError(describeApiError(err, "投稿に失敗しました"));
@@ -81,7 +81,7 @@ export default function MentorRequestForm() {
 		<form
 			onSubmit={handleSubmit}
 			className="space-y-4"
-			aria-label="相談募集フォーム"
+			aria-label="相談投稿フォーム"
 		>
 			{error && (
 				<p

--- a/client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx
+++ b/client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx
@@ -66,7 +66,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("", "body has content");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談投稿フォーム"));
 		});
 		expect(screen.getByRole("alert").textContent).toMatch(/タイトル/);
 		expect(createMentorRequestMock).not.toHaveBeenCalled();
@@ -76,7 +76,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("title", "");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談投稿フォーム"));
 		});
 		expect(screen.getByRole("alert").textContent).toMatch(/本文/);
 		expect(createMentorRequestMock).not.toHaveBeenCalled();
@@ -87,14 +87,14 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("Hello", "body content");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談投稿フォーム"));
 		});
 		expect(createMentorRequestMock).toHaveBeenCalledWith({
 			title: "Hello",
 			body: "body content",
 			target_skill_tag_names: [],
 		});
-		expect(toastSuccessMock).toHaveBeenCalledWith("募集を投稿しました");
+		expect(toastSuccessMock).toHaveBeenCalledWith("相談を投稿しました");
 		expect(routerPushMock).toHaveBeenCalledWith("/mentor/wanted/42");
 	});
 
@@ -103,7 +103,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("t", "b", "  django ,  drf, ,  python ");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談投稿フォーム"));
 		});
 		expect(createMentorRequestMock).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -119,7 +119,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("t", "b", "foo");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談投稿フォーム"));
 		});
 		expect(screen.getByRole("alert").textContent).toMatch(/未登録/);
 		expect(routerPushMock).not.toHaveBeenCalled();

--- a/client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx
+++ b/client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx
@@ -66,7 +66,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("", "body has content");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
 		});
 		expect(screen.getByRole("alert").textContent).toMatch(/タイトル/);
 		expect(createMentorRequestMock).not.toHaveBeenCalled();
@@ -76,7 +76,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("title", "");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
 		});
 		expect(screen.getByRole("alert").textContent).toMatch(/本文/);
 		expect(createMentorRequestMock).not.toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("Hello", "body content");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
 		});
 		expect(createMentorRequestMock).toHaveBeenCalledWith({
 			title: "Hello",
@@ -103,7 +103,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("t", "b", "  django ,  drf, ,  python ");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
 		});
 		expect(createMentorRequestMock).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -119,7 +119,7 @@ describe("MentorRequestForm (P11-06)", () => {
 		render(<MentorRequestForm />);
 		fillForm("t", "b", "foo");
 		await act(async () => {
-			fireEvent.submit(screen.getByLabelText("メンター募集フォーム"));
+			fireEvent.submit(screen.getByLabelText("相談募集フォーム"));
 		});
 		expect(screen.getByRole("alert").textContent).toMatch(/未登録/);
 		expect(routerPushMock).not.toHaveBeenCalled();

--- a/docs/specs/mentor-form-labels-spec.md
+++ b/docs/specs/mentor-form-labels-spec.md
@@ -1,0 +1,113 @@
+# mentor form / CTA label 統一 仕様 (#753 + #754)
+
+> Version: 0.1
+> 作成日: 2026-05-17
+> 関連 Issue: #753, #754
+> 親 spec: [`mentor-nav-labels-spec.md`](./mentor-nav-labels-spec.md) (#744、 nav label 改修)
+
+---
+
+## 0. 背景
+
+#744 で nav label を「メンター募集」 → 「相談を募集中」 / 「メンターを探す」 → 「メンター一覧」 に rename したが、 spec §2.3 で意図的に out-of-scope とした 2 つの surface に旧 terminology が残存:
+
+1. **`MentorRequestForm.tsx` aria-label「メンター募集フォーム」** (#753):
+   screen reader user が page (「相談を投稿する」 h1) を聞いた直後に form を聞くと「メンター募集フォーム」 と読み上げられ whiplash
+
+2. **`/mentor/wanted` の「募集を出す」 CTA** (#754):
+   page header「相談を募集中」 と同じ header 内の CTA が「募集を出す」 で、 「募集」 が 2 度出てきて意味が二重 (header = 状態、 CTA = action)。 さらに遷移先 h1「相談を投稿する」 と verb が齟齬
+
+両 issue は code-reviewer (#744 review) で LOW として上がった指摘で、 cross-link 上「セットで進める」 と合意済。 本 PR で 1 つの terminology unification concern としてまとめて処理する。
+
+---
+
+## 1. 変更内容
+
+### 1.1 #753: MentorRequestForm aria-label
+
+`client/src/components/mentorship/MentorRequestForm.tsx:84`:
+
+```diff
+- aria-label="メンター募集フォーム"
++ aria-label="相談募集フォーム"
+```
+
+選択肢 A 採用 (#753 issue 本文より、 「メンター」 部分だけ「相談」 に置換、 minimal change で page との semantic 一致)。
+
+### 1.2 #753 ついで修正: submit button
+
+同じ form の submit button (`MentorRequestForm.tsx:156`) も「募集を投稿する」 → 「相談を投稿する」 に変更:
+
+```diff
+- {submitting ? "投稿中…" : "募集を投稿する"}
++ {submitting ? "投稿中…" : "相談を投稿する"}
+```
+
+理由: form name (aria-label) が「相談募集フォーム」 になるので、 submit button も「相談を投稿する」 で内部一貫性。 page h1「相談を投稿する」 とも一致。
+
+### 1.3 #754: `/mentor/wanted` CTA
+
+`client/src/app/(template)/mentor/wanted/page.tsx:104`:
+
+```diff
+- {isAuthenticated ? "募集を出す" : "ログインして募集する"}
++ {isAuthenticated ? "相談を投稿する" : "ログインして相談する"}
+```
+
+選択肢 A 採用 (#754 issue 本文より、 max consistency。 遷移先 `/mentor/wanted/new` の h1「相談を投稿する」 + form submit button「相談を投稿する」 と完全 alignment)。
+
+`page.tsx:5` の JSDoc comment 内の文字列も追従:
+
+```diff
+- * 「募集を出す」 CTA を auth のみで表示、 anon は「ログインして募集する」 で
++ * 「相談を投稿する」 CTA を auth のみで表示、 anon は「ログインして相談する」 で
+```
+
+### 1.4 test 追従 (2 files)
+
+- `client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx`: 5 件の `getByLabelText("メンター募集フォーム")` を「相談募集フォーム」 に更新
+- `client/e2e/mentor-board.spec.ts`: 4 件 (「募集を出す」 link / 「募集を投稿する」 button / 「ログインして募集する」 link / comment) を新 label に追従
+
+---
+
+## 2. やらない
+
+- form 内の field label / placeholder (「タイトル」「本文」 等は機能名でそのまま)
+- backend / API / model 名 (`MentorRequest`, `mentor_request`) は変更しない
+- 「相談」 terminology を他 surface (timeline / DM / 通知) に伝播させる作業は別 PR
+
+---
+
+## 3. test
+
+### 3.1 unit (vitest)
+
+- 既存 `MentorRequestForm.test.tsx` の 5 case が新 aria-label で全 green
+- 既存 `tsc / lint` 全 green
+- 全 vitest suite (100+ files) regression なし
+
+### 3.2 E2E (stg、 spot check)
+
+- `client/e2e/mentor-board.spec.ts` MENTOR-1 golden path が新 label で全 pass
+- stg 反映後に Playwright MCP で `/mentor/wanted` を踏み、 CTA「相談を投稿する」 が表示、 click で `/mentor/wanted/new` に遷移、 form submit button「相談を投稿する」 が表示を確認
+
+### 3.3 完了判定
+
+- [ ] aria-label / button / link の 4 string が全 surface で「相談」 系に統一
+- [ ] grep で `client/src/` `client/e2e/` 配下に「メンター募集フォーム」「募集を出す」「ログインして募集する」「募集を投稿する」 が残っていない (spec doc / comment は除く)
+- [ ] tsc / lint / vitest 全 green
+- [ ] stg で screen reader (or DOM `aria-label` 確認) で form が「相談募集フォーム」 と認識される
+
+---
+
+## 4. ロールバック
+
+PR revert 1 発で復旧。 backend / API / DB / route 触らない。 4 file の string 変更のみ。
+
+---
+
+## 5. 関連
+
+- 親 audit: #741 ui-ux-tester L-2
+- 親 PR: #752 / #744 (nav label rename、 §2.3 で本 issue を out-of-scope と明示)
+- code-reviewer review of #752 で LOW として指摘


### PR DESCRIPTION
Closes #753
Closes #754

## Summary

#744 で nav label を「メンター募集」 → 「相談を募集中」 / page h1 を「相談を投稿する」 に rename した後、 §2.3 で意図的に out-of-scope とした 2 surface に旧 terminology が残存していた。 cross-link 上「セットで進める」 と合意した 1 つの terminology unification concern として本 PR でまとめて処理。

### Before / After

| location | before | after |
|---|---|---|
| MentorRequestForm aria-label | 「メンター募集フォーム」 | **「相談募集フォーム」** |
| MentorRequestForm submit | 「募集を投稿する」 | **「相談を投稿する」** |
| /mentor/wanted CTA (auth) | 「募集を出す」 | **「相談を投稿する」** |
| /mentor/wanted CTA (anon) | 「ログインして募集する」 | **「ログインして相談する」** |

これで end-to-end の動線 (nav → page → CTA → 遷移先 → form → submit) が全て「相談」 系に統一される。

詳細: [`docs/specs/mentor-form-labels-spec.md`](../blob/feature/issue-753-754-mentor-form-labels/docs/specs/mentor-form-labels-spec.md)

## 変更ファイル (5 files, +129 / -15)

- `client/src/components/mentorship/MentorRequestForm.tsx`
- `client/src/components/mentorship/__tests__/MentorRequestForm.test.tsx` (5 件追従)
- `client/src/app/(template)/mentor/wanted/page.tsx` (CTA + JSDoc)
- `client/e2e/mentor-board.spec.ts` (3 件追従)
- `docs/specs/mentor-form-labels-spec.md` (新規)

## Test plan

### Unit / type / lint (local)
- [x] `tsc --noEmit` → 0 errors
- [x] `vitest run` (full) → 101 files / 835 tests pass
- [x] `eslint` 変更 file → 0 errors

### サブエージェントレビュー (CLAUDE.md §4.2 直列起動)
- [ ] `typescript-reviewer`
- [ ] `code-reviewer`

### stg verify (CD 反映後)
- [ ] `/mentor/wanted` CTA が「相談を投稿する」 / anon「ログインして相談する」 表示
- [ ] click で `/mentor/wanted/new` に遷移、 form aria-label が「相談募集フォーム」、 submit button「相談を投稿する」
- [ ] DOM `aria-label` で screen reader 経路を確認

## Rollback

PR revert 1 発で復旧。 backend / API / DB 触らず frontend label のみ。