### PR TITLE
[bug][tweets] 下書き呼び出し→投稿で edit_count が動くバグを修正 (#769)

### DIFF
--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -580,4 +580,6 @@ class TweetUpdateSerializer(serializers.Serializer):
             body=new_body,
             updated_at=now,
         )
+        # database-reviewer LOW: fields= を省略しないこと (全カラム SELECT になり、
+        # draft autosave 系の高頻度経路で性能劣化する)。 必要 field だけ refresh。
         instance.refresh_from_db(fields=["body", "updated_at"])

--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -523,12 +523,19 @@ class TweetUpdateSerializer(serializers.Serializer):
     """PATCH /api/v1/tweets/<id>/ 用の write-only serializer。
 
     本文だけが編集可能。tags / images は編集不可 (SPEC §3.5)。
-    実際の編集は ``Tweet.record_edit`` に委譲する — これにより:
-      - 30 分以内制約
-      - 5 回制約
-      - TweetEdit の自動生成
-      - edit_count の原子インクリメント
-    が全て担保される。
+
+    #769 fix: draft (published_at IS NULL) と published で振る舞いを分岐する。
+    - **draft**: 「下書きを書いている」 だけなので record_edit は経由しない。
+      plain update (body + updated_at) のみ。 edit_count / last_edited_at /
+      TweetEdit は触らない。 30 分 / 5 回制約も適用しない。
+    - **published**: 従来どおり ``Tweet.record_edit`` に委譲する — これにより:
+        - 30 分以内制約
+        - 5 回制約
+        - TweetEdit の自動生成
+        - edit_count の原子インクリメント
+      が全て担保される。
+
+    spec: docs/specs/draft-edit-limit-fix-spec.md §3.1
     """
 
     body = serializers.CharField(max_length=TWEET_BODY_MAX_LENGTH)
@@ -542,12 +549,36 @@ class TweetUpdateSerializer(serializers.Serializer):
         return value
 
     def update(self, instance: Tweet, validated_data: dict[str, Any]) -> Tweet:
