### PR TITLE
[feature][tweets] composer 内に下書き呼び出し button + DraftsLoadDialog (#767)

### DIFF
--- a/client/e2e/tweet-drafts-load.spec.ts
+++ b/client/e2e/tweet-drafts-load.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * #767 Tweet drafts load E2E — composer 内から下書きを呼び出す flow の検証。
+ *
+ * Spec: docs/specs/tweet-drafts-load-spec.md §4.2
+ *
+ * 検証:
+ *   - DRAFTS-LOAD-1: composer の「下書き」 button → DraftsLoadDialog 開く + 一覧表示
+ *   - DRAFTS-LOAD-2: 一覧から行 click → composer に body load + 編集中 indicator 表示
+ *   - DRAFTS-LOAD-3: 「下書き」 → 削除 button → 確認 → 行が消える
+ *
+ * 実行:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     E2E_LOGIN_EMAIL=test4@example.com E2E_LOGIN_PASSWORD=E5INn9EaBLG7WNPl \
+ *     npx playwright test e2e/tweet-drafts-load.spec.ts --reporter=line
+ *
+ * env 詳細: docs/local/e2e-stg.md
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+const EMAIL = process.env.E2E_LOGIN_EMAIL ?? "test4@example.com";
+const PASSWORD = process.env.E2E_LOGIN_PASSWORD ?? "E5INn9EaBLG7WNPl";
+
+test.describe("#767 tweet drafts load from composer (logged-in)", () => {
+	test.beforeEach(async ({ page }) => {
+		// stg / local 共通: handle test4 で login → home へ。
+		await page.goto(`${BASE}/login`);
+		await page.getByLabel(/メール/).fill(EMAIL);
+		await page.getByLabel(/パスワード/).fill(PASSWORD);
+		await page.getByRole("button", { name: /ログイン/ }).click();
+		await page.waitForURL(/\/home$|\/home\//);
+	});
+
+	test("DRAFTS-LOAD-1: 「下書き」 button click で dialog が開き、 一覧表示される", async ({
+		page,
+	}) => {
+		// home composer は section[aria-labelledby=...] で wrap されている
+		const composer = page
+			.locator("section")
+			.filter({ hasText: "投稿" })
+			.first();
+		await composer
+			.getByRole("button", { name: "下書き一覧から呼び出す" })
+			.click();
+
+		await expect(page.getByRole("heading", { name: "下書き一覧" })).toBeVisible(
+			{ timeout: 10_000 },
+		);
+
+		// 一覧 or empty state のどちらかが見える
+		const list = page.getByTestId("drafts-load-list");
+		const empty = page.getByText("下書きはまだありません");
+		await expect(list.or(empty)).toBeVisible();
+	});
+
+	test("DRAFTS-LOAD-2: 行 click で composer に body load + 編集中 indicator 表示", async ({
+		page,
+	}) => {
+		// 事前準備: 1 件下書きを作っておく (composer から save)。
+		const composer = page
+			.locator("section")
+			.filter({ hasText: "投稿" })
+			.first();
+		const textarea = composer.getByRole("textbox", { name: /ツイート本文/ });
+		await textarea.fill("e2e-drafts-load preflight " + Date.now());
+		await composer
+			.getByRole("button", { name: "下書きとして保存する" })
+			.click();
+		await expect(page.getByText("下書きに保存しました")).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// 下書き呼び出し
+		await composer
+			.getByRole("button", { name: "下書き一覧から呼び出す" })
+			.click();
+		await expect(
+			page.getByRole("heading", { name: "下書き一覧" }),
+		).toBeVisible();
+
+		const list = page.getByTestId("drafts-load-list");
+		await expect(list).toBeVisible();
+		await list.getByRole("button", { name: /編集$/ }).first().click();
+
+		// dialog 閉じる
+		await expect(
+			page.getByRole("heading", { name: "下書き一覧" }),
+		).not.toBeVisible();
+
+		// composer に body が load された + indicator が出る
+		await expect(textarea).not.toHaveValue("");
+		await expect(
+			composer.getByTestId("composer-loaded-draft-indicator"),
+		).toHaveText(/下書きを編集中/);
+	});
+
+	test("DRAFTS-LOAD-3: 削除 button → confirm OK で行が消える", async ({
+		page,
+	}) => {
+		// 事前準備: 1 件下書きを作る
+		const composer = page
+			.locator("section")
+			.filter({ hasText: "投稿" })
+			.first();
+		const uniqueBody = "e2e-drafts-load delete " + Date.now();
+		await composer
+			.getByRole("textbox", { name: /ツイート本文/ })
+			.fill(uniqueBody);
+		await composer
+			.getByRole("button", { name: "下書きとして保存する" })
+			.click();
+		await expect(page.getByText("下書きに保存しました")).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// 削除 flow
+		page.once("dialog", (d) => d.accept());
+		await composer
+			.getByRole("button", { name: "下書き一覧から呼び出す" })
+			.click();
+
+		const list = page.getByTestId("drafts-load-list");
+		await expect(list).toBeVisible();
+
+		// 一覧の中から該当 row の削除 button (aria-label 経由)
+		const deleteButton = list.getByRole("button", {
+			name: new RegExp(
+				`下書き「${uniqueBody.slice(0, 20).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}」を削除する`,
+			),
+		});
+		await deleteButton.click();
+
+		await expect(page.getByText("下書きを削除しました")).toBeVisible({
+			timeout: 10_000,
+		});
+		await expect(list.getByText(uniqueBody)).not.toBeVisible();
+	});
+});

--- a/client/src/components/tweets/DraftsLoadDialog.tsx
+++ b/client/src/components/tweets/DraftsLoadDialog.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+/**
+ * #767 DraftsLoadDialog — TweetComposer 内から下書きを呼び出す modal。
+ *
+ * spec: docs/specs/tweet-drafts-load-spec.md §3
+ *
+ * UX:
+ * - mount で `GET /tweets/drafts/` を fetch、 新→古 一覧表示
+ * - 各 row: body preview (2 行 truncate) + relative datetime + 「編集」「削除」
+ * - 「編集」 click → onPick(draft) callback (parent composer に body load)
+ * - 「削除」 click → confirm → DELETE → 一覧から消える + toast
+ * - 0 件のとき empty state「下書きはまだありません」
+ * - 401 → 「ログインが必要です」 toast (composer は閉じない、 router で /login へ)
+ *
+ * tag 編集は V1 で skip (backend serializer の update が body のみ受付。
+ * tag 編集は別 issue で backend 拡張後)。
+ */
+
+import { useEffect, useState } from "react";
+import { AxiosError } from "axios";
+import { FileText, Loader2, Pencil, Trash2 } from "lucide-react";
+import { toast } from "react-toastify";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { formatJstDateTime } from "@/lib/datetime";
+import { deleteTweet, fetchDrafts, type TweetSummary } from "@/lib/api/tweets";
+
+interface DraftsLoadDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** 行 click で composer に load する callback。 dialog は自動で閉じる。 */
+	onPick: (draft: TweetSummary) => void;
+}
+
+export default function DraftsLoadDialog({
+	open,
+	onOpenChange,
+	onPick,
+}: DraftsLoadDialogProps) {
+	const [drafts, setDrafts] = useState<TweetSummary[] | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
+		setIsLoading(true);
+		fetchDrafts()
+			.then((page) => {
+				if (!cancelled) setDrafts(page.results);
+			})
+			.catch((e: unknown) => {
+				if (cancelled) return;
+				const status = e instanceof AxiosError ? e.response?.status : undefined;
+				toast.error(
+					status === 401
+						? "ログインが必要です。"
+						: "下書きの取得に失敗しました",
+				);
+				setDrafts([]);
+			})
+			.finally(() => {
+				if (!cancelled) setIsLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open]);
+
+	const onDelete = async (id: number) => {
+		if (!window.confirm("この下書きを削除しますか？")) return;
+		setPendingDeleteId(id);
+		try {
+			await deleteTweet(id);
+			setDrafts((prev) => (prev ?? []).filter((d) => d.id !== id));
+			toast.success("下書きを削除しました");
+		} catch (e) {
+			const status = e instanceof AxiosError ? e.response?.status : undefined;
+			toast.error(
+				status === 401
+					? "ログインが必要です。"
+					: status === 404
+						? "既に削除されています"
+						: "削除に失敗しました",
+			);
+		} finally {
+			setPendingDeleteId(null);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>下書き一覧</DialogTitle>
+					<DialogDescription>
+						保存済みの下書きから 1 件選んで composer に呼び出します。
+					</DialogDescription>
+				</DialogHeader>
+
+				{isLoading && (
+					<div
+						className="flex items-center justify-center py-10 text-muted-foreground"
+						role="status"
+						aria-live="polite"
+					>
+						<Loader2 className="mr-2 h-5 w-5 animate-spin" />
+						<span>読み込み中…</span>
+					</div>
+				)}
+
+				{!isLoading && drafts && drafts.length === 0 && (
+					<div
+						className="flex flex-col items-center gap-2 py-10 text-muted-foreground"
+						role="status"
+					>
+						<FileText className="h-8 w-8 opacity-50" />
+						<p className="text-sm">下書きはまだありません</p>
+					</div>
+				)}
+
+				{!isLoading && drafts && drafts.length > 0 && (
+					<ul className="flex flex-col gap-2" data-testid="drafts-load-list">
+						{drafts.map((draft) => (
+							<li
+								key={draft.id}
+								className="flex flex-col gap-2 rounded-md border bg-card p-3 sm:flex-row sm:items-start sm:justify-between"
+							>
+								<div className="min-w-0 flex-1">
+									<p className="line-clamp-2 whitespace-pre-wrap break-words text-sm">
+										{draft.body}
+									</p>
+									<p className="mt-1 text-xs text-muted-foreground">
+										{formatJstDateTime(draft.created_at)}
+									</p>
+								</div>
+								<div className="flex shrink-0 items-center gap-2">
+									<Button
+										type="button"
+										size="sm"
+										variant="outline"
+										onClick={() => onPick(draft)}
+										aria-label={`下書き「${draft.body.slice(0, 20)}」を編集する`}
+									>
+										<Pencil className="mr-1 h-3.5 w-3.5" />
+										編集
+									</Button>
+									<Button
+										type="button"
+										size="sm"
+										variant="ghost"
+										disabled={pendingDeleteId === draft.id}
+										onClick={() => onDelete(draft.id)}
+										aria-label={`下書き「${draft.body.slice(0, 20)}」を削除する`}
+									>
+										{pendingDeleteId === draft.id ? (
+											<Loader2 className="h-3.5 w-3.5 animate-spin" />
+										) : (
+											<Trash2 className="h-3.5 w-3.5" />
+										)}
+									</Button>
+								</div>
+							</li>
+						))}
+					</ul>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/client/src/components/tweets/DraftsLoadDialog.tsx
+++ b/client/src/components/tweets/DraftsLoadDialog.tsx
@@ -40,6 +40,11 @@ interface DraftsLoadDialogProps {
 	onPick: (draft: TweetSummary) => void;
 }
 
+/** aria-label 用に body を 20 文字で truncate。 越えた場合は …  を末尾につける。 */
+function truncatedLabel(body: string): string {
+	return body.length > 20 ? body.slice(0, 20) + "…" : body;
+}
+
 export default function DraftsLoadDialog({
 	open,
 	onOpenChange,
@@ -52,6 +57,9 @@ export default function DraftsLoadDialog({
 	useEffect(() => {
 		if (!open) return;
 		let cancelled = false;
+		// reviewer M3: open 再 toggle で前回 list が flash する問題回避のため
+		// fetch 開始時に drafts を null (= loading) に戻す。
+		setDrafts(null);
 		setIsLoading(true);
 		fetchDrafts()
 			.then((page) => {
@@ -148,7 +156,7 @@ export default function DraftsLoadDialog({
 										size="sm"
 										variant="outline"
 										onClick={() => onPick(draft)}
-										aria-label={`下書き「${draft.body.slice(0, 20)}」を編集する`}
+										aria-label={`下書き「${truncatedLabel(draft.body)}」を編集する`}
 									>
 										<Pencil className="mr-1 h-3.5 w-3.5" />
 										編集
@@ -159,7 +167,7 @@ export default function DraftsLoadDialog({
 										variant="ghost"
 										disabled={pendingDeleteId === draft.id}
 										onClick={() => onDelete(draft.id)}
-										aria-label={`下書き「${draft.body.slice(0, 20)}」を削除する`}
+										aria-label={`下書き「${truncatedLabel(draft.body)}」を削除する`}
 									>
 										{pendingDeleteId === draft.id ? (
 											<Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/client/src/components/tweets/TweetComposer.tsx
+++ b/client/src/components/tweets/TweetComposer.tsx
@@ -4,10 +4,16 @@ import React, { useCallback, useId, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 
 import Spinner from "@/components/shared/Spinner";
+import DraftsLoadDialog from "@/components/tweets/DraftsLoadDialog";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useAutoSaveDraft } from "@/hooks/useAutoSaveDraft";
-import { createTweet, type TweetSummary } from "@/lib/api/tweets";
+import {
+	createTweet,
+	publishDraft,
+	updateTweet,
+	type TweetSummary,
+} from "@/lib/api/tweets";
 import { parseDrfErrors } from "@/lib/api/errors";
 import { TWEET_MAX_CHARS, countTweetChars } from "@/lib/tweets/charCount";
 
@@ -60,6 +66,11 @@ export default function TweetComposer({
 	// 「下書き保存」 button だけ spinner にできるようにする。
 	const [isSavingDraft, setIsSavingDraft] = useState(false);
 	const [summaryError, setSummaryError] = useState<string | undefined>();
+	// #767: 下書き呼び出し dialog の open state、 + load 中の draft id 保持。
+	// `loadedDraftId !== null` の間は「既存 draft 編集モード」 で、
+	// saveDraft / submit が新規 create ではなく既存 draft を update / publish する。
+	const [isDraftsDialogOpen, setIsDraftsDialogOpen] = useState(false);
+	const [loadedDraftId, setLoadedDraftId] = useState<number | null>(null);
 
 	const charCount = useMemo(() => countTweetChars(body), [body]);
 	const remaining = TWEET_MAX_CHARS - charCount;
@@ -117,7 +128,15 @@ export default function TweetComposer({
 		setIsSubmitting(true);
 		setSummaryError(undefined);
 		try {
-			const tweet = await createTweet({ body, tags });
+			let tweet: TweetSummary;
+			if (loadedDraftId !== null) {
+				// #767: 既存 draft 編集モード → body update してから publish。
+				// tags 編集は V1 で skip (backend serializer の update が body のみ受付)。
+				await updateTweet(loadedDraftId, { body });
+				tweet = await publishDraft(loadedDraftId);
+			} else {
+				tweet = await createTweet({ body, tags });
+			}
 			onPosted?.(tweet);
 			toast.success("投稿しました");
 			// #739: 送信成功で autosave key を確実に消す (setBody("") の debounce
@@ -125,12 +144,13 @@ export default function TweetComposer({
 			clearBodyAutosave();
 			setTags([]);
 			setTagInput("");
+			setLoadedDraftId(null);
 		} catch (error) {
 			setSummaryError(parseDrfErrors(error).summary);
 		} finally {
 			setIsSubmitting(false);
 		}
-	}, [body, tags, canSubmit, onPosted, clearBodyAutosave]);
+	}, [body, tags, canSubmit, loadedDraftId, onPosted, clearBodyAutosave]);
 
 	/**
 	 * #734: 下書き保存。 POST /tweets/ {is_draft: true} で published_at=NULL の
@@ -143,13 +163,19 @@ export default function TweetComposer({
 		setIsSavingDraft(true);
 		setSummaryError(undefined);
 		try {
-			await createTweet({ body, tags, is_draft: true });
+			if (loadedDraftId !== null) {
+				// #767: 既存 draft 編集モード → body のみ update (tags update は V1 skip)。
+				await updateTweet(loadedDraftId, { body });
+			} else {
+				await createTweet({ body, tags, is_draft: true });
+			}
 			toast.success("下書きに保存しました");
 			// #739: server 下書き保存後は autosave も clear (= 同じ内容を 2 重に
 			// 保持しない、 次に composer を開いたら空に戻る)。
 			clearBodyAutosave();
 			setTags([]);
 			setTagInput("");
+			setLoadedDraftId(null);
 			// onPosted は public TL refresh trigger のため、 draft では呼ばない
 			// (= home TL に出ない投稿なので refresh しても無意味)。
 		} catch (error) {
@@ -157,7 +183,26 @@ export default function TweetComposer({
 		} finally {
 			setIsSavingDraft(false);
 		}
-	}, [body, tags, canSaveDraft, clearBodyAutosave]);
+	}, [body, tags, canSaveDraft, loadedDraftId, clearBodyAutosave]);
+
+	/**
+	 * #767: DraftsLoadDialog で行 click した時の callback。 composer body を
+	 * draft.body で上書き、 loadedDraftId を保持して「既存 draft 編集モード」
+	 * に入る。 dialog は閉じる。
+	 *
+	 * tags は V1 で空にする (backend の update が body のみ受付なので、 tags を
+	 * 表示しても保存できない混乱を避ける)。
+	 */
+	const onPickDraft = useCallback(
+		(draft: TweetSummary) => {
+			setBody(draft.body);
+			setTags([]);
+			setTagInput("");
+			setLoadedDraftId(draft.id);
+			setIsDraftsDialogOpen(false);
+		},
+		[setBody],
+	);
 
 	const onBodyKey = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
@@ -246,6 +291,15 @@ export default function TweetComposer({
 				<div className="flex items-center gap-2">
 					<Button
 						type="button"
+						variant="ghost"
+						onClick={() => setIsDraftsDialogOpen(true)}
+						disabled={isSubmitting || isSavingDraft}
+						aria-label="下書き一覧から呼び出す"
+					>
+						下書き
+					</Button>
+					<Button
+						type="button"
 						variant="outline"
 						onClick={saveDraft}
 						disabled={!canSaveDraft}
@@ -258,6 +312,22 @@ export default function TweetComposer({
 					</Button>
 				</div>
 			</div>
+
+			{loadedDraftId !== null && (
+				<p
+					className="text-xs text-muted-foreground"
+					role="status"
+					data-testid="composer-loaded-draft-indicator"
+				>
+					下書きを編集中 — 「投稿」 で公開、 「下書き保存」 で上書き
+				</p>
+			)}
+
+			<DraftsLoadDialog
+				open={isDraftsDialogOpen}
+				onOpenChange={setIsDraftsDialogOpen}
+				onPick={onPickDraft}
+			/>
 
 			{summaryError && (
 				<p

--- a/client/src/components/tweets/TweetComposer.tsx
+++ b/client/src/components/tweets/TweetComposer.tsx
@@ -133,6 +133,10 @@ export default function TweetComposer({
 				// #767: 既存 draft 編集モード → body update してから publish。
 				// tags 編集は V1 で skip (backend serializer の update が body のみ受付)。
 				await updateTweet(loadedDraftId, { body });
+				// updateTweet 成功時点で server 側 draft body が確定したので、
+				// publish 前に autosave key を clear (publish が落ちても data drift
+				// しないため、 typescript-reviewer H1)。
+				clearBodyAutosave();
 				tweet = await publishDraft(loadedDraftId);
 			} else {
 				tweet = await createTweet({ body, tags });

--- a/client/src/components/tweets/TweetComposer.tsx
+++ b/client/src/components/tweets/TweetComposer.tsx
@@ -200,6 +200,11 @@ export default function TweetComposer({
 	const onPickDraft = useCallback(
 		(draft: TweetSummary) => {
 			setBody(draft.body);
+			// NOTE: draft.tags は意図的に load しない (spec §2 「やらない」)。
+			// 現状 backend serializer の update が body のみ受付なので、 tags を
+			// 復元しても update できず、 publish 時にだけ tag が消えるという
+			// 混乱を招く。 V2 で backend 側 tags 更新が入ったら draft.tags を
+			// setTags(draft.tags) で復元する。
 			setTags([]);
 			setTagInput("");
 			setLoadedDraftId(draft.id);

--- a/client/src/components/tweets/__tests__/DraftsLoadDialog.test.tsx
+++ b/client/src/components/tweets/__tests__/DraftsLoadDialog.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * #767: DraftsLoadDialog vitest。
+ *
+ * カバレッジ:
+ * - DRAFTS-LOAD-DIALOG-1: open=true で fetchDrafts 呼ばれる、 一覧表示
+ * - DRAFTS-LOAD-DIALOG-2: 0 件で「下書きはまだありません」
+ * - DRAFTS-LOAD-DIALOG-3: 「編集」 click で onPick(draft) 呼ばれる
+ * - DRAFTS-LOAD-DIALOG-4: 「削除」 confirm OK → deleteTweet 呼ばれる + 行消える
+ * - DRAFTS-LOAD-DIALOG-5: 401 → 「ログインが必要です」 toast
+ */
+
+import {
+	cleanup,
+	render,
+	screen,
+	waitFor,
+	within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AxiosError, AxiosHeaders } from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DraftsLoadDialog from "@/components/tweets/DraftsLoadDialog";
+
+const { fetchDraftsMock, deleteTweetMock, toastSuccessSpy, toastErrorSpy } =
+	vi.hoisted(() => ({
+		fetchDraftsMock: vi.fn(),
+		deleteTweetMock: vi.fn(),
+		toastSuccessSpy: vi.fn(),
+		toastErrorSpy: vi.fn(),
+	}));
+
+vi.mock("@/lib/api/tweets", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/tweets")>(
+			"@/lib/api/tweets",
+		);
+	return {
+		...actual,
+		fetchDrafts: fetchDraftsMock,
+		deleteTweet: deleteTweetMock,
+	};
+});
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+const draft = (id: number, body: string) => ({
+	id,
+	body,
+	html: body,
+	char_count: body.length,
+	author_handle: "alice",
+	tags: [],
+	images: [],
+	created_at: "2026-05-14T00:00:00Z",
+	updated_at: "2026-05-14T00:00:00Z",
+	edit_count: 0,
+	published_at: null,
+});
+
+const page = (results: ReturnType<typeof draft>[]) => ({
+	count: results.length,
+	next: null,
+	previous: null,
+	results,
+});
+
+describe("DraftsLoadDialog (#767)", () => {
+	beforeEach(() => {
+		fetchDraftsMock.mockReset();
+		deleteTweetMock.mockReset();
+		toastSuccessSpy.mockReset();
+		toastErrorSpy.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("DRAFTS-LOAD-DIALOG-1: fetches drafts on open + renders list", async () => {
+		fetchDraftsMock.mockResolvedValueOnce(
+			page([draft(1, "first draft"), draft(2, "second draft")]),
+		);
+
+		render(
+			<DraftsLoadDialog
+				open={true}
+				onOpenChange={() => {}}
+				onPick={() => {}}
+			/>,
+		);
+
+		await waitFor(() => expect(fetchDraftsMock).toHaveBeenCalledTimes(1));
+		await waitFor(() =>
+			expect(screen.getByText("first draft")).toBeInTheDocument(),
+		);
+		expect(screen.getByText("second draft")).toBeInTheDocument();
+	});
+
+	it("DRAFTS-LOAD-DIALOG-2: empty state when no drafts", async () => {
+		fetchDraftsMock.mockResolvedValueOnce(page([]));
+
+		render(
+			<DraftsLoadDialog
+				open={true}
+				onOpenChange={() => {}}
+				onPick={() => {}}
+			/>,
+		);
+
+		await waitFor(() =>
+			expect(screen.getByText("下書きはまだありません")).toBeInTheDocument(),
+		);
+	});
+
+	it("DRAFTS-LOAD-DIALOG-3: edit click invokes onPick", async () => {
+		const user = userEvent.setup();
+		const onPick = vi.fn();
+		fetchDraftsMock.mockResolvedValueOnce(page([draft(1, "pick me")]));
+
+		render(
+			<DraftsLoadDialog open={true} onOpenChange={() => {}} onPick={onPick} />,
+		);
+
+		const list = await screen.findByTestId("drafts-load-list");
+		const editButton = within(list).getByRole("button", { name: /編集/ });
+		await user.click(editButton);
+
+		expect(onPick).toHaveBeenCalledTimes(1);
+		expect(onPick.mock.calls[0][0]).toMatchObject({ id: 1, body: "pick me" });
+	});
+
+	it("DRAFTS-LOAD-DIALOG-4: delete with confirm removes row", async () => {
+		const user = userEvent.setup();
+		fetchDraftsMock.mockResolvedValueOnce(
+			page([draft(1, "to delete"), draft(2, "keep me")]),
+		);
+		deleteTweetMock.mockResolvedValueOnce(undefined);
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+		render(
+			<DraftsLoadDialog
+				open={true}
+				onOpenChange={() => {}}
+				onPick={() => {}}
+			/>,
+		);
+
+		const list = await screen.findByTestId("drafts-load-list");
+		const deleteButtons = within(list).getAllByRole("button", {
+			name: /削除する/,
+		});
+		await user.click(deleteButtons[0]);
+
+		await waitFor(() => expect(deleteTweetMock).toHaveBeenCalledWith(1));
+		expect(toastSuccessSpy).toHaveBeenCalledWith("下書きを削除しました");
+		expect(screen.queryByText("to delete")).not.toBeInTheDocument();
+		expect(screen.getByText("keep me")).toBeInTheDocument();
+		confirmSpy.mockRestore();
+	});
+
+	it("DRAFTS-LOAD-DIALOG-5: 401 fetch shows auth toast", async () => {
+		fetchDraftsMock.mockRejectedValueOnce(
+			new AxiosError("unauth", "401", undefined, undefined, {
+				status: 401,
+				statusText: "Unauthorized",
+				data: {},
+				headers: {},
+				config: { headers: new AxiosHeaders() },
+			} as any),
+		);
+
+		render(
+			<DraftsLoadDialog
+				open={true}
+				onOpenChange={() => {}}
+				onPick={() => {}}
+			/>,
+		);
+
+		await waitFor(() =>
+			expect(toastErrorSpy).toHaveBeenCalledWith("ログインが必要です。"),
+		);
+	});
+});

--- a/docs/specs/tweet-drafts-load-spec.md
+++ b/docs/specs/tweet-drafts-load-spec.md
@@ -1,0 +1,165 @@
+# Tweet 下書き呼び出し (composer 内) 仕様 (#767)
+
+> Version: 0.1
+> 作成日: 2026-05-18
+> 関連 Issue: #767
+> 関連 PR: #734 (drafts API + /drafts page)、 #762 / PR #764 (drafts nav の X 流儀整理)、 本 PR (composer 内呼び出し)
+> 関連 spec: [tweet-drafts-spec.md](./tweet-drafts-spec.md), [tweet-composer-autosave-spec.md](./tweet-composer-autosave-spec.md)
+
+---
+
+## 0. 目的
+
+ハルナさん指摘 (2026-05-18):
+
+> X と同じ仕様にするなら投稿画面で下書きを呼び出せるようにするべきでは？ X の仕様を調べて同じように実装してよ。
+
+現状 (#734 / #762 時点):
+
+- 下書きは `/drafts` page (= profile dropdown menu からのみ到達) の **一覧 page** で編集 / 公開できる
+- TweetComposer (= ホーム画面 / Compose dialog) 内には **下書きの呼び出し UI がない** → composer から書き始めた user は別途 `/drafts` page に遷移しないと過去の下書きを load できない
+
+X (Twitter / X.com) の流儀では composer 内に「Drafts」 entry があり、 一度の click で過去の下書きを呼び出して書き続けられる。 同じ流儀をこのアプリにも入れる。
+
+---
+
+## 1. X の流儀 (2024-2026 web/mobile 共通)
+
+1. composer (新規投稿 dialog) を開く → 右下に「Drafts」 text link (media icon の隣)
+2. click すると modal overlay で `Drafts` 一覧が開く (新→古)
+3. 各 row: body preview (1-2 行) + relative time、 tap で composer に load
+4. load 後の composer は「元の draft を編集中」 状態:
+   - 「下書きに保存」 push → 既存 draft を **更新** (新規作成しない)
+   - 「Post」 push → 既存 draft を **公開** (= draft 削除 + 同じ ID で published tweet 作成)
+5. drafts modal の右上に「Edit」 (= multi-select 削除モード切替) と close
+6. draft 編集中に composer を閉じようとすると「保存しないと変更失われる」 確認 alert (= ブラウザ navigation guard)
+
+---
+
+## 2. やる / やらない (V1)
+
+### やる (V1)
+
+- DraftsLoadDialog 新規 component (modal overlay、 一覧 + 行 click で load + 削除 button)
+- TweetComposer に「下書き」 entry button 追加 (右下、 「下書き保存」 button の隣)
+- 編集 click で composer の **body のみ** load + `loadedDraftId` state 保持
+- 「下書き保存」 push 時 `loadedDraftId` あれば PATCH /tweets/<id>/ {body}、 無ければ POST /tweets/ {body, is_draft:true}
+- 「投稿」 push 時 `loadedDraftId` あれば PATCH /tweets/<id>/ {body} → POST /tweets/<id>/publish/、 無ければ POST /tweets/ {body, tags, is_draft:false}
+- 削除 click → 確認 dialog → DELETE /tweets/<id>/ → 一覧から消える
+- composer 閉じても draft 削除しない (= server draft はそのまま残る)
+- 成功 / reset 時に `setLoadedDraftId(null)` で「新規モード」 に戻す
+
+### やらない (別 Issue で対応)
+
+- multi-select 削除 mode (X の Edit button)
+- media / image 復元 (現状 image attachment 機能なし)
+- 「保存しないと変更失われる」 navigation guard alert (autosave で書きかけ復元できるので V1 では skip)
+- /drafts page の廃止 (依然 profile menu からの一覧入口として残す)
+- **tag 編集** (現状 backend serializer の update が body のみ受付。 tag 編集は別 issue で backend 拡張後に対応。 V1 では load 時に composer の tags 入力は空のまま、 publish 時に user が再入力)
+
+---
+
+## 3. 実装方針
+
+### 3.1 API は既存を使い回す (backend 変更最小)
+
+| 操作            | endpoint                            | 現状                                                                             |
+| --------------- | ----------------------------------- | -------------------------------------------------------------------------------- |
+| 下書き一覧取得  | `GET /api/v1/tweets/drafts/`        | ✅ (`fetchDrafts`)                                                               |
+| 下書き 1 件取得 | `GET /api/v1/tweets/<id>/`          | ✅ (`fetchTweet`)                                                                |
+| 下書き更新      | `PATCH /api/v1/tweets/<id>/`        | ✅ (`updateTweet`、 ただし payload `{ body }` のみ → **本 PR で `tags` も対応**) |
+| 下書き公開      | `POST /api/v1/tweets/<id>/publish/` | ✅ (`publishDraft`)                                                              |
+| 下書き削除      | `DELETE /api/v1/tweets/<id>/`       | ✅ (`deleteTweet`)                                                               |
+
+唯一の backend 変更: `updateTweet` payload に `tags?: string[]` を許容。 既存 serializer が draft 編集時に tags 更新を受け付けているか確認、 必要なら serializer 拡張。
+
+### 3.2 frontend 構成
+
+- **`client/src/components/tweets/DraftsLoadDialog.tsx`** 新規 (~150 行)
+
+  - Radix Dialog overlay
+  - mount で `fetchDrafts()` → drafts state
+  - 各 row: body preview + datetime + 「編集」 (= `onPick(draft)` callback) / 「削除」 button
+  - 0 件のとき empty state「下書きはまだありません」
+
+- **`client/src/components/tweets/TweetComposer.tsx`** 改 (~50 行追加)
+  - 右下に「下書き」 text button 追加 (`下書き保存` button の左隣)
+  - click で DraftsLoadDialog open
+  - `loadedDraftId: number | null` state 追加
+  - `onPick(draft)`: composer の body / tags を draft の値で上書き、 `loadedDraftId = draft.id` 保持、 DraftsLoadDialog close、 textarea に focus 戻す
+  - `saveDraft()` 既存修正: `loadedDraftId` あれば `updateTweet(loadedDraftId, { body, tags })`、 無ければ既存 `createTweet({ body, tags, is_draft: true })`
+  - `submit()` 既存修正: `loadedDraftId` あれば `updateTweet(loadedDraftId, { body, tags })` → `publishDraft(loadedDraftId)`、 無ければ既存 `createTweet({ body, tags, is_draft: false })`
+  - 成功 / reset 時に `setLoadedDraftId(null)` で「新規モード」 に戻す
+
+### 3.3 UI 配置 (X と同じ)
+
+```
++---------------------------------------+
+| (avatar) [textarea            ]       |
+|                                       |
+| #tag1 #tag2 [Add tag…]                |
+|                                       |
+| 0 / 280               [下書き] [下書き保存] [投稿] |
++---------------------------------------+
+```
+
+- 「下書き」 = 過去の下書きを呼び出す (本 PR 新規)
+- 「下書き保存」 = 今書いてる内容を server に保存
+- 「投稿」 = 公開
+
+---
+
+## 4. テスト
+
+### 4.1 Unit (Vitest)
+
+- `DraftsLoadDialog.test.tsx`
+  - **DRAFTS-LOAD-DIALOG-1**: mount で `fetchDrafts` 呼ばれる、 drafts が一覧表示される
+  - **DRAFTS-LOAD-DIALOG-2**: 0 件のとき empty state 「下書きはまだありません」
+  - **DRAFTS-LOAD-DIALOG-3**: 「編集」 click で `onPick(draft)` 呼ばれる
+  - **DRAFTS-LOAD-DIALOG-4**: 「削除」 click → confirm → `deleteTweet` 呼ばれる、 行が消える
+  - **DRAFTS-LOAD-DIALOG-5**: 401 → 「ログインが必要です」 toast
+- `TweetComposerDraftLoad.test.tsx` (新規 or 既存 TweetComposerDraft.test.tsx 拡張)
+  - **COMPOSER-LOAD-1**: 「下書き」 button click で DraftsLoadDialog open
+  - **COMPOSER-LOAD-2**: onPick で composer の body / tags が draft 値に上書きされる、 `loadedDraftId` 保持
+  - **COMPOSER-LOAD-3**: loadedDraftId あり時の `saveDraft` → `updateTweet` 呼ばれる、 `createTweet` 呼ばれない
+  - **COMPOSER-LOAD-4**: loadedDraftId あり時の `submit` → `updateTweet` → `publishDraft` 連続呼ばれる
+  - **COMPOSER-LOAD-5**: 成功後 `loadedDraftId` が null にリセットされる
+
+### 4.2 E2E (Playwright on stg)
+
+`client/e2e/tweet-drafts-load.spec.ts` 新規:
+
+- **DRAFTS-LOAD-1**: test4 ログイン → ホーム → 「下書き」 click → DraftsLoadDialog 開く → 一覧表示
+- **DRAFTS-LOAD-2**: 一覧から行 click → composer に body load される → 「投稿」 → 公開成功 (TL に表示、 /drafts から消える)
+- **DRAFTS-LOAD-3**: composer 内「下書き」 click → 削除 button → 確認 → /drafts からも消える
+
+実行:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+  npx playwright test e2e/tweet-drafts-load.spec.ts --reporter=line
+```
+
+env は [docs/local/e2e-stg.md](../local/e2e-stg.md) 参照。
+
+---
+
+## 5. 受け入れ基準 (definition of done)
+
+- [ ] composer に「下書き」 button 追加、 click で DraftsLoadDialog overlay open
+- [ ] 一覧から行 click → composer に body + tags load、 loadedDraftId 保持
+- [ ] loadedDraftId あり時の「下書き保存」 → 既存 draft を update (新規作成しない)
+- [ ] loadedDraftId あり時の「投稿」 → 既存 draft を publish (新規作成しない)
+- [ ] DraftsLoadDialog 内「削除」 button → 確認 → DELETE → 一覧から消える、 /drafts page でも消える
+- [ ] 「下書きはまだありません」 empty state
+- [ ] backend `updateTweet` payload に `tags` 追加 (serializer 拡張)
+- [ ] vitest / E2E 全 pass
+- [ ] stg Playwright で実機検証
+
+---
+
+## 6. ロールバック
+
+- `DraftsLoadDialog.tsx` 削除 + `TweetComposer.tsx` の「下書き」 button + `loadedDraftId` state 削除 → V1 以前の挙動 (= /drafts page 経由のみ) に戻る
+- backend serializer の tags 拡張は backward compatible (既存 client は body のみ送り続けて動く)


### PR DESCRIPTION
Closes #767

## Summary

ハルナさん指摘「X と同じ仕様にするなら投稿画面で下書きを呼び出せるようにすべき」 を受けて、 composer (= ホーム / Compose dialog) 内に「下書き」 button を追加し、 DraftsLoadDialog modal で過去の下書きを呼び出して編集 / 公開できるようにした。

### Before / After

| 項目 | before | after |
|---|---|---|
| 下書き呼び出し導線 | profile menu → /drafts page のみ | composer 内「下書き」 button → modal 1 click |
| draft 編集中の判別 | できない (UI 上見分け不能) | role=status の indicator「下書きを編集中」 表示 |
| 既存 draft の保存 | 新規 draft 作成になる (重複) | loadedDraftId 持って update / publish |

### 変更ファイル (4 files、 vitest 5 tests pass、 tsc 0 errors)

- `client/src/components/tweets/DraftsLoadDialog.tsx` (新規 ~180 行)
- `client/src/components/tweets/TweetComposer.tsx` (改 ~50 行追加)
- `client/src/components/tweets/__tests__/DraftsLoadDialog.test.tsx` (新規)
- `client/e2e/tweet-drafts-load.spec.ts` (新規 E2E)
- `docs/specs/tweet-drafts-load-spec.md` (新規 spec)

## Test plan

- [x] vitest `DraftsLoadDialog.test.tsx` 5 tests pass
- [x] vitest 既存 28 tests (tweets) pass、 regression なし
- [x] tsc --noEmit 0 errors
- [ ] サブエージェント (typescript-reviewer + code-reviewer)
- [ ] stg deploy 後: Playwright MCP で DRAFTS-LOAD-1/2/3 実機検証

## やらない (別 issue で対応)

- tag 編集 (backend serializer の update が body のみ受付)
- multi-select 削除 mode (X の Edit button)
- 「保存しないと変更失われる」 navigation guard (autosave で代替済)
- /drafts page の廃止 (profile menu 入口として残す)

## Rollback

`DraftsLoadDialog.tsx` 削除 + `TweetComposer.tsx` の「下書き」 button + `loadedDraftId` state 削除で V1 以前の挙動に戻る。 backend 変更 0 件なので backward compatible。