### PR TITLE
[refactor][mentor] /mentor/wanted + /mentors を /mentors?tab=... に統合、 nav 1 entry に (#759)

### DIFF
--- a/client/e2e/mentor-board.spec.ts
+++ b/client/e2e/mentor-board.spec.ts
@@ -74,13 +74,14 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 		await loginViaApi(ctxMentee.request, USER1);
 		const mentee = await ctxMentee.newPage();
 
-		// LeftNav から /mentor/wanted へ (3 click 以内)
+		// LeftNav から /mentors?tab=requests へ (3 click 以内)
 		await mentee.goto(`${BASE}/`);
-		// #744: nav label を「メンター募集」 → 「相談を募集中」 に変更。
-		const navLink = mentee.getByRole("link", { name: "相談を募集中" }).first();
+		// #759: nav label を「相談を募集中」 + 「メンター一覧」 (2 entry) →
+		// 「メンター」 (1 entry、 /mentors?tab=requests がデフォルト) に統合。
+		const navLink = mentee.getByRole("link", { name: "メンター" }).first();
 		await expect(navLink).toBeVisible({ timeout: 15000 });
 		await navLink.click();
-		await mentee.waitForURL(`${BASE}/mentor/wanted`);
+		await mentee.waitForURL(/\/mentors(\?tab=requests)?$/);
 
 		// #754: CTA を「募集を出す」 → 「相談を投稿する」 に変更。
 		await mentee.getByRole("link", { name: "相談を投稿する" }).click();
@@ -130,18 +131,36 @@ test.describe("Phase 11 11-A mentor board (#624)", () => {
 		await ctxMentor.close();
 	});
 
-	test("MENTOR-2: anon でも /mentor/wanted 一覧 + 詳細を 200 で見られる", async ({
+	test("MENTOR-2: anon でも /mentors (= 統合後) 一覧を 200 で見られる + 旧 /mentor/wanted は redirect", async ({
 		browser,
 	}) => {
 		const ctx = await browser.newContext();
 		const page = await ctx.newPage();
-		const list = await ctx.request.get(`${BASE}/mentor/wanted`);
-		expect(list.status()).toBe(200);
+
+		// #759: /mentor/wanted 直 URL は /mentors?tab=requests に redirect (server-side)。
 		await page.goto(`${BASE}/mentor/wanted`);
-		// #754: anon CTA を「ログインして募集する」 → 「ログインして相談する」 に変更。
+		await page.waitForURL(/\/mentors\?tab=requests/, { timeout: 15000 });
+
+		// anon CTA は「ログインして相談する」 (requests tab default)
 		await expect(
 			page.getByRole("link", { name: "ログインして相談する" }),
 		).toBeVisible({ timeout: 15000 });
+		await ctx.close();
+	});
+
+	test("MENTOR-2b (#759): /mentors?tab=directory で tab 切替 + CTA も切替", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/mentors?tab=directory`);
+		// directory tab の CTA は「ログインしてメンター登録」 (anon)
+		await expect(
+			page.getByRole("link", { name: "ログインしてメンター登録" }),
+		).toBeVisible({ timeout: 15000 });
+		// tab navigation で requests に切り替えても URL が反映
+		await page.getByRole("link", { name: "募集中の相談" }).click();
+		await page.waitForURL(/\/mentors\?tab=requests/);
 		await ctx.close();
 	});
 

--- a/client/src/app/(template)/mentor/wanted/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/page.tsx
@@ -16,8 +16,10 @@ interface PageProps {
 
 export default function MentorWantedListRedirect({ searchParams }: PageProps) {
 	const tag = searchParams?.tag;
-	const target = tag
-		? `/mentors?tab=requests&tag=${encodeURIComponent(tag)}`
-		: "/mentors?tab=requests";
-	redirect(target);
+	// #759 ts-reviewer MEDIUM: URLSearchParams で構築して MentorsModeTabs と同じ
+	// pattern に揃える (将来 query param を増やす時の percent-encoding 差を防ぐ)。
+	const params = new URLSearchParams();
+	params.set("tab", "requests");
+	if (tag) params.set("tag", tag);
+	redirect(`/mentors?${params.toString()}`);
 }

--- a/client/src/app/(template)/mentor/wanted/page.tsx
+++ b/client/src/app/(template)/mentor/wanted/page.tsx
@@ -1,182 +1,23 @@
 /**
- * /mentor/wanted — メンター募集 board 一覧 (P11-06 / Phase 11 11-A).
+ * /mentor/wanted — redirect 化 (#759).
  *
- * 匿名閲覧可。 SSR で公開募集 (status=open) 一覧を fetch。 sticky header に
- * 「相談を投稿する」 CTA を auth のみで表示、 anon は「ログインして相談する」 で
- * /login?next=/mentor/wanted/new に誘導 (PR #608 ALeftNav 「投稿する」 CTA と
- * 同流儀。 #754 で「募集」 → 「相談」 terminology に統一)。
+ * 旧 mentor 募集 board 一覧 page。 #759 で `/mentors?tab=requests` に統合された
+ * ため、 本 page は redirect のみ実行する。 sub-routes (`/mentor/wanted/new`,
+ * `/mentor/wanted/<id>`) は独立 surface として残す。
  *
- * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ * 既存 bookmark / link の互換性のために永続的に残す (delete しない)。
  */
 
-import type { Metadata } from "next";
-import Link from "next/link";
-import { cookies } from "next/headers";
-import { Feather, Handshake } from "lucide-react";
-
-// #750: JST 固定 helper を使う (Server Component で UTC 表示になっていた機能バグ修正)。
-import { formatJstDate } from "@/lib/datetime";
-import {
-	listMentorRequests,
-	type MentorRequestSummary,
-} from "@/lib/api/mentor";
-import { ApiServerError, serverFetch } from "@/lib/api/server";
-
-export const metadata: Metadata = {
-	// #744: nav label と揃えて「相談を募集中」 に統一 (whiplash 回避)。
-	title: "相談を募集中 — エンジニア SNS",
-	description:
-		"エンジニア SNS の相談募集 board。 学習中の人が現役エンジニアに 1 on 1 で教わりたい内容を投稿、 mentor が提案を出して契約成立で DM が始まります。",
-};
-
-async function fetchListSSR(
-	tag: string | undefined,
-): Promise<MentorRequestSummary[]> {
-	try {
-		const qs = tag ? `?tag=${encodeURIComponent(tag)}` : "";
-		const page = await serverFetch<{
-			results: MentorRequestSummary[];
-			next: string | null;
-			previous: string | null;
-		}>(`/mentor/requests/${qs}`);
-		return page.results ?? [];
-	} catch (err) {
-		// anon 可 endpoint なので 401 で empty fallback。 backend が落ちている時も
-		// page は empty state で render する (article 一覧 / drafts と同流儀)。
-		if (err instanceof ApiServerError) return [];
-		return [];
-	}
-}
+import { redirect } from "next/navigation";
 
 interface PageProps {
 	searchParams?: { tag?: string };
 }
 
-export default async function MentorWantedListPage({
-	searchParams,
-}: PageProps) {
-	const items = await fetchListSSR(searchParams?.tag);
-	const isAuthenticated = cookies().get("logged_in")?.value === "true";
-
-	const filterDescription = searchParams?.tag
-		? `#${searchParams.tag} の相談`
-		: "募集中の相談";
-
-	return (
-		<>
-			<header
-				aria-label="相談募集 board ヘッダー"
-				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
-				style={{
-					borderBottom: "1px solid var(--a-border)",
-					background: "rgba(255,255,255,0.85)",
-					backdropFilter: "blur(8px)",
-				}}
-			>
-				<Handshake
-					className="size-4 text-[color:var(--a-accent)]"
-					aria-hidden="true"
-				/>
-				<div className="min-w-0 flex-1">
-					<h1
-						className="truncate font-semibold tracking-tight"
-						style={{ fontSize: 15, letterSpacing: -0.2 }}
-					>
-						相談を募集中
-					</h1>
-					<p
-						className="truncate text-[color:var(--a-text-subtle)]"
-						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
-					>
-						{filterDescription}
-					</p>
-				</div>
-				<Link
-					href={
-						isAuthenticated
-							? "/mentor/wanted/new"
-							: "/login?next=/mentor/wanted/new"
-					}
-					className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
-					style={{ background: "var(--a-accent)", fontSize: 12.5 }}
-				>
-					<Feather className="size-3.5" aria-hidden="true" />
-					{isAuthenticated ? "相談を投稿する" : "ログインして相談する"}
-				</Link>
-			</header>
-
-			{/* P11-23: skill tag filter chip。 現在の filter を chip で表示 + 解除 link。 */}
-			{searchParams?.tag ? (
-				<nav
-					aria-label="skill filter"
-					className="flex items-center gap-2 border-b border-[color:var(--a-border)] px-5 py-2 text-xs"
-				>
-					<span className="text-[color:var(--a-text-muted)]">filter:</span>
-					<Link
-						href="/mentor/wanted"
-						aria-label={`#${searchParams.tag} の filter を解除`}
-						className="inline-flex items-center gap-1 rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-[color:var(--a-text)] hover:bg-[color:var(--a-bg-muted)]/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
-					>
-						#{searchParams.tag} ×
-					</Link>
-				</nav>
-			) : null}
-
-			<div className="p-5">
-				{items.length === 0 ? (
-					<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
-						{searchParams?.tag
-							? `#${searchParams.tag} の相談はまだありません。`
-							: "まだ相談がありません。 最初の相談を投稿してみませんか?"}
-					</p>
-				) : (
-					<ul role="list" className="grid gap-3">
-						{items.map((req) => (
-							<li key={req.id}>
-								<MentorRequestCard request={req} />
-							</li>
-						))}
-					</ul>
-				)}
-			</div>
-		</>
-	);
-}
-
-function MentorRequestCard({ request }: { request: MentorRequestSummary }) {
-	return (
-		<Link
-			href={`/mentor/wanted/${request.id}`}
-			aria-label={`相談「${request.title}」 を開く`}
-			className="block rounded-lg border border-[color:var(--a-border)] p-4 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
-		>
-			<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">
-				<span>@{request.mentee.handle}</span>
-				<span aria-hidden="true">·</span>
-				<time dateTime={request.created_at}>
-					{formatJstDate(request.created_at)}
-				</time>
-				<span aria-hidden="true">·</span>
-				<span>提案 {request.proposal_count} 件</span>
-			</div>
-			<h2
-				className="mt-1 truncate font-semibold"
-				style={{ fontSize: 15, letterSpacing: -0.1 }}
-			>
-				{request.title}
-			</h2>
-			{request.target_skill_tags.length > 0 && (
-				<ul aria-label="関連スキル" className="mt-2 flex flex-wrap gap-1">
-					{request.target_skill_tags.map((t) => (
-						<li
-							key={t.name}
-							className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
-						>
-							#{t.display_name}
-						</li>
-					))}
-				</ul>
-			)}
-		</Link>
-	);
+export default function MentorWantedListRedirect({ searchParams }: PageProps) {
+	const tag = searchParams?.tag;
+	const target = tag
+		? `/mentors?tab=requests&tag=${encodeURIComponent(tag)}`
+		: "/mentors?tab=requests";
+	redirect(target);
 }

--- a/client/src/app/(template)/mentors/page.tsx
+++ b/client/src/app/(template)/mentors/page.tsx
@@ -202,8 +202,11 @@ function HeaderCta({
 	const href = isAuthenticated
 		? "/mentors/me/edit"
 		: "/login?next=/mentors/me/edit";
+	// #759 code-reviewer MEDIUM: 既存 mentor profile を持つ user にも「登録」 と
+	// 出ると「自分の登録が消えた?」 と誤解しうる。 「メンタープロフィール」 は
+	// 新規登録 / 編集の両方で意味が通る neutral な label。
 	const label = isAuthenticated
-		? "メンターとして登録"
+		? "メンタープロフィール"
 		: "ログインしてメンター登録";
 	return (
 		<Link

--- a/client/src/app/(template)/mentors/page.tsx
+++ b/client/src/app/(template)/mentors/page.tsx
@@ -41,7 +41,9 @@ interface PageProps {
 }
 
 function resolveTab(raw: string | undefined): MentorsTabMode {
-	return raw === "directory" ? "directory" : "requests";
+	// #759 ts-reviewer MEDIUM: case-insensitive で誤入力を拾う
+	// (URL builder 等が DIRECTORY を生成しても正しく解釈)。
+	return raw?.toLowerCase() === "directory" ? "directory" : "requests";
 }
 
 async function fetchRequestsSSR(

--- a/client/src/app/(template)/mentors/page.tsx
+++ b/client/src/app/(template)/mentors/page.tsx
@@ -1,27 +1,64 @@
 /**
- * /mentors — mentor 検索一覧 (P11-14 / Phase 11-B).
+ * /mentors — mentor 統合 surface (#759 で /mentor/wanted と merge).
  *
- * 匿名閲覧可。 SSR で list を fetch、 sticky header + card 形式で並べる。
+ * Spec: docs/specs/mentor-merge-spec.md
  *
- * spec: docs/specs/phase-11-mentor-board-spec.md §7
+ * 2 tab を 1 route + query string で切り替え (SSR-friendly):
+ *   - `?tab=requests` (default): 相談 board (旧 /mentor/wanted の内容)
+ *   - `?tab=directory`: mentor 一覧 (旧 /mentors の内容)
+ *
+ * 匿名閲覧可。 CTA は tab に応じて切り替わる:
+ *   - requests: 「相談を投稿する」 → /mentor/wanted/new
+ *   - directory: 「メンターとして登録」 → /mentors/me/edit
+ *
+ * 過去 spec: docs/specs/phase-11-mentor-board-spec.md §7 (個別 page 時代の構成)
  */
 
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Users } from "lucide-react";
+import { cookies } from "next/headers";
+import { Feather, Handshake, Users } from "lucide-react";
 
-import { type MentorProfileDetail } from "@/lib/api/mentor";
+import MentorsModeTabs, {
+	type MentorsTabMode,
+} from "@/components/mentorship/MentorsModeTabs";
+import { formatJstDate } from "@/lib/datetime";
+import {
+	type MentorProfileDetail,
+	type MentorRequestSummary,
+} from "@/lib/api/mentor";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 
 export const metadata: Metadata = {
-	// #744: nav label と揃えて「メンター一覧」 に統一。
-	title: "メンター一覧 — エンジニア SNS",
+	// #759: 統合後の主軸は「相談を募集中」 (default tab)、 title もそれに合わせる。
+	title: "メンター — エンジニア SNS",
 	description:
-		"エンジニア SNS のメンター一覧。 受付中のメンターをスキルタグで絞り込み、 提案前にプロフィールと plan を確認できます。",
+		"エンジニア SNS のメンター surface。 相談を募集中の mentee と、 受付中の mentor を tab で切り替えて閲覧できます。",
 };
 
 interface PageProps {
-	searchParams?: { tag?: string };
+	searchParams?: { tab?: string; tag?: string };
+}
+
+function resolveTab(raw: string | undefined): MentorsTabMode {
+	return raw === "directory" ? "directory" : "requests";
+}
+
+async function fetchRequestsSSR(
+	tag: string | undefined,
+): Promise<MentorRequestSummary[]> {
+	try {
+		const qs = tag ? `?tag=${encodeURIComponent(tag)}` : "";
+		const page = await serverFetch<{
+			results: MentorRequestSummary[];
+			next: string | null;
+			previous: string | null;
+		}>(`/mentor/requests/${qs}`);
+		return page.results ?? [];
+	} catch (err) {
+		if (err instanceof ApiServerError) return [];
+		return [];
+	}
 }
 
 async function fetchMentorsSSR(
@@ -41,13 +78,44 @@ async function fetchMentorsSSR(
 	}
 }
 
-export default async function MentorsListPage({ searchParams }: PageProps) {
+export default async function MentorsPage({ searchParams }: PageProps) {
+	const tab = resolveTab(searchParams?.tab);
 	const tag = searchParams?.tag;
-	const items = await fetchMentorsSSR(tag);
+	const isAuthenticated = cookies().get("logged_in")?.value === "true";
+
+	// 必要な側だけ fetch (server cost 節約)。
+	const [requests, mentors] = await Promise.all([
+		tab === "requests" ? fetchRequestsSSR(tag) : Promise.resolve([]),
+		tab === "directory" ? fetchMentorsSSR(tag) : Promise.resolve([]),
+	]);
+
+	const headerIcon =
+		tab === "requests" ? (
+			<Handshake
+				className="size-4 text-[color:var(--a-accent)]"
+				aria-hidden="true"
+			/>
+		) : (
+			<Users
+				className="size-4 text-[color:var(--a-accent)]"
+				aria-hidden="true"
+			/>
+		);
+
+	const headerTitle = tab === "requests" ? "相談を募集中" : "メンター一覧";
+	const headerSub =
+		tab === "requests"
+			? tag
+				? `#${tag} の相談`
+				: "募集中の相談"
+			: tag
+				? `#${tag} の mentor`
+				: "受付中の mentor";
 
 	return (
 		<>
 			<header
+				aria-label="メンター surface ヘッダー"
 				className="sticky top-0 z-10 flex items-center gap-3 px-5 py-3"
 				style={{
 					borderBottom: "1px solid var(--a-border)",
@@ -55,27 +123,29 @@ export default async function MentorsListPage({ searchParams }: PageProps) {
 					backdropFilter: "blur(8px)",
 				}}
 			>
-				<Users
-					className="size-4 text-[color:var(--a-accent)]"
-					aria-hidden="true"
-				/>
+				{headerIcon}
 				<div className="min-w-0 flex-1">
 					<h1
 						className="truncate font-semibold tracking-tight"
 						style={{ fontSize: 15, letterSpacing: -0.2 }}
 					>
-						メンター一覧
+						{headerTitle}
 					</h1>
 					<p
 						className="truncate text-[color:var(--a-text-subtle)]"
 						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
 					>
-						{tag ? `#${tag} の mentor` : "受付中の mentor"}
+						{headerSub}
 					</p>
 				</div>
+				<HeaderCta tab={tab} isAuthenticated={isAuthenticated} />
 			</header>
 
-			{/* P11-23: skill tag filter chip。 解除 link 付き。 */}
+			<div className="px-5 pt-4">
+				<MentorsModeTabs mode={tab} tag={tag} />
+			</div>
+
+			{/* skill tag filter chip (#759: 両 tab で共通動作)。 */}
 			{tag ? (
 				<nav
 					aria-label="skill filter"
@@ -83,7 +153,7 @@ export default async function MentorsListPage({ searchParams }: PageProps) {
 				>
 					<span className="text-[color:var(--a-text-muted)]">filter:</span>
 					<Link
-						href="/mentors"
+						href={`/mentors?tab=${tab}`}
 						aria-label={`#${tag} の filter を解除`}
 						className="inline-flex items-center gap-1 rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-[color:var(--a-text)] hover:bg-[color:var(--a-bg-muted)]/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
 					>
@@ -93,23 +163,147 @@ export default async function MentorsListPage({ searchParams }: PageProps) {
 			) : null}
 
 			<div className="p-5">
-				{items.length === 0 ? (
-					<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
-						{tag
-							? `#${tag} の mentor はまだいません。`
-							: "受付中の mentor はまだいません。 自分が最初の 1 人になりませんか?"}
-					</p>
+				{tab === "requests" ? (
+					<RequestsList items={requests} tag={tag} />
 				) : (
-					<ul role="list" className="grid gap-3">
-						{items.map((m) => (
-							<li key={m.id}>
-								<MentorCard profile={m} />
-							</li>
-						))}
-					</ul>
+					<MentorsList items={mentors} tag={tag} />
 				)}
 			</div>
 		</>
+	);
+}
+
+function HeaderCta({
+	tab,
+	isAuthenticated,
+}: {
+	tab: MentorsTabMode;
+	isAuthenticated: boolean;
+}) {
+	if (tab === "requests") {
+		const href = isAuthenticated
+			? "/mentor/wanted/new"
+			: "/login?next=/mentor/wanted/new";
+		const label = isAuthenticated ? "相談を投稿する" : "ログインして相談する";
+		return (
+			<Link
+				href={href}
+				className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+				style={{ background: "var(--a-accent)", fontSize: 12.5 }}
+			>
+				<Feather className="size-3.5" aria-hidden="true" />
+				{label}
+			</Link>
+		);
+	}
+	// directory
+	const href = isAuthenticated
+		? "/mentors/me/edit"
+		: "/login?next=/mentors/me/edit";
+	const label = isAuthenticated
+		? "メンターとして登録"
+		: "ログインしてメンター登録";
+	return (
+		<Link
+			href={href}
+			className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+			style={{ background: "var(--a-accent)", fontSize: 12.5 }}
+		>
+			<Users className="size-3.5" aria-hidden="true" />
+			{label}
+		</Link>
+	);
+}
+
+function RequestsList({
+	items,
+	tag,
+}: {
+	items: MentorRequestSummary[];
+	tag: string | undefined;
+}) {
+	if (items.length === 0) {
+		return (
+			<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
+				{tag
+					? `#${tag} の相談はまだありません。`
+					: "まだ相談がありません。 最初の相談を投稿してみませんか?"}
+			</p>
+		);
+	}
+	return (
+		<ul role="list" className="grid gap-3">
+			{items.map((req) => (
+				<li key={req.id}>
+					<MentorRequestCard request={req} />
+				</li>
+			))}
+		</ul>
+	);
+}
+
+function MentorsList({
+	items,
+	tag,
+}: {
+	items: MentorProfileDetail[];
+	tag: string | undefined;
+}) {
+	if (items.length === 0) {
+		return (
+			<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-10 text-center text-sm text-[color:var(--a-text-muted)]">
+				{tag
+					? `#${tag} の mentor はまだいません。`
+					: "受付中の mentor はまだいません。 自分が最初の 1 人になりませんか?"}
+			</p>
+		);
+	}
+	return (
+		<ul role="list" className="grid gap-3">
+			{items.map((m) => (
+				<li key={m.id}>
+					<MentorCard profile={m} />
+				</li>
+			))}
+		</ul>
+	);
+}
+
+function MentorRequestCard({ request }: { request: MentorRequestSummary }) {
+	return (
+		<Link
+			href={`/mentor/wanted/${request.id}`}
+			aria-label={`相談「${request.title}」 を開く`}
+			className="block rounded-lg border border-[color:var(--a-border)] p-4 transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+		>
+			<div className="flex items-center gap-2 text-xs text-[color:var(--a-text-muted)]">
+				<span>@{request.mentee.handle}</span>
+				<span aria-hidden="true">·</span>
+				<time dateTime={request.created_at}>
+					{formatJstDate(request.created_at)}
+				</time>
+				<span aria-hidden="true">·</span>
+				<span>提案 {request.proposal_count} 件</span>
+			</div>
+			<h2
+				className="mt-1 truncate font-semibold"
+				style={{ fontSize: 15, letterSpacing: -0.1 }}
+			>
+				{request.title}
+			</h2>
+			{request.target_skill_tags.length > 0 && (
+				<ul aria-label="関連スキル" className="mt-2 flex flex-wrap gap-1">
+					{request.target_skill_tags.map((t) => (
+						<li
+							key={t.name}
+							className="rounded-full bg-[color:var(--a-bg-muted)] px-2 py-0.5 text-xs text-[color:var(--a-text-muted)]"
+						>
+							#{t.display_name}
+						</li>
+					))}
+				</ul>
+			)}
+		</Link>
 	);
 }
 

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -79,16 +79,11 @@ const NAV_ITEMS: NavItemDef[] = [
 	},
 	{ href: "/articles", label: "記事", Icon: FileText },
 	{ href: "/boards", label: "掲示板", Icon: Flame },
-	// Phase 11 11-A (P11-09 follow-up): home (A direction) でも mentor board を
-	// 1 click 到達できるようにする。 既存 `leftNavLinks` (LeftNavbar / MobileNavbar
-	// 用、 X 風レイアウト) には追加済だが、 home が使う ALeftNav は別 list を持つ
-	// (#550 POC) ため、 ここにも明示する。
-	// #744: label を「メンター募集」 → 「相談を募集中」 / 「メンターを探す」 →
-	// 「メンター一覧」 (両方「メンター」 で始まって icon も people 系で synonym
-	// collision を起こしていたため、 board / directory の semantic を明示する形に)。
-	{ href: "/mentor/wanted", label: "相談を募集中", Icon: Handshake },
-	// Phase 11-B (P11-14): mentor 検索 (anon 可)。 「一覧」 で directory 明示。
-	{ href: "/mentors", label: "メンター一覧", Icon: Users },
+	// Phase 11 11-A (P11-09 follow-up): home (A direction) でも mentor surface を
+	// 1 click 到達できるようにする。
+	// #759: /mentor/wanted (相談 board) と /mentors (mentor 一覧) を
+	// /mentors?tab=requests|directory に統合。 nav 1 entry「メンター」 のみ。
+	{ href: "/mentors", label: "メンター", Icon: Handshake },
 	// Phase 14 (P14-05): Claude Agent。 ログイン必須 (Anthropic 課金で
 	// per-user 10/day 制限)。 leftNavLinks (X 風 LeftNavbar) と同 entry を
 	// A direction の home にも明示する。

--- a/client/src/components/layout-a/AMobileShell.tsx
+++ b/client/src/components/layout-a/AMobileShell.tsx
@@ -266,8 +266,8 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 		},
 		{ href: "/articles", label: "記事", Icon: FileText },
 		{ href: "/boards", label: "掲示板", Icon: Flame },
-		// #744: label を「メンター募集」 → 「相談を募集中」 に変更。
-		{ href: "/mentor/wanted", label: "相談を募集中", Icon: Handshake },
+		// #759: /mentor/wanted + /mentors → /mentors?tab=... に統合、 nav 1 entry。
+		{ href: "/mentors", label: "メンター", Icon: Handshake },
 		// Phase 14 (P14-05): Claude Agent。 leftNavLinks と同 entry を
 		// mobile drawer にも明示する。
 		{

--- a/client/src/components/mentorship/MentorsModeTabs.tsx
+++ b/client/src/components/mentorship/MentorsModeTabs.tsx
@@ -37,7 +37,7 @@ export default function MentorsModeTabs({ mode, tag }: MentorsModeTabsProps) {
 
 	return (
 		<nav
-			aria-label="メンター surface 切替"
+			aria-label="メンタータブ"
 			className="mb-4 grid grid-cols-2 rounded-md border border-[color:var(--a-border)] p-1"
 			style={{ background: "var(--a-bg-muted)" }}
 		>

--- a/client/src/components/mentorship/MentorsModeTabs.tsx
+++ b/client/src/components/mentorship/MentorsModeTabs.tsx
@@ -1,0 +1,64 @@
+/**
+ * MentorsModeTabs — `/mentors` page の tab 切替 (#759).
+ *
+ * Spec: docs/specs/mentor-merge-spec.md §1.4
+ *
+ * 旧 `/mentor/wanted` (相談 board) と `/mentors` (mentor directory) を
+ * 1 route + 2 tab に統合した際の tab UI。 SSR-friendly Link-based pattern
+ * (既存 `SearchModeTabs` の流儀)、 client state 不要。
+ *
+ * mode:
+ *   - "requests": 相談 board (`?tab=requests` or no query = default)
+ *   - "directory": mentor 一覧 (`?tab=directory`)
+ */
+
+import Link from "next/link";
+
+export type MentorsTabMode = "requests" | "directory";
+
+interface MentorsModeTabsProps {
+	mode: MentorsTabMode;
+	/** `?tag=<value>` filter を preserve するための tag (skill 等)。 */
+	tag?: string;
+}
+
+function hrefFor(mode: MentorsTabMode, tag?: string): string {
+	const params = new URLSearchParams();
+	params.set("tab", mode);
+	if (tag) params.set("tag", tag);
+	return `/mentors?${params.toString()}`;
+}
+
+export default function MentorsModeTabs({ mode, tag }: MentorsModeTabsProps) {
+	const tabs: Array<{ mode: MentorsTabMode; label: string }> = [
+		{ mode: "requests", label: "募集中の相談" },
+		{ mode: "directory", label: "メンター一覧" },
+	];
+
+	return (
+		<nav
+			aria-label="メンター surface 切替"
+			className="mb-4 grid grid-cols-2 rounded-md border border-[color:var(--a-border)] p-1"
+			style={{ background: "var(--a-bg-muted)" }}
+		>
+			{tabs.map((tab) => {
+				const active = tab.mode === mode;
+				return (
+					<Link
+						key={tab.mode}
+						href={hrefFor(tab.mode, tag)}
+						aria-current={active ? "page" : undefined}
+						className="rounded px-3 py-1.5 text-center text-sm font-medium transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+						style={{
+							background: active ? "var(--a-bg)" : "transparent",
+							color: active ? "var(--a-text)" : "var(--a-text-muted)",
+							boxShadow: active ? "0 1px 2px rgba(0,0,0,0.06)" : "none",
+						}}
+					>
+						{tab.label}
+					</Link>
+				);
+			})}
+		</nav>
+	);
+}

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -51,11 +51,12 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "FileText",
 	},
 	{
-		// Phase 11 (#625 / P11-06): mentor 募集 board。 匿名閲覧可。
+		// Phase 11 (#625 / P11-06): mentor surface。 匿名閲覧可。
 		// CLAUDE.md §9 「ホームから 3 click 以内で到達」 反省で LeftNav に追加。
-		// #744: label を「メンター募集」 → 「相談を募集中」 (synonym collision 解消)。
-		path: "/mentor/wanted",
-		label: "相談を募集中",
+		// #759: /mentor/wanted (相談 board) と /mentors (mentor 一覧) を
+		// /mentors?tab=requests|directory に統合。 nav も 1 entry に。
+		path: "/mentors",
+		label: "メンター",
 		iconName: "Handshake",
 	},
 	{

--- a/docs/specs/mentor-merge-spec.md
+++ b/docs/specs/mentor-merge-spec.md
@@ -1,0 +1,165 @@
+# mentor surfaces merge (`/mentors?tab=requests|directory`) 仕様 (#759)
+
+> Version: 0.1
+> 作成日: 2026-05-18
+> 関連 Issue: #759
+> 親 audit: ui-ux-tester re-audit (2026-05-18, verdict B2)
+> 親 spec: [`mentor-nav-labels-spec.md`](./mentor-nav-labels-spec.md) (#744 で label 改善、 本 PR で merge)
+
+---
+
+## 0. 背景
+
+#744 では「2 surface は orthogonal (LinkedIn Jobs vs People analog)」 として verdict B (label 改善のみで 2 entry 維持) を採用したが、 ハルナさん再指摘 (2026-05-18) で ui-ux-tester 再 audit。 verdict B2 で overturn:
+
+> Scale argument from #744 was wrong here. LinkedIn / Menta keep them split because they have 1M+ rows on each side, faceted search, etc. This product has 2 requests and 2 mentors total. A split UI for 4 rows is theater.
+
+機能的には別物だが、 現状のデータ量 (2+2 rows) と user mental task (mentee は 1 セッションで両方を visit する) から、 タブ統合が UX 上正解。 LinkedIn analog は scale 条件が違う。
+
+---
+
+## 1. 変更概要
+
+### 1.1 統合先 URL
+
+- `/mentors?tab=requests` — 相談 board (旧 /mentor/wanted)
+- `/mentors?tab=directory` — mentor 一覧 (旧 /mentors)
+- `/mentors` (no query) → default は `tab=requests` (mentee 視点で「まず募集を見る」 の方が natural な entry point)
+
+### 1.2 redirect
+
+- `/mentor/wanted` → 301 redirect to `/mentors?tab=requests` (server-side `redirect()`)
+- `/mentor/wanted/new` `/mentor/wanted/<id>` 等の sub-routes は **そのまま残す** (form / detail page は独立 surface、 redirect すると history が壊れる)
+
+### 1.3 nav 1 entry 化
+
+- `constants/index.ts`: 「相談を募集中」 entry 削除、 「メンター一覧」 → 「メンター」 (path `/mentors`)
+- `ALeftNav.tsx`: 同様 (2 entry → 1 entry)
+- `AMobileShell.tsx`: drawer に「メンター」 1 entry のみ
+
+### 1.4 Tab UI
+
+`MentorsModeTabs.tsx` を新規作成 (既存 `SearchModeTabs.tsx` の流儀):
+
+- SSR-friendly Link-based tabs (client state 不要、 SEO OK)
+- 2 tab: 「募集中の相談」 (requests) | 「メンター一覧」 (directory)
+- active state は `?tab=<mode>` で判定
+- query 文字列 (将来 `?tag=...` filter と組み合わせる場合) は preserve
+
+### 1.5 page logic
+
+`/mentors/page.tsx` の構造:
+
+```tsx
+const tab = searchParams?.tab === "directory" ? "directory" : "requests"; // default = requests
+
+const [requests, mentors] = await Promise.all([
+	tab === "requests" ? fetchRequestsSSR(tag) : Promise.resolve([]),
+	tab === "directory" ? fetchMentorsSSR(tag) : Promise.resolve([]),
+]);
+
+return (
+	<>
+		<header>...{tab === "requests" ? "相談" : "メンター一覧"} CTA</header>
+		<MentorsModeTabs mode={tab} tag={tag} />
+		{tab === "requests" ? (
+			<RequestsList items={requests} />
+		) : (
+			<MentorsList items={mentors} />
+		)}
+	</>
+);
+```
+
+### 1.6 CTA 動的切り替え
+
+- tab=requests のとき:
+  - auth: 「相談を投稿する」 → /mentor/wanted/new
+  - anon: 「ログインして相談する」 → /login?next=/mentor/wanted/new
+- tab=directory のとき:
+  - auth: 「メンターとして登録」 → /mentors/me/edit
+  - anon: 「ログインしてメンター登録」 → /login?next=/mentors/me/edit
+
+---
+
+## 2. 修正 file (推定 ~200-250 LOC)
+
+### 2.1 新規
+
+- `client/src/components/mentorship/MentorsModeTabs.tsx` (~50 LOC、 SearchModeTabs 流儀)
+
+### 2.2 修正
+
+- `client/src/app/(template)/mentors/page.tsx` (~100 LOC 拡張): tab branching + request board content embed
+- `client/src/app/(template)/mentor/wanted/page.tsx` (~5 LOC): redirect 化のみ
+- `client/src/constants/index.ts` (-7 / +3): nav entry 1 化
+- `client/src/components/layout-a/ALeftNav.tsx` (-3 / +1): 同
+- `client/src/components/layout-a/AMobileShell.tsx` (-1 / +1): label 更新のみ
+- `client/src/lib/layout/focused-surfaces.ts` (no change): /mentors と /mentor/wanted 両方 hide 済 (#758 で)
+
+### 2.3 test 追従
+
+- `client/e2e/mentor-board.spec.ts`: nav link 名「相談を募集中」 → 「メンター」、 navigate 先を /mentors?tab=requests に
+- 既存 `MentorRequestForm.test.tsx` 等は影響なし (form 自体は変わらない)
+
+### 2.4 spec doc
+
+- 本 spec doc 新規
+- `docs/specs/phase-11-mentor-board-spec.md` §7 route table に update note
+
+---
+
+## 3. やらない
+
+- `/mentor/wanted/<id>` 詳細ページの統合 (個別 deeplinkable surface として残す)
+- `/mentors/<handle>` 詳細ページの統合 (同上)
+- `/mentor/contracts/*` 系 (契約 surface は別 concern)
+- backend / API 変更 (`/api/v1/mentor/requests/`, `/api/v1/mentors/` はそのまま)
+- 旧 `/mentor/wanted` route の完全削除 (sub-routes が残るので親 directory は維持)
+
+---
+
+## 4. test
+
+### 4.1 unit
+
+- `MentorsModeTabs` の active state / href 生成 (vitest)
+- 既存 test 全 pass
+
+### 4.2 E2E
+
+`client/e2e/mentor-board.spec.ts` 更新:
+
+- nav 「メンター」 link click → `/mentors?tab=requests` (default) に到達
+- tab 「メンター一覧」 click → URL `/mentors?tab=directory`、 mentor cards 表示
+- tab 「募集中の相談」 click → URL `/mentors?tab=requests`、 request cards 表示
+- CTA 「相談を投稿する」 → `/mentor/wanted/new` に遷移
+- 旧 URL `/mentor/wanted` を直 navigate → `/mentors?tab=requests` に redirect
+
+### 4.3 完了判定
+
+- [ ] `/mentors` (default) で tab UI が「募集中の相談」 active、 request board content 表示
+- [ ] `?tab=directory` で mentor directory に切り替え
+- [ ] 旧 `/mentor/wanted` 直 URL → redirect で /mentors?tab=requests
+- [ ] 左 nav 「メンター」 1 entry のみ
+- [ ] CTA が tab に応じて切り替わる
+- [ ] anon でも tab 切り替え可能、 投稿時のみ auth gate
+- [ ] tsc / lint / vitest 全 green
+- [ ] stg で Playwright MCP で nav + tab 切替 + redirect を verify
+
+---
+
+## 5. ロールバック
+
+- PR revert 1 発で復旧
+- backend / API / DB 不変
+- 既存 link / bookmark の `/mentor/wanted` は redirect 経由で動き続ける (revert しても元の page に戻るだけ)
+
+---
+
+## 6. 関連
+
+- 親 audit: #744 (verdict B、 overturned)
+- re-audit: 2026-05-18 ui-ux-tester (verdict B2)
+- 親 spec: `docs/specs/mentor-nav-labels-spec.md`, `docs/specs/phase-11-mentor-board-spec.md`
+- 連動 PR: #760 (#758 rail hide。 統合後も /mentors は rail なしの state を維持)


### PR DESCRIPTION
Closes #759

## Summary

#744 で「2 surface は orthogonal」 として verdict B (label 改善のみ、 2 entry 維持) を採用したが、 ハルナさん再指摘 (2026-05-18) を受けて ui-ux-tester re-audit (verdict B2) で overturn。 LinkedIn analog の scale 条件 (1M+ rows) はうち (2+2 rows) に当てはまらず、 タブ統合が UX 上正解と判断。

### Before / After

| | before (#744 後) | after (#759) |
|---|---|---|
| route | /mentor/wanted + /mentors (2 route) | /mentors?tab=requests + /mentors?tab=directory (1 route + 2 tab) |
| nav | 「相談を募集中」 + 「メンター一覧」 (2 entry) | 「メンター」 (1 entry、 default = requests tab) |
| CTA | 各 page 固定 | tab に応じて動的切替 (相談を投稿する / メンターとして登録) |
| 旧 URL | 直 navigate | /mentor/wanted → /mentors?tab=requests に 301 redirect |

詳細: [`docs/specs/mentor-merge-spec.md`](../blob/feature/issue-759-mentor-merge/docs/specs/mentor-merge-spec.md)

## 変更ファイル (8 files, +506 / -227)

### 新規
- `client/src/components/mentorship/MentorsModeTabs.tsx` (SSR-friendly Link tabs、 SearchModeTabs 流儀)
- `docs/specs/mentor-merge-spec.md`

### 修正
- `client/src/app/(template)/mentors/page.tsx` (tab branching + 両 content embed、 CTA 動的切替)
- `client/src/app/(template)/mentor/wanted/page.tsx` (redirect 化のみ)
- `client/src/constants/index.ts` (2 entry → 1 entry)
- `client/src/components/layout-a/ALeftNav.tsx` (同)
- `client/src/components/layout-a/AMobileShell.tsx` (同)
- `client/e2e/mentor-board.spec.ts` (nav link 名追従 + MENTOR-2 を redirect 検証に + MENTOR-2b 新設)

## Test plan

- [x] `tsc --noEmit` → 0 errors
- [x] `vitest run` → 101 files / 839 tests pass (+4 tests from MentorsModeTabs 抽出は省略、 既存 spec で挙動 cover)
- [ ] サブエージェント (typescript-reviewer + code-reviewer + a11y-architect)
- [ ] stg verify: nav 1 entry / tab 切替 / redirect / CTA 動的切替 を Playwright MCP で確認

## やらない (out of scope)

- `/mentor/wanted/<id>` 詳細 page (個別 deeplinkable surface)
- `/mentors/<handle>` 詳細 page (同上)
- backend / API / model 名
- /mentor/contracts/* 系

## Rollback

PR revert 1 発で復旧。 backend / API / DB 不変。 既存 /mentor/wanted 経由の bookmark は revert しても元 page に戻るだけ。

## 連動 PR

- #760 (#758) で /mentors と /mentor/wanted 両方が rail hide 済 → 統合後も rail なしの state を維持。