### PR TITLE
[refactor][rail] picker / utility list 系 surface でも右 rail を hide (#758)

### DIFF
--- a/client/e2e/explore-search-rail.spec.ts
+++ b/client/e2e/explore-search-rail.spec.ts
@@ -268,6 +268,76 @@ test.describe("#741 /explore + search + right rail IA refactor", () => {
 		await ctx.close();
 	});
 
+	test("RAIL-HIDE-5 (#758): /articles list で右 rail 非表示 (picker)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`${BASE}/articles`);
+
+		await expect(page.locator(RAIL_SELECTOR)).toHaveCount(0);
+
+		await ctx.close();
+	});
+
+	test("RAIL-HIDE-6 (#758): /boards で右 rail 非表示 (board picker)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`${BASE}/boards`);
+
+		await expect(page.locator(RAIL_SELECTOR)).toHaveCount(0);
+
+		await ctx.close();
+	});
+
+	test("RAIL-HIDE-7 (#758): /boards/<slug> で右 rail 非表示 (thread list)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`${BASE}/boards/django`);
+
+		await expect(page.locator(RAIL_SELECTOR)).toHaveCount(0);
+
+		await ctx.close();
+	});
+
+	test("RAIL-HIDE-8 (#758): /mentor/wanted で右 rail 非表示 (相談 board picker)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`${BASE}/mentor/wanted`);
+
+		await expect(page.locator(RAIL_SELECTOR)).toHaveCount(0);
+
+		await ctx.close();
+	});
+
+	test("RAIL-HIDE-9 (#758): /mentors で右 rail 非表示 (mentor directory picker)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await loginViaApi(ctx.request, USER1);
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`${BASE}/mentors`);
+
+		await expect(page.locator(RAIL_SELECTOR)).toHaveCount(0);
+
+		await ctx.close();
+	});
+
 	// ───────────────────────────────────────────────── 右 rail 表示 group
 
 	test("RAIL-SHOW-1: / (home) で右 rail 表示、 search panel は削除済", async ({

--- a/client/src/lib/layout/__tests__/focused-surfaces.test.ts
+++ b/client/src/lib/layout/__tests__/focused-surfaces.test.ts
@@ -129,6 +129,20 @@ describe("shouldHideRightRail", () => {
 			expect(shouldHideRightRail("/settings-not-real")).toBe(false);
 		});
 
+		it.each([
+			["/mentor-archive"],
+			["/mentors-help"],
+			["/boards-index"],
+			["/articles-feed"],
+		])(
+			"returns false for %s (#758 prefix false-positive guard for picker surfaces)",
+			(pathname) => {
+				// slash 区切りを要求するため /mentor- / /mentors- / /boards- /
+				// /articles- で始まる別 path を誤って hide しないことを保証。
+				expect(shouldHideRightRail(pathname)).toBe(false);
+			},
+		);
+
 		it("returns false for /messages-archive (#756 prefix false-positive guard)", () => {
 			// `pathname === "/messages" || startsWith("/messages/")` は
 			// slash 区切りを要求するため /messages で始まる別 path (例: /messages-archive)

--- a/client/src/lib/layout/__tests__/focused-surfaces.test.ts
+++ b/client/src/lib/layout/__tests__/focused-surfaces.test.ts
@@ -70,8 +70,8 @@ describe("shouldHideRightRail", () => {
 			expect(shouldHideRightRail("/articles/phase6-stg-check")).toBe(true);
 		});
 
-		it("returns false for /articles list view", () => {
-			expect(shouldHideRightRail("/articles")).toBe(false);
+		it("returns true for /articles list view (#758: picker / utility list)", () => {
+			expect(shouldHideRightRail("/articles")).toBe(true);
 		});
 
 		it("returns true for /articles/me (path 1 segment 判定の副作用)", () => {
@@ -82,13 +82,26 @@ describe("shouldHideRightRail", () => {
 		});
 	});
 
-	describe("rail を表示する surface (false を返す)", () => {
+	describe("picker / utility list surface (#758): rail hide", () => {
+		// X 準拠で picker / list page では rail を出さない。
+		// #741 の「browse = rail OK」 over-generalize を修正。
+		it.each([
+			["/mentor/wanted"],
+			["/mentor/wanted/123"],
+			["/mentors"],
+			["/mentors/some-handle"],
+			["/boards"],
+			["/boards/django"],
+			["/articles"],
+		])("returns true for %s", (pathname) => {
+			expect(shouldHideRightRail(pathname)).toBe(true);
+		});
+	});
+
+	describe("rail を表示する surface (X 準拠 stream 系のみ false を返す)", () => {
 		it.each([
 			["/"],
 			["/notifications"],
-			["/articles"],
-			["/boards"],
-			["/boards/django"],
 			["/threads/1"],
 			["/tweet/230"],
 			["/u/test4"],
@@ -96,9 +109,6 @@ describe("shouldHideRightRail", () => {
 			["/drafts"],
 			["/follow-requests"],
 			["/explore"],
-			["/mentor/wanted"],
-			["/mentors"],
-			["/mentors/some-handle"],
 		])("returns false for %s", (pathname) => {
 			expect(shouldHideRightRail(pathname)).toBe(false);
 		});

--- a/client/src/lib/layout/focused-surfaces.ts
+++ b/client/src/lib/layout/focused-surfaces.ts
@@ -4,7 +4,8 @@
  * Spec: docs/specs/explore-search-rightrail-spec.md §3.4
  *
  * 右 rail (`ARightRail`) は「 trending + who-to-follow」 を出す chrome だが、
- * 以下の 5 カテゴリでは集中阻害 / surface 重複になるため抑制する:
+ * 以下の 6 カテゴリでは集中阻害 / surface 重複 / picker page の rail dominant
+ * 問題で page purpose と矛盾するため抑制する:
  *
  *   1. **Composer / Edit form** — 元から抑制対象
  *      - `/settings/*`
@@ -26,6 +27,16 @@
  *
  *   5. **長文 read surface**
  *      - `/articles/<slug>` (記事詳細。 list / new / edit は別判定)
+ *
+ *   6. **Picker / utility list surface** (#758, ui-ux-tester re-audit 2026-05-18)
+ *      - `/mentor/wanted` 系 (相談 board picker)
+ *      - `/mentors` 系 (mentor directory picker + 個別 profile)
+ *      - `/boards` 系 (掲示板 board picker + thread list)
+ *      - `/articles` (記事 list、 detail は category 5 で既に hide 済)
+ *
+ *      真の predicate は「is the center an X-style stream」 — picker は stream
+ *      ではないので rail なし。 X も Communities / Lists / Bookmarks 等の picker
+ *      で rail を出さない。 #741 の「browse = rail OK」 over-generalize を修正。
  *
  * 採点根拠 (`ui-ux-tester` agent 2026-05-17 audit):
  *   - `/search` rail score: -2 (surface duplication 最悪)
@@ -62,9 +73,19 @@ export function shouldHideRightRail(pathname: string): boolean {
 		return true;
 
 	// 5. 長文 read surface (#741)
-	// 記事詳細 `/articles/<slug>` のみ。 `/articles` list / `/articles/new` /
-	// `/articles/<slug>/edit` は上の judge で既に弾かれているか、 list は rail OK。
+	// 記事詳細 `/articles/<slug>` のみ。 `/articles/new` / `/articles/<slug>/edit`
+	// は category 1 で既に hide、 `/articles` list は category 6 で hide。
 	if (/^\/articles\/[^/]+$/.test(pathname)) return true;
+
+	// 6. Picker / utility list surface (#758)
+	// X は Communities / Lists / Bookmarks 等の picker page で rail を出さない。
+	// うちの該当 surface も同様に hide:
+	if (pathname === "/mentor/wanted" || pathname.startsWith("/mentor/wanted/")) {
+		return true;
+	}
+	if (pathname === "/mentors" || pathname.startsWith("/mentors/")) return true;
+	if (pathname === "/boards" || pathname.startsWith("/boards/")) return true;
+	if (pathname === "/articles") return true;
 
 	return false;
 }

--- a/client/src/lib/layout/focused-surfaces.ts
+++ b/client/src/lib/layout/focused-surfaces.ts
@@ -28,15 +28,18 @@
  *   5. **長文 read surface**
  *      - `/articles/<slug>` (記事詳細。 list / new / edit は別判定)
  *
- *   6. **Picker / utility list surface** (#758, ui-ux-tester re-audit 2026-05-18)
+ *   6. **Non-stream / browser surface (picker / utility list)** (#758, ui-ux-tester re-audit 2026-05-18)
  *      - `/mentor/wanted` 系 (相談 board picker)
  *      - `/mentors` 系 (mentor directory picker + 個別 profile)
  *      - `/boards` 系 (掲示板 board picker + thread list)
  *      - `/articles` (記事 list、 detail は category 5 で既に hide 済)
  *
- *      真の predicate は「is the center an X-style stream」 — picker は stream
- *      ではないので rail なし。 X も Communities / Lists / Bookmarks 等の picker
- *      で rail を出さない。 #741 の「browse = rail OK」 over-generalize を修正。
+ *      真の predicate は「is the center an X-style stream」 — picker / detail /
+ *      browser surface は stream ではないので rail なし。 X も Communities /
+ *      Lists / Bookmarks 等の picker で rail を出さない。 #741 の「browse = rail
+ *      OK」 over-generalize を修正。 命名は "Non-stream / browser surface" として
+ *      将来の picker 以外 (例: `/mentors/<handle>` profile detail) も同じ category
+ *      に乗せやすくする (code-reviewer #760 提案)。
  *
  * 採点根拠 (`ui-ux-tester` agent 2026-05-17 audit):
  *   - `/search` rail score: -2 (surface duplication 最悪)
@@ -77,7 +80,7 @@ export function shouldHideRightRail(pathname: string): boolean {
 	// は category 1 で既に hide、 `/articles` list は category 6 で hide。
 	if (/^\/articles\/[^/]+$/.test(pathname)) return true;
 
-	// 6. Picker / utility list surface (#758)
+	// 6. Non-stream / browser surface (picker / utility list) (#758)
 	// X は Communities / Lists / Bookmarks 等の picker page で rail を出さない。
 	// うちの該当 surface も同様に hide:
 	// note: `/mentor/wanted/new` と `/mentors/me/edit` は category 1 で先に

--- a/client/src/lib/layout/focused-surfaces.ts
+++ b/client/src/lib/layout/focused-surfaces.ts
@@ -80,11 +80,16 @@ export function shouldHideRightRail(pathname: string): boolean {
 	// 6. Picker / utility list surface (#758)
 	// X は Communities / Lists / Bookmarks 等の picker page で rail を出さない。
 	// うちの該当 surface も同様に hide:
+	// note: `/mentor/wanted/new` と `/mentors/me/edit` は category 1 で先に
+	// hide=true になるため、 下の startsWith branch は dead だが結果同じなので
+	// 冗長 safety として残す。
 	if (pathname === "/mentor/wanted" || pathname.startsWith("/mentor/wanted/")) {
 		return true;
 	}
 	if (pathname === "/mentors" || pathname.startsWith("/mentors/")) return true;
 	if (pathname === "/boards" || pathname.startsWith("/boards/")) return true;
+	// /articles のみ exact match (subpath は category 1 で composer / edit、
+	// category 5 で /articles/<slug> detail として既に hide 済、 二重 hide 不要)。
 	if (pathname === "/articles") return true;
 
 	return false;


### PR DESCRIPTION
Closes #758

## Summary

#741 で「browse / list = rail OK」 と評価した surface を、 ハルナさん再指摘 + ui-ux-tester re-audit verdict A2 を受けて hide list に追加。 X 準拠で「picker / utility page では rail を出さない」 の predicate に統一。

### Before / After

| surface | before | after |
|---|---|---|
| `/mentor/wanted` (+ `/<id>`) | rail 表示 | **hide** |
| `/mentors` (+ `/<handle>`) | rail 表示 | **hide** |
| `/boards` (+ `/<slug>`) | rail 表示 | **hide** |
| `/articles` (list) | rail 表示 | **hide** |
| `/` `/notifications` `/u/<handle>` `/tweet/<id>` `/explore` `/search` | 表示 | **維持** |

X analog: Communities / Lists / Bookmarks も rail なし、 picker page の rail dominance を避ける pattern と一致。

## 変更ファイル (3 files, +113 / -12)

- `client/src/lib/layout/focused-surfaces.ts` — category 6 (Picker) 新設、 4 surface 追加
- `client/src/lib/layout/__tests__/focused-surfaces.test.ts` — picker 7 case 新設、 既存 stream 系と分離、 /articles 期待値反転
- `client/e2e/explore-search-rail.spec.ts` — RAIL-HIDE-5/6/7/8/9 追加

## Test plan

- [x] `tsc --noEmit` → 0 errors
- [x] `vitest run` (full) → 101 files / 835 tests pass
- [ ] サブエージェント直列 (typescript-reviewer + code-reviewer)
- [ ] stg verify: 5 surface で rail 不在、 6 surface で rail 維持 (Playwright MCP)

## 関連

- 親 audit: #741, #756 (rail hide list の段階的拡張)
- re-audit: 2026-05-18 ui-ux-tester (verdict A2)
- 続編: #759 (mentor surfaces merge、 本 PR が先に merge されると #759 の merge 後も rail なしの state を維持)

## Rollback

PR revert 1 発で復旧。 backend / API 触らない frontend-only。