### PR TITLE
[refactor][agents] redundant is_deleted=False filter を削除、 maintenance trap 防止 (#771)

### DIFF
--- a/apps/agents/tests/test_tools.py
+++ b/apps/agents/tests/test_tools.py
@@ -275,6 +275,36 @@ class TestDraftsHiddenFromAgentTools:
         assert "public py tweet" in out
         assert "DRAFT-PY-SECRET" not in out
 
+    def test_read_my_recent_tweets_excludes_soft_deleted(self):
+        """#771: redundant `is_deleted=False` filter を削除しても、 manager
+        既定 (= ``is_deleted=False, published_at__isnull=False``) で
+        論理削除済 tweet は agent から見えないままであること。
+        """
+        me = _make_user("me-soft-rec@example.com", "me_soft_rec")
+        Tweet.objects.create(author=me, body="alive one")
+        deleted = Tweet.objects.create(author=me, body="DELETED-SECRET")
+        deleted.soft_delete()
+        out = read_my_recent_tweets(me)
+        assert "alive one" in out
+        assert "DELETED-SECRET" not in out
+
+    def test_search_tweets_by_tag_excludes_soft_deleted(self):
+        """#771: search でも同様に論理削除済 tweet が見えないこと。"""
+        me = _make_user("me-soft-tag@example.com", "me_soft_tag")
+        tag = Tag.objects.create(
+            name="rust-soft-771",
+            display_name="RUST",
+            is_approved=True,
+        )
+        alive = Tweet.objects.create(author=me, body="alive rust tweet")
+        alive.tags.add(tag)
+        deleted = Tweet.objects.create(author=me, body="DELETED-RUST-SECRET")
+        deleted.tags.add(tag)
+        deleted.soft_delete()
+        out = search_tweets_by_tag(me, "rust-soft-771")
+        assert "alive rust tweet" in out
+        assert "DELETED-RUST-SECRET" not in out
+
 
 # ---------------------------------------------------------------------------
 # #735: 鍵アカ user の tweet は agent tool に露出してはならない

--- a/apps/agents/tools.py
+++ b/apps/agents/tools.py
@@ -91,11 +91,15 @@ def read_my_recent_tweets(user: AbstractBaseUser, limit: int = 10) -> str:
         該当 0 件なら ``"# 最近の自分の tweet (0 件)\n(無し)"``。
     """
     n = _clamp(limit, 1, _MAX_RECENT_TWEETS)
+    # #771: ``Tweet.objects`` (TweetManager 既定) が ``is_deleted=False`` +
+    # ``published_at__isnull=False`` を自動適用するので、 ここで明示する必要
+    # なし。 draft / soft-delete された tweet は agent からは絶対に読まれない。
+    # この信頼は ``apps/tweets/managers.py`` ``TweetManager.get_queryset`` に
+    # 集約されているので、 manager 既定を変えるときは agent tool 経路を要再点検。
     qs = (
         Tweet.objects.filter(
             author=user,
             type=TweetType.ORIGINAL,
-            is_deleted=False,
         )
         .order_by("-created_at")
         .select_related("author")[:n]
@@ -208,10 +212,12 @@ def search_tweets_by_tag(
     if not Tag.objects.filter(name=tag_name).exists():
         return f"# tag '{tag_name}' は存在しません"
 
+    # #771: ``Tweet.objects`` (TweetManager 既定) が ``is_deleted=False`` +
+    # ``published_at__isnull=False`` を自動適用する。 詳細は read_my_recent_tweets
+    # のコメントを参照。
     qs = (
         Tweet.objects.filter(
             tags__name=tag_name,
-            is_deleted=False,
             type=TweetType.ORIGINAL,
         )
         # #735: 鍵アカ author の tweet は viewer (= agent 起動者) が approved


### PR DESCRIPTION
## Summary

#771 (= #769 silent-failure-hunter が発見した HIGH #3、 maintenance trap 防止 refactor) の対応。 priority:medium。

`apps/agents/tools.py` の `read_my_recent_tweets` / `search_tweets_by_tag` が `Tweet.objects.filter(..., is_deleted=False, ...)` の形で **redundant な明示 filter** を持っていた。 `Tweet.objects` (TweetManager 既定) が既に `is_deleted=False` + `published_at__isnull=False` を自動適用するため。

現状はバグではないが、 将来 `Tweet.objects` → `Tweet.all_objects` / `all_with_drafts()` への書き換えが入ったとき、 残った `is_deleted=False` だけが「safety filter 揃っている」 ように見えて draft が agent 出力に漏洩する maintenance trap。

## 修正

- 両 helper の filter から `is_deleted=False` を削除
- 「manager 既定で is_deleted + published_at__isnull を自動適用」 のコメントを明示
- デグレ防止 test 2 件追加:
  - `test_read_my_recent_tweets_excludes_soft_deleted`
  - `test_search_tweets_by_tag_excludes_soft_deleted`

## Test plan

- [ ] 既存 `test_read_my_recent_tweets_excludes_own_drafts` / `test_search_tweets_by_tag_excludes_drafts` が引き続き pass (= manager 既定が draft 除外を担保している証明)
- [ ] 新 `*_excludes_soft_deleted` が pass (= `is_deleted=False` filter を消しても論理削除済が見えないこと)

## Review

- python-reviewer / code-reviewer 直列 (= 小さい refactor なので集約 review)
- backend のみ / frontend touch なし

Closes #771
Refs #769 (= 検出元、 silent-failure-hunter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
