### PR TITLE
[bug][tweets] draft 作成時の signal 副作用漏洩を修正 (#770)

### DIFF
--- a/apps/tweets/side_effects.py
+++ b/apps/tweets/side_effects.py
@@ -1,0 +1,159 @@
+"""Tweet create / publish 時の副作用群 helper (#770)。
+
+post_save signal (`on_tweet_created`) と publish action の両方から呼ばれ、
+公開時に 1 回だけ以下の副作用を発火する:
+
+- reply / quote / repost の counter bump (= ORIGINAL なら no-op)
+- mention notification dispatch
+- OGP fetch celery enqueue (URL があれば)
+- home TL cache invalidate (author のみ)
+
+#770 fix: draft (= published_at IS NULL) では絶対に呼ばれてはいけない。
+caller (signal handler / publish action) が `published_at IS NOT NULL` を保証
+した上で `transaction.on_commit` 内で `emit_create_side_effects(tweet_pk)` を
+call する。 defense-in-depth で関数冒頭でも `published_at` を確認する。
+
+python-reviewer HIGH (#770 review): caller が pk を渡し、 helper 内で
+`Tweet.all_objects.get(pk)` で fresh fetch することで `instance` の mutable
+キャプチャ問題 (= lambda closure 内で別 mutator に上書きされる) を排除する。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from django.db.models import F
+from django.db.models.functions import Greatest
+
+from apps.common.blocking import safe_notify
+from apps.tweets.models import Tweet, TweetType
+
+# #412: mention 抽出の正規表現と上限。spec §12 より handle 数 10 超過時は
+# Celery off-load を検討する想定だが、本 Issue では同期処理 + 上限で抑える。
+_MENTION_RE = re.compile(r"(?<![A-Za-z0-9_])@([A-Za-z0-9_]{3,30})")
+MAX_MENTION_NOTIFY = 10
+
+
+def _bump_field(tweet_pk: int | None, field: str, delta: int) -> None:
+    if tweet_pk is None:
+        return
+    if delta >= 0:
+        Tweet.all_objects.filter(pk=tweet_pk).update(**{field: F(field) + delta})
+    else:
+        Tweet.all_objects.filter(pk=tweet_pk).update(**{field: Greatest(F(field) + delta, 0)})
+
+
+def emit_create_side_effects(tweet_pk: int) -> None:
+    """tweet 公開時の副作用群を発火する (signal handler / publish action 共通)。
+
+    呼び出し元 (= transaction.on_commit 内で実行される想定):
+    - `on_tweet_created` (post_save signal): published_at IS NOT NULL の create でのみ呼ぶ
+    - `TweetViewSet.publish` action: draft → publish の遷移直後に呼ぶ
+
+    #770 python-reviewer HIGH: caller の lambda closure で mutable instance を
+    つかむのではなく pk を渡してもらい、 ここで fresh fetch する。 これにより
+    refresh_from_db 後の他処理で instance が再 mutate されても影響を受けない。
+
+    #770 python-reviewer HIGH: defense-in-depth で `published_at IS NULL` の
+    tweet なら ValueError を投げる (silent な誤呼出を loud にする)。
+    """
+    try:
+        instance = Tweet.all_objects.get(pk=tweet_pk)
+    except Tweet.DoesNotExist:
+        # tweet が transaction commit 後に削除されたケース (= rare)。
+        # silent skip でよい (= 副作用を発火しても意味がない)。
+        return
+
+    if instance.published_at is None:
+        raise ValueError(f"emit_create_side_effects called on unpublished tweet pk={tweet_pk}")
+
+    actor = instance.author
+    target_type = instance.type
+    reply_to_pk = instance.reply_to_id
+    quote_of_pk = instance.quote_of_id
+    repost_of_pk = instance.repost_of_id
+    reply_to_obj = instance.reply_to
+    quote_of_obj = instance.quote_of
+    repost_of_obj = instance.repost_of
+    body = instance.body
+
+    if target_type == TweetType.REPLY:
+        _bump_field(reply_to_pk, "reply_count", 1)
+        if reply_to_obj is not None:
+            # #412: target_type/target_id を追加 (Notification 解決用)
+            safe_notify(
+                kind="reply",
+                recipient=reply_to_obj.author,
+                actor=actor,
+                target_type="tweet",
+                target_id=tweet_pk,
+            )
+    elif target_type == TweetType.QUOTE:
+        _bump_field(quote_of_pk, "quote_count", 1)
+        if quote_of_obj is not None:
+            safe_notify(
+                kind="quote",
+                recipient=quote_of_obj.author,
+                actor=actor,
+                target_type="tweet",
+                target_id=tweet_pk,
+            )
+    elif target_type == TweetType.REPOST:
+        _bump_field(repost_of_pk, "repost_count", 1)
+        if repost_of_obj is not None:
+            safe_notify(
+                kind="repost",
+                recipient=repost_of_obj.author,
+                actor=actor,
+                target_type="tweet",
+                target_id=tweet_pk,
+            )
+
+    # P2-07: OGP fetch を enqueue (URL を含む original / quote / reply が対象)。
+    # repost は body=空なので skip。
+    if target_type != TweetType.REPOST and body:
+        from apps.tweets.ogp import extract_first_url
+        from apps.tweets.tasks import fetch_ogp_for_tweet
+
+        if extract_first_url(body):
+            fetch_ogp_for_tweet.delay(tweet_pk)
+
+    # #412: mention 抽出 → 各 user に kind=mention 通知。
+    # repost は body=空なのでスキップ。reply / quote / mention は重複しても
+    # 別 kind なので Notification 行は別。
+    if target_type != TweetType.REPOST and body:
+        _dispatch_mention_notifications(body=body, actor=actor, tweet_pk=tweet_pk)
+
+    # #311: 投稿者の home TL cache を invalidate。これがないと cache TTL
+    # (10 min) 経過まで自分の新規投稿が home に出ない。フォロワーの cache
+    # invalidate は fan-out コストが大きいので Phase 4 で fan-out-on-write
+    # を検討する際にまとめて対応 (本 PR では author 自身のみ)。
+    from apps.timeline.services import invalidate_home_tl
+
+    invalidate_home_tl(actor)
+
+
+def _dispatch_mention_notifications(*, body: str, actor: Any, tweet_pk: int | None) -> None:
+    """body 中の @handle を抽出し、実存する active user に mention 通知を発火.
+
+    自分自身 (`@<actor.handle>`) は self-notify guard で無視される。
+    重複 handle は set で排除済。
+    spec §12 + python-reviewer MED: handle 数の上限を MAX_MENTION_NOTIFY (=10) で
+    cap。それ以上は Celery off-load を別 Issue で対応する。
+    """
+    handles = {m.group(1) for m in _MENTION_RE.finditer(body)}
+    if not handles:
+        return
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    users = User.objects.filter(username__in=handles, is_active=True)[:MAX_MENTION_NOTIFY]
+    for user in users:
+        safe_notify(
+            kind="mention",
+            recipient=user,
+            actor=actor,
+            target_type="tweet",
+            target_id=tweet_pk,
+        )

--- a/apps/tweets/side_effects.py
+++ b/apps/tweets/side_effects.py
@@ -20,6 +20,7 @@ python-reviewer HIGH (#770 review): caller が pk を渡し、 helper 内で
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
@@ -29,13 +30,15 @@ from django.db.models.functions import Greatest
 from apps.common.blocking import safe_notify
 from apps.tweets.models import Tweet, TweetType
 
+logger = logging.getLogger(__name__)
+
 # #412: mention 抽出の正規表現と上限。spec §12 より handle 数 10 超過時は
 # Celery off-load を検討する想定だが、本 Issue では同期処理 + 上限で抑える。
 _MENTION_RE = re.compile(r"(?<![A-Za-z0-9_])@([A-Za-z0-9_]{3,30})")
 MAX_MENTION_NOTIFY = 10
 
 
-def _bump_field(tweet_pk: int | None, field: str, delta: int) -> None:
+def bump_field(tweet_pk: int | None, field: str, delta: int) -> None:
     if tweet_pk is None:
         return
     if delta >= 0:
@@ -66,7 +69,12 @@ def emit_create_side_effects(tweet_pk: int) -> None:
         return
 
     if instance.published_at is None:
-        raise ValueError(f"emit_create_side_effects called on unpublished tweet pk={tweet_pk}")
+        # code-reviewer MEDIUM: Django は ``transaction.on_commit`` callback 内の
+        # 例外を silent に swallow するので、 ValueError raise だけでは Sentry に
+        # 届かない。 明示的に error ログを残してから raise する。
+        msg = f"emit_create_side_effects called on unpublished tweet pk={tweet_pk}"
+        logger.error(msg)
+        raise ValueError(msg)
 
     actor = instance.author
     target_type = instance.type
@@ -79,7 +87,7 @@ def emit_create_side_effects(tweet_pk: int) -> None:
     body = instance.body
 
     if target_type == TweetType.REPLY:
-        _bump_field(reply_to_pk, "reply_count", 1)
+        bump_field(reply_to_pk, "reply_count", 1)
         if reply_to_obj is not None:
             # #412: target_type/target_id を追加 (Notification 解決用)
             safe_notify(
@@ -90,7 +98,7 @@ def emit_create_side_effects(tweet_pk: int) -> None:
                 target_id=tweet_pk,
             )
     elif target_type == TweetType.QUOTE:
-        _bump_field(quote_of_pk, "quote_count", 1)
+        bump_field(quote_of_pk, "quote_count", 1)
         if quote_of_obj is not None:
             safe_notify(
                 kind="quote",
@@ -100,7 +108,7 @@ def emit_create_side_effects(tweet_pk: int) -> None:
                 target_id=tweet_pk,
             )
     elif target_type == TweetType.REPOST:
-        _bump_field(repost_of_pk, "repost_count", 1)
+        bump_field(repost_of_pk, "repost_count", 1)
         if repost_of_obj is not None:
             safe_notify(
                 kind="repost",

--- a/apps/tweets/signals.py
+++ b/apps/tweets/signals.py
@@ -9,167 +9,47 @@ partial UniqueConstraint で reject されるため、signal はそのまま +1 
 - reply  → reply_to.author に Notification(kind=REPLY)
 - repost → repost_of.author に Notification(kind=REPOST)
 - quote  → quote_of.author に Notification(kind=QUOTE)
+
+#770: create / publish 時の副作用群 (mention 通知 / counter bump / OGP / TL
+cache invalidate) は ``apps/tweets/side_effects.py`` の
+``emit_create_side_effects(tweet_pk)`` に集約し、 signal handler と publish
+action の両方から `transaction.on_commit` で 1 回だけ call する。
 """
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from django.db import transaction
-from django.db.models import F
-from django.db.models.functions import Greatest
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
-from apps.common.blocking import safe_notify
 from apps.tweets.language_detection import detect_language
 from apps.tweets.models import Tweet, TweetType
-
-# #412: mention 抽出の正規表現と上限。spec §12 より handle 数 10 超過時は
-# Celery off-load を検討する想定だが、本 Issue では同期処理 + 上限で抑える。
-_MENTION_RE = re.compile(r"(?<![A-Za-z0-9_])@([A-Za-z0-9_]{3,30})")
-MAX_MENTION_NOTIFY = 10
-
-
-def _bump_field(tweet_pk: int | None, field: str, delta: int) -> None:
-    if tweet_pk is None:
-        return
-    if delta >= 0:
-        Tweet.all_objects.filter(pk=tweet_pk).update(**{field: F(field) + delta})
-    else:
-        Tweet.all_objects.filter(pk=tweet_pk).update(**{field: Greatest(F(field) + delta, 0)})
+from apps.tweets.side_effects import _bump_field, emit_create_side_effects
 
 
 @receiver(post_save, sender=Tweet)
 def on_tweet_created(sender: type[Tweet], instance: Tweet, created: bool, **kwargs: Any) -> None:
-    """Reply / Repost / Quote 作成時に元ツイートの count を +1.
+    """published tweet の作成時に副作用群を発火する。
 
     P2-07: 本文に URL があれば OGP 取得タスクを enqueue する.
 
     #770 fix: draft (published_at IS NULL) 作成時は副作用を発火させない。
     mention 通知 / counter bump / OGP fetch / home TL cache invalidate はすべて
-    公開時 (= publish action 内で `_emit_create_side_effects` を手動 call) に
-    1 回だけ発火する。 これにより:
-    - draft の @mention で公開前に通知が飛ぶ情報漏洩を防ぐ
-    - draft の URL に対する無駄な OGP fetch を防ぐ
-    - draft 作成時の cache evict を防ぐ
-    - reply/quote/repost (= ORIGINAL 以外) は spec §3.1 で draft 不許可だが
-      defense-in-depth として guard を効かせる
+    公開時 (= publish action 内で `emit_create_side_effects` を手動 call) に
+    1 回だけ発火する。
     """
     if not created:
         return
     # #770: draft で副作用 skip。 publish action 側で手動 call される。
     if instance.published_at is None:
         return
-    transaction.on_commit(lambda: _emit_create_side_effects(instance))
-
-
-def _emit_create_side_effects(instance: Tweet) -> None:
-    """tweet 公開時の副作用群を発火する (signal handler / publish action 共通)。
-
-    呼び出し元:
-    - `on_tweet_created` (post_save signal): published_at IS NOT NULL の create でのみ呼ぶ
-    - `TweetViewSet.publish` action: draft → publish の遷移直後に
-      `transaction.on_commit(lambda: _emit_create_side_effects(instance))` で 1 回呼ぶ
-
-    副作用:
-    - reply / quote / repost の counter bump (= ORIGINAL なら no-op)
-    - mention notification dispatch
-    - OGP fetch celery enqueue (URL があれば)
-    - home TL cache invalidate (author のみ)
-    """
-    actor = instance.author
-    target_type = instance.type
-    reply_to_pk = instance.reply_to_id
-    quote_of_pk = instance.quote_of_id
-    repost_of_pk = instance.repost_of_id
-    reply_to_obj = instance.reply_to
-    quote_of_obj = instance.quote_of
-    repost_of_obj = instance.repost_of
+    # python-reviewer HIGH (#770): lambda closure で mutable instance を握らず
+    # pk を渡して on_commit 内で fresh fetch する。 これにより refresh_from_db
+    # 後の他処理で instance が上書きされても影響を受けない。
     tweet_pk = instance.pk
-    body = instance.body
-
-    if target_type == TweetType.REPLY:
-        _bump_field(reply_to_pk, "reply_count", 1)
-        if reply_to_obj is not None:
-            # #412: target_type/target_id を追加 (Notification 解決用)
-            safe_notify(
-                kind="reply",
-                recipient=reply_to_obj.author,
-                actor=actor,
-                target_type="tweet",
-                target_id=tweet_pk,
-            )
-    elif target_type == TweetType.QUOTE:
-        _bump_field(quote_of_pk, "quote_count", 1)
-        if quote_of_obj is not None:
-            safe_notify(
-                kind="quote",
-                recipient=quote_of_obj.author,
-                actor=actor,
-                target_type="tweet",
-                target_id=tweet_pk,
-            )
-    elif target_type == TweetType.REPOST:
-        _bump_field(repost_of_pk, "repost_count", 1)
-        if repost_of_obj is not None:
-            safe_notify(
-                kind="repost",
-                recipient=repost_of_obj.author,
-                actor=actor,
-                target_type="tweet",
-                target_id=tweet_pk,
-            )
-
-    # P2-07: OGP fetch を enqueue (URL を含む original / quote / reply が対象)。
-    # repost は body=空なので skip。
-    if target_type != TweetType.REPOST and body:
-        from apps.tweets.ogp import extract_first_url
-
-        if extract_first_url(body):
-            from apps.tweets.tasks import fetch_ogp_for_tweet
-
-            fetch_ogp_for_tweet.delay(tweet_pk)
-
-    # #412: mention 抽出 → 各 user に kind=mention 通知。
-    # repost は body=空なのでスキップ。reply / quote / mention は重複しても
-    # 別 kind なので Notification 行は別。
-    if target_type != TweetType.REPOST and body:
-        _dispatch_mention_notifications(body=body, actor=actor, tweet_pk=tweet_pk)
-
-    # #311: 投稿者の home TL cache を invalidate。これがないと cache TTL
-    # (10 min) 経過まで自分の新規投稿が home に出ない。フォロワーの cache
-    # invalidate は fan-out コストが大きいので Phase 4 で fan-out-on-write
-    # を検討する際にまとめて対応 (本 PR では author 自身のみ)。
-    from apps.timeline.services import invalidate_home_tl
-
-    invalidate_home_tl(actor)
-
-
-def _dispatch_mention_notifications(*, body: str, actor: Any, tweet_pk: int | None) -> None:
-    """body 中の @handle を抽出し、実存する active user に mention 通知を発火.
-
-    自分自身 (`@<actor.handle>`) は self-notify guard で無視される。
-    重複 handle は set で排除済。
-    spec §12 + python-reviewer MED: handle 数の上限を MAX_MENTION_NOTIFY (=10) で
-    cap。それ以上は Celery off-load を別 Issue で対応する。
-    """
-    handles = {m.group(1) for m in _MENTION_RE.finditer(body)}
-    if not handles:
-        return
-    from django.contrib.auth import get_user_model
-
-    User = get_user_model()
-    users = User.objects.filter(username__in=handles, is_active=True)[:MAX_MENTION_NOTIFY]
-    for user in users:
-        safe_notify(
-            kind="mention",
-            recipient=user,
-            actor=actor,
-            target_type="tweet",
-            target_id=tweet_pk,
-        )
+    transaction.on_commit(lambda: emit_create_side_effects(tweet_pk))
 
 
 @receiver(post_delete, sender=Tweet)

--- a/apps/tweets/signals.py
+++ b/apps/tweets/signals.py
@@ -46,9 +46,39 @@ def on_tweet_created(sender: type[Tweet], instance: Tweet, created: bool, **kwar
     """Reply / Repost / Quote 作成時に元ツイートの count を +1.
 
     P2-07: 本文に URL があれば OGP 取得タスクを enqueue する.
+
+    #770 fix: draft (published_at IS NULL) 作成時は副作用を発火させない。
+    mention 通知 / counter bump / OGP fetch / home TL cache invalidate はすべて
+    公開時 (= publish action 内で `_emit_create_side_effects` を手動 call) に
+    1 回だけ発火する。 これにより:
+    - draft の @mention で公開前に通知が飛ぶ情報漏洩を防ぐ
+    - draft の URL に対する無駄な OGP fetch を防ぐ
+    - draft 作成時の cache evict を防ぐ
+    - reply/quote/repost (= ORIGINAL 以外) は spec §3.1 で draft 不許可だが
+      defense-in-depth として guard を効かせる
     """
     if not created:
         return
+    # #770: draft で副作用 skip。 publish action 側で手動 call される。
+    if instance.published_at is None:
+        return
+    transaction.on_commit(lambda: _emit_create_side_effects(instance))
+
+
+def _emit_create_side_effects(instance: Tweet) -> None:
+    """tweet 公開時の副作用群を発火する (signal handler / publish action 共通)。
+
+    呼び出し元:
+    - `on_tweet_created` (post_save signal): published_at IS NOT NULL の create でのみ呼ぶ
+    - `TweetViewSet.publish` action: draft → publish の遷移直後に
+      `transaction.on_commit(lambda: _emit_create_side_effects(instance))` で 1 回呼ぶ
+
+    副作用:
+    - reply / quote / repost の counter bump (= ORIGINAL なら no-op)
+    - mention notification dispatch
+    - OGP fetch celery enqueue (URL があれば)
+    - home TL cache invalidate (author のみ)
+    """
     actor = instance.author
     target_type = instance.type
     reply_to_pk = instance.reply_to_id
@@ -60,64 +90,61 @@ def on_tweet_created(sender: type[Tweet], instance: Tweet, created: bool, **kwar
     tweet_pk = instance.pk
     body = instance.body
 
-    def _bump() -> None:
-        if target_type == TweetType.REPLY:
-            _bump_field(reply_to_pk, "reply_count", 1)
-            if reply_to_obj is not None:
-                # #412: target_type/target_id を追加 (Notification 解決用)
-                safe_notify(
-                    kind="reply",
-                    recipient=reply_to_obj.author,
-                    actor=actor,
-                    target_type="tweet",
-                    target_id=tweet_pk,
-                )
-        elif target_type == TweetType.QUOTE:
-            _bump_field(quote_of_pk, "quote_count", 1)
-            if quote_of_obj is not None:
-                safe_notify(
-                    kind="quote",
-                    recipient=quote_of_obj.author,
-                    actor=actor,
-                    target_type="tweet",
-                    target_id=tweet_pk,
-                )
-        elif target_type == TweetType.REPOST:
-            _bump_field(repost_of_pk, "repost_count", 1)
-            if repost_of_obj is not None:
-                safe_notify(
-                    kind="repost",
-                    recipient=repost_of_obj.author,
-                    actor=actor,
-                    target_type="tweet",
-                    target_id=tweet_pk,
-                )
+    if target_type == TweetType.REPLY:
+        _bump_field(reply_to_pk, "reply_count", 1)
+        if reply_to_obj is not None:
+            # #412: target_type/target_id を追加 (Notification 解決用)
+            safe_notify(
+                kind="reply",
+                recipient=reply_to_obj.author,
+                actor=actor,
+                target_type="tweet",
+                target_id=tweet_pk,
+            )
+    elif target_type == TweetType.QUOTE:
+        _bump_field(quote_of_pk, "quote_count", 1)
+        if quote_of_obj is not None:
+            safe_notify(
+                kind="quote",
+                recipient=quote_of_obj.author,
+                actor=actor,
+                target_type="tweet",
+                target_id=tweet_pk,
+            )
+    elif target_type == TweetType.REPOST:
+        _bump_field(repost_of_pk, "repost_count", 1)
+        if repost_of_obj is not None:
+            safe_notify(
+                kind="repost",
+                recipient=repost_of_obj.author,
+                actor=actor,
+                target_type="tweet",
+                target_id=tweet_pk,
+            )
 
-        # P2-07: OGP fetch を enqueue (URL を含む original / quote / reply が対象)。
-        # repost は body=空なので skip。
-        if target_type != TweetType.REPOST and body:
-            from apps.tweets.ogp import extract_first_url
+    # P2-07: OGP fetch を enqueue (URL を含む original / quote / reply が対象)。
+    # repost は body=空なので skip。
+    if target_type != TweetType.REPOST and body:
+        from apps.tweets.ogp import extract_first_url
 
-            if extract_first_url(body):
-                from apps.tweets.tasks import fetch_ogp_for_tweet
+        if extract_first_url(body):
+            from apps.tweets.tasks import fetch_ogp_for_tweet
 
-                fetch_ogp_for_tweet.delay(tweet_pk)
+            fetch_ogp_for_tweet.delay(tweet_pk)
 
-        # #412: mention 抽出 → 各 user に kind=mention 通知。
-        # repost は body=空なのでスキップ。reply / quote / mention は重複しても
-        # 別 kind なので Notification 行は別。
-        if target_type != TweetType.REPOST and body:
-            _dispatch_mention_notifications(body=body, actor=actor, tweet_pk=tweet_pk)
+    # #412: mention 抽出 → 各 user に kind=mention 通知。
+    # repost は body=空なのでスキップ。reply / quote / mention は重複しても
+    # 別 kind なので Notification 行は別。
+    if target_type != TweetType.REPOST and body:
+        _dispatch_mention_notifications(body=body, actor=actor, tweet_pk=tweet_pk)
 
-        # #311: 投稿者の home TL cache を invalidate。これがないと cache TTL
-        # (10 min) 経過まで自分の新規投稿が home に出ない。フォロワーの cache
-        # invalidate は fan-out コストが大きいので Phase 4 で fan-out-on-write
-        # を検討する際にまとめて対応 (本 PR では author 自身のみ)。
-        from apps.timeline.services import invalidate_home_tl
+    # #311: 投稿者の home TL cache を invalidate。これがないと cache TTL
+    # (10 min) 経過まで自分の新規投稿が home に出ない。フォロワーの cache
+    # invalidate は fan-out コストが大きいので Phase 4 で fan-out-on-write
+    # を検討する際にまとめて対応 (本 PR では author 自身のみ)。
+    from apps.timeline.services import invalidate_home_tl
 
-        invalidate_home_tl(actor)
-
-    transaction.on_commit(_bump)
+    invalidate_home_tl(actor)
 
 
 def _dispatch_mention_notifications(*, body: str, actor: Any, tweet_pk: int | None) -> None:

--- a/apps/tweets/signals.py
+++ b/apps/tweets/signals.py
@@ -26,7 +26,7 @@ from django.dispatch import receiver
 
 from apps.tweets.language_detection import detect_language
 from apps.tweets.models import Tweet, TweetType
-from apps.tweets.side_effects import _bump_field, emit_create_side_effects
+from apps.tweets.side_effects import bump_field, emit_create_side_effects
 
 
 @receiver(post_save, sender=Tweet)
@@ -62,11 +62,11 @@ def on_tweet_deleted(sender: type[Tweet], instance: Tweet, **kwargs: Any) -> Non
 
     def _bump() -> None:
         if target_type == TweetType.REPLY:
-            _bump_field(reply_to_pk, "reply_count", -1)
+            bump_field(reply_to_pk, "reply_count", -1)
         elif target_type == TweetType.QUOTE:
-            _bump_field(quote_of_pk, "quote_count", -1)
+            bump_field(quote_of_pk, "quote_count", -1)
         elif target_type == TweetType.REPOST:
-            _bump_field(repost_of_pk, "repost_count", -1)
+            bump_field(repost_of_pk, "repost_count", -1)
 
     transaction.on_commit(_bump)
 

--- a/apps/tweets/tests/test_draft_signal_side_effects.py
+++ b/apps/tweets/tests/test_draft_signal_side_effects.py
@@ -1,0 +1,235 @@
+"""#770 fix: draft 作成時に on_tweet_created signal の副作用が発火しないこと。
+
+spec: docs/specs/draft-signal-side-effect-fix-spec.md §3
+
+副作用 (= signal の発火対象):
+1. mention 通知 (= safe_notify kind=mention)
+2. counter bump (= reply_count / quote_count / repost_count)
+3. OGP fetch celery enqueue (= fetch_ogp_for_tweet.delay)
+4. home TL cache invalidate (= invalidate_home_tl)
+
+draft (= published_at IS NULL) 作成時はこれら全てが skip され、
+publish action 実行時に **1 回だけ** 発火する。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIClient
+
+from apps.notifications.models import Notification
+from apps.tweets.models import Tweet
+from apps.tweets.tests._factories import make_user
+
+
+@pytest.fixture
+def authed_client():
+    def _make(user):
+        c = APIClient()
+        c.force_authenticate(user=user)
+        return c
+
+    return _make
+
+
+@pytest.fixture
+def mention_target():
+    """draft 内で @<handle> 参照される実存 user。"""
+    return make_user(username="mentionee_770")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+class TestDraftCreationSkipsSideEffects:
+    """#770 §3 Happy path HP-1 + 副作用 SE-1〜4。
+
+    draft 作成では mention 通知 / OGP / invalidate_home_tl が一切発火しない。
+    """
+
+    def test_hp1_draft_create_does_not_dispatch_mention(self, authed_client, mention_target):
+        u = make_user()
+        c = authed_client(u)
+        body = f"hi @{mention_target.username}, draft preview"
+        resp = c.post(
+            "/api/v1/tweets/",
+            {"body": body, "is_draft": True},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        # SE-1: mention 通知が 0 件
+        assert Notification.objects.filter(recipient=mention_target, kind="mention").count() == 0
+
+    def test_se3_draft_create_does_not_enqueue_ogp(self, authed_client):
+        u = make_user()
+        c = authed_client(u)
+        with patch("apps.tweets.tasks.fetch_ogp_for_tweet.delay") as mock_delay:
+            resp = c.post(
+                "/api/v1/tweets/",
+                {
+                    "body": "draft with link https://example.com/foo",
+                    "is_draft": True,
+                },
+                format="json",
+            )
+            assert resp.status_code == 201, resp.data
+            mock_delay.assert_not_called()
+
+    def test_se4_draft_create_does_not_invalidate_home_tl(self, authed_client):
+        u = make_user()
+        c = authed_client(u)
+        with patch("apps.timeline.services.invalidate_home_tl") as mock_inv:
+            resp = c.post(
+                "/api/v1/tweets/",
+                {"body": "draft body, no cache invalidate expected", "is_draft": True},
+                format="json",
+            )
+            assert resp.status_code == 201, resp.data
+            mock_inv.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Degrade prevention: 公開 tweet の作成は従来どおり副作用発火
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+class TestPublishedTweetCreationFiresSideEffects:
+    """#770 §3 HP-2 / SE-5 (デグレ防止)。 普通の tweet 作成 (is_draft=false) は
+    従来どおり全副作用が 1 回ずつ発火する。
+    """
+
+    def test_hp2_publish_tweet_dispatches_mention_once(self, authed_client, mention_target):
+        u = make_user()
+        c = authed_client(u)
+        body = f"published @{mention_target.username}, normal post"
+        resp = c.post(
+            "/api/v1/tweets/",
+            {"body": body},  # is_draft 省略 = 公開
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        # mention 通知 1 件
+        assert Notification.objects.filter(recipient=mention_target, kind="mention").count() == 1
+
+    def test_se5_publish_tweet_invalidates_home_tl_once(self, authed_client):
+        u = make_user()
+        c = authed_client(u)
+        with patch("apps.timeline.services.invalidate_home_tl") as mock_inv:
+            resp = c.post(
+                "/api/v1/tweets/",
+                {"body": "published, expect 1 invalidate"},
+                format="json",
+            )
+            assert resp.status_code == 201, resp.data
+            assert mock_inv.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Draft → Publish path: 副作用を 1 回だけ発火 (signal で 0 件 + publish で 1 件)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+class TestDraftToPublishFiresSideEffectsOnce:
+    """#770 §3 HP-3 / SE-6 (デグレ防止)。 draft → publish で副作用 1 回発火。"""
+
+    def test_hp3_draft_then_publish_dispatches_mention_once(self, authed_client, mention_target):
+        u = make_user()
+        c = authed_client(u)
+        body = f"hello @{mention_target.username}"
+        # draft 作成 → 通知 0
+        d_resp = c.post(
+            "/api/v1/tweets/",
+            {"body": body, "is_draft": True},
+            format="json",
+        )
+        draft_id = d_resp.data["id"]
+        assert Notification.objects.filter(recipient=mention_target, kind="mention").count() == 0
+        # publish → 通知 1
+        p_resp = c.post(f"/api/v1/tweets/{draft_id}/publish/")
+        assert p_resp.status_code == 200, p_resp.data
+        assert Notification.objects.filter(recipient=mention_target, kind="mention").count() == 1
+
+    def test_se6_draft_then_publish_invalidates_home_tl_once(self, authed_client):
+        u = make_user()
+        c = authed_client(u)
+        # draft 作成は invalidate なし
+        with patch("apps.timeline.services.invalidate_home_tl") as mock_inv_draft:
+            d_resp = c.post(
+                "/api/v1/tweets/",
+                {"body": "draft for publish test", "is_draft": True},
+                format="json",
+            )
+            assert d_resp.status_code == 201
+            mock_inv_draft.assert_not_called()
+
+        draft_id = d_resp.data["id"]
+
+        # publish で invalidate 1 回
+        with patch("apps.timeline.services.invalidate_home_tl") as mock_inv_publish:
+            p_resp = c.post(f"/api/v1/tweets/{draft_id}/publish/")
+            assert p_resp.status_code == 200, p_resp.data
+            assert mock_inv_publish.call_count == 1
+
+    def test_publish_with_body_dispatches_mention_for_new_body(self, authed_client, mention_target):
+        """publish 時に body を上書きしたとき、 新 body の @mention で通知発火。
+
+        旧 body の @ は飛ばない (= publish action 内で _emit_create_side_effects を
+        instance.refresh_from_db() 後に呼ぶので、 最新 body に対して走る)。
+        """
+        u = make_user()
+        c = authed_client(u)
+        # 旧 body は mentionee_770 だが publish で新 mention に切り替える
+        new_target = make_user(username="newmention_770")
+        d_resp = c.post(
+            "/api/v1/tweets/",
+            {"body": f"@{mention_target.username} draft", "is_draft": True},
+            format="json",
+        )
+        draft_id = d_resp.data["id"]
+        p_resp = c.post(
+            f"/api/v1/tweets/{draft_id}/publish/",
+            {"body": f"@{new_target.username} final body"},
+            format="json",
+        )
+        assert p_resp.status_code == 200, p_resp.data
+        # 新 target に 1 件、 旧 target には 0 件
+        assert Notification.objects.filter(recipient=new_target, kind="mention").count() == 1
+        assert Notification.objects.filter(recipient=mention_target, kind="mention").count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 失敗系: publish 既に公開済みなら副作用も発火しない
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+class TestPublishFailuresDoNotFireSideEffects:
+    """#770 §3 FF-2: publish が 400 で返るとき副作用は走らない。"""
+
+    def test_ff2_already_published_400_does_not_dispatch_mention(
+        self, authed_client, mention_target
+    ):
+        u = make_user()
+        # 普通の published tweet を作る (= mention 1 件発火する)
+        c = authed_client(u)
+        c.post(
+            "/api/v1/tweets/",
+            {"body": f"@{mention_target.username} normal post"},
+            format="json",
+        )
+        before = Notification.objects.filter(recipient=mention_target, kind="mention").count()
+        assert before == 1
+        # この公開済 tweet を publish 再 call → 400
+        t = Tweet.all_objects.filter(author=u).first()
+        resp = c.post(f"/api/v1/tweets/{t.id}/publish/")
+        assert resp.status_code == 400
+        # mention 通知が増えていない
+        after = Notification.objects.filter(recipient=mention_target, kind="mention").count()
+        assert after == before

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -493,6 +493,16 @@ class TweetViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         instance.refresh_from_db()
+
+        # #770 fix: signal handler が draft で skip するため、 公開時に副作用
+        # (= mention 通知 / counter bump / OGP fetch / home TL invalidate) を
+        # `transaction.on_commit` で 1 回だけ発火させる。 通常 tweet 作成経路
+        # (= POST /tweets/ で is_draft=false) と同じ helper を共有することで
+        # セマンティクスを揃える。
+        from apps.tweets.signals import _emit_create_side_effects
+
+        transaction.on_commit(lambda: _emit_create_side_effects(instance))
+
         out = TweetDetailSerializer(
             instance,
             context=self.get_serializer_context(),

--- a/apps/tweets/views.py
+++ b/apps/tweets/views.py
@@ -48,6 +48,7 @@ from apps.tweets.serializers import (
     TweetListSerializer,
     TweetUpdateSerializer,
 )
+from apps.tweets.side_effects import emit_create_side_effects
 
 # #769: publish action での body length validation 用 (P1-10 char_count の lazy import
 # pattern を踏襲、 module 未配備時は len() のみで足切り)
@@ -498,10 +499,10 @@ class TweetViewSet(viewsets.ModelViewSet):
         # (= mention 通知 / counter bump / OGP fetch / home TL invalidate) を
         # `transaction.on_commit` で 1 回だけ発火させる。 通常 tweet 作成経路
         # (= POST /tweets/ で is_draft=false) と同じ helper を共有することで
-        # セマンティクスを揃える。
-        from apps.tweets.signals import _emit_create_side_effects
-
-        transaction.on_commit(lambda: _emit_create_side_effects(instance))
+        # セマンティクスを揃える。 python-reviewer HIGH (#770): lambda で
+        # mutable instance を握らず pk を渡して helper 内で fresh fetch する。
+        tweet_pk = instance.pk
+        transaction.on_commit(lambda: emit_create_side_effects(tweet_pk))
 
         out = TweetDetailSerializer(
             instance,

--- a/docs/specs/draft-signal-side-effect-fix-spec.md
+++ b/docs/specs/draft-signal-side-effect-fix-spec.md
@@ -1,0 +1,162 @@
+# draft 作成時の signal 副作用漏洩 修正 仕様書 (#770)
+
+> Version: 0.1
+> 作成日: 2026-05-18
+> 関連 Issue: #770
+> 関連 PR: 本 PR (= fix)
+> 関連 spec: [tweet-drafts-spec.md](./tweet-drafts-spec.md) §3.1 (= draft は ORIGINAL only)、 [draft-edit-limit-fix-spec.md](./draft-edit-limit-fix-spec.md) (= #769 の編集制約 fix、 同じ「draft 経路の silent 副作用」 カテゴリ)
+> 関連 Issue (follow-up out of scope): なし
+
+---
+
+## 0. 目的
+
+`apps/tweets/signals.py:44-120` `on_tweet_created` post_save signal が draft (= `published_at IS NULL`) 作成時にも発火し、 以下の **公開前副作用** が裏で動いている:
+
+| 副作用                   | 影響度   | 詳細                                                                                                                                    |
+| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| mention 通知             | **HIGH** | draft body に `@user` が含まれていると `safe_notify(kind=mention)` が作成時点で対象 user に飛ぶ → **公開前情報漏洩** + 公開時に重複通知 |
+| counter bump             | LOW      | draft は spec §3.1 で ORIGINAL only と決まっているので顕在化しないが、 defense-in-depth で guard が欲しい                               |
+| OGP fetch                | LOW      | draft の URL に対して `fetch_ogp_for_tweet` celery task が enqueue される → 公開しない draft なのに外部 fetch                           |
+| home TL cache invalidate | LOW      | draft 作成だけで `invalidate_home_tl(actor)` が呼ばれて cache が evict される                                                           |
+
+`tweet-drafts-spec.md` §5.1 では「agent tool は Manager 既定で draft 除外」 と書かれているが、 **signal 経路** の同種の guard が抜けていた。 #769 (draft 編集 → edit_count 動く) と同根の「draft 経路で裏発火する副作用」 カテゴリの第 2 弾。
+
+---
+
+## 1. やる / やらない
+
+### やる
+
+- `apps/tweets/signals.py` の `on_tweet_created` 冒頭に `if instance.published_at is None: return` を追加 (= draft では副作用全 skip)
+- 副作用群を `_emit_create_side_effects(instance)` helper に切り出し (= signal handler と publish action の共有)
+- `apps/tweets/views.py` の `publish` action 内で `transaction.on_commit(lambda: _emit_create_side_effects(instance))` を call (= 公開時に 1 回だけ発火)
+- backend pytest 4 系統で 7+ ケース追加 (§3 参照)
+
+### やらない (別 Issue で対応)
+
+- draft 編集 (= PATCH) で副作用発火 (= record_edit / `_save_draft_body` は元々 signal を bypass するため、 そもそも発火しない、 fix 不要)
+- 既存 draft で誤って付いた notification の backfill / cleanup (= prod 環境の draft 関連 notification は少数と推定、 不要)
+- fan-out-on-write の cache invalidate (= フォロワーの home TL cache invalidate は別 Issue で Phase 4 で扱う)
+
+---
+
+## 2. 実装方針
+
+### 2.1 `_emit_create_side_effects` helper
+
+**file**: `apps/tweets/signals.py`
+
+```python
+def _emit_create_side_effects(instance: Tweet) -> None:
+    """tweet 公開時の副作用群を発火する (signal handler / publish action 共通)。
+
+    signal handler は `created=True` + `published_at IS NOT NULL` でのみ呼ぶ。
+    publish action は `transaction.on_commit(lambda: _emit_create_side_effects(instance))`
+    で公開直後に 1 回だけ呼ぶ。
+
+    副作用:
+    - reply / quote / repost の counter bump (= ORIGINAL なら no-op)
+    - mention notification dispatch
+    - OGP fetch celery enqueue (URL があれば)
+    - home TL cache invalidate (author のみ)
+    """
+    # 既存 `on_tweet_created._bump()` の中身を移植 (= 重複コードを除去)
+    ...
+```
+
+### 2.2 `on_tweet_created` を draft で skip
+
+```python
+@receiver(post_save, sender=Tweet)
+def on_tweet_created(sender, instance, created, **kwargs):
+    if not created:
+        return
+    # #770 fix: draft (published_at IS NULL) では副作用を発火しない。
+    # publish action 側で _emit_create_side_effects を手動 call することで
+    # 公開時に 1 回だけ発火させる。
+    if instance.published_at is None:
+        return
+    transaction.on_commit(lambda: _emit_create_side_effects(instance))
+```
+
+### 2.3 `publish` action での手動発火
+
+**file**: `apps/tweets/views.py`
+
+```python
+@action(detail=True, methods=["post"], url_path="publish", ...)
+@transaction.atomic
+def publish(self, request, pk=None):
+    ...
+    Tweet.all_objects.filter(pk=instance.pk, published_at__isnull=True).update(**update_fields)
+    instance.refresh_from_db()
+
+    # #770 fix: publish 完了時に signal 相当の副作用を発火 (= post_save が
+    # draft で skip されているため、 publish action 側で明示的に call)
+    from apps.tweets.signals import _emit_create_side_effects
+
+    transaction.on_commit(lambda: _emit_create_side_effects(instance))
+
+    out = TweetDetailSerializer(...).data
+    return Response(out, status=200)
+```
+
+### 2.4 影響範囲
+
+- `apps/tweets/signals.py` (= `_emit_create_side_effects` 切り出し + `on_tweet_created` で draft skip)
+- `apps/tweets/views.py` (= publish action で手動発火)
+- `apps/tweets/tests/test_drafts.py` (= 7+ ケース追加)
+- `apps/tweets/tests/test_signals.py` (= 既存 test の更新が必要なら)
+
+---
+
+## 3. テスト (4 系統)
+
+### 3.1 backend pytest
+
+#### Happy path
+
+- **HP-1**: draft 作成 (`POST /tweets/ {is_draft: true}`) → 副作用 0 件 (mention 通知 / counter / OGP / cache 全部発火しない)
+- **HP-2**: 公開 tweet 作成 (`POST /tweets/`) → 従来どおり副作用発火 (= デグレ防止)
+- **HP-3**: draft → publish (`POST /tweets/<id>/publish/`) → 副作用 1 回発火 (= mention 通知 1 件、 OGP enqueue 1 件、 home TL invalidate 1 回)
+
+#### 境界
+
+- **BD-1**: draft body 内に `@user_a @user_b @user_c` mention があっても通知発火 0 件 (= draft skip 確認)
+- **BD-2**: draft body 内に `https://example.com/foo` URL があっても `fetch_ogp_for_tweet` 0 件
+- **BD-3**: draft body 内に `@u1 ... @u10 @u11` 11 個 mention → publish 時に MAX_MENTION_NOTIFY (=10) で cap、 11 個目は通知発火しない (既存上限挙動の維持)
+
+#### 失敗系
+
+- **FF-1**: draft 作成で IntegrityError → commit されないため副作用も発火しない (既存挙動の確認)
+- **FF-2**: publish 失敗 (= 既に公開済みで 400) → `transaction.on_commit` まで届かないため副作用発火しない
+
+#### 期待しない副作用
+
+- **SE-1**: draft 作成後 `Notification.objects.filter(kind='mention').count() == 0`
+- **SE-2**: draft 作成後 親 tweet の counter (reply_count 等) が変わらない (= ORIGINAL only だが defense-in-depth)
+- **SE-3**: draft 作成時 celery task `fetch_ogp_for_tweet.delay()` が呼ばれない (= `unittest.mock.patch` で検証)
+- **SE-4**: draft 作成時 `invalidate_home_tl(actor)` が呼ばれない (= 同 mock 検証)
+- **SE-5 (degrade 防止)**: 普通の tweet 作成 → 全副作用が **1 回ずつ** 発火 (= 0 でも 2 でもない、 デグレなし)
+- **SE-6 (degrade 防止)**: draft → publish → 全副作用が **1 回ずつ** 発火 (= signal で 0 件 + publish で 1 件 = 計 1 件)
+
+---
+
+## 4. 受け入れ基準 (definition of done)
+
+- [ ] `on_tweet_created` が draft で skip するよう修正
+- [ ] `_emit_create_side_effects` helper に副作用群を切り出し
+- [ ] `publish` action が `transaction.on_commit` で手動 call
+- [ ] backend pytest 11 ケース全 pass
+- [ ] `pr-test-analyzer` agent で 4 系統揃ってる確認
+- [ ] `silent-failure-hunter` agent で「他の signal handler で同種の漏洩がない」 を再点検
+- [ ] python-reviewer / security-reviewer / database-reviewer / code-reviewer 直列で CRITICAL/HIGH なし
+- [ ] stg 反映後、 実機で「draft 内 @user 書いて保存 → 当該 user の /notifications に出ない」、 「publish 押した瞬間に当該 user の /notifications に出る」 を確認
+
+---
+
+## 5. ロールバック
+
+- `on_tweet_created` の draft skip を削除 + `publish` action の手動 call を削除 → 元の漏洩状態に戻る
+- backward compatible: 既存 published tweet 作成経路は変えない

--- a/docs/specs/draft-signal-side-effect-fix-spec.md
+++ b/docs/specs/draft-signal-side-effect-fix-spec.md
@@ -1,11 +1,15 @@
 # draft 作成時の signal 副作用漏洩 修正 仕様書 (#770)
 
-> Version: 0.1
+> Version: 0.2
 > 作成日: 2026-05-18
-> 関連 Issue: #770
-> 関連 PR: 本 PR (= fix)
-> 関連 spec: [tweet-drafts-spec.md](./tweet-drafts-spec.md) §3.1 (= draft は ORIGINAL only)、 [draft-edit-limit-fix-spec.md](./draft-edit-limit-fix-spec.md) (= #769 の編集制約 fix、 同じ「draft 経路の silent 副作用」 カテゴリ)
-> 関連 Issue (follow-up out of scope): なし
+> 改訂履歴:
+>
+> - 0.1 (2026-05-18): 初稿
+> - 0.2 (2026-05-18): python-reviewer 指摘で `_emit_create_side_effects` を `apps/tweets/side_effects.py` の public `emit_create_side_effects(tweet_pk)` に切り出し。 caller は pk を渡し helper 内で fresh fetch + `published_at IS NULL` で `ValueError` を raise する defense-in-depth を追加。
+>   関連 Issue: #770
+>   関連 PR: 本 PR (= fix)
+>   関連 spec: [tweet-drafts-spec.md](./tweet-drafts-spec.md) §3.1 (= draft は ORIGINAL only)、 [draft-edit-limit-fix-spec.md](./draft-edit-limit-fix-spec.md) (= #769 の編集制約 fix、 同じ「draft 経路の silent 副作用」 カテゴリ)
+>   関連 Issue (follow-up out of scope): なし
 
 ---
 
@@ -29,8 +33,8 @@
 ### やる
 
 - `apps/tweets/signals.py` の `on_tweet_created` 冒頭に `if instance.published_at is None: return` を追加 (= draft では副作用全 skip)
-- 副作用群を `_emit_create_side_effects(instance)` helper に切り出し (= signal handler と publish action の共有)
-- `apps/tweets/views.py` の `publish` action 内で `transaction.on_commit(lambda: _emit_create_side_effects(instance))` を call (= 公開時に 1 回だけ発火)
+- 副作用群を `emit_create_side_effects(instance)` helper に切り出し (= signal handler と publish action の共有)
+- `apps/tweets/views.py` の `publish` action 内で `transaction.on_commit(lambda: emit_create_side_effects(instance))` を call (= 公開時に 1 回だけ発火)
 - backend pytest 4 系統で 7+ ケース追加 (§3 参照)
 
 ### やらない (別 Issue で対応)
@@ -43,16 +47,16 @@
 
 ## 2. 実装方針
 
-### 2.1 `_emit_create_side_effects` helper
+### 2.1 `emit_create_side_effects` helper
 
-**file**: `apps/tweets/signals.py`
+**file**: `apps/tweets/side_effects.py` (= 新規モジュール、 signals.py と views.py 両方から top-level import)
 
 ```python
-def _emit_create_side_effects(instance: Tweet) -> None:
+def emit_create_side_effects(instance: Tweet) -> None:
     """tweet 公開時の副作用群を発火する (signal handler / publish action 共通)。
 
     signal handler は `created=True` + `published_at IS NOT NULL` でのみ呼ぶ。
-    publish action は `transaction.on_commit(lambda: _emit_create_side_effects(instance))`
+    publish action は `transaction.on_commit(lambda: emit_create_side_effects(instance))`
     で公開直後に 1 回だけ呼ぶ。
 
     副作用:
@@ -73,11 +77,11 @@ def on_tweet_created(sender, instance, created, **kwargs):
     if not created:
         return
     # #770 fix: draft (published_at IS NULL) では副作用を発火しない。
-    # publish action 側で _emit_create_side_effects を手動 call することで
+    # publish action 側で emit_create_side_effects を手動 call することで
     # 公開時に 1 回だけ発火させる。
     if instance.published_at is None:
         return
-    transaction.on_commit(lambda: _emit_create_side_effects(instance))
+    transaction.on_commit(lambda: emit_create_side_effects(instance))
 ```
 
 ### 2.3 `publish` action での手動発火
@@ -94,9 +98,9 @@ def publish(self, request, pk=None):
 
     # #770 fix: publish 完了時に signal 相当の副作用を発火 (= post_save が
     # draft で skip されているため、 publish action 側で明示的に call)
-    from apps.tweets.signals import _emit_create_side_effects
+    from apps.tweets.signals import emit_create_side_effects
 
-    transaction.on_commit(lambda: _emit_create_side_effects(instance))
+    transaction.on_commit(lambda: emit_create_side_effects(instance))
 
     out = TweetDetailSerializer(...).data
     return Response(out, status=200)
@@ -104,7 +108,7 @@ def publish(self, request, pk=None):
 
 ### 2.4 影響範囲
 
-- `apps/tweets/signals.py` (= `_emit_create_side_effects` 切り出し + `on_tweet_created` で draft skip)
+- `apps/tweets/signals.py` (= `emit_create_side_effects` 切り出し + `on_tweet_created` で draft skip)
 - `apps/tweets/views.py` (= publish action で手動発火)
 - `apps/tweets/tests/test_drafts.py` (= 7+ ケース追加)
 - `apps/tweets/tests/test_signals.py` (= 既存 test の更新が必要なら)
@@ -146,7 +150,7 @@ def publish(self, request, pk=None):
 ## 4. 受け入れ基準 (definition of done)
 
 - [ ] `on_tweet_created` が draft で skip するよう修正
-- [ ] `_emit_create_side_effects` helper に副作用群を切り出し
+- [ ] `emit_create_side_effects` helper に副作用群を切り出し
 - [ ] `publish` action が `transaction.on_commit` で手動 call
 - [ ] backend pytest 11 ケース全 pass
 - [ ] `pr-test-analyzer` agent で 4 系統揃ってる確認


### PR DESCRIPTION
## Summary

#770 (= ハルナさんが #769 fix の後で silent-failure-hunter agent が見つけた draft 経路の silent 副作用) の修正。 mention 通知 / counter / OGP / TL cache invalidate が draft 作成時にも発火していたのを止める。

**Root cause**: `apps/tweets/signals.py:on_tweet_created` post_save handler が `created=True` で発火していて、 draft (= `published_at IS NULL`) 作成時も含めて副作用群を発火させていた。 特に **mention 通知が公開前に飛ぶ情報漏洩** が HIGH。

**修正**:
- `apps/tweets/side_effects.py` (新規 module): 副作用 helper `emit_create_side_effects(tweet_pk)` を切り出し。 caller は pk を渡し helper 内で fresh fetch + defense-in-depth で `published_at IS NULL` なら `ValueError` raise (= silent な誤呼出を loud にする)
- `signals.py` `on_tweet_created`: 冒頭で `if instance.published_at is None: return` (draft skip) + lambda は pk capture pattern
- `views.py` `publish` action: `transaction.on_commit(lambda: emit_create_side_effects(tweet_pk))` を `refresh_from_db()` 後に call → 公開時に 1 回だけ副作用発火

## Test plan

backend pytest (`apps/tweets/tests/test_draft_signal_side_effects.py` 新規、 4 系統):

- [ ] HP-1 / SE-1: draft で mention 通知 0 件
- [ ] SE-3: draft で `fetch_ogp_for_tweet.delay` 0 回 (mock)
- [ ] SE-4: draft で `invalidate_home_tl` 0 回 (mock)
- [ ] HP-2 / SE-5 (デグレ防止): 公開 tweet 作成は従来どおり副作用 1 回
- [ ] HP-3 / SE-6 (デグレ防止): draft → publish で副作用 1 回 (signal 0 + publish 1)
- [ ] publish body 上書きで新 mention 発火、 旧 mention 0 件
- [ ] FF-2: already_published 400 で副作用なし

## Review

- python-reviewer: HIGH 2 件 (lambda mutable capture、 guard 不足) + MEDIUM 2 件 (local import、 mock path) → 全部反映済 (= side_effects.py 切り出し + pk capture + ValueError guard)
- security-reviewer / database-reviewer / code-reviewer: 本 PR 内で直列に呼ぶ予定

## stg verify (post-merge)

stg CD 完了後、 Playwright MCP で:
- test4 で draft 「@test5 hello」 を「下書き保存」 → test5 の `/notifications` に **mention 通知が出ないこと** を確認
- 同じ draft を「投稿」 push → test5 の `/notifications` に **mention 通知が 1 件出ること** を確認

Closes #770
Refs #769 (PR #772, 同 category 第 1 弾)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
