### PR TITLE
[refactor][drafts] /drafts publish toast を「投稿しました」 に統一 (#774)

### DIFF
--- a/client/e2e/drafts.spec.ts
+++ b/client/e2e/drafts.spec.ts
@@ -183,7 +183,8 @@ test.describe("#734 Tweet 下書き機能", () => {
 		const row = page.locator("li", { hasText: marker }).first();
 		await row.getByRole("button", { name: "下書きを公開する" }).click();
 
-		await expect(page.getByText(/公開しました/)).toBeVisible({
+		// #774: toast 文言は composer と統一して「投稿しました」。
+		await expect(page.getByText(/投稿しました/)).toBeVisible({
 			timeout: 10_000,
 		});
 		// 行が消える

--- a/client/src/components/drafts/DraftsPanel.tsx
+++ b/client/src/components/drafts/DraftsPanel.tsx
@@ -40,7 +40,8 @@ export default function DraftsPanel({ initial }: DraftsPanelProps) {
 		try {
 			await publishDraft(id);
 			setDrafts((prev) => prev.filter((d) => d.id !== id));
-			toast.success("公開しました");
+			// #774: composer の「投稿」 と統一して「投稿しました」 (= X 流儀)。
+			toast.success("投稿しました");
 			router.refresh();
 		} catch (e) {
 			const status = e instanceof AxiosError ? e.response?.status : undefined;

--- a/client/src/components/drafts/__tests__/DraftsPanel.test.tsx
+++ b/client/src/components/drafts/__tests__/DraftsPanel.test.tsx
@@ -107,7 +107,7 @@ describe("DraftsPanel (#734)", () => {
 		await waitFor(() => {
 			expect(publishDraftMock).toHaveBeenCalledWith(1);
 		});
-		expect(toastSuccessSpy).toHaveBeenCalledWith("公開しました");
+		expect(toastSuccessSpy).toHaveBeenCalledWith("投稿しました");
 		// 行が消えて empty state になる
 		await waitFor(() => {
 			expect(screen.queryByText("ready")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

#774 (gan-evaluator agent が #769 verify 中に指摘した文言ゆらぎ) の対応。 priority:low、 3 file 3 行の小 fix。

`DraftsPanel.tsx` (`/drafts` page) の publish 成功 toast が「公開しました」 だったが、 `TweetComposer` の「投稿」 button からの toast「投稿しました」 と揺れていた。 仕様書 (`tweet-drafts-spec.md` §4.2 / `tweet-drafts-load-spec.md` §3.3) の golden path にも「投稿しました」 と書かれており、 X 流儀 (= Post = 投稿) にも揃う。

## 修正

- `client/src/components/drafts/DraftsPanel.tsx`: `toast.success("公開しました")` → `"投稿しました"`
- `client/src/components/drafts/__tests__/DraftsPanel.test.tsx`: 文言 assertion 更新
- `client/e2e/drafts.spec.ts`: regex を `/投稿しました/` に更新

`apps/articles/` 配下の「公開しました」 (= 記事 publish flow) は scope 外。 記事と tweet で意味合いが違う ("article を 公開" は自然) ので触らない。

## Test plan

- [ ] vitest pass (= `DraftsPanel.test.tsx` の「投稿しました」 assert)
- [ ] stg 反映後、 `/drafts` で「公開する」 click → toast「投稿しました」 を実機確認
- [ ] e2e/drafts.spec.ts も新 regex で pass

## Review

- typescript-reviewer + code-reviewer 直列 (= 軽微な文言変更、 集約 review)

Closes #774
Refs #769 (gan-evaluator 検出元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
