### PR TITLE
[refactor][rail] X 準拠で /messages 全体を rail hide (#756)

### DIFF
--- a/client/e2e/explore-search-rail.spec.ts
+++ b/client/e2e/explore-search-rail.spec.ts
@@ -307,7 +307,7 @@ test.describe("#741 /explore + search + right rail IA refactor", () => {
 		await ctx.close();
 	});
 
-	test("RAIL-SHOW-3: /messages list で右 rail 表示 (list 系維持)", async ({
+	test("RAIL-HIDE-4 (#756): /messages list で右 rail 非表示 (X 2-pane 準拠)", async ({
 		browser,
 	}) => {
 		const ctx = await browser.newContext();
@@ -316,7 +316,8 @@ test.describe("#741 /explore + search + right rail IA refactor", () => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await page.goto(`${BASE}/messages`);
 
-		await expect(page.locator(RAIL_SELECTOR)).toBeVisible({ timeout: 15000 });
+		// #756: X 準拠で /messages 全体 (list + thread + invitations) を hide。
+		await expect(page.locator(RAIL_SELECTOR)).toHaveCount(0);
 
 		await ctx.close();
 	});

--- a/client/src/lib/layout/__tests__/focused-surfaces.test.ts
+++ b/client/src/lib/layout/__tests__/focused-surfaces.test.ts
@@ -41,7 +41,7 @@ describe("shouldHideRightRail", () => {
 		});
 	});
 
-	describe("private read/write (#741): /messages/<id>", () => {
+	describe("private read/write (#741 個別、 #756 で /messages 全体に拡張)", () => {
 		it("returns true for individual thread /messages/abc123", () => {
 			expect(shouldHideRightRail("/messages/abc123")).toBe(true);
 		});
@@ -52,12 +52,12 @@ describe("shouldHideRightRail", () => {
 			).toBe(true);
 		});
 
-		it("returns false for /messages list view (browse)", () => {
-			expect(shouldHideRightRail("/messages")).toBe(false);
+		it("returns true for /messages list view (#756: X 準拠で 2-pane の右側 thread 占有)", () => {
+			expect(shouldHideRightRail("/messages")).toBe(true);
 		});
 
-		it("returns false for /messages/invitations sub-page", () => {
-			expect(shouldHideRightRail("/messages/invitations")).toBe(false);
+		it("returns true for /messages/invitations sub-page (#756: DM section 配下)", () => {
+			expect(shouldHideRightRail("/messages/invitations")).toBe(true);
 		});
 	});
 
@@ -86,8 +86,6 @@ describe("shouldHideRightRail", () => {
 		it.each([
 			["/"],
 			["/notifications"],
-			["/messages"],
-			["/messages/invitations"],
 			["/articles"],
 			["/boards"],
 			["/boards/django"],

--- a/client/src/lib/layout/__tests__/focused-surfaces.test.ts
+++ b/client/src/lib/layout/__tests__/focused-surfaces.test.ts
@@ -118,5 +118,12 @@ describe("shouldHideRightRail", () => {
 			// /settings で始まる別 path は誤って rail を隠さない。
 			expect(shouldHideRightRail("/settings-not-real")).toBe(false);
 		});
+
+		it("returns false for /messages-archive (#756 prefix false-positive guard)", () => {
+			// `pathname === "/messages" || startsWith("/messages/")` は
+			// slash 区切りを要求するため /messages で始まる別 path (例: /messages-archive)
+			// を誤って rail 抑制しない。 typescript-reviewer LOW 提案の対称テスト。
+			expect(shouldHideRightRail("/messages-archive")).toBe(false);
+		});
 	});
 });

--- a/client/src/lib/layout/focused-surfaces.ts
+++ b/client/src/lib/layout/focused-surfaces.ts
@@ -19,7 +19,10 @@
  *      - `/agent` / `/agent/*` (Claude Agent LLM chat workspace)
  *
  *   4. **Private read/write surface**
- *      - `/messages/<id>` (個別 DM thread。 list と invitations は除外して rail 表示)
+ *      - `/messages` 全体 (#756: list + thread + invitations すべて hide)。
+ *        X (Twitter) は DM を 2-pane (会話一覧 + active thread or empty state) で
+ *        構成しているため右側が thread pane に占有され、 trending rail を出す
+ *        スペース自体ない。 X 準拠路線で同じ挙動にする。
  *
  *   5. **長文 read surface**
  *      - `/articles/<slug>` (記事詳細。 list / new / edit は別判定)
@@ -52,13 +55,11 @@ export function shouldHideRightRail(pathname: string): boolean {
 	// 3. Focused single-task surface (#741)
 	if (pathname === "/agent" || pathname.startsWith("/agent/")) return true;
 
-	// 4. Private read/write surface (#741)
-	// /messages list (browse) と /messages/invitations は除外して rail を残す。
-	// 個別 thread `/messages/<id>` のみ抑制。
-	// 負の lookahead `(?!invitations$)` で /messages/invitations を弾く。
-	if (/^\/messages\/(?!invitations$)[^/]+$/.test(pathname)) {
+	// 4. Private read/write surface (#741 で個別 thread、 #756 で全体に拡張)
+	// X 準拠: /messages 全体 (list + thread + invitations + 等) を hide。
+	// X は DM を 2-pane (一覧 + thread) で組むので、 右 rail を出すスペース自体ない。
+	if (pathname === "/messages" || pathname.startsWith("/messages/"))
 		return true;
-	}
 
 	// 5. 長文 read surface (#741)
 	// 記事詳細 `/articles/<slug>` のみ。 `/articles` list / `/articles/new` /

--- a/docs/specs/explore-search-rightrail-spec.md
+++ b/docs/specs/explore-search-rightrail-spec.md
@@ -132,17 +132,19 @@
 `ARightRail.tsx:44-49` の `hideOnFocusedSurface` 判定に以下を追加:
 
 ```ts
+// 現在の shipped 実装 (#741 → #756 update 後)
 pathname === "/search" ||
 	pathname.startsWith("/search/") ||
 	pathname === "/agent" ||
 	pathname.startsWith("/agent/") ||
-	/^\/messages\/(?!invitations$)[^/]+$/.test(pathname) ||
+	pathname === "/messages" ||
+	pathname.startsWith("/messages/") ||
 	/^\/articles\/[^/]+$/.test(pathname);
 ```
 
 - `/search`: search panel 重複 (H-2) 解消 → そもそも rail 全体を隠す
 - `/agent`: LLM chat workspace 集中 (H-3) 確保
-- `/messages/<id>`: 個別 DM thread の集中 (M-2) 確保。 `/messages` list と `/messages/invitations` は除外
+- `/messages*`: **#741** で個別 thread のみ hide だったが、 **#756** で X 準拠 (DM 2-pane で右側 thread 占有) に統一して list + invitations + 全 sub-page を hide 対象に
 - `/articles/<slug>`: 長文記事読みの集中 (M-1) 確保。 list (`/articles`)、 new (`/articles/new`)、 edit (`/articles/<slug>/edit`) は別判定で既に excluded
 
 > **#756 update (2026-05-18)**: `/messages` list と `/messages/invitations` も hide 対象に拡張。 X (Twitter) は DM section を 2-pane (会話一覧 + active thread or empty state) で組んでおり右 rail を出すスペース自体ない。 X 準拠路線で統一。 詳細: `docs/specs/explore-search-rightrail-spec.md` §8 (本 doc は元の #741 状態を保持、 §8 で update を追記する流儀)。
@@ -217,7 +219,7 @@ pathname === "/search" ||
 | 7   | `/agent` に直接 navigate                                | test4             | 右 rail 非表示、 chat UI のみ                                                                         |
 | 8   | `/articles/<existing-slug>` を開く                      | test4             | 右 rail 非表示、 長文記事本文のみ                                                                     |
 | 9   | `/` (home) を開く                                       | test4             | 右 rail **表示** (trending + who-to-follow)、 search panel 削除済確認                                 |
-| 10  | `/messages` list を開く                                 | test4             | 右 rail 表示 (list は browse なので維持)                                                              |
+| 10  | `/messages` list を開く                                 | test4             | **#756**: 右 rail **非表示** (X 準拠の DM 2-pane 路線、 旧 #741 は browse 系として表示していたが反転) |
 | 11  | `/notifications` を開く                                 | test4             | 右 rail 表示 (空 state を rail が補完)                                                                |
 | 12  | 右 rail の dummy footer text が削除されていることを確認 | test4             | `about · pricing` text が DOM に **存在しない**                                                       |
 

--- a/docs/specs/explore-search-rightrail-spec.md
+++ b/docs/specs/explore-search-rightrail-spec.md
@@ -145,6 +145,8 @@ pathname === "/search" ||
 - `/messages/<id>`: 個別 DM thread の集中 (M-2) 確保。 `/messages` list と `/messages/invitations` は除外
 - `/articles/<slug>`: 長文記事読みの集中 (M-1) 確保。 list (`/articles`)、 new (`/articles/new`)、 edit (`/articles/<slug>/edit`) は別判定で既に excluded
 
+> **#756 update (2026-05-18)**: `/messages` list と `/messages/invitations` も hide 対象に拡張。 X (Twitter) は DM section を 2-pane (会話一覧 + active thread or empty state) で組んでおり右 rail を出すスペース自体ない。 X 準拠路線で統一。 詳細: `docs/specs/explore-search-rightrail-spec.md` §8 (本 doc は元の #741 状態を保持、 §8 で update を追記する流儀)。
+
 #### 3.4.2 search panel 削除
 
 `ARightRail.tsx:63-90` の `<Link href="/search">` block 全体を削除。 `/explore` 最上部に search box が常設されるので冗長。


### PR DESCRIPTION
Closes #756

## Summary

#741 では `/messages/<id>` (個別 DM thread) のみ rail hide、 `/messages` list と `/messages/invitations` は browse 系として rail を残していたが、 X (Twitter) は DM section を **2-pane** (会話一覧 + active thread or empty state) で組んでおり右側が thread pane に占有されるため、 trending rail を出すスペース自体ない。

ハルナさん指摘 (2026-05-18):
> メッセージ画面とかでも右におすすめフォロワーとか表示されるの不要だと思うんですが。

X 準拠路線で `/messages` 全体を hide 対象に拡張。

## 変更ファイル (4 files, +18 / -16)

- `client/src/lib/layout/focused-surfaces.ts` (messages 判定 簡素化)
- `client/src/lib/layout/__tests__/focused-surfaces.test.ts` (list と invitations の期待値を hide に反転)
- `client/e2e/explore-search-rail.spec.ts` (RAIL-SHOW-3 → RAIL-HIDE-4)
- `docs/specs/explore-search-rightrail-spec.md` (§3.4.1 に #756 update ノート追加)

## Test plan

- [x] `tsc --noEmit` → 0 errors
- [x] `vitest run src/lib/layout` → 41/41 pass
- [ ] サブエージェント (typescript-reviewer + code-reviewer)
- [ ] stg verify: `/messages` (logged-in) で rail 不在 確認

## Out of scope

- 「全画面で右 rail 廃止」 → X 準拠路線 (home / notifications / profile / tweet 詳細 では rail 維持)
- DM section 自体の 2-pane 化 (現状は単一 column、 別 issue 案件)

## Rollback

PR revert 1 発で復旧。 backend / API 触らない、 1 行ロジック変更 + test 追従のみ。