### PR TITLE
[security][xss] Django + Next.js security headers + CSP report-only 配備 (#763)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 588
+        "line_number": 603
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T07:28:51Z"
+  "generated_at": "2026-05-18T03:20:14Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "config/settings/base.py",
         "hashed_secret": "0e2e61ee729cb98085cc76e518bb34fba9afd365",
         "is_verified": false,
-        "line_number": 603
+        "line_number": 605
       }
     ],
     "docs/operations/email-auth.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-18T03:20:14Z"
+  "generated_at": "2026-05-18T03:35:15Z"
 }

--- a/client/e2e/security-headers.spec.ts
+++ b/client/e2e/security-headers.spec.ts
@@ -58,4 +58,19 @@ test.describe("#763 Security headers (Next.js middleware)", () => {
 
 		await api.dispose();
 	});
+
+	test("SECURITY-HEADERS-3: _next/static は matcher 除外で CSP が乗らない", async () => {
+		// /_next/static/* は middleware の matcher 除外対象。
+		// CSP / Permissions-Policy が emit されないことを検証 (asset chunk が
+		// CSP 違反で blocked されないための保険)。
+		const api = await request.newContext();
+		const response = await api.get(`${BASE}/_next/static/`);
+
+		const headers = response.headers();
+		// CSP は middleware からのみ emit される。 static asset には乗らない。
+		expect(headers["content-security-policy-report-only"]).toBeUndefined();
+		expect(headers["permissions-policy"]).toBeUndefined();
+
+		await api.dispose();
+	});
 });

--- a/client/e2e/security-headers.spec.ts
+++ b/client/e2e/security-headers.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * #763 Security headers E2E — Next.js middleware が emit する HTTP headers の検証.
+ *
+ * Spec: docs/specs/xss-defense-spec.md §6.1
+ *
+ * 検証:
+ *   - SECURITY-HEADERS-1: / (home) response に security headers 4 種が乗る
+ *   - SECURITY-HEADERS-2: /explore (anon-accessible) でも同様に乗る
+ *   - SECURITY-HEADERS-3: Next.js 内部 (`/_next/static/*`) には乗らない (matcher 除外)
+ *
+ * 実行:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     npx playwright test e2e/security-headers.spec.ts --reporter=line
+ */
+
+import { expect, request, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+test.describe("#763 Security headers (Next.js middleware)", () => {
+	test("SECURITY-HEADERS-1: / response に必須 headers が乗る", async () => {
+		const api = await request.newContext();
+		const response = await api.get(`${BASE}/`);
+		expect(response.status()).toBeLessThan(500);
+
+		const headers = response.headers();
+
+		// X-Content-Type-Options: nosniff
+		expect(headers["x-content-type-options"]).toBe("nosniff");
+
+		// Referrer-Policy: strict-origin-when-cross-origin
+		expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+
+		// Permissions-Policy: camera/mic/geo を deny
+		expect(headers["permissions-policy"]).toContain("camera=()");
+		expect(headers["permissions-policy"]).toContain("microphone=()");
+		expect(headers["permissions-policy"]).toContain("geolocation=()");
+
+		// CSP report-only (Phase 1)
+		const csp = headers["content-security-policy-report-only"];
+		expect(csp).toBeTruthy();
+		expect(csp).toContain("default-src 'self'");
+		expect(csp).toContain("frame-ancestors 'none'");
+		expect(csp).toContain("object-src 'none'");
+
+		await api.dispose();
+	});
+
+	test("SECURITY-HEADERS-2: /explore (anon) でも同 headers が乗る", async () => {
+		const api = await request.newContext();
+		const response = await api.get(`${BASE}/explore`);
+		expect(response.status()).toBeLessThan(500);
+
+		const headers = response.headers();
+		expect(headers["x-content-type-options"]).toBe("nosniff");
+		expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+		expect(headers["content-security-policy-report-only"]).toBeTruthy();
+
+		await api.dispose();
+	});
+});

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -1,0 +1,79 @@
+/**
+ * Next.js middleware — HTTP security headers (#763).
+ *
+ * Spec: docs/specs/xss-defense-spec.md §3.2
+ *
+ * 全 HTML response に以下の security headers を emit する:
+ *
+ * - **X-Content-Type-Options: nosniff** — browser の MIME sniffing 防止
+ * - **Referrer-Policy: strict-origin-when-cross-origin** — full URL leak 防止
+ * - **Permissions-Policy** — camera/microphone/geolocation 等の機能 access を全 deny
+ * - **Content-Security-Policy-Report-Only** — XSS 最終防衛線。 Phase 1 は
+ *   report-only mode で配備 (漏れ検出のみ、 既存機能は壊さない)。 Phase 2 で
+ *   nonce 実装 + enforce 移行 (別 PR)。
+ *
+ * Django 側 (`config/settings/base.py` + `production.py`) でも独立に
+ * SECURE_HSTS_SECONDS / SECURE_CONTENT_TYPE_NOSNIFF / SECURE_REFERRER_POLICY を
+ * 設定済。 これは API response (HTML を返さない) の保護。 Next.js middleware は
+ * frontend HTML response の保護。
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * CSP report-only mode (Phase 1)。
+ *
+ * 注意:
+ * - script-src に 'unsafe-inline' 'unsafe-eval' を許容している。 Next.js / Tailwind
+ *   の inline script / runtime style 注入で必要。 Phase 2 で nonce-based に切替予定。
+ * - img-src は data: / blob: / 全 https を許容 (S3 / CloudFront / 外部画像 OGP 等)。
+ * - connect-src は wss: (WebSocket DM) + Sentry を allowlist。
+ * - frame-ancestors 'none' で clickjacking 対策 (Django X-Frame-Options と重ね)。
+ *
+ * 詳細: docs/specs/xss-defense-spec.md §3.2
+ */
+const CSP_DIRECTIVES = [
+	"default-src 'self'",
+	"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+	"style-src 'self' 'unsafe-inline'",
+	"img-src 'self' data: https: blob:",
+	"font-src 'self' data:",
+	"connect-src 'self' wss: https://*.sentry.io",
+	"media-src 'self' https: blob:",
+	"frame-src 'none'",
+	"frame-ancestors 'none'",
+	"object-src 'none'",
+	"base-uri 'self'",
+	"form-action 'self'",
+	"upgrade-insecure-requests",
+].join("; ");
+
+export function middleware(_request: NextRequest) {
+	const response = NextResponse.next();
+
+	// MIME sniffing 防止
+	response.headers.set("X-Content-Type-Options", "nosniff");
+
+	// Referrer leak 防止 (Sentry / CDN への referrer に handle/article slug が leak しない)
+	response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+
+	// 不要な browser 機能 access を全 deny (SNS で camera/mic/GPS は使わない)
+	response.headers.set(
+		"Permissions-Policy",
+		"camera=(), microphone=(), geolocation=()",
+	);
+
+	// CSP report-only (Phase 1)。 Phase 2 で nonce 実装 + enforce 移行。
+	response.headers.set("Content-Security-Policy-Report-Only", CSP_DIRECTIVES);
+
+	return response;
+}
+
+/**
+ * matcher: security headers が必要なのは HTML response のみ。
+ * Next.js 内部 (`_next/static`, `_next/image`, `favicon.ico`) は skip。
+ */
+export const config = {
+	matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -72,8 +72,9 @@ export function middleware(_request: NextRequest) {
 
 /**
  * matcher: security headers が必要なのは HTML response のみ。
- * Next.js 内部 (`_next/static`, `_next/image`, `favicon.ico`) は skip。
+ * Next.js 内部 (`_next/static`, `_next/image`, `favicon.ico`) と
+ * Sentry tunnel route (`monitoring/sentry`、 proxied JSON) は skip。
  */
 export const config = {
-	matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+	matcher: ["/((?!_next/static|_next/image|favicon.ico|monitoring).*)"],
 };

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -426,6 +426,21 @@ CSRF_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SAMESITE = "Lax"
 
+# #763: HTTP security headers (XSS / clickjacking / referrer / MIME sniff の defense-in-depth)。
+# Django SecurityMiddleware が emit する response headers を有効化する。
+# spec: docs/specs/xss-defense-spec.md §3.1
+#
+# - SECURE_CONTENT_TYPE_NOSNIFF: X-Content-Type-Options: nosniff を emit
+#   (browser の MIME sniffing 攻撃を防ぐ、 例: image/png として upload された HTML が
+#   text/html として実行される問題を弾く)
+# - SECURE_BROWSER_XSS_FILTER: X-XSS-Protection: 1; mode=block を emit (legacy、
+#   modern browsers は ignore するが scanner / 古い browser 向けに残す)
+# - SECURE_REFERRER_POLICY: strict-origin-when-cross-origin で full URL leak を防ぐ
+#   (Sentry / CDN への referrer に handle / article slug などが leak しない)
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
 # F1-6: CORS 設定。Next.js frontend からの cross-origin リクエストを許可。
 # stg/prod では env CORS_ALLOWED_ORIGINS (カンマ区切り) を必須化。
 # local では空のままで django-cors-headers の default 動作 (全 origin 拒否) になるが、

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -433,12 +433,14 @@ SESSION_COOKIE_SAMESITE = "Lax"
 # - SECURE_CONTENT_TYPE_NOSNIFF: X-Content-Type-Options: nosniff を emit
 #   (browser の MIME sniffing 攻撃を防ぐ、 例: image/png として upload された HTML が
 #   text/html として実行される問題を弾く)
-# - SECURE_BROWSER_XSS_FILTER: X-XSS-Protection: 1; mode=block を emit (legacy、
-#   modern browsers は ignore するが scanner / 古い browser 向けに残す)
 # - SECURE_REFERRER_POLICY: strict-origin-when-cross-origin で full URL leak を防ぐ
 #   (Sentry / CDN への referrer に handle / article slug などが leak しない)
+#
+# 注: `SECURE_BROWSER_XSS_FILTER` (X-XSS-Protection) は Django 4.0+ で
+# SecurityMiddleware が無視するようになった。 modern browsers (Chrome 78+, Firefox 全 ver)
+# も非サポート。 必要なら nginx / ALB 側で header injection するか custom middleware を
+# 立てる。 ここでは emit しない。
 SECURE_CONTENT_TYPE_NOSNIFF = True
-SECURE_BROWSER_XSS_FILTER = True
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
 # F1-6: CORS 設定。Next.js frontend からの cross-origin リクエストを許可。

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -79,13 +79,23 @@ STATIC_URL = "/static/"
 # THROTTLE_RATES が import 時に固定されるため、production.py での後付け
 # override は無効だった)。本ファイルでは throttle 関連 override は行わない。
 
-# #763: HSTS (HTTP Strict Transport Security)。 production 専用 (stg は短期 max-age
-# でも browser cache に長期残るのを避けたいので production のみ有効化)。
+# #763: HSTS (HTTP Strict Transport Security)。
 # spec: docs/specs/xss-defense-spec.md §3.1
 #
-# - max-age=31536000 (1 year): 業界標準
-# - includeSubDomains: 全 subdomain に HSTS 適用 (api.example.com / *.codeplace.me 等)
-# - preload: HSTS preload list (https://hstspreload.org/) 提出可能、 hardest 保護
-SECURE_HSTS_SECONDS = 31_536_000  # 1 year
-SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-SECURE_HSTS_PRELOAD = True
+# stg と production 両方が DJANGO_SETTINGS_MODULE=config.settings.production で動くため、
+# env `HSTS_PROFILE` で profile 切替する。 default は safe (stg) = 5 分。
+# production environment では ECS task definition で HSTS_PROFILE=production を inject。
+#
+# - HSTS_PROFILE=production: max-age=31536000 (1 year) + includeSubDomains + preload
+#   (業界標準、 真の本番ドメインで HSTS preload list 提出可能、 hardest 保護)
+# - HSTS_PROFILE=stg (default): max-age=300 (5 分)
+#   (stg は domain 切替 / 停止リスクがあるので browser cache に長期残らないよう短く)
+_HSTS_PROFILE = getenv("HSTS_PROFILE", "stg")
+if _HSTS_PROFILE == "production":
+    SECURE_HSTS_SECONDS = 31_536_000  # 1 year
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+else:
+    SECURE_HSTS_SECONDS = 300  # 5 min, stg-safe
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+    SECURE_HSTS_PRELOAD = False

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -78,3 +78,14 @@ STATIC_URL = "/static/"
 # 定義時に分岐させる方針に変更 (DRF SimpleRateThrottle の class-level
 # THROTTLE_RATES が import 時に固定されるため、production.py での後付け
 # override は無効だった)。本ファイルでは throttle 関連 override は行わない。
+
+# #763: HSTS (HTTP Strict Transport Security)。 production 専用 (stg は短期 max-age
+# でも browser cache に長期残るのを避けたいので production のみ有効化)。
+# spec: docs/specs/xss-defense-spec.md §3.1
+#
+# - max-age=31536000 (1 year): 業界標準
+# - includeSubDomains: 全 subdomain に HSTS 適用 (api.example.com / *.codeplace.me 等)
+# - preload: HSTS preload list (https://hstspreload.org/) 提出可能、 hardest 保護
+SECURE_HSTS_SECONDS = 31_536_000  # 1 year
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True

--- a/docs/specs/xss-defense-spec.md
+++ b/docs/specs/xss-defense-spec.md
@@ -1,0 +1,211 @@
+# XSS 防御 / Security Headers 仕様 (#763)
+
+> Version: 0.1
+> 作成日: 2026-05-18
+> 関連 Issue: #763
+> 関連 audit: security-reviewer 2026-05-18 (systematic audit + 2026 industry baseline 比較)
+> 関連 PR: 過去 #134 (tweet sanitize), #198 (DOMPurify 2-layer), 本 PR (security headers + spec 集約)
+
+---
+
+## 0. 目的
+
+ハルナさん指摘 (2026-05-18):
+
+> 掲示板とか SNS 投稿とかにおいて格納型のクロスサイトスクリプティング対策は現在どうしていますか？ とくに対策していなかったら 5ch とか X とかほかの有名な投稿サイトの対策を調べて、 このアプリも同じように対策してよ。 どういう対策をしているか仕様にも書いておいて。
+
+本 spec で:
+
+1. 既存の defense-in-depth (bleach + DOMPurify) の流儀を文書化
+2. 2026 industry baseline (X / GitHub / Reddit / 5ch) 比較
+3. **gap fix**: Security headers 追加 (Django + Next.js)、 CSP 配備 (report-only → enforce 段階)
+4. 新規投稿 surface 追加時のチェックリスト
+
+---
+
+## 1. 現状サマリ (security-reviewer audit 2026-05-18)
+
+### 1.1 各 surface の sanitize 流儀
+
+| surface                                     | backend sanitize                                                                                                                                       | frontend sanitize                                             | gap                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | -------------------------------------- |
+| **Tweet** (`apps/tweets/`)                  | markdown2 → bleach.clean (allowlist) → linkify、 javascript:/data: 弾く、 protocol-relative URL strip、 `target="_blank" rel="nofollow noopener"` 強制 | DOMPurify (`sanitizeTweetHtml.ts`) + ExpandableBody useEffect | NONE (#134 で security-reviewer 通過)  |
+| **Article** (`apps/articles/`)              | 同 bleach 流儀 + `_MAX_BODY_BYTES=100_000` DoS guard + `noreferrer`                                                                                    | DOMPurify (`ArticleBody.tsx` useEffect)                       | NONE                                   |
+| **Board** (`apps/boards/`)                  | **なし** (raw TextField のみ)                                                                                                                          | React text node 自動 escape (`ThreadPostItem.tsx`)            | MEDIUM (将来 rich-text 化で破綻リスク) |
+| **DM** (`apps/dm/`)                         | strip whitespace のみ                                                                                                                                  | React text node 自動 escape (`MessageBubble.tsx`)             | MEDIUM (同上)                          |
+| **Mentorship** (`apps/mentorship/`)         | **なし** (raw TextField のみ)                                                                                                                          | React text node 自動 escape                                   | MEDIUM (同上)                          |
+| **Profile** (display_name / bio / headline) | Django CharField (自動 escape)                                                                                                                         | React text node 自動 escape                                   | MEDIUM (同上)                          |
+
+### 1.2 Security Headers 現状
+
+| header                            | status                                            | 推奨                                                                       |
+| --------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
+| `Content-Security-Policy`         | **未設定** (Next.js / Django / nginx すべて 0 件) | 本 PR で追加 (report-only 先行)                                            |
+| `X-Frame-Options: DENY`           | ✅ (Django default、 clickjacking 対策)           | keep + CSP `frame-ancestors 'none'` で重ね                                 |
+| `X-Content-Type-Options: nosniff` | **未設定**                                        | 本 PR で追加 (Django `SECURE_CONTENT_TYPE_NOSNIFF=True`)                   |
+| `Strict-Transport-Security`       | **未設定**                                        | 本 PR で追加 (production のみ、 `SECURE_HSTS_SECONDS=31536000`)            |
+| `Referrer-Policy`                 | **未設定**                                        | 本 PR で追加 (`strict-origin-when-cross-origin`)                           |
+| `Permissions-Policy`              | **未設定**                                        | 本 PR で追加 (`camera=(), microphone=(), geolocation=()`)                  |
+| `X-XSS-Protection`                | **未設定**                                        | 本 PR で追加 (legacy だが scanner 対策、 `SECURE_BROWSER_XSS_FILTER=True`) |
+
+---
+
+## 2. 2026 Industry baseline 比較
+
+| platform        | CSP strategy                                                                                            |
+| --------------- | ------------------------------------------------------------------------------------------------------- |
+| **X (Twitter)** | nonce-based `script-src`, `frame-ancestors 'none'`, `Referrer-Policy: strict-origin-when-cross-origin`  |
+| **GitHub**      | 最も厳しい UGC CSP: nonce 毎 script、 `default-src 'none'` ベース、 directive ごとに explicit allowlist |
+| **5ch**         | server-rendered HTML、 JS 実行なし → CSP 最小 or なし (legacy)。 比較対象として参考にならない           |
+| **Reddit**      | report-only で長期配備 → 漏れ検出後 enforce (cautious rollout model)                                    |
+
+うちは **Reddit 流儀の段階的配備** を採用: report-only で先行 → 漏れ検出 → nonce 実装 → enforce。
+
+---
+
+## 3. 修正方針 (本 PR scope)
+
+### 3.1 Django security headers (cheap、 5 行追加)
+
+`config/settings/base.py`:
+
+```python
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+```
+
+`config/settings/production.py`:
+
+```python
+SECURE_HSTS_SECONDS = 31536000  # 1 year
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True
+```
+
+### 3.2 Next.js security headers + CSP middleware
+
+`client/src/middleware.ts` 新規:
+
+```ts
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+	const response = NextResponse.next();
+
+	// Security headers (Next.js 側、 Django だけだと frontend response に乗らない)
+	response.headers.set("X-Content-Type-Options", "nosniff");
+	response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+	response.headers.set(
+		"Permissions-Policy",
+		"camera=(), microphone=(), geolocation=()",
+	);
+
+	// CSP report-only 配備 (Phase 1)。 漏れ検出後 nonce 実装 + enforce 移行 (Phase 2 別 PR)。
+	// - 'unsafe-inline' は Tailwind / Next.js script に必要 (nonce 化は Phase 2)
+	// - img-src は S3 / CloudFront を allowlist
+	// - connect-src は Sentry tunnel (/monitoring/sentry) + WebSocket
+	const csp = [
+		"default-src 'self'",
+		"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' data: https: blob:",
+		"font-src 'self' data:",
+		"connect-src 'self' wss: https://*.sentry.io",
+		"media-src 'self' https: blob:",
+		"frame-src 'none'",
+		"frame-ancestors 'none'",
+		"object-src 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+		"upgrade-insecure-requests",
+	].join("; ");
+
+	// Phase 1: report-only で漏れ検出のみ。 enforce は Phase 2 で nonce 実装後。
+	response.headers.set("Content-Security-Policy-Report-Only", csp);
+
+	return response;
+}
+
+export const config = {
+	matcher: [
+		// Skip Next internals + static assets (security headers は HTML response にだけ必要)
+		"/((?!_next/static|_next/image|favicon.ico).*)",
+	],
+};
+```
+
+### 3.3 spec doc 集約 (本 file)
+
+各 surface の sanitize 流儀 + CSP 仕様 + 新規 surface 追加時 checklist を **1 ヶ所に集約**。 SPEC.md の各機能 § には「XSS 対策: bleach + DOMPurify + CSP (詳細: `docs/specs/xss-defense-spec.md`)」 と 1 行追記する future PR を別出し。
+
+---
+
+## 4. やらない (本 PR scope 外、 別 issue で対応)
+
+- **CSP enforce 移行 + nonce 実装** → Phase 2 別 PR (本 PR は report-only)
+- **Board / DM / Mentorship / Profile 用 backend shared sanitizer** → 別 issue (現状 React 自動 escape で安全、 防御深化として別 PR)
+- **bleach `div[class]` allowlist 厳格化** → 別 issue (M-3、 attack surface 小)
+- **subresource integrity (SRI) for third-party scripts** → 現状 third-party script ほぼなし、 別 issue
+- **WAF (AWS WAF) 導入** → infra issue
+
+---
+
+## 5. 新規投稿 surface 追加時 checklist
+
+1. **backend**: user-input field を model に追加するとき、 raw `TextField` で保存するなら frontend で必ず React text node (auto-escape) で render する旨を comment に明記
+2. **HTML rendering したいなら**: `apps/tweets/rendering.py` の bleach pipeline を流用 (`render_markdown_html` 等)。 新規に bleach allowlist を作らない
+3. **frontend `dangerouslySetInnerHTML`**: 必ず DOMPurify を経由 (`isomorphic-dompurify`、 useEffect で client-side 適用)
+4. **新規 third-party domain**: img / connect / script src を Next.js middleware の CSP に追加 (例: 新規 CDN、 analytics)
+5. **CSP violation report**: stg / production の CSP-Report-Only が出す violation を Sentry / structlog で監視 (#763 後続 issue)
+
+---
+
+## 6. テスト
+
+### 6.1 unit / E2E
+
+- 既存 sanitize 流儀の test (`sanitizeTweetHtml.test.ts`, `ArticleBody.test.tsx` 等) は不変
+- 新規: `client/e2e/security-headers.spec.ts` (新規) で:
+  - `/` response に `X-Content-Type-Options: nosniff` が乗っているか
+  - `Referrer-Policy: strict-origin-when-cross-origin` が乗っているか
+  - `Content-Security-Policy-Report-Only` header が乗っているか (Phase 1)
+  - `frame-ancestors 'none'` を含むか
+
+### 6.2 完了判定
+
+- [ ] Django settings 3 + 3 行追加、 base.py / production.py で test 全 pass
+- [ ] Next.js `middleware.ts` 新規、 stg response に security headers が乗る
+- [ ] CSP report-only 配備、 violation report がない (or 想定範囲内)
+- [ ] spec doc (本 file) が完成
+- [ ] tsc / lint / vitest / pytest 全 green
+- [ ] stg で curl で headers 確認
+
+---
+
+## 7. ロールバック
+
+- Django settings 削除のみで back to なし state (HSTS 1 year は browser cache に残るので production deploy 前に十分検証する)
+- Next.js `middleware.ts` 削除で headers なし
+- CSP は report-only 配備のため violation で機能が壊れることはない (= safe rollout)
+
+---
+
+## 8. Phase 2 (別 PR、 本 PR scope 外) の outline
+
+- **CSP nonce 実装**: Next.js middleware で `crypto.randomUUID()` で nonce 生成、 root layout に inject、 enforce mode 切替
+- **CSP violation reporting endpoint**: `/api/v1/csp-report/` 新設、 Sentry に転送
+- **Backend shared sanitizer**: `apps/common/sanitize.py` で `clean_plaintext(text: str) -> str` を統一 helper、 全 user-input fields の `clean()` で適用
+
+---
+
+## 9. 関連
+
+- 親 audit: security-reviewer 2026-05-18 (systematic XSS audit + 2026 industry baseline)
+- 過去 sanitize 系 PR: #134 (tweet), #198 (DOMPurify 2-layer)
+- 参考:
+  - [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+  - [MDN CSP guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+  - [Django Security Settings](https://docs.djangoproject.com/en/5.0/ref/settings/#security)
+  - [Next.js Security Headers](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy)

--- a/docs/specs/xss-defense-spec.md
+++ b/docs/specs/xss-defense-spec.md
@@ -38,15 +38,15 @@
 
 ### 1.2 Security Headers 現状
 
-| header                            | status                                            | 推奨                                                                       |
-| --------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
-| `Content-Security-Policy`         | **未設定** (Next.js / Django / nginx すべて 0 件) | 本 PR で追加 (report-only 先行)                                            |
-| `X-Frame-Options: DENY`           | ✅ (Django default、 clickjacking 対策)           | keep + CSP `frame-ancestors 'none'` で重ね                                 |
-| `X-Content-Type-Options: nosniff` | **未設定**                                        | 本 PR で追加 (Django `SECURE_CONTENT_TYPE_NOSNIFF=True`)                   |
-| `Strict-Transport-Security`       | **未設定**                                        | 本 PR で追加 (production のみ、 `SECURE_HSTS_SECONDS=31536000`)            |
-| `Referrer-Policy`                 | **未設定**                                        | 本 PR で追加 (`strict-origin-when-cross-origin`)                           |
-| `Permissions-Policy`              | **未設定**                                        | 本 PR で追加 (`camera=(), microphone=(), geolocation=()`)                  |
-| `X-XSS-Protection`                | **未設定**                                        | 本 PR で追加 (legacy だが scanner 対策、 `SECURE_BROWSER_XSS_FILTER=True`) |
+| header                            | status                                            | 推奨                                                                      |
+| --------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------- |
+| `Content-Security-Policy`         | **未設定** (Next.js / Django / nginx すべて 0 件) | 本 PR で追加 (report-only 先行)                                           |
+| `X-Frame-Options: DENY`           | ✅ (Django default、 clickjacking 対策)           | keep + CSP `frame-ancestors 'none'` で重ね                                |
+| `X-Content-Type-Options: nosniff` | **未設定**                                        | 本 PR で追加 (Django `SECURE_CONTENT_TYPE_NOSNIFF=True`)                  |
+| `Strict-Transport-Security`       | **未設定**                                        | 本 PR で追加 (env `HSTS_PROFILE`、 stg=5min / production=1year + preload) |
+| `Referrer-Policy`                 | **未設定**                                        | 本 PR で追加 (`strict-origin-when-cross-origin`)                          |
+| `Permissions-Policy`              | **未設定**                                        | 本 PR で追加 (`camera=(), microphone=(), geolocation=()`)                 |
+| `X-XSS-Protection`                | **未設定** (Django 4.0+ で middleware が無視)     | emit しない (modern browsers 非サポート、 legacy scanner は nginx 側で)   |
 
 ---
 
@@ -71,16 +71,23 @@
 
 ```python
 SECURE_CONTENT_TYPE_NOSNIFF = True
-SECURE_BROWSER_XSS_FILTER = True
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+# 注: SECURE_BROWSER_XSS_FILTER は Django 4.0+ で middleware が無視するので emit しない
 ```
 
-`config/settings/production.py`:
+`config/settings/production.py` — stg と production 両方が `config.settings.production`
+を load するため、 env `HSTS_PROFILE` で profile 切替する:
 
 ```python
-SECURE_HSTS_SECONDS = 31536000  # 1 year
-SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-SECURE_HSTS_PRELOAD = True
+_HSTS_PROFILE = getenv("HSTS_PROFILE", "stg")  # default は safe
+if _HSTS_PROFILE == "production":
+    SECURE_HSTS_SECONDS = 31_536_000  # 1 year
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+else:
+    SECURE_HSTS_SECONDS = 300  # 5 min stg-safe (domain 切替リスク回避)
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+    SECURE_HSTS_PRELOAD = False
 ```
 
 ### 3.2 Next.js security headers + CSP middleware
@@ -187,7 +194,7 @@ export const config = {
 
 ## 7. ロールバック
 
-- Django settings 削除のみで back to なし state (HSTS 1 year は browser cache に残るので production deploy 前に十分検証する)
+- Django settings 削除のみで back to なし state (stg は HSTS max-age=300 のみ、 5 分で browser cache 失効。 production profile を有効化するのは真の本番ドメイン確定後)
 - Next.js `middleware.ts` 削除で headers なし
 - CSP は report-only 配備のため violation で機能が壊れることはない (= safe rollout)
 

--- a/docs/specs/xss-defense-spec.md
+++ b/docs/specs/xss-defense-spec.md
@@ -130,8 +130,9 @@ export function middleware(request: NextRequest) {
 
 export const config = {
 	matcher: [
-		// Skip Next internals + static assets (security headers は HTML response にだけ必要)
-		"/((?!_next/static|_next/image|favicon.ico).*)",
+		// Skip Next internals + static assets + Sentry tunnel (security headers は HTML response にだけ必要)
+		// `monitoring` は Sentry tunnel route (proxied JSON、 HTML ではない)
+		"/((?!_next/static|_next/image|favicon.ico|monitoring).*)",
 	],
 };
 ```


### PR DESCRIPTION
Closes #763

## Summary

ハルナさん指摘「掲示板とか SNS 投稿の格納型 XSS 対策、 X / 5ch と同じように対策して、 仕様にも書いて」 を受けて security-reviewer に systematic audit させ、 4 HIGH (CSP 全くなし / NOSNIFF 未設定 / HSTS 未設定 / Referrer-Policy 未設定) を Reddit 流儀の段階的配備で対応。

既存 sanitize (tweet/article は bleach + DOMPurify defense-in-depth 完備、 board/dm/mentorship/profile は React 自動 escape) と、 industry baseline (X / GitHub / Reddit / 5ch) 比較を spec doc に集約。

### Before / After

| 項目 | before | after |
|---|---|---|
| `X-Content-Type-Options: nosniff` | 未設定 | **設定済** (Django + Next.js 両方) |
| `Strict-Transport-Security` | 未設定 | **1 year preload** (production のみ) |
| `Referrer-Policy` | 未設定 | **strict-origin-when-cross-origin** |
| `Permissions-Policy` | 未設定 | **camera/mic/geo deny** |
| `Content-Security-Policy` | 未設定 | **Report-Only 配備** (Phase 1、 漏れ検出のみ) |
| XSS 対策仕様の集約 | なし | **`docs/specs/xss-defense-spec.md`** |

## 変更ファイル (6 files, +379 / -2)

- `config/settings/base.py` (Django security headers 3 行追加)
- `config/settings/production.py` (HSTS 3 行追加、 production 限定)
- `client/src/middleware.ts` (新規、 Next.js security headers + CSP)
- `client/e2e/security-headers.spec.ts` (新規、 headers 検証)
- `docs/specs/xss-defense-spec.md` (新規、 全 surface sanitize 流儀 + industry baseline + 段階配備 plan)
- `.secrets.baseline` (auto update)

## Test plan

- [x] `tsc --noEmit` → 0 errors
- [x] `vitest run` → 101 files / 839 tests pass
- [x] Django settings load verification (base + production env complete)
- [ ] サブエージェント (security-reviewer + code-reviewer)
- [ ] stg deploy 後: `curl -I https://stg.codeplace.me/` で security headers 確認、 CSP violation report 監視 (Sentry / structlog)

## 段階的配備 (本 PR は Phase 1)

- **Phase 1 (本 PR)**: report-only 配備、 既存機能を壊さず漏れ検出のみ
- **Phase 2 (別 PR)**: nonce 実装 + enforce 移行 + CSP violation 報告 endpoint 新設

## やらない (別 issue で対応)

- Board / DM / Mentorship / Profile 用 backend shared sanitizer (現状 React escape で安全、 defense-in-depth として別 PR)
- bleach `div[class]` 厳格化
- SRI / AWS WAF (別 infra issue)

## Rollback

`config/settings/{base,production}.py` の追加行と `client/src/middleware.ts` 削除で復旧。 ただし HSTS は browser cache に 1 year 残るため、 production deploy 前に十分検証。 CSP は report-only 配備なので既存機能を壊さない (safe rollout)。