### PR TITLE
[refactor][drafts] /drafts list の body 表示を 2 行 truncate に統一 (#773)

### DIFF
--- a/client/src/components/drafts/DraftsPanel.tsx
+++ b/client/src/components/drafts/DraftsPanel.tsx
@@ -109,7 +109,11 @@ export default function DraftsPanel({ initial }: DraftsPanelProps) {
 							>
 								作成日時: {formatJstDateTime(d.created_at)}
 							</div>
-							<div className="whitespace-pre-wrap" style={{ fontSize: 14 }}>
+							{/* #773: 長文 draft で row が縦に膨らんで「公開する」 / 「削除」 が画面外に流れるのを防ぐため、 2 行で truncate (X 流儀)。 a11y: line-clamp は CSS 上の見た目省略なので DOM の text content には full body が残る = screen reader には全文届く。 */}
+							<div
+								className="line-clamp-2 whitespace-pre-wrap break-words"
+								style={{ fontSize: 14 }}
+							>
 								{d.body}
 							</div>
 							{d.tags && d.tags.length > 0 ? (


### PR DESCRIPTION
## Summary

#773 (gan-evaluator agent が #769 verify 中に指摘した別 issue) の対応。 priority:low、 5 行 1 file の小 fix。

`DraftsPanel.tsx` (`/drafts` page) の draft row が body を全文表示しており、 280 字いっぱいの draft があると row が縦に膨らんで「公開する」 / 「削除」 button が画面外に流れる懸念があった。 X / Twitter 流儀 (= row は 1-2 行 preview + 末尾 「…」) に揃える。

`DraftsLoadDialog` (composer 内 dialog) は既に同 pattern (`line-clamp-2 whitespace-pre-wrap break-words`) を採用済なので、 `DraftsPanel.tsx` に揃えるだけ。

## 修正

- `DraftsPanel.tsx` body row に Tailwind `line-clamp-2 whitespace-pre-wrap break-words` を追加
- a11y: `line-clamp` は CSS 上の overflow:hidden + `-webkit-line-clamp` で見た目だけ省略 → DOM の text content には full body が残る → screen reader には全文届く (option A 採用)

## Test plan

- [ ] stg 反映後、 `/drafts` で長文 draft (= 280 字) を表示して 2 行で省略されることを実機確認
- [ ] same `/drafts` で短い draft (= 1 行) は省略されないことを確認
- [ ] screen reader / axe-core 等の a11y check で body 全文が DOM に残っていることを確認

vitest 追加なし (= className に `line-clamp-2` が含まれていれば動作確認できるが、 JSDOM では line-height の実評価ができないため意味薄い)。 stg 実機確認で代替。

## Review

- typescript-reviewer + code-reviewer 直列 (= frontend のみ、 小 fix)
- a11y-architect (= line-clamp の DOM/AT 挙動の妥当性確認)

Closes #773
Refs #769 (gan-evaluator 検出元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