-        """``Tweet.record_edit`` に委譲する。
+        """draft / published を分岐し、 draft なら plain update、 published なら
+        ``Tweet.record_edit`` に委譲する。
 
         editor は context['request'].user から取得する。
         record_edit は ValidationError を投げる可能性があるので、
         view 側 ``perform_update`` はそれを 400 に map する。
         """
-        editor = self.context["request"].user
-        instance.record_edit(new_body=validated_data["body"], editor=editor)
+        new_body = validated_data["body"]
+        # #769: draft の body 書き換えは「編集」 ではないので record_edit を bypass。
+        if instance.published_at is None:
+            self._save_draft_body(instance, new_body)
+        else:
+            editor = self.context["request"].user
+            instance.record_edit(new_body=new_body, editor=editor)
         return instance
+
+    @staticmethod
+    def _save_draft_body(instance: Tweet, new_body: str) -> None:
+        """draft の body を plain update。 edit_count / last_edited_at は触らない。
+
+        #769: ``.update()`` は ``auto_now`` (updated_at) を bypass しないように
+        明示的に ``updated_at=now()`` を渡す (silent-failure-hunter MEDIUM #5)。
+        body 長検証は serializer の ``validate_body`` で既に通過しているが、
+        record_edit と同じ guard を defense-in-depth で再評価しない (= 重複検証回避)。
+        """
+        from django.utils import timezone
+
+        now = timezone.now()
+        Tweet.all_objects.filter(pk=instance.pk).update(
+            body=new_body,
+            updated_at=now,
+        )
+        instance.refresh_from_db(fields=["body", "updated_at"])

--- a/apps/tweets/serializers.py
+++ b/apps/tweets/serializers.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from django.core.validators import URLValidator
 from django.db import transaction
+from django.utils import timezone
 from rest_framework import serializers
 
 from apps.tags.models import Tag
@@ -569,13 +570,11 @@ class TweetUpdateSerializer(serializers.Serializer):
     def _save_draft_body(instance: Tweet, new_body: str) -> None:
         """draft の body を plain update。 edit_count / last_edited_at は触らない。
 
-        #769: ``.update()`` は ``auto_now`` (updated_at) を bypass しないように
+        #769: ``.update()`` は ``auto_now`` (updated_at) を bypass するため
         明示的に ``updated_at=now()`` を渡す (silent-failure-hunter MEDIUM #5)。
         body 長検証は serializer の ``validate_body`` で既に通過しているが、
         record_edit と同じ guard を defense-in-depth で再評価しない (= 重複検証回避)。
         """
-        from django.utils import timezone
-
         now = timezone.now()
         Tweet.all_objects.filter(pk=instance.pk).update(
             body=new_body,

--- a/apps/tweets/tests/test_drafts.py
+++ b/apps/tweets/tests/test_drafts.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import pytest
 from rest_framework.test import APIClient
 
-from apps.tweets.models import Tweet
+from apps.tweets.models import Tweet, TweetEdit
 from apps.tweets.tests._factories import make_user
 
 # ---------------------------------------------------------------------------
@@ -324,7 +324,6 @@ class TestDraftPatchDoesNotRecordEdit:
         assert d.edit_count == 0
         assert d.last_edited_at is None
         # TweetEdit 履歴が作られていない
-        from apps.tweets.models import TweetEdit
 
         assert TweetEdit.objects.filter(tweet=d).count() == 0
 
@@ -362,18 +361,21 @@ class TestDraftPatchBoundary:
         d.refresh_from_db()
         assert d.body == "v6"
         assert d.edit_count == 0  # 一度も加算されていない
-        from apps.tweets.models import TweetEdit
 
         assert TweetEdit.objects.filter(tweet=d).count() == 0
 
     def test_bd2_draft_can_be_patched_after_30_min_window(self, authed_client):
-        """draft 作成から 31 分後でも PATCH 可能 (= 公開済みの 30 分 window 制約は適用されない)。"""
+        """draft 作成から 31 分後でも PATCH 可能 (= 公開済みの 30 分 window 制約は適用されない)。
+
+        python-reviewer MEDIUM: ``authed_client`` も draft 作成と同じ freeze_time scope
+        に入れて、 token TTL 等の時刻依存処理が一貫した時刻で動くようにする。
+        """
         from freezegun import freeze_time
 
         u = make_user()
         with freeze_time("2026-05-18 00:00:00"):
             d = Tweet.objects.create(author=u, body="v0", published_at=None)
-        c = authed_client(u)
+            c = authed_client(u)
         with freeze_time("2026-05-18 00:31:00"):  # 31 分後
             resp = c.patch(
                 f"/api/v1/tweets/{d.id}/",
@@ -473,7 +475,6 @@ class TestPublishWithBody:
         assert d.body == "y"
         assert d.edit_count == 0  # 「編集済」 にならない
         assert d.last_edited_at is None
-        from apps.tweets.models import TweetEdit
 
         assert TweetEdit.objects.filter(tweet=d).count() == 0
 
@@ -549,7 +550,6 @@ class TestPostPublishEditDegradation:
         assert d.body == "post-publish edit"
         assert d.edit_count == 1
         assert d.last_edited_at is not None
-        from apps.tweets.models import TweetEdit
 
         assert TweetEdit.objects.filter(tweet=d).count() == 1
 

--- a/apps/tweets/tests/test_drafts.py
+++ b/apps/tweets/tests/test_drafts.py
@@ -527,6 +527,36 @@ class TestPublishWithBody:
         )
         assert resp.status_code == 400
 
+    def test_ff4_publish_with_non_string_body_400(self, authed_client):
+        """security-reviewer MEDIUM: 非 string の body は 400。"""
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="x", published_at=None)
+        c = authed_client(u)
+        resp = c.post(
+            f"/api/v1/tweets/{d.id}/publish/",
+            {"body": ["a", "b", "c"]},
+            format="json",
+        )
+        assert resp.status_code == 400
+        d.refresh_from_db()
+        # draft はまだ未公開のまま (publish が走っていない)
+        assert d.published_at is None
+
+    def test_ff5_publish_with_blank_body_400(self, authed_client):
+        """security-reviewer LOW: 空 / 空白だけの body は 400。"""
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="non-empty", published_at=None)
+        c = authed_client(u)
+        for blank in ["", "   ", "\n\t"]:
+            resp = c.post(
+                f"/api/v1/tweets/{d.id}/publish/",
+                {"body": blank},
+                format="json",
+            )
+            assert resp.status_code == 400, blank
+        d.refresh_from_db()
+        assert d.published_at is None  # 未公開のまま
+
 
 @pytest.mark.django_db
 class TestPostPublishEditDegradation:

--- a/apps/tweets/tests/test_drafts.py
+++ b/apps/tweets/tests/test_drafts.py
@@ -292,3 +292,279 @@ class TestDraftHiddenFromPublicEndpoints:
         # draft は含まれない
         for t in items:
             assert t.published_at is not None
+
+
+# ---------------------------------------------------------------------------
+# #769 fix: draft の PATCH は record_edit を経由しない
+#
+# spec: docs/specs/draft-edit-limit-fix-spec.md §4.1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDraftPatchDoesNotRecordEdit:
+    """#769 §4.1 期待しない副作用 SE-1〜3 + Happy path HP-1。
+
+    draft (= published_at IS NULL) の body 書き換えは「下書きを書いている」 だけで
+    「編集」 ではないため、 edit_count / last_edited_at / TweetEdit を触らない。
+    """
+
+    def test_hp1_draft_patch_returns_200_and_does_not_increment_edit_count(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="initial", published_at=None)
+        c = authed_client(u)
+        resp = c.patch(
+            f"/api/v1/tweets/{d.id}/",
+            {"body": "hello"},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.data
+        d.refresh_from_db()
+        assert d.body == "hello"
+        assert d.edit_count == 0
+        assert d.last_edited_at is None
+        # TweetEdit 履歴が作られていない
+        from apps.tweets.models import TweetEdit
+
+        assert TweetEdit.objects.filter(tweet=d).count() == 0
+
+    def test_se3_draft_patch_updates_updated_at_but_not_last_edited_at(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="initial", published_at=None)
+        old_updated_at = d.updated_at
+        c = authed_client(u)
+        resp = c.patch(
+            f"/api/v1/tweets/{d.id}/",
+            {"body": "x"},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.data
+        d.refresh_from_db()
+        assert d.updated_at > old_updated_at  # 動く
+        assert d.last_edited_at is None  # 動かない
+
+
+@pytest.mark.django_db
+class TestDraftPatchBoundary:
+    """#769 §4.1 境界 BD-1 / BD-2。 draft は 5 回 / 30 分制約の対象外。"""
+
+    def test_bd1_draft_can_be_patched_six_times_in_a_row(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="v0", published_at=None)
+        c = authed_client(u)
+        for i in range(1, 7):  # 6 回連続
+            resp = c.patch(
+                f"/api/v1/tweets/{d.id}/",
+                {"body": f"v{i}"},
+                format="json",
+            )
+            assert resp.status_code == 200, (i, resp.data)
+        d.refresh_from_db()
+        assert d.body == "v6"
+        assert d.edit_count == 0  # 一度も加算されていない
+        from apps.tweets.models import TweetEdit
+
+        assert TweetEdit.objects.filter(tweet=d).count() == 0
+
+    def test_bd2_draft_can_be_patched_after_30_min_window(self, authed_client):
+        """draft 作成から 31 分後でも PATCH 可能 (= 公開済みの 30 分 window 制約は適用されない)。"""
+        from freezegun import freeze_time
+
+        u = make_user()
+        with freeze_time("2026-05-18 00:00:00"):
+            d = Tweet.objects.create(author=u, body="v0", published_at=None)
+        c = authed_client(u)
+        with freeze_time("2026-05-18 00:31:00"):  # 31 分後
+            resp = c.patch(
+                f"/api/v1/tweets/{d.id}/",
+                {"body": "after-30min"},
+                format="json",
+            )
+        assert resp.status_code == 200, resp.data
+        d.refresh_from_db()
+        assert d.body == "after-30min"
+        assert d.edit_count == 0
+
+
+@pytest.mark.django_db
+class TestPublishedTweetEditConstraintsPreserved:
+    """#769 §4.1 BD-3 / BD-4。 公開済み tweet の edit 経路 (= record_edit) は壊さない。"""
+
+    def test_bd3_published_tweet_hits_5_edit_limit(self, authed_client):
+        u = make_user()
+        t = Tweet.objects.create(author=u, body="v0")  # auto-publishes
+        c = authed_client(u)
+        for i in range(1, 6):  # 5 回までは 200
+            resp = c.patch(
+                f"/api/v1/tweets/{t.id}/",
+                {"body": f"v{i}"},
+                format="json",
+            )
+            assert resp.status_code == 200, (i, resp.data)
+        # 6 回目で 400「これ以上編集できません」
+        resp = c.patch(
+            f"/api/v1/tweets/{t.id}/",
+            {"body": "v6"},
+            format="json",
+        )
+        assert resp.status_code == 400
+        t.refresh_from_db()
+        assert t.edit_count == 5  # 5 で止まっている
+        assert t.body == "v5"  # v6 は反映されていない
+
+    def test_bd4_edit_count_4_succeeds_5_succeeds_then_caps(self, authed_client):
+        u = make_user()
+        t = Tweet.objects.create(author=u, body="v0")
+        # fixture で edit_count を 4 に進める
+        Tweet.all_objects.filter(pk=t.pk).update(edit_count=4)
+        c = authed_client(u)
+        # ちょうど 5 回目の edit → 200
+        resp = c.patch(
+            f"/api/v1/tweets/{t.id}/",
+            {"body": "fifth"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        t.refresh_from_db()
+        assert t.edit_count == 5
+        # edit_count=5 で次の PATCH は 400
+        resp = c.patch(
+            f"/api/v1/tweets/{t.id}/",
+            {"body": "sixth"},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+class TestPublishWithBody:
+    """#769 §4.1 HP-2 / SE-1 / SE-2 / SE-5。 publish action が optional body を受ける。"""
+
+    def test_hp2_publish_with_body_overwrites(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="draft body", published_at=None)
+        c = authed_client(u)
+        resp = c.post(
+            f"/api/v1/tweets/{d.id}/publish/",
+            {"body": "published body"},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.data
+        assert resp.data["body"] == "published body"
+        assert resp.data["published_at"] is not None
+        d.refresh_from_db()
+        assert d.body == "published body"
+        # spec §2.1: 公開時に created_at == published_at に揃える
+        assert d.created_at == d.published_at
+        # silent-failure MEDIUM #5: updated_at も動く
+        assert d.updated_at >= d.published_at
+
+    def test_se1_publish_does_not_record_edit(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="x", published_at=None)
+        c = authed_client(u)
+        resp = c.post(
+            f"/api/v1/tweets/{d.id}/publish/",
+            {"body": "y"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        d.refresh_from_db()
+        assert d.body == "y"
+        assert d.edit_count == 0  # 「編集済」 にならない
+        assert d.last_edited_at is None
+        from apps.tweets.models import TweetEdit
+
+        assert TweetEdit.objects.filter(tweet=d).count() == 0
+
+    def test_se2_publish_after_five_patches_still_succeeds_with_edit_count_zero(
+        self, authed_client
+    ):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="v0", published_at=None)
+        c = authed_client(u)
+        for i in range(1, 6):
+            c.patch(
+                f"/api/v1/tweets/{d.id}/",
+                {"body": f"v{i}"},
+                format="json",
+            )
+        # publish with new body
+        resp = c.post(
+            f"/api/v1/tweets/{d.id}/publish/",
+            {"body": "final"},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.data
+        d.refresh_from_db()
+        assert d.body == "final"
+        assert d.edit_count == 0
+
+    def test_publish_without_body_keeps_existing_body_backward_compat(self, authed_client):
+        """既存挙動: body を渡さない publish は body をそのまま公開 (regression check)。"""
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="existing", published_at=None)
+        c = authed_client(u)
+        resp = c.post(f"/api/v1/tweets/{d.id}/publish/")
+        assert resp.status_code == 200, resp.data
+        d.refresh_from_db()
+        assert d.body == "existing"
+        assert d.published_at is not None
+
+    def test_ff3_publish_with_too_long_body_400(self, authed_client):
+        """body length validation: 181 chars → 400。"""
+        from apps.tweets.models import TWEET_BODY_MAX_LENGTH
+
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="x", published_at=None)
+        c = authed_client(u)
+        too_long = "a" * (TWEET_BODY_MAX_LENGTH + 1)
+        resp = c.post(
+            f"/api/v1/tweets/{d.id}/publish/",
+            {"body": too_long},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+class TestPostPublishEditDegradation:
+    """#769 §4.1 SE-4。 publish 後の tweet は従来 record_edit 経路で edit 可能。"""
+
+    def test_se4_publish_then_edit_increments_edit_count(self, authed_client):
+        u = make_user()
+        d = Tweet.objects.create(author=u, body="v0", published_at=None)
+        c = authed_client(u)
+        # publish (body 渡さず)
+        resp = c.post(f"/api/v1/tweets/{d.id}/publish/")
+        assert resp.status_code == 200
+        # 公開後の tweet を edit → 従来どおり record_edit が走る
+        resp = c.patch(
+            f"/api/v1/tweets/{d.id}/",
+            {"body": "post-publish edit"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        d.refresh_from_db()
+        assert d.body == "post-publish edit"
+        assert d.edit_count == 1
+        assert d.last_edited_at is not None
+        from apps.tweets.models import TweetEdit
+
+        assert TweetEdit.objects.filter(tweet=d).count() == 1
+
+
+@pytest.mark.django_db
+class TestDraftPatchAuth:
+    """#769 §4.1 FF-2。 匿名で draft PATCH は不可。"""
+
+    def test_ff2_anonymous_patch_draft_unauthorized(self):
+        owner = make_user()
+        d = Tweet.objects.create(author=owner, body="x", published_at=None)
+        c = APIClient()
+        resp = c.patch(
+            f"/api/v1/tweets/{d.id}/",
+            {"body": "y"},
+            format="json",
+        )
+        assert resp.status_code in (401, 403)

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -442,9 +442,16 @@ class TweetViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # #769: optional body の length validation
+        # #769: optional body の validation。 publish action は serializer を経由
+        # しないため type / length / blank を全部ここで担保する (security-reviewer
+        # MEDIUM: `isinstance(body, str)` 抜けで {"body": [...]} のような payload が
+        # len() を通過する穴を塞ぐ。 LOW: 空文字 / 空白だけの body も拒否)。
         body = request.data.get("body")
         if body is not None:
+            if not isinstance(body, str):
+                raise ValidationError({"body": "文字列で指定してください。"})
+            if not body.strip():
+                raise ValidationError({"body": "本文を入力してください。"})
             if len(body) > TWEET_BODY_MAX_LENGTH:
                 raise ValidationError(
                     {"body": f"本文は {TWEET_BODY_MAX_LENGTH} 字以内で入力してください。"}

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from typing import Any
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from django.utils import timezone
 from rest_framework import serializers as drf_serializers
 from rest_framework import status, viewsets
@@ -410,6 +411,7 @@ class TweetViewSet(viewsets.ModelViewSet):
         url_path="publish",
         permission_classes=[IsAuthenticated],
     )
+    @transaction.atomic
     def publish(self, request: Request, pk: int | None = None) -> Response:
         """POST /api/v1/tweets/<id>/publish/ — 自分の下書きを公開する。
 

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -38,14 +38,32 @@ from rest_framework.response import Response
 
 from apps.common.cookie_auth import CookieAuthentication
 from apps.common.throttling import PostTweetThrottle
+from apps.tweets.language_detection import detect_language
 from apps.tweets.managers import TweetQuerySet
-from apps.tweets.models import Tweet
+from apps.tweets.models import TWEET_BODY_MAX_LENGTH, Tweet
 from apps.tweets.serializers import (
     TweetCreateSerializer,
     TweetDetailSerializer,
     TweetListSerializer,
     TweetUpdateSerializer,
 )
+
+# #769: publish action での body length validation 用 (P1-10 char_count の lazy import
+# pattern を踏襲、 module 未配備時は len() のみで足切り)
+try:
+    from apps.tweets.char_count import (  # type: ignore[attr-defined]
+        TWEET_MAX_CHARS,
+        count_tweet_chars,
+    )
+
+    _HAS_CHAR_COUNT = True
+except ImportError:  # pragma: no cover - P1-10 が merge されたら到達しない
+    _HAS_CHAR_COUNT = False
+    TWEET_MAX_CHARS = TWEET_BODY_MAX_LENGTH
+
+    def count_tweet_chars(_body: str) -> int:  # type: ignore[no-redef]
+        return 0  # fallback never used (gated by _HAS_CHAR_COUNT)
+
 
 # Action 定数 (マジックストリング排除)
 ACTION_LIST = "list"
@@ -425,28 +443,18 @@ class TweetViewSet(viewsets.ModelViewSet):
             )
 
         # #769: optional body の length validation
-        body = request.data.get("body") if hasattr(request, "data") else None
+        body = request.data.get("body")
         if body is not None:
-            from apps.tweets.models import TWEET_BODY_MAX_LENGTH
-
             if len(body) > TWEET_BODY_MAX_LENGTH:
                 raise ValidationError(
                     {"body": f"本文は {TWEET_BODY_MAX_LENGTH} 字以内で入力してください。"}
                 )
-            try:
-                from apps.tweets.char_count import (
-                    TWEET_MAX_CHARS,
-                    count_tweet_chars,
+            if _HAS_CHAR_COUNT and count_tweet_chars(body) > TWEET_MAX_CHARS:
+                raise ValidationError(
+                    {
+                        "body": f"本文は URL / Markdown 換算で {TWEET_MAX_CHARS} 字以内にしてください。"
+                    }
                 )
-
-                if count_tweet_chars(body) > TWEET_MAX_CHARS:
-                    raise ValidationError(
-                        {
-                            "body": f"本文は URL / Markdown 換算で {TWEET_MAX_CHARS} 字以内にしてください。"
-                        }
-                    )
-            except ImportError:
-                pass  # char_count module 未配備時は len() のみで足切り済
 
         now = timezone.now()
         # spec §2.1: 公開時に created_at == published_at に揃え、 .update() は
@@ -460,11 +468,21 @@ class TweetViewSet(viewsets.ModelViewSet):
             update_fields["body"] = body
             # silent-failure LOW #7: .update() は pre_save signal を bypass するため
             # auto_detect_language が走らない → 明示的に language を再検出する。
-            from apps.tweets.language_detection import detect_language
-
             update_fields["language"] = detect_language(body)
 
-        Tweet.all_objects.filter(pk=instance.pk).update(**update_fields)
+        # #769 python-reviewer HIGH (TOCTOU): `instance.published_at IS NULL` の
+        # check と .update() の間に他リクエストが publish してしまうと double-publish
+        # する。 `.filter(published_at__isnull=True).update()` の行数で勝者判定する
+        # ことで race を排除する (= 後勝ちの 1 行のみが更新成功、 他は 0 行返却)。
+        updated = Tweet.all_objects.filter(
+            pk=instance.pk,
+            published_at__isnull=True,
+        ).update(**update_fields)
+        if updated == 0:
+            return Response(
+                {"detail": "already_published"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         instance.refresh_from_db()
         out = TweetDetailSerializer(
             instance,

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -395,12 +395,21 @@ class TweetViewSet(viewsets.ModelViewSet):
     def publish(self, request: Request, pk: int | None = None) -> Response:
         """POST /api/v1/tweets/<id>/publish/ — 自分の下書きを公開する。
 
-        spec: docs/specs/tweet-drafts-spec.md §3.2
+        spec: docs/specs/tweet-drafts-spec.md §3.2 + docs/specs/draft-edit-limit-fix-spec.md §3.2
 
         - 自分の下書き (= `published_at IS NULL` + author=user) のみ
         - 他人の下書き ID → 404 隠蔽 (= ある事実を漏らさない)
         - 既に公開済み → 400
-        - 成功時: `published_at = created_at = now()` に更新し、 detail を返す
+        - 成功時: `published_at = created_at = updated_at = now()` に更新し、 detail を返す
+
+        #769 fix: optional `body` を受け取り、 公開時に body も上書きできる。
+        これにより frontend は「PATCH → publish」 の 2 段呼び出しを廃して 1 段で済む
+        (= record_edit 不発火 = edit_count が動かず、 「編集済」 badge も付かない)。
+
+        - body が指定された場合のみ length validation を実施 (TWEET_BODY_MAX_LENGTH / TWEET_MAX_CHARS)
+        - `.update()` は ``auto_now`` (updated_at) と pre_save signal を bypass するため、
+          `updated_at=now` を明示し、 body 更新時は `language` も明示的に再検出する
+          (silent-failure-hunter MEDIUM #5 / LOW #7)
         """
         instance = self.get_object()  # `_DRAFT_AWARE_ACTIONS` で all_with_drafts
         if instance.author_id != request.user.pk:
@@ -414,13 +423,48 @@ class TweetViewSet(viewsets.ModelViewSet):
                 {"detail": "already_published"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        # #769: optional body の length validation
+        body = request.data.get("body") if hasattr(request, "data") else None
+        if body is not None:
+            from apps.tweets.models import TWEET_BODY_MAX_LENGTH
+
+            if len(body) > TWEET_BODY_MAX_LENGTH:
+                raise ValidationError(
+                    {"body": f"本文は {TWEET_BODY_MAX_LENGTH} 字以内で入力してください。"}
+                )
+            try:
+                from apps.tweets.char_count import (
+                    TWEET_MAX_CHARS,
+                    count_tweet_chars,
+                )
+
+                if count_tweet_chars(body) > TWEET_MAX_CHARS:
+                    raise ValidationError(
+                        {
+                            "body": f"本文は URL / Markdown 換算で {TWEET_MAX_CHARS} 字以内にしてください。"
+                        }
+                    )
+            except ImportError:
+                pass  # char_count module 未配備時は len() のみで足切り済
+
         now = timezone.now()
-        # auto_now_add の `created_at` も同時に更新する (spec §2.1)。
-        # bulk update で auto_now_add を回避し、 公開時刻を時系列に正しく載せる。
-        Tweet.all_objects.filter(pk=instance.pk).update(
-            published_at=now,
-            created_at=now,
-        )
+        # spec §2.1: 公開時に created_at == published_at に揃え、 .update() は
+        # auto_now を bypass するので updated_at も明示する。
+        update_fields: dict[str, Any] = {
+            "published_at": now,
+            "created_at": now,
+            "updated_at": now,
+        }
+        if body is not None:
+            update_fields["body"] = body
+            # silent-failure LOW #7: .update() は pre_save signal を bypass するため
+            # auto_detect_language が走らない → 明示的に language を再検出する。
+            from apps.tweets.language_detection import detect_language
+
+            update_fields["language"] = detect_language(body)
+
+        Tweet.all_objects.filter(pk=instance.pk).update(**update_fields)
         instance.refresh_from_db()
         out = TweetDetailSerializer(
             instance,

--- a/client/e2e/tweet-drafts-edit-limit.spec.ts
+++ b/client/e2e/tweet-drafts-edit-limit.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * #769 fix: draft 呼び出し→投稿で edit_count が動かないことの E2E 検証。
+ *
+ * Spec: docs/specs/draft-edit-limit-fix-spec.md §4.3
+ *
+ * 検証:
+ *   - E2E-DRAFT-1 (HP-1 / SE-1): 下書き保存 → load → 投稿 → TL に表示、 「編集済」 badge 付かない
+ *   - E2E-DRAFT-2 (BD-3 デグレ防止): 公開済み tweet を 5 回 edit → 5 回目までは 200 / 「編集済」 表示、 6 回目は 400
+ *   - E2E-DRAFT-3 (SE-1 network check): draft load → 「投稿」 → publish 1 req のみ、 PATCH は出ない
+ *   - E2E-DRAFT-4 (SE-4 デグレ防止): draft 公開後の tweet を edit → 「編集済」 badge が **付く**
+ *
+ * 実行:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     E2E_LOGIN_EMAIL=test4@example.com E2E_LOGIN_PASSWORD=E5INn9EaBLG7WNPl \
+ *     npx playwright test e2e/tweet-drafts-edit-limit.spec.ts --reporter=line
+ *
+ * env 詳細: docs/local/e2e-stg.md
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+const EMAIL = process.env.E2E_LOGIN_EMAIL ?? "test4@example.com";
+const PASSWORD = process.env.E2E_LOGIN_PASSWORD ?? "E5INn9EaBLG7WNPl";
+
+test.describe("#769 tweet draft publish — edit_count 不動の検証", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(`${BASE}/login`);
+		await page.getByLabel(/メール/).fill(EMAIL);
+		await page.getByLabel(/パスワード/).fill(PASSWORD);
+		await page.getByRole("button", { name: /ログイン/ }).click();
+		// stg は /home でも / でも homepage に着く。 どちらでも OK にする
+		await page.waitForURL(new RegExp(`^${BASE}/(home/?)?$`), {
+			timeout: 15_000,
+		});
+	});
+
+	test("E2E-DRAFT-1: 下書き保存 → load → 投稿で TL に表示、 「編集済」 badge が付かない", async ({
+		page,
+	}) => {
+		const composer = page
+			.locator("section")
+			.filter({ hasText: "投稿" })
+			.first();
+		const uniqueBody = `#769 e2e-1 ${Date.now()}`;
+
+		// Step 1: composer で下書き保存
+		await composer
+			.getByRole("textbox", { name: /ツイート本文/ })
+			.fill(uniqueBody);
+		await composer
+			.getByRole("button", { name: "下書きとして保存する" })
+			.click();
+		await expect(page.getByText("下書きに保存しました")).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// Step 2: 下書き呼び出し → 編集 click → composer に load
+		await composer
+			.getByRole("button", { name: "下書き一覧から呼び出す" })
+			.click();
+		const list = page.getByTestId("drafts-load-list");
+		await expect(list).toBeVisible();
+		await list
+			.getByRole("button", { name: new RegExp(uniqueBody.slice(0, 8)) })
+			.filter({ hasText: /編集$/ })
+			.first()
+			.click();
+		await expect(
+			composer.getByTestId("composer-loaded-draft-indicator"),
+		).toHaveText(/下書きを編集中/);
+
+		// Step 3: 「投稿」 → TL に表示される、 「編集済」 badge は付かない
+		await composer.getByRole("button", { name: /^投稿$/ }).click();
+		await expect(page.getByText("投稿しました")).toBeVisible({
+			timeout: 10_000,
+		});
+		// TL に当該 body が出る
+		const tlArticle = page
+			.getByRole("article")
+			.filter({ hasText: uniqueBody })
+			.first();
+		await expect(tlArticle).toBeVisible({ timeout: 10_000 });
+		// 「編集済」 badge が **付いていない**
+		await expect(tlArticle.getByText("編集済")).toHaveCount(0);
+	});
+
+	test("E2E-DRAFT-3 (network): draft load → 「投稿」 で publishDraft 1 req のみ、 PATCH は出ない", async ({
+		page,
+	}) => {
+		const composer = page
+			.locator("section")
+			.filter({ hasText: "投稿" })
+			.first();
+		const uniqueBody = `#769 e2e-3 ${Date.now()}`;
+
+		// 下書き保存
+		await composer
+			.getByRole("textbox", { name: /ツイート本文/ })
+			.fill(uniqueBody);
+		await composer
+			.getByRole("button", { name: "下書きとして保存する" })
+			.click();
+		await expect(page.getByText("下書きに保存しました")).toBeVisible();
+
+		// load
+		await composer
+			.getByRole("button", { name: "下書き一覧から呼び出す" })
+			.click();
+		const list = page.getByTestId("drafts-load-list");
+		await expect(list).toBeVisible();
+		await list.getByRole("button", { name: /編集$/ }).first().click();
+		await expect(
+			composer.getByTestId("composer-loaded-draft-indicator"),
+		).toHaveText(/下書きを編集中/);
+
+		// network 監視 + 「投稿」 click
+		const tweetRequests: { method: string; url: string }[] = [];
+		page.on("request", (req) => {
+			const url = req.url();
+			if (/\/api\/v1\/tweets\//.test(url) && req.method() !== "GET") {
+				tweetRequests.push({ method: req.method(), url });
+			}
+		});
+		await composer.getByRole("button", { name: /^投稿$/ }).click();
+		await expect(page.getByText("投稿しました")).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// publishDraft の POST が 1 回だけ、 PATCH (= updateTweet) は 0 回
+		const publishCalls = tweetRequests.filter((r) =>
+			/\/publish\/?$/.test(r.url),
+		);
+		const patchCalls = tweetRequests.filter(
+			(r) => r.method === "PATCH" && !/\/publish\/?$/.test(r.url),
+		);
+		expect(publishCalls.length).toBe(1);
+		expect(patchCalls.length).toBe(0);
+	});
+
+	test("E2E-DRAFT-4 (SE-4 デグレ防止): draft 公開後の tweet を edit すると「編集済」 badge が付く", async ({
+		page,
+	}) => {
+		const composer = page
+			.locator("section")
+			.filter({ hasText: "投稿" })
+			.first();
+		const uniqueBody = `#769 e2e-4 ${Date.now()}`;
+
+		// 下書き保存 → load → 投稿
+		await composer
+			.getByRole("textbox", { name: /ツイート本文/ })
+			.fill(uniqueBody);
+		await composer
+			.getByRole("button", { name: "下書きとして保存する" })
+			.click();
+		await expect(page.getByText("下書きに保存しました")).toBeVisible();
+		await composer
+			.getByRole("button", { name: "下書き一覧から呼び出す" })
+			.click();
+		const list = page.getByTestId("drafts-load-list");
+		await expect(list).toBeVisible();
+		await list.getByRole("button", { name: /編集$/ }).first().click();
+		await composer.getByRole("button", { name: /^投稿$/ }).click();
+		await expect(page.getByText("投稿しました")).toBeVisible();
+
+		// 公開直後の tweet (= 「編集済」 badge なし) を確認
+		const tlArticle = page
+			.getByRole("article")
+			.filter({ hasText: uniqueBody })
+			.first();
+		await expect(tlArticle).toBeVisible();
+		await expect(tlArticle.getByText("編集済")).toHaveCount(0);
+
+		// その tweet を edit (= 通常の record_edit 経路を通る)
+		await tlArticle
+			.getByRole("button", { name: /ツイートのその他メニュー/ })
+			.click();
+		// 「編集」 menu item — UI 実装に依存するため、 メニュー内の最初の「編集」 をクリック
+		const editMenuItem = page.getByRole("menuitem", { name: /編集/ }).first();
+		if (await editMenuItem.isVisible({ timeout: 2_000 })) {
+			await editMenuItem.click();
+			// TweetEditForm が開く前提
+			const editTextarea = page
+				.getByRole("textbox", { name: /ツイート本文/ })
+				.last();
+			await editTextarea.fill(`${uniqueBody} edited`);
+			await page
+				.getByRole("button", { name: /保存|更新|完了/ })
+				.first()
+				.click();
+			await expect(page.getByText(/編集を保存|更新しました/)).toBeVisible({
+				timeout: 10_000,
+			});
+
+			// edit 後の TL article で「編集済」 badge が付くこと
+			const editedArticle = page
+				.getByRole("article")
+				.filter({ hasText: `${uniqueBody} edited` })
+				.first();
+			await expect(editedArticle.getByText("編集済")).toBeVisible();
+		} else {
+			test.skip(
+				true,
+				"edit menu UI が見つからない (= TweetEditForm 経路の UI 変更時はこの test を更新)",
+			);
+		}
+	});
+});

--- a/client/e2e/tweet-drafts-edit-limit.spec.ts
+++ b/client/e2e/tweet-drafts-edit-limit.spec.ts
@@ -5,7 +5,7 @@
  *
  * 検証:
  *   - E2E-DRAFT-1 (HP-1 / SE-1): 下書き保存 → load → 投稿 → TL に表示、 「編集済」 badge 付かない
- *   - E2E-DRAFT-2 (BD-3 デグレ防止): 公開済み tweet を 5 回 edit → 5 回目までは 200 / 「編集済」 表示、 6 回目は 400
+ *   - (E2E-DRAFT-2 は pytest BD-3 / BD-4 で代替 — spec §4.3 参照)
  *   - E2E-DRAFT-3 (SE-1 network check): draft load → 「投稿」 → publish 1 req のみ、 PATCH は出ない
  *   - E2E-DRAFT-4 (SE-4 デグレ防止): draft 公開後の tweet を edit → 「編集済」 badge が **付く**
  *

--- a/client/src/components/tweets/TweetComposer.tsx
+++ b/client/src/components/tweets/TweetComposer.tsx
@@ -130,14 +130,11 @@ export default function TweetComposer({
 		try {
 			let tweet: TweetSummary;
 			if (loadedDraftId !== null) {
-				// #767: 既存 draft 編集モード → body update してから publish。
-				// tags 編集は V1 で skip (backend serializer の update が body のみ受付)。
-				await updateTweet(loadedDraftId, { body });
-				// updateTweet 成功時点で server 側 draft body が確定したので、
-				// publish 前に autosave key を clear (publish が落ちても data drift
-				// しないため、 typescript-reviewer H1)。
-				clearBodyAutosave();
-				tweet = await publishDraft(loadedDraftId);
+				// #769 fix: 既存 draft 編集モードは publish に body を直接渡して
+				// 1 リクエストで「最新 body + 公開」 を実現する。 旧 2 段呼び出し
+				// (updateTweet → publishDraft) は draft でも record_edit を経由し
+				// edit_count が +1 されてしまうため廃止。
+				tweet = await publishDraft(loadedDraftId, { body });
 			} else {
 				tweet = await createTweet({ body, tags });
 			}

--- a/client/src/components/tweets/__tests__/TweetComposerDraftLoad.test.tsx
+++ b/client/src/components/tweets/__tests__/TweetComposerDraftLoad.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * #769 fix: TweetComposer の「draft 呼び出し→投稿」 1 段化のテスト。
+ *
+ * 旧実装は loadedDraftId !== null のとき `updateTweet` → `publishDraft` の
+ * 2 段呼び出しになっており、 PATCH が draft でも record_edit を発火し
+ * edit_count を +1 してしまうバグがあった (= 「これ以上編集できません」 / 「編集済」 badge)。
+ *
+ * 修正後: loadedDraftId !== null + 「投稿」 → `publishDraft(id, { body })` の 1 段。
+ * `updateTweet` は呼ばれない。
+ *
+ * spec: docs/specs/draft-edit-limit-fix-spec.md §4.2 (COMPOSER-DRAFT-PUBLISH-1 / -2 / SAVE-1)
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import TweetComposer from "@/components/tweets/TweetComposer";
+
+const {
+	createTweetMock,
+	updateTweetMock,
+	publishDraftMock,
+	fetchDraftsMock,
+	toastSuccessSpy,
+	toastErrorSpy,
+} = vi.hoisted(() => ({
+	createTweetMock: vi.fn(),
+	updateTweetMock: vi.fn(),
+	publishDraftMock: vi.fn(),
+	fetchDraftsMock: vi.fn(),
+	toastSuccessSpy: vi.fn(),
+	toastErrorSpy: vi.fn(),
+}));
+
+vi.mock("@/lib/api/tweets", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/api/tweets")>(
+			"@/lib/api/tweets",
+		);
+	return {
+		...actual,
+		createTweet: createTweetMock,
+		updateTweet: updateTweetMock,
+		publishDraft: publishDraftMock,
+		fetchDrafts: fetchDraftsMock,
+	};
+});
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+function makeTweetFixture(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 100,
+		body: "loaded draft body",
+		html: "<p>loaded draft body</p>",
+		char_count: 17,
+		author_handle: "test4",
+		tags: [],
+		images: [],
+		created_at: "2026-05-18T13:44:00Z",
+		updated_at: "2026-05-18T13:44:00Z",
+		edit_count: 0,
+		published_at: null,
+		...overrides,
+	};
+}
+
+async function openComposerAndLoadDraft() {
+	const draft = makeTweetFixture();
+	fetchDraftsMock.mockResolvedValueOnce({
+		count: 1,
+		next: null,
+		previous: null,
+		results: [draft],
+	});
+	render(<TweetComposer />);
+	// 「下書き」 button click → DraftsLoadDialog open
+	await userEvent.click(
+		screen.getByRole("button", { name: /下書き一覧から呼び出す/ }),
+	);
+	// 一覧の「編集」 click → onPick → composer に load
+	await waitFor(() => {
+		expect(screen.getByRole("button", { name: /編集/ })).toBeInTheDocument();
+	});
+	await userEvent.click(screen.getByRole("button", { name: /編集/ }));
+	return draft;
+}
+
+describe("TweetComposer draft load → 投稿 1 段化 (#769)", () => {
+	beforeEach(() => {
+		createTweetMock.mockReset();
+		updateTweetMock.mockReset();
+		publishDraftMock.mockReset();
+		fetchDraftsMock.mockReset();
+		toastSuccessSpy.mockReset();
+		toastErrorSpy.mockReset();
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("COMPOSER-DRAFT-PUBLISH-1: load 後の「投稿」 で publishDraft(id, {body}) を 1 回だけ呼ぶ (updateTweet は呼ばれない)", async () => {
+		const draft = await openComposerAndLoadDraft();
+		const publishedTweet = makeTweetFixture({
+			id: draft.id,
+			body: "loaded draft body",
+			published_at: "2026-05-18T13:45:00Z",
+			edit_count: 0,
+		});
+		publishDraftMock.mockResolvedValueOnce(publishedTweet);
+
+		// 「投稿」 click
+		await userEvent.click(screen.getByRole("button", { name: /^投稿$/ }));
+
+		await waitFor(() => {
+			expect(publishDraftMock).toHaveBeenCalledTimes(1);
+			expect(publishDraftMock).toHaveBeenCalledWith(draft.id, {
+				body: "loaded draft body",
+			});
+		});
+		// 重要: updateTweet は呼ばれない (= 1 段化の検証)
+		expect(updateTweetMock).not.toHaveBeenCalled();
+		expect(toastSuccessSpy).toHaveBeenCalledWith("投稿しました");
+	});
+
+	it("COMPOSER-DRAFT-PUBLISH-2 (回帰): loadedDraftId なし + 「投稿」 → 従来どおり createTweet が呼ばれる", async () => {
+		const newTweet = makeTweetFixture({
+			id: 200,
+			body: "fresh post",
+			published_at: "2026-05-18T13:50:00Z",
+		});
+		createTweetMock.mockResolvedValueOnce(newTweet);
+		render(<TweetComposer />);
+
+		const textarea = screen.getByPlaceholderText(/いまどうしてる/);
+		await userEvent.type(textarea, "fresh post");
+		await userEvent.click(screen.getByRole("button", { name: /^投稿$/ }));
+
+		await waitFor(() => {
+			expect(createTweetMock).toHaveBeenCalledTimes(1);
+			expect(createTweetMock).toHaveBeenCalledWith({
+				body: "fresh post",
+				tags: [],
+			});
+		});
+		expect(publishDraftMock).not.toHaveBeenCalled();
+		expect(updateTweetMock).not.toHaveBeenCalled();
+	});
+
+	it("COMPOSER-DRAFT-SAVE-1 (回帰): loadedDraftId あり + 「下書き保存」 → 引き続き updateTweet が呼ばれる", async () => {
+		const draft = await openComposerAndLoadDraft();
+		const updated = makeTweetFixture({
+			id: draft.id,
+			body: "loaded draft body",
+		});
+		updateTweetMock.mockResolvedValueOnce(updated);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /下書きとして保存する/ }),
+		);
+
+		await waitFor(() => {
+			expect(updateTweetMock).toHaveBeenCalledTimes(1);
+			expect(updateTweetMock).toHaveBeenCalledWith(draft.id, {
+				body: "loaded draft body",
+			});
+		});
+		// publishDraft / createTweet は呼ばれない (= save 経路は変更なし)
+		expect(publishDraftMock).not.toHaveBeenCalled();
+		expect(createTweetMock).not.toHaveBeenCalled();
+		expect(toastSuccessSpy).toHaveBeenCalledWith("下書きに保存しました");
+	});
+});

--- a/client/src/lib/api/tweets.ts
+++ b/client/src/lib/api/tweets.ts
@@ -189,13 +189,26 @@ export async function fetchDrafts(
  *
  * 自分の下書きを公開する。 publish 成功時は published_at が入った tweet を返す。
  * 他人の draft → 404、 既に公開済み → 400。
+ *
+ * #769 fix: optional `body` を渡せる。 composer の「投稿」 ボタンで draft を
+ * 公開する際に「PATCH してから publish」 の 2 段呼び出しを避け、 1 リクエストで
+ * 「最新 body + 公開」 を実現する (= record_edit 不発火 = edit_count 動かず、
+ * 「編集済」 badge も付かない)。 body を渡さない場合は従来挙動 (= 既存 body のまま公開)。
  */
+export interface PublishDraftPayload {
+	body?: string;
+}
+
 export async function publishDraft(
 	id: number | string,
+	payload: PublishDraftPayload = {},
 	client: AxiosInstance = api,
 ): Promise<TweetSummary> {
 	await ensureCsrfToken(client);
-	const res = await client.post<TweetSummary>(`/tweets/${id}/publish/`);
+	const res = await client.post<TweetSummary>(
+		`/tweets/${id}/publish/`,
+		payload,
+	);
 	return res.data;
 }
 

--- a/docs/specs/draft-edit-limit-fix-spec.md
+++ b/docs/specs/draft-edit-limit-fix-spec.md
@@ -1,0 +1,315 @@
+# 下書き呼び出し→投稿で edit_count が動くバグの修正 仕様書 (#769)
+
+> Version: 0.2
+> 作成日: 2026-05-18
+> 関連 Issue: #769
+> 関連 PR: 本 PR (= fix)
+> 関連 spec: [tweet-drafts-spec.md](./tweet-drafts-spec.md) (= #734 元仕様、 §2.1 が真の挙動定義), [tweet-drafts-load-spec.md](./tweet-drafts-load-spec.md) (= #767 / PR #768、 本バグ混入元)
+> 関連 Issue (out of scope, follow-up): #770 (signals.py の draft 副作用漏洩 = mention 通知 / counter / OGP / TL cache), #771 (agents/tools.py の filter 重複整理)
+>
+> 改訂履歴:
+>
+> - 0.1 (2026-05-18): 初稿
+> - 0.2 (2026-05-18): pr-test-analyzer + silent-failure-hunter agent の指摘を反映。 §3.2 に updated_at / language 再検出を明示、 §4 に HP-2 / BD-4 / SE-missing-1 / POST-PUBLISH-EDIT を追加、 FF-1 / E2E-DRAFT-2 を削除 (既存 test と重複 / pytest で代替)、 §4.2 vitest の assert 強化
+
+---
+
+## 0. 目的
+
+draft (= `published_at IS NULL`) の body を書き換える操作は **「下書きを書いている」** だけであり、 公開済み tweet 用の Twitter 互換 edit 機能 (= 30 分以内 / 5 回まで制約、 `edit_count` インクリメント、 「編集済」 badge 表示) **の対象外** であるべき。 しかし現在の実装は draft の PATCH も `Tweet.record_edit()` を経由しているため:
+
+1. **「これ以上編集できません」 で投稿不可**: composer の `submit()` が draft 公開時に `updateTweet` → `publishDraft` の 2 段で呼ぶため、 PATCH 段階で `record_edit` が走り 5 回を超えると 400 で投稿不可
+2. **「編集済」 badge 誤表示**: draft → publish の publish 経路の前段の PATCH (= 同 submit() フロー) で edit_count が +1 されるため、 公開直後の tweet に「編集済」 badge が付く
+
+仕様書 [`tweet-drafts-spec.md`](./tweet-drafts-spec.md) §2.1 の table:
+
+| 状態         | created_at                             | published_at |
+| ------------ | -------------------------------------- | ------------ |
+| 下書き作成時 | 作成時刻 (記録のみ、 並びには使わない) | NULL         |
+| 下書きを公開 | 公開時刻に更新                         | 公開時刻     |
+| 下書きを編集 | 変更しない                             | NULL のまま  |
+| 公開後の編集 | 変更しない (= 既存挙動)                | 変更しない   |
+
+「下書きを編集」 の行は **edit_count / last_edited_at に言及していない** = 触らないのが筋。 本 spec で明文化する。
+
+---
+
+## 1. 用語の整理 (混同を排除)
+
+| 用語                          | 定義                                                   | edit_count を動かすか | 30 min / 5 回制約 | TweetEdit 行作成 |
+| ----------------------------- | ------------------------------------------------------ | --------------------- | ----------------- | ---------------- |
+| **下書きを書く**              | published_at IS NULL の Tweet の body を書き換える     | **No**                | **No**            | **No**           |
+| **下書きを公開する**          | published_at IS NULL → published_at = now()            | **No**                | **No**            | **No**           |
+| **公開済み tweet を編集する** | published_at IS NOT NULL の Tweet の body を書き換える | **Yes**               | **Yes**           | **Yes**          |
+
+「下書きを書く」 と「下書きを公開する」 は **編集ではない**。 「公開済み tweet を編集する」 だけが従来の record_edit 経路。
+
+---
+
+## 2. やる / やらない
+
+### やる
+
+- `TweetUpdateSerializer.update()` で `instance.published_at is None` なら `record_edit()` を経由せず plain update (body のみ、 `updated_at` も自然に更新)
+- `publish` action 経路で **publish 直前に body を上書きする経路** を追加 (frontend の 2 段呼び出しを 1 段にする) — または publish action 自体が optional `body` を受け取れるようにする
+- frontend `TweetComposer.tsx` の `submit()` を「PATCH → publish」 の 2 段から「publish に body を渡す 1 段」 に変更
+- backend pytest で 4 系統 8 ケース追加 (§4 参照)
+- Playwright spec `client/e2e/tweet-drafts-edit-limit.spec.ts` 新規 (§4 参照)
+
+### やらない (別 Issue で対応)
+
+- 過去にこのバグで `edit_count=1` になって公開された tweet の backfill (= 該当 tweet を `edit_count=0` に戻す migration)
+  - 理由: stg 確認時点で該当数僅少 (test4 の 1 件)、 prod は本 PR の前に deploy された経緯がなく稀少と推定。 後で backfill が必要と判定したら別 Issue で migration を切る
+- `TweetEdit` テーブルの履歴清掃 (= 上記 backfill した tweet に対応する TweetEdit 行削除)
+- 「下書き編集」 という UI 用語の見直し (= 「下書きを書く」 への文言変更): UX 改善は別 Issue (#767 系の continuation)
+
+---
+
+## 3. 実装方針
+
+### 3.1 backend: `TweetUpdateSerializer.update()` を draft / published で分岐
+
+**file**: `apps/tweets/serializers.py`
+
+```python
+class TweetUpdateSerializer(serializers.Serializer):
+    body = serializers.CharField(max_length=TWEET_BODY_MAX_LENGTH)
+
+    def validate_body(self, value: str) -> str:
+        # 既存どおり
+        ...
+
+    def update(self, instance: Tweet, validated_data: dict[str, Any]) -> Tweet:
+        editor = self.context["request"].user
+        new_body = validated_data["body"]
+
+        # #769 fix: draft (published_at IS NULL) は「編集」 ではなく「下書きを書いている」
+        # だけなので record_edit を経由しない。 edit_count / last_edited_at / TweetEdit
+        # は触らない。 plain update (body + updated_at のみ)。
+        if instance.published_at is None:
+            self._save_draft_body(instance, new_body)
+        else:
+            # 公開済み tweet の編集は従来どおり record_edit (= 30min / 5 回 / TweetEdit)
+            instance.record_edit(new_body=new_body, editor=editor)
+        return instance
+
+    @staticmethod
+    def _save_draft_body(instance: Tweet, new_body: str) -> None:
+        """draft の body だけ更新。 edit_count / last_edited_at は触らない。
+
+        #769: record_edit の長さ検証と同じ guard をここでも掛ける (DRY: helper 化を別 PR で検討)。
+        """
+        if len(new_body) > TWEET_BODY_MAX_LENGTH:
+            raise DjangoValidationError(
+                {"body": f"本文は {TWEET_BODY_MAX_LENGTH} 字以内で入力してください。"}
+            )
+        if count_tweet_chars(new_body) > TWEET_MAX_CHARS:
+            raise DjangoValidationError(
+                {"body": f"本文は URL / Markdown 換算で {TWEET_MAX_CHARS} 字以内にしてください。"}
+            )
+
+        now = timezone.now()
+        Tweet.all_objects.filter(pk=instance.pk).update(
+            body=new_body,
+            updated_at=now,
+        )
+        instance.refresh_from_db(fields=["body", "updated_at"])
+```
+
+**設計判断**:
+
+- `record_edit` を「published 専用 API」 として位置づけを明確化。 内部の `can_edit()` も published 専用 (= caller 責任で draft を弾く)
+- draft の plain update は新 helper `_save_draft_body` に切り出し。 将来 model layer に持っていく可能性も視野
+- `_save_draft_body` の length 検証は record_edit と重複するが、 helper 化は別 PR (= YAGNI、 まずバグを確実に潰す)
+
+### 3.2 backend: `publish` action で body も同時更新できるようにする
+
+**file**: `apps/tweets/views.py`
+
+```python
+@action(
+    detail=True,
+    methods=["post"],
+    url_path="publish",
+    permission_classes=[IsAuthenticated],
+)
+def publish(self, request: Request, pk: int | None = None) -> Response:
+    """POST /api/v1/tweets/<id>/publish/ — 自分の下書きを公開する。
+
+    #769 fix: optional body を受け取り、 公開時に body も上書きする。
+    これにより frontend は composer 内で「PATCH してから publish」 の 2 段呼び出しを
+    やめて、 1 リクエストで「最新 body + 公開」 を実現できる (= record_edit 不発火)。
+
+    silent-failure-hunter MEDIUM #5: `.update()` は `auto_now` を bypass するので
+    `updated_at=now` を明示する。
+
+    silent-failure-hunter LOW #7: body を上書きする場合、 `.update()` は pre_save signal
+    も bypass するため `auto_detect_language` が走らない。 publish action 内で `detect_language`
+    を直接呼んで `language` field も更新する。 body 更新なしなら language も変えない。
+    """
+    instance = self.get_object()  # `_DRAFT_AWARE_ACTIONS` で all_with_drafts
+    if instance.author_id != request.user.pk:
+        return Response({"detail": "Not found."}, status=404)
+    if instance.published_at is not None:
+        return Response({"detail": "already_published"}, status=400)
+
+    # #769: body が来ていれば draft 段階で先に上書き (= plain update)
+    body = request.data.get("body")
+    if body is not None:
+        # validate body length (既存 validate_body と同じ guard)
+        if len(body) > TWEET_BODY_MAX_LENGTH:
+            raise ValidationError({"body": f"本文は {TWEET_BODY_MAX_LENGTH} 字以内で入力してください。"})
+        if count_tweet_chars(body) > TWEET_MAX_CHARS:
+            raise ValidationError({"body": f"本文は URL / Markdown 換算で {TWEET_MAX_CHARS} 字以内にしてください。"})
+
+    now = timezone.now()
+    update_fields = {
+        "published_at": now,
+        "created_at": now,  # spec §2.1: 公開時に created_at も now() に揃える
+        "updated_at": now,  # silent-failure MEDIUM #5: .update() は auto_now bypass
+    }
+    if body is not None:
+        update_fields["body"] = body
+        # silent-failure LOW #7: pre_save signal が bypass されるので language 再検出を明示
+        from apps.tweets.signals import detect_language  # 局所 import で循環回避
+        update_fields["language"] = detect_language(body)
+
+    Tweet.all_objects.filter(pk=instance.pk).update(**update_fields)
+    instance.refresh_from_db()
+    serializer = TweetDetailSerializer(instance, context=self.get_serializer_context())
+    return Response(serializer.data, status=200)
+```
+
+### 3.3 frontend: `submit()` の 2 段呼び出しを 1 段にする
+
+**file**: `client/src/components/tweets/TweetComposer.tsx`
+
+```typescript
+// 旧:
+if (loadedDraftId !== null) {
+	await updateTweet(loadedDraftId, { body }); // ← #769 元凶
+	tweet = await publishDraft(loadedDraftId);
+}
+
+// 新:
+if (loadedDraftId !== null) {
+	tweet = await publishDraft(loadedDraftId, { body }); // 1 段で body も渡す
+}
+```
+
+**file**: `client/src/lib/api/tweets.ts`
+
+```typescript
+// publishDraft の signature を拡張
+export async function publishDraft(
+    id: number,
+    payload?: { body?: string },
+): Promise<TweetDetail> {
+    // body があれば POST body に含める
+    ...
+}
+```
+
+`saveDraft()` の `loadedDraftId !== null` 経路は引き続き `updateTweet(loadedDraftId, { body })` を使う。 これは backend §3.1 で draft 専用 plain update が走るようになるので副作用なし。
+
+### 3.4 影響範囲
+
+- `apps/tweets/serializers.py` (= `TweetUpdateSerializer.update` 分岐 + `_save_draft_body` 追加)
+- `apps/tweets/views.py` (= `publish` action で optional body 受け入れ)
+- `apps/tweets/tests/test_drafts.py` (= 4 系統 8 ケース pytest 追加)
+- `client/src/lib/api/tweets.ts` (= `publishDraft` signature 拡張)
+- `client/src/components/tweets/TweetComposer.tsx` (= `submit()` の 2 段 → 1 段)
+- `client/e2e/tweet-drafts-edit-limit.spec.ts` (= 新規 Playwright spec)
+- `client/src/components/tweets/__tests__/TweetComposerDraft.test.tsx` (= 既存 vitest を 1 段呼び出しに合わせて更新)
+
+---
+
+## 4. テスト (4 系統)
+
+### 4.1 backend pytest (`apps/tweets/tests/test_drafts.py` に追加)
+
+#### Happy path
+
+- **HP-1**: 自分の draft に PATCH `{body: "hello"}` → 200、 DB の `body=="hello"`、 `edit_count=0`、 `last_edited_at=null`、 `TweetEdit` 行作成されない、 `updated_at` は動く
+- **HP-2**: draft `POST /tweets/<id>/publish/ {body: "world"}` → 200、 returned tweet の `body=="world"` (= optional body が正しく上書きされる正検証)、 `published_at!=null`、 `created_at==published_at` (spec §2.1)、 `updated_at==published_at`
+
+#### 境界
+
+- **BD-1**: 同じ draft に PATCH を 6 回連続送る → 全 6 回 200、 `edit_count=0` のまま、 `TweetEdit` 行 0 件
+- **BD-2**: draft 作成から 31 分後 (= `freezegun` などで時間進める) に PATCH → 200 (= 30 分 window 制約が適用されない)
+- **BD-3**: 公開済み tweet を 5 回 PATCH → 5 回目までは 200、 6 回目で 400「これ以上編集できません」 (= 公開済みの 5 回制約は壊れていない)
+- **BD-4**: fixture で `edit_count=4` の公開済み tweet を作る → PATCH → 200、 `edit_count==5`。 同じく `edit_count=5` の公開済みに PATCH → 400 (= 「ちょうど」 境界の直接検証)
+
+#### 失敗系
+
+- ~~**FF-1**: 他人の draft に PATCH → 404~~ → 既存 `test_drafts.py::TestDraftEditDeleteHiding::test_other_user_patch_other_draft_404` と重複につき本 PR では追加しない (= 既存 test に委ねる)
+- **FF-2**: 匿名で `PATCH /tweets/<draft-id>/` → 401 (= IsAuthenticated 通過しない)
+- **FF-3**: `publish {body: <181 字>}` → 400 (= 既存 validate_body と同じ length guard)
+
+#### 期待しない副作用
+
+- **SE-1**: draft `POST /tweets/<id>/publish/ {body: "x"}` → 200、 returned tweet の `edit_count=0`、 `last_edited_at=null`、 `TweetEdit` 行作成されない、 body == "x" (= HP-2 と統合済の正・負併記)
+- **SE-2**: draft に 5 回 PATCH した後 `POST /publish/ {body: "y"}` → 200、 `edit_count=0`、 公開後の body は "y"
+- **SE-3**: draft PATCH 後の `updated_at` は動くが `last_edited_at` は null のまま
+- **SE-4 (POST-PUBLISH-EDIT, デグレ防止)**: draft を publish → 公開済みになった tweet に PATCH → `edit_count==1`、 `last_edited_at!=null`、 `TweetEdit` 行 1 件、 「編集済」 status の API field が立つ。 「publish 後は record_edit 経路が有効になる」 ことの統合確認
+- **SE-5 (language 再検出, LOW #7)**: draft に `publish {body: "Привет"}` (= cyrillic) → returned tweet の `language=="ru"` (= signal bypass しても language は更新される)
+
+#### existing test の更新
+
+- 既存 `apps/tweets/tests/test_drafts.py` の publish action test (= `body` を渡さない既存 path) は引き続き pass すること (backward compatible)
+- `updated_at` 関連の既存 test があれば、 publish action が `updated_at=now` を明示する変更で挙動が変わる箇所がないか確認
+
+### 4.2 frontend vitest (`__tests__/TweetComposerDraft.test.tsx` 更新)
+
+- **COMPOSER-DRAFT-PUBLISH-1**: loadedDraftId あり + 「投稿」 → `publishDraft` が **1 回だけ** 呼ばれ、 引数が `(id, { body: <現在の textarea body> })` であることを assert (= 1 段化 + body 引数の検証)。 `updateTweet` は呼ばれない
+- **COMPOSER-DRAFT-PUBLISH-2 (回帰)**: loadedDraftId なし + 「投稿」 → 従来どおり `createTweet({ body, tags })` が呼ばれる (= 新規投稿経路の backward compat)
+- **COMPOSER-DRAFT-SAVE-1 (回帰)**: loadedDraftId あり + 「下書き保存」 → 引き続き `updateTweet(id, { body })` が呼ばれる (= saveDraft 経路は変更しない)
+
+### 4.3 E2E Playwright (`client/e2e/tweet-drafts-edit-limit.spec.ts` 新規)
+
+stg 反映後に実機実行。 シナリオは backend pytest の重要部分を UI 視点で再検証 (= 重複は pytest に委ね、 UI でしか取れないものに集中):
+
+- **E2E-DRAFT-1 (HP-1 / SE-1)**: test4 ログイン → composer 開く → body 入力 → 「下書き保存」 → 「下書き」 button → 一覧から「編集」 → 「投稿」 → TL に表示、 **「編集済」 badge が付かない** (= UI 上で副作用が見えない)
+- ~~E2E-DRAFT-2 (BD-1, fetch で 6 回 PATCH)~~ → pytest BD-1 で代替につき E2E 削除 (= API 層の境界は backend test に委ねる)
+- ~~E2E-DRAFT-2 (BD-3, 5 回 edit limit)~~ → pytest BD-3 / BD-4 で代替につき E2E 削除 (= UI 依存度が高く脆い、 backend test に委ねる)
+- **E2E-DRAFT-3 (SE-1 network check)**: draft load → 「投稿」 → network panel 確認: `POST /api/v1/tweets/<id>/publish/` の単独 1 リクエストのみ、 `PATCH /api/v1/tweets/<id>/` は **発生しない** (= 1 段化の network 視点検証)
+- **E2E-DRAFT-4 (SE-4 デグレ防止)**: draft 公開 → 公開直後の tweet を composer で edit → 「編集済」 badge が **付く**、 `edit_count==1` (= publish 後の record_edit 経路は壊れていない、 edit menu UI に依存するため stg 反映時に skip 判定が入る場合あり)
+
+実行:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test4@example.com \
+PLAYWRIGHT_USER1_PASSWORD=E5INn9EaBLG7WNPl \
+PLAYWRIGHT_USER1_HANDLE=test4 \
+PLAYWRIGHT_USER2_EMAIL=test5@example.com \
+PLAYWRIGHT_USER2_PASSWORD=jIZU2eTUpDra8oKH \
+PLAYWRIGHT_USER2_HANDLE=test5 \
+  npx playwright test e2e/tweet-drafts-edit-limit.spec.ts --reporter=line
+```
+
+env は [docs/local/e2e-stg.md](../local/e2e-stg.md) 参照。
+
+---
+
+## 5. 受け入れ基準 (definition of done)
+
+- [ ] backend `TweetUpdateSerializer.update` が draft / published で分岐 (`_save_draft_body` helper)
+- [ ] `publish` action が optional `body` を受け取り 1 リクエストで draft + 公開できる + `updated_at=now` を明示 + `language` 再検出
+- [ ] frontend `submit()` が `publishDraft(id, { body })` の 1 段呼び出しに変わっている
+- [ ] backend pytest 10 ケース (HP-1 / HP-2 / BD-1 / BD-2 / BD-3 / BD-4 / FF-2 / FF-3 / SE-1 / SE-2 / SE-3 / SE-4 / SE-5) 全 pass
+- [ ] frontend vitest 3 ケース (COMPOSER-DRAFT-PUBLISH-1 + 回帰 -2 / SAVE-1) + 既存 test backward compat
+- [ ] stg 反映後、 Playwright spec 3 シナリオ (E2E-DRAFT-1 / -3 / -4) 全 pass (E2E-DRAFT-2 は pytest BD-3/-4 で代替済)
+- [x] `pr-test-analyzer` agent で 4 系統点検済 (2026-05-18、 指摘を v0.2 で反映)
+- [x] `silent-failure-hunter` agent で draft 経路の副作用走査済 (2026-05-18、 別 issue #770 / #771 起票、 MEDIUM #5 / LOW #7 は本 PR scope に含めた)
+- [ ] `gan-evaluator` agent で実機採点 (= 「編集済」 が出ない / 投稿成功通知 / 「これ以上編集できません」 がもう出ない)
+- [ ] python-reviewer / security-reviewer / database-reviewer / code-reviewer 直列で CRITICAL/HIGH なし
+- [ ] PR description で 4 系統 × 全 case を 1 行ずつチェックボックスで明示
+
+---
+
+## 6. ロールバック
+
+- `TweetUpdateSerializer.update` の分岐削除 → 元の record_edit 一本に戻る (= バグ復活)
+- `publish` action の optional body 受け入れ削除 → frontend は 2 段呼び出しに戻す
+- backward compatible (= 既存 published tweet edit API は変えない、 既存 publish API も body を渡さなければ従来挙動)

--- a/docs/specs/draft-edit-limit-fix-spec.md
+++ b/docs/specs/draft-edit-limit-fix-spec.md
@@ -97,17 +97,10 @@ class TweetUpdateSerializer(serializers.Serializer):
     def _save_draft_body(instance: Tweet, new_body: str) -> None:
         """draft の body だけ更新。 edit_count / last_edited_at は触らない。
 
-        #769: record_edit の長さ検証と同じ guard をここでも掛ける (DRY: helper 化を別 PR で検討)。
+        #769: body の長さ / char count 検証は serializer の ``validate_body`` で
+        既に通過しているため、 ここで冗長 guard は書かない (= 二重検証回避)。
+        helper 化検討は別 PR (= YAGNI)。
         """
-        if len(new_body) > TWEET_BODY_MAX_LENGTH:
-            raise DjangoValidationError(
-                {"body": f"本文は {TWEET_BODY_MAX_LENGTH} 字以内で入力してください。"}
-            )
-        if count_tweet_chars(new_body) > TWEET_MAX_CHARS:
-            raise DjangoValidationError(
-                {"body": f"本文は URL / Markdown 換算で {TWEET_MAX_CHARS} 字以内にしてください。"}
-            )
-
         now = timezone.now()
         Tweet.all_objects.filter(pk=instance.pk).update(
             body=new_body,


### PR DESCRIPTION
## Summary

下書きを呼び出して「投稿」 を押すと「これ以上編集できません」 が出る、 公開直後の tweet に「編集済」 badge が付く、 という #769 の修正。 PR #768 (composer 内 drafts-load) で混入したバグ。

**Root cause**: `TweetUpdateSerializer.update()` が `instance.published_at is None` を判定せず record_edit 経由で edit_count を +1 していた。 composer の `submit()` も `updateTweet → publishDraft` の 2 段呼び出しで、 publish 前に必ず PATCH = record_edit が走る構造だった。

**修正**: draft の PATCH は plain update に分岐 + publish action が optional `body` を受け取って 1 リクエストで「最新 body + 公開」 を実現 (= record_edit 不発火、 edit_count=0 のまま公開、 「編集済」 badge も付かない)。

副次的に silent-failure-hunter agent が見つけた:
- MEDIUM #5: `.update()` が `auto_now` を bypass する問題 → publish action で `updated_at=now()` を明示
- LOW #7: `.update()` が pre_save signal を bypass する問題 → publish 時の body 上書き後に `detect_language` を明示再検出

別 Issue 起票済 (本 PR scope 外):
- #770: `signals.py` の `on_tweet_created` が draft 作成時に mention 通知 / counter / OGP / TL cache を発火させる silent 副作用
- #771: `agents/tools.py` の redundant filter 整理 (maintenance trap 防止)

## Test plan

CLAUDE.md §4.5 完了判定 + draft-edit-limit-fix-spec.md §5 受け入れ基準:

### backend pytest (apps/tweets/tests/test_drafts.py)
- [ ] Happy: HP-1 (draft PATCH 200 / edit_count=0) / HP-2 (publish with body 上書き)
- [ ] 境界: BD-1 (6 回 PATCH 全 200) / BD-2 (31 分後 PATCH OK) / BD-3 (公開済み 5 回上限) / BD-4 (edit_count=4-5 ちょうど境界)
- [ ] 失敗: FF-2 (匿名 PATCH 401) / FF-3 (body length 違反 400)
- [ ] 副作用: SE-1 (edit_count=0/TweetEdit 0 件/last_edited_at null) / SE-2 (5 回 PATCH 後 publish 成功) / SE-3 (updated_at 動く / last_edited_at 動かない) / SE-4 (publish 後 edit で record_edit 経路) / SE-5 (language 再検出)
- [ ] 既存 publish 挙動 (body 渡さず) は backward compat

### frontend vitest (TweetComposerDraftLoad.test.tsx)
- [ ] COMPOSER-DRAFT-PUBLISH-1: publishDraft(id, {body}) 1 回のみ、 updateTweet 呼ばれない
- [ ] COMPOSER-DRAFT-PUBLISH-2 (回帰): loadedDraftId なしで createTweet 経路
- [ ] COMPOSER-DRAFT-SAVE-1 (回帰): 下書き保存は updateTweet 経路維持

### E2E Playwright (tweet-drafts-edit-limit.spec.ts) — stg 反映後 Claude 自身で実機実行
- [ ] E2E-DRAFT-1: 下書き保存 → load → 投稿 → TL 表示、 「編集済」 badge **付かない**
- [ ] E2E-DRAFT-3: network 監視で publish 1 req、 PATCH 0 件
- [ ] E2E-DRAFT-4 (デグレ防止): publish 後 edit で「編集済」 badge **付く**

### agent 採点 (stg 反映後)
- [ ] gan-evaluator agent で副作用採点
- [ ] python-reviewer / security-reviewer / database-reviewer / code-reviewer 直列

### 前提 / 環境
- stg URL: https://stg.codeplace.me
- test user: test4@example.com / E5INn9EaBLG7WNPl
- 実行: `PLAYWRIGHT_BASE_URL=https://stg.codeplace.me E2E_LOGIN_EMAIL=test4@example.com E2E_LOGIN_PASSWORD=E5INn9EaBLG7WNPl npx playwright test e2e/tweet-drafts-edit-limit.spec.ts`

Closes #769
Refs #770, #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
