### PR TITLE
[refactor][articles] ArticleEditor を Zenn 流に refine (= 本文拡大 + 右 sidebar + Write/Preview タブ) (#780)

### DIFF
--- a/client/e2e/article-editor-zenn.spec.ts
+++ b/client/e2e/article-editor-zenn.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * #780 ArticleEditor Zenn 流 refine の E2E 検証。
+ *
+ * Spec: docs/specs/article-editor-zenn-refine-spec.md §4.2
+ *
+ * 検証:
+ *   - E2E-ZENN-1: /articles/new で main col に textarea + 右 sidebar に title input が visible
+ *   - E2E-ZENN-2: 本文 markdown 入力 → Preview tab click → preview pane に rendered HTML
+ *   - E2E-ZENN-3: keyboard ArrowRight で Preview tab に切替
+ *   - E2E-ZENN-4: 「画像を追加」 button が Write tab 中に visible (Preview 中は hidden)
+ *   - E2E-ZENN-5: 公開ステータス radio で「公開」 → 「公開する」 button → confirm → toast「公開しました」 → /articles/<slug>
+ *
+ * 実行:
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     E2E_LOGIN_EMAIL=test4@example.com E2E_LOGIN_PASSWORD=E5INn9EaBLG7WNPl \
+ *     npx playwright test e2e/article-editor-zenn.spec.ts --reporter=line
+ *
+ * env 詳細: docs/local/e2e-stg.md
+ */
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+const EMAIL = process.env.E2E_LOGIN_EMAIL ?? "test4@example.com";
+const PASSWORD = process.env.E2E_LOGIN_PASSWORD ?? "E5INn9EaBLG7WNPl";
+
+test.describe("#780 ArticleEditor Zenn 流 refine", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(`${BASE}/login`);
+		await page.getByLabel(/メール/).fill(EMAIL);
+		await page.getByLabel(/パスワード/).fill(PASSWORD);
+		await page.getByRole("button", { name: /ログイン/ }).click();
+		await page.waitForURL(new RegExp(`^${BASE}/(home/?)?$`), {
+			timeout: 15_000,
+		});
+		await page.goto(`${BASE}/articles/new`);
+	});
+
+	test("E2E-ZENN-1: /articles/new で main 本文 + 右 sidebar に title input が見える", async ({
+		page,
+	}) => {
+		// main col の本文 textarea
+		await expect(page.getByLabel("本文 (Markdown)")).toBeVisible();
+		// 右 sidebar のタイトル input
+		await expect(
+			page.getByLabel(/タイトル/, { exact: false }).first(),
+		).toBeVisible();
+		// 公開ステータス fieldset
+		await expect(page.getByText("公開ステータス")).toBeVisible();
+	});
+
+	test("E2E-ZENN-2: 本文に Markdown 入力 → Preview tab click で rendered heading が表示", async ({
+		page,
+	}) => {
+		await page.getByLabel("本文 (Markdown)").fill("## subhead\n\nbody text");
+		await page.getByRole("tab", { name: "Preview" }).click();
+		await expect(
+			page.getByRole("heading", { name: "subhead", level: 2 }),
+		).toBeVisible();
+	});
+
+	test("E2E-ZENN-3: ArrowRight キーで Preview tab に切替", async ({ page }) => {
+		const writeTab = page.getByRole("tab", { name: "Write" });
+		await writeTab.focus();
+		await page.keyboard.press("ArrowRight");
+		await expect(page.getByRole("tab", { name: "Preview" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+	});
+
+	test("E2E-ZENN-4: 「画像を追加」 button は Write tab で visible、 Preview tab で hidden", async ({
+		page,
+	}) => {
+		// 初期 = Write tab
+		await expect(
+			page.getByRole("button", { name: "画像を追加" }),
+		).toBeVisible();
+		// Preview tab に切替
+		await page.getByRole("tab", { name: "Preview" }).click();
+		await expect(
+			page.getByRole("button", { name: "画像を追加" }),
+		).not.toBeVisible();
+	});
+
+	test("E2E-ZENN-5: 公開 = published で保存 → confirm → toast「公開しました」 → 詳細ページへ遷移", async ({
+		page,
+	}) => {
+		const uniqueTitle = `#780 e2e ${Date.now()}`;
+		// タイトル + 本文
+		await page
+			.getByLabel(/タイトル/, { exact: false })
+			.first()
+			.fill(uniqueTitle);
+		await page
+			.getByLabel("本文 (Markdown)")
+			.fill("## Section\n\nE2E body for #780 publish path.");
+		// 公開ステータスを「公開」 に切替
+		await page.getByLabel("公開").check();
+		// confirm dialog を accept
+		page.once("dialog", (d) => d.accept());
+		// 保存 button (status=published なので「公開する」)
+		await page.getByRole("button", { name: "公開する" }).click();
+		// toast / 遷移
+		await expect(page.getByText(/公開しました/)).toBeVisible({
+			timeout: 15_000,
+		});
+		await page.waitForURL(new RegExp(`${BASE}/articles/`), { timeout: 15_000 });
+	});
+});

--- a/client/src/components/articles/ArticleEditor.tsx
+++ b/client/src/components/articles/ArticleEditor.tsx
@@ -27,6 +27,7 @@ import {
 	type ClipboardEvent,
 	type DragEvent,
 	type FormEvent,
+	type KeyboardEvent,
 } from "react";
 import { toast } from "react-toastify";
 
@@ -150,6 +151,8 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [isDragging, setIsDragging] = useState(false);
+	// #780 fix: Write / Preview のタブ切替 (Zenn 流)。 同時並列ではなく排他切替。
+	const [viewMode, setViewMode] = useState<"write" | "preview">("write");
 
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -171,6 +174,32 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 			ta.setSelectionRange(target, target);
 		}
 	}, [body]);
+
+	// #780: Write タブに戻ったら textarea にフォーカスを戻す (UX 改善)。
+	useEffect(() => {
+		if (viewMode === "write") {
+			textareaRef.current?.focus({ preventScroll: true });
+		}
+	}, [viewMode]);
+
+	// #780: tablist keyboard nav。 ArrowLeft/Right で前/次の tab に自動 activate、
+	// Home/End は 2 tab しかないため Write/Preview を直接指す。
+	const handleTabKey = useCallback((e: KeyboardEvent<HTMLButtonElement>) => {
+		if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+			e.preventDefault();
+			setViewMode((m) => (m === "write" ? "preview" : "write"));
+			return;
+		}
+		if (e.key === "Home") {
+			e.preventDefault();
+			setViewMode("write");
+			return;
+		}
+		if (e.key === "End") {
+			e.preventDefault();
+			setViewMode("preview");
+		}
+	}, []);
 
 	const tags = tagsInput
 		.split(/[,\s]+/)
@@ -348,8 +377,19 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 	// #616: title と body 1 行目の h1 が一致しているか。 null なら警告なし。
 	const titleH1Duplicate = detectBodyH1MatchesTitle(title, body);
 
+	// #780: 保存 button の label (= mode + status の組み合わせで決まる)
+	const submitLabel = submitting
+		? "保存中…"
+		: mode === "create"
+			? status === "published"
+				? "公開する"
+				: "下書き保存"
+			: status === "published"
+				? "更新して公開"
+				: "更新";
+
 	return (
-		<form onSubmit={handleSubmit} className="space-y-4">
+		<form onSubmit={handleSubmit} className="space-y-3">
 			{error && (
 				<p
 					role="alert"
@@ -359,218 +399,264 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 				</p>
 			)}
 
-			<label className="block">
-				<span className="block text-sm font-medium">タイトル</span>
-				<input
-					type="text"
-					value={title}
-					onChange={(e) => setTitle(e.target.value)}
-					maxLength={120}
-					placeholder="記事のタイトル (1〜120 字)"
-					required
-					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-				/>
-			</label>
-
-			<label className="block">
-				<span className="block text-sm font-medium">
-					slug (任意、未指定なら title から自動生成)
-				</span>
-				<input
-					type="text"
-					value={slug}
-					onChange={(e) => setSlug(e.target.value)}
-					maxLength={120}
-					placeholder="my-first-post"
-					pattern="[\w\-]+"
-					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-				/>
-			</label>
-
-			<label className="block">
-				<span className="block text-sm font-medium">
-					タグ (カンマ区切り、最大 5 個)
-				</span>
-				<input
-					type="text"
-					value={tagsInput}
-					onChange={(e) => setTagsInput(e.target.value)}
-					placeholder="django, nextjs, aws"
-					className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-				/>
-				{tags.length > 0 && (
-					<ul aria-label="入力中のタグ" className="mt-1 flex flex-wrap gap-1">
-						{tags.map((t) => (
-							<li
-								key={t}
-								className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+			{/* #780 Zenn 流 2-col layout: main (editor/preview) + 右 sidebar (metadata)。
+			    desktop ≥ lg で 2 col、 mobile では metadata が main 下に積み下がる。 */}
+			<div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+				{/* main col: tablist + editor / preview panel */}
+				<div className="flex min-w-0 flex-col">
+					{/* tablist (Write / Preview) + 右端に「画像を追加」 + Cancel + 保存 */}
+					<div className="flex flex-wrap items-center gap-2 border-b border-border pb-2">
+						<div
+							role="tablist"
+							aria-label="エディタ表示モード"
+							aria-orientation="horizontal"
+							className="flex items-center gap-1"
+						>
+							<button
+								type="button"
+								role="tab"
+								id="editor-tab-write"
+								aria-selected={viewMode === "write"}
+								aria-controls="editor-panel-write"
+								tabIndex={viewMode === "write" ? 0 : -1}
+								onClick={() => setViewMode("write")}
+								onKeyDown={handleTabKey}
+								className={`min-h-[32px] rounded-t border-b-2 px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+									viewMode === "write"
+										? "border-[color:var(--a-accent)] text-foreground"
+										: "border-transparent text-muted-foreground hover:text-foreground"
+								}`}
 							>
-								#{t}
-							</li>
-						))}
-					</ul>
-				)}
-			</label>
-
-			<div className="grid gap-3 lg:grid-cols-2">
-				<div className="block">
-					<div className="flex items-center justify-between gap-2">
-						<label
-							htmlFor="article-body-textarea"
-							className="block text-sm font-medium"
-						>
-							本文 (Markdown)
-						</label>
-						<button
-							type="button"
-							onClick={() => fileInputRef.current?.click()}
-							// a11y-architect H-1: WCAG 2.2 SC 2.5.8 Target Size Minimum
-							// (24×24 CSS px) を満たすため min-h-[24px] + py-1。
-							// a11y-architect M-3: aria-haspopup="dialog" で OS file picker
-							// が開くことを SR に通知。
-							className="inline-flex min-h-[24px] items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
-							aria-label="画像を追加"
-							aria-haspopup="dialog"
-						>
-							<ImagePlus className="size-3.5" aria-hidden="true" />
-							画像を追加
-						</button>
-						<input
-							ref={fileInputRef}
-							type="file"
-							// a11y-architect M-2: hidden input でも programmatic click 経由で
-							// 操作するため、 偶発的に SR に拾われた時のために label を補強。
-							aria-label="画像ファイルを選択"
-							accept="image/jpeg,image/png,image/webp,image/gif"
-							multiple
-							hidden
-							onChange={handleFilesFromInput}
-						/>
+								Write
+							</button>
+							<button
+								type="button"
+								role="tab"
+								id="editor-tab-preview"
+								aria-selected={viewMode === "preview"}
+								aria-controls="editor-panel-preview"
+								tabIndex={viewMode === "preview" ? 0 : -1}
+								onClick={() => setViewMode("preview")}
+								onKeyDown={handleTabKey}
+								className={`min-h-[32px] rounded-t border-b-2 px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+									viewMode === "preview"
+										? "border-[color:var(--a-accent)] text-foreground"
+										: "border-transparent text-muted-foreground hover:text-foreground"
+								}`}
+							>
+								Preview
+							</button>
+						</div>
+						{/* tablist の右側 (= form 行動 button 群) */}
+						<div className="ml-auto flex flex-wrap items-center gap-2">
+							{viewMode === "write" && (
+								<>
+									<button
+										type="button"
+										onClick={() => fileInputRef.current?.click()}
+										// a11y-architect H-1 / M-3 既存維持
+										className="inline-flex min-h-[32px] items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+										aria-label="画像を追加"
+										aria-haspopup="dialog"
+									>
+										<ImagePlus className="size-3.5" aria-hidden="true" />
+										画像を追加
+									</button>
+									<input
+										ref={fileInputRef}
+										type="file"
+										aria-label="画像ファイルを選択"
+										accept="image/jpeg,image/png,image/webp,image/gif"
+										multiple
+										hidden
+										onChange={handleFilesFromInput}
+									/>
+								</>
+							)}
+							<button
+								type="button"
+								onClick={handleCancel}
+								disabled={submitting}
+								className="min-h-[32px] rounded-full border border-border px-4 py-1 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted disabled:opacity-50"
+							>
+								キャンセル
+							</button>
+							<button
+								type="submit"
+								disabled={submitting}
+								className="min-h-[32px] rounded-full bg-primary px-4 py-1 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+							>
+								{submitLabel}
+							</button>
+						</div>
 					</div>
-					<textarea
-						ref={textareaRef}
-						id="article-body-textarea"
-						value={body}
-						onChange={(e) => setBody(e.target.value)}
-						onPaste={handlePaste}
-						onDrop={handleDrop}
-						onDragOver={handleDragOver}
-						onDragLeave={handleDragLeave}
-						rows={20}
-						maxLength={100_000}
-						placeholder={
-							"# Heading\n\n本文を Markdown で...\n画像はドラッグ&ドロップ or ペーストでも追加できます"
-						}
-						required
-						aria-describedby="body-help"
-						className={`mt-1 h-[28rem] w-full rounded p-3 font-mono text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-							isDragging
-								? // a11y-architect H-2: WCAG 1.4.1 / 1.4.11 を満たすため色だけ
-									// でなく border-dashed + ring で形状変化も付与する。
-									"ring-[color:var(--a-accent)]/40 border-2 border-dashed border-[color:var(--a-accent)] bg-[color:var(--a-bg-subtle)] ring-2"
-								: "border border-border bg-background"
-						}`}
-					/>
-					<p id="body-help" className="mt-1 text-xs text-muted-foreground">
-						画像はドラッグ&ドロップ / ペースト / 「画像を追加」 button
-						で挿入できます (jpeg / png / webp / gif、 5 MiB まで)。
-					</p>
-					{titleH1Duplicate !== null && (
-						// #616: title と body 先頭 h1 が一致するなら、 詳細ページで H1 が
-						// 重複表示されるので作者に警告。 inline で非モーダル、 author の
-						// 意図的な選択は妨げない (block しない、 publish も通す)。
-						<p
-							role="status"
-							aria-live="polite"
-							className="mt-1 rounded border border-yellow-400/60 bg-yellow-50/80 px-2 py-1 text-xs text-yellow-900 dark:border-yellow-500/30 dark:bg-yellow-900/20 dark:text-yellow-100"
-						>
-							タイトルと本文 1 行目「# {titleH1Duplicate}」 が同じです。
-							詳細ページで見出しが二重に表示される可能性があります。
-						</p>
-					)}
-				</div>
-				<div className="block">
-					<span className="block text-sm font-medium">プレビュー</span>
-					{/* a11y-architect M-1: 集約 SR 通知。 画像 1 件ごとに polite が
-					    連発するのを防ぐ。 視覚 list は live region から外す。 */}
-					<p role="status" aria-live="polite" className="sr-only">
-						{activeUploadRows.length > 0
-							? `${activeUploadRows.length} 件の画像をアップロード中`
-							: ""}
-					</p>
-					{activeUploadRows.length > 0 && (
-						<ul
-							aria-label="アップロード中の画像"
-							className="mt-1 space-y-1 rounded border border-dashed border-border bg-muted/20 p-2 text-xs"
-						>
-							{activeUploadRows.map((r) => (
-								<li key={r.id} className="text-muted-foreground">
-									{r.state === "queued" ? "⏳ 待機中: " : "⬆ アップロード中: "}
-									{r.filename}
-								</li>
-							))}
-						</ul>
-					)}
+
+					{/* Write tabpanel */}
 					<div
+						role="tabpanel"
+						id="editor-panel-write"
+						aria-labelledby="editor-tab-write"
+						hidden={viewMode !== "write"}
+						className="mt-2 flex min-h-0 flex-1 flex-col"
+					>
+						<textarea
+							ref={textareaRef}
+							id="article-body-textarea"
+							value={body}
+							onChange={(e) => setBody(e.target.value)}
+							onPaste={handlePaste}
+							onDrop={handleDrop}
+							onDragOver={handleDragOver}
+							onDragLeave={handleDragLeave}
+							maxLength={100_000}
+							placeholder={
+								"# Heading\n\n本文を Markdown で...\n画像はドラッグ&ドロップ or ペーストでも追加できます"
+							}
+							required
+							aria-label="本文 (Markdown)"
+							aria-describedby="body-help"
+							className={`h-[calc(100vh-220px)] min-h-[24rem] w-full rounded p-3 font-mono text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+								isDragging
+									? "ring-[color:var(--a-accent)]/40 border-2 border-dashed border-[color:var(--a-accent)] bg-[color:var(--a-bg-subtle)] ring-2"
+									: "border border-border bg-background"
+							}`}
+						/>
+						<p id="body-help" className="mt-1 text-xs text-muted-foreground">
+							画像はドラッグ&ドロップ / ペースト / 「画像を追加」 button
+							で挿入できます (jpeg / png / webp / gif、 5 MiB まで)。
+						</p>
+						{titleH1Duplicate !== null && (
+							<p
+								role="status"
+								aria-live="polite"
+								className="mt-1 rounded border border-yellow-400/60 bg-yellow-50/80 px-2 py-1 text-xs text-yellow-900 dark:border-yellow-500/30 dark:bg-yellow-900/20 dark:text-yellow-100"
+							>
+								タイトルと本文 1 行目「# {titleH1Duplicate}」 が同じです。
+								詳細ページで見出しが二重に表示される可能性があります。
+							</p>
+						)}
+						{/* a11y-architect M-1: 集約 SR 通知。 視覚 list は別途。 */}
+						<p role="status" aria-live="polite" className="sr-only">
+							{activeUploadRows.length > 0
+								? `${activeUploadRows.length} 件の画像をアップロード中`
+								: ""}
+						</p>
+						{activeUploadRows.length > 0 && (
+							<ul
+								aria-label="アップロード中の画像"
+								className="mt-1 space-y-1 rounded border border-dashed border-border bg-muted/20 p-2 text-xs"
+							>
+								{activeUploadRows.map((r) => (
+									<li key={r.id} className="text-muted-foreground">
+										{r.state === "queued"
+											? "⏳ 待機中: "
+											: "⬆ アップロード中: "}
+										{r.filename}
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+
+					{/* Preview tabpanel */}
+					<div
+						role="tabpanel"
+						id="editor-panel-preview"
+						aria-labelledby="editor-tab-preview"
+						hidden={viewMode !== "preview"}
+						tabIndex={0}
 						aria-label="本文プレビュー"
-						className="mt-1 h-[28rem] overflow-y-auto rounded border border-border bg-muted/20 p-4 text-sm"
+						className="mt-2 h-[calc(100vh-220px)] min-h-[24rem] overflow-y-auto rounded border border-border bg-muted/20 p-4 text-sm"
 					>
 						<MarkdownPreview body={body} />
+						<p className="mt-3 text-xs text-muted-foreground">
+							※ 投稿後はサーバー側のサニタイザを通した HTML が表示されます。
+						</p>
 					</div>
-					<p className="mt-1 text-xs text-muted-foreground">
-						※ 投稿後はサーバー側のサニタイザを通した HTML が表示されます。
-					</p>
 				</div>
-			</div>
 
-			<fieldset className="flex items-center gap-4">
-				<legend className="sr-only">公開ステータス</legend>
-				<label className="flex items-center gap-2 text-sm">
-					<input
-						type="radio"
-						name="status"
-						value="draft"
-						checked={status === "draft"}
-						onChange={() => setStatus("draft")}
-					/>
-					下書き
-				</label>
-				<label className="flex items-center gap-2 text-sm">
-					<input
-						type="radio"
-						name="status"
-						value="published"
-						checked={status === "published"}
-						onChange={() => setStatus("published")}
-					/>
-					公開
-				</label>
-			</fieldset>
+				{/* 右 sidebar: タイトル / slug / タグ / 公開ステータス */}
+				<aside aria-label="記事の設定" className="space-y-3 lg:pt-2">
+					<label className="block">
+						<span className="block text-sm font-medium">タイトル</span>
+						<input
+							type="text"
+							value={title}
+							onChange={(e) => setTitle(e.target.value)}
+							maxLength={120}
+							placeholder="記事のタイトル (1〜120 字)"
+							required
+							className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						/>
+					</label>
 
-			<div className="flex flex-wrap items-center gap-3">
-				<button
-					type="button"
-					onClick={handleCancel}
-					disabled={submitting}
-					className="rounded-full border border-border px-6 py-2 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted disabled:opacity-50"
-				>
-					キャンセル
-				</button>
-				<button
-					type="submit"
-					disabled={submitting}
-					className="rounded-full bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-				>
-					{submitting
-						? "保存中…"
-						: mode === "create"
-							? status === "published"
-								? "公開する"
-								: "下書き保存"
-							: status === "published"
-								? "更新して公開"
-								: "更新"}
-				</button>
+					<label className="block">
+						<span className="block text-sm font-medium">
+							slug (任意、未指定なら title から自動生成)
+						</span>
+						<input
+							type="text"
+							value={slug}
+							onChange={(e) => setSlug(e.target.value)}
+							maxLength={120}
+							placeholder="my-first-post"
+							pattern="[\w\-]+"
+							className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						/>
+					</label>
+
+					<label className="block">
+						<span className="block text-sm font-medium">
+							タグ (カンマ区切り、最大 5 個)
+						</span>
+						<input
+							type="text"
+							value={tagsInput}
+							onChange={(e) => setTagsInput(e.target.value)}
+							placeholder="django, nextjs, aws"
+							className="mt-1 w-full rounded border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						/>
+						{tags.length > 0 && (
+							<ul
+								aria-label="入力中のタグ"
+								className="mt-1 flex flex-wrap gap-1"
+							>
+								{tags.map((t) => (
+									<li
+										key={t}
+										className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+									>
+										#{t}
+									</li>
+								))}
+							</ul>
+						)}
+					</label>
+
+					<fieldset className="space-y-2 rounded border border-border bg-muted/10 p-3">
+						<legend className="px-1 text-sm font-medium">公開ステータス</legend>
+						<label className="flex items-center gap-2 text-sm">
+							<input
+								type="radio"
+								name="status"
+								value="draft"
+								checked={status === "draft"}
+								onChange={() => setStatus("draft")}
+							/>
+							下書き
+						</label>
+						<label className="flex items-center gap-2 text-sm">
+							<input
+								type="radio"
+								name="status"
+								value="published"
+								checked={status === "published"}
+								onChange={() => setStatus("published")}
+							/>
+							公開
+						</label>
+					</fieldset>
+				</aside>
 			</div>
 		</form>
 	);

--- a/client/src/components/articles/ArticleEditor.tsx
+++ b/client/src/components/articles/ArticleEditor.tsx
@@ -164,19 +164,31 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 
 	// code-reviewer H-2 反映: body 更新ごとに pendingCaretRef を flush。 dep array
 	// なしの useEffect は毎レンダー走ってオーバーヘッドになるので body を観測する形に。
+	// typescript-reviewer HIGH (#780): viewMode が "preview" のとき textarea は
+	// hidden なので、 focus / setSelectionRange を skip する (= 不可視要素への
+	// focus 奪取を防ぐ)。 viewMode は ref 経由ではなく毎レンダー closure 経由で読む
+	// (= 再 schedule 不要、 「現在の状態」 として参照するだけ)。
 	useEffect(() => {
 		if (pendingCaretRef.current === null) return;
 		const target = pendingCaretRef.current;
 		pendingCaretRef.current = null;
 		const ta = textareaRef.current;
-		if (ta) {
+		if (ta && viewMode === "write") {
 			ta.focus();
 			ta.setSelectionRange(target, target);
 		}
-	}, [body]);
+	}, [body, viewMode]);
 
 	// #780: Write タブに戻ったら textarea にフォーカスを戻す (UX 改善)。
+	// typescript-reviewer HIGH (#780): mount 時の発火を抑制。 default viewMode が
+	// "write" のため、 初回 mount で page 全体の focus を奪うのを防ぐ。 切替時のみ
+	// focus を返す。
+	const firstViewModeRender = useRef(true);
 	useEffect(() => {
+		if (firstViewModeRender.current) {
+			firstViewModeRender.current = false;
+			return;
+		}
 		if (viewMode === "write") {
 			textareaRef.current?.focus({ preventScroll: true });
 		}

--- a/client/src/components/articles/__tests__/ArticleEditor.test.tsx
+++ b/client/src/components/articles/__tests__/ArticleEditor.test.tsx
@@ -232,6 +232,37 @@ describe("ArticleEditor", () => {
 			);
 		});
 
+		it("BD-2: End キーで Preview tab、 Home キーで Write tab に jump", () => {
+			render(<ArticleEditor mode="create" />);
+			const writeTab = screen.getByRole("tab", { name: "Write" });
+			// End → Preview
+			fireEvent.keyDown(writeTab, { key: "End" });
+			expect(screen.getByRole("tab", { name: "Preview" })).toHaveAttribute(
+				"aria-selected",
+				"true",
+			);
+			// Home → Write
+			const previewTab = screen.getByRole("tab", { name: "Preview" });
+			fireEvent.keyDown(previewTab, { key: "Home" });
+			expect(screen.getByRole("tab", { name: "Write" })).toHaveAttribute(
+				"aria-selected",
+				"true",
+			);
+		});
+
+		it("HP-3: Preview → Write 切替で textarea に focus が戻る (= firstViewModeRender guard 後)", () => {
+			render(<ArticleEditor mode="create" />);
+			// 初期は Write tab。 mount 直後の useEffect は firstViewModeRender で skip されるため
+			// textarea にいきなり focus は飛ばない (= 検証は body 全体の activeElement を見ない)。
+			// Preview に切替 → Write に戻す → textarea が document.activeElement
+			fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+			fireEvent.click(screen.getByRole("tab", { name: "Write" }));
+			const textarea = screen.getByLabelText("本文 (Markdown)", {
+				exact: false,
+			}) as HTMLTextAreaElement;
+			expect(document.activeElement).toBe(textarea);
+		});
+
 		it("SE-2: Preview に切り替えても title / slug / tags / status の input 値は維持される", () => {
 			render(<ArticleEditor mode="create" />);
 			const titleInput = screen.getByLabelText(/タイトル/, {

--- a/client/src/components/articles/__tests__/ArticleEditor.test.tsx
+++ b/client/src/components/articles/__tests__/ArticleEditor.test.tsx
@@ -175,21 +175,101 @@ describe("ArticleEditor", () => {
 
 	it("T-EDIT-2 preview pane renders heading from body markdown", () => {
 		render(<ArticleEditor mode="create" />);
-		const textarea = screen
-			.getByLabelText("本文 (Markdown)", {
-				exact: false,
-			})
-			.matches?.("textarea")
-			? screen.getByLabelText("本文 (Markdown)", { exact: false })
-			: (screen
-					.getAllByRole("textbox")
-					.find((el) => el.tagName === "TEXTAREA") as HTMLTextAreaElement);
-
+		const textarea = screen.getByLabelText("本文 (Markdown)", {
+			exact: false,
+		}) as HTMLTextAreaElement;
 		fireEvent.change(textarea, { target: { value: "# title\n\nhello" } });
-		// preview pane に <h1>title</h1> が render
+		// #780: Write tab default で preview pane は hidden = accessibility tree
+		// から除外されている。 Preview tab に切り替えてから rendered HTML を確認。
+		fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
 		expect(
 			screen.getByRole("heading", { name: "title", level: 1 }),
 		).toBeInTheDocument();
+	});
+
+	// #780 Zenn 流 refactor: Write / Preview タブ切替
+	describe("#780 Write/Preview タブ切替", () => {
+		it("HP-1: 初期表示で Write tab が aria-selected=true、 Preview pane は hidden", () => {
+			render(<ArticleEditor mode="create" />);
+			const writeTab = screen.getByRole("tab", { name: "Write" });
+			const previewTab = screen.getByRole("tab", { name: "Preview" });
+			expect(writeTab).toHaveAttribute("aria-selected", "true");
+			expect(previewTab).toHaveAttribute("aria-selected", "false");
+			// preview tabpanel は hidden だが DOM には存在
+			const previewPanel = document.getElementById("editor-panel-preview");
+			expect(previewPanel).not.toBeNull();
+			expect(previewPanel).toHaveAttribute("hidden");
+		});
+
+		it("HP-2: Preview tab click で aria-selected が切り替わり、 textarea は hidden、 preview pane が visible", () => {
+			render(<ArticleEditor mode="create" />);
+			fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+			expect(screen.getByRole("tab", { name: "Preview" })).toHaveAttribute(
+				"aria-selected",
+				"true",
+			);
+			expect(screen.getByRole("tab", { name: "Write" })).toHaveAttribute(
+				"aria-selected",
+				"false",
+			);
+			const writePanel = document.getElementById("editor-panel-write");
+			expect(writePanel).toHaveAttribute("hidden");
+		});
+
+		it("BD-1: ArrowRight キーで Preview に切替、 ArrowLeft で Write に戻る", () => {
+			render(<ArticleEditor mode="create" />);
+			const writeTab = screen.getByRole("tab", { name: "Write" });
+			fireEvent.keyDown(writeTab, { key: "ArrowRight" });
+			expect(screen.getByRole("tab", { name: "Preview" })).toHaveAttribute(
+				"aria-selected",
+				"true",
+			);
+			const previewTab = screen.getByRole("tab", { name: "Preview" });
+			fireEvent.keyDown(previewTab, { key: "ArrowLeft" });
+			expect(screen.getByRole("tab", { name: "Write" })).toHaveAttribute(
+				"aria-selected",
+				"true",
+			);
+		});
+
+		it("SE-2: Preview に切り替えても title / slug / tags / status の input 値は維持される", () => {
+			render(<ArticleEditor mode="create" />);
+			const titleInput = screen.getByLabelText(/タイトル/, {
+				selector: "input",
+			}) as HTMLInputElement;
+			fireEvent.change(titleInput, { target: { value: "回帰検証用タイトル" } });
+			fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+			expect(
+				(
+					screen.getByLabelText(/タイトル/, {
+						selector: "input",
+					}) as HTMLInputElement
+				).value,
+			).toBe("回帰検証用タイトル");
+		});
+
+		it("SE-3 (デグレ防止): Preview tab 中も form submit が走り createArticle が呼ばれる", async () => {
+			createArticleMock.mockResolvedValueOnce({ slug: "ok-slug" });
+			render(<ArticleEditor mode="create" />);
+			const titleInput = screen.getByLabelText(/タイトル/, {
+				selector: "input",
+			}) as HTMLInputElement;
+			fireEvent.change(titleInput, { target: { value: "preview submit" } });
+			const body = screen.getByLabelText("本文 (Markdown)", {
+				exact: false,
+			}) as HTMLTextAreaElement;
+			fireEvent.change(body, { target: { value: "## sub" } });
+			// Preview に切替
+			fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+			// 保存 button は tablist の右端にあり、 default status=draft なので「下書き保存」
+			const submitBtn = screen.getByRole("button", {
+				name: "下書き保存",
+			}) as HTMLButtonElement;
+			await act(async () => {
+				submitBtn.click();
+			});
+			expect(createArticleMock).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	it("T-EDIT-3 file picker via 「画像を追加」 button enqueues selected files", () => {

--- a/docs/specs/article-editor-zenn-refine-spec.md
+++ b/docs/specs/article-editor-zenn-refine-spec.md
@@ -1,0 +1,266 @@
+# ArticleEditor の Zenn 流 refine 仕様書 (#780)
+
+> Version: 0.1
+> 作成日: 2026-05-18
+> 関連 Issue: #780
+> 関連 PR: 本 PR (= fix)
+> 参照: Zenn (https://zenn.dev) の記事編集 UI
+
+---
+
+## 0. 目的
+
+ハルナさん指摘 (2026-05-18):
+
+> 記事を書くところさ、記事の書く範囲が狭くなっているのがいやなんだよね。 タイトルとかは右にもっていってくれるかな？ あと、 プレビューなんだけど、 zenn とかを参考にしてよ。 プレビュータブを押すとプレビュー画面に切り替わっているでしょ。 全体的に zenn を参考に refine してほしい。
+
+`ArticleEditor.tsx` を Zenn 流の編集 UI に refactor し、 **本文を書く範囲を広く**、 **タイトル等 metadata を右 sidebar に**、 **Write / Preview をタブ切替** にする。
+
+---
+
+## 1. 現状の不満 (= 修正前)
+
+| 課題                    | 現状                                                    |
+| ----------------------- | ------------------------------------------------------- |
+| 本文書く範囲が狭い      | `lg:grid-cols-2` で本文 50% / preview 50% の左右 split  |
+| metadata が上に積まれる | タイトル / slug / タグ が上部縦並びでスクロール必要     |
+| preview 常時並列        | edit と preview を同時表示 (= Zenn 流 tab 切替ではない) |
+
+## 2. やる / やらない
+
+### やる (= 本 PR scope)
+
+**Layout (desktop ≥ lg)**:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                                              │
+│  ┌─────────────────────────────────────────┐ ┌────────────┐ │
+│  │ [Write] [Preview]    [Cancel] [保存]    │ │ タイトル    │ │
+│  ├─────────────────────────────────────────┤ │ slug       │ │
+│  │                                          │ │ タグ        │ │
+│  │  Markdown editor (Write tab active)      │ │ 公開状態    │ │
+│  │  OR                                      │ │            │ │
+│  │  MarkdownPreview (Preview tab active)    │ │            │ │
+│  │                                          │ │            │ │
+│  │  高さ: h-[calc(100vh-180px)]             │ │            │ │
+│  │  幅: 70%                                  │ │ 幅: 30%    │ │
+│  │                                          │ │            │ │
+│  └─────────────────────────────────────────┘ └────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- `grid grid-cols-1 lg:grid-cols-[1fr_320px]` で main 列 + 右 sidebar
+- main 列: 上部に `role="tablist"` で Write / Preview tab、 直下に tabpanel
+- right col: タイトル input / slug input / タグ input / 公開ステータス radio を縦並び
+- 行動 button (Cancel / 保存) は tablist の右端に inline 配置
+
+**Tab pattern (WAI-ARIA)**:
+
+- `role="tablist"` `aria-label="エディタ表示モード"`
+- 各 tab: `role="tab"` `aria-selected` `aria-controls=<panel id>`
+- tabpanel: `role="tabpanel"` `aria-labelledby=<tab id>` `tabIndex={0}`
+- keyboard: ArrowLeft / ArrowRight で次/前の tab に focus + activate (= 自動 activate モード)
+- click でも切替可
+
+**State**:
+
+- `viewMode: "write" | "preview"`、 default `"write"`
+- Preview に切り替えると現在の `body` (= textarea state) でレンダリング
+- Write に戻すと textarea にフォーカスを戻す (= UX 改善)
+
+**Mobile (< lg)**:
+
+- `grid-cols-1` で main col のみ、 sidebar は main col の下に積み下がる
+- tablist は引き続き上部に表示
+
+**a11y (新規 + 既存維持)**:
+
+- 既存の textarea `aria-describedby="body-help"`、 「画像を追加」 button の aria 属性、 `role="status"` のアップロード通知、 公開ステータス radio fieldset → そのまま維持
+- 新規: tab pattern に `aria-orientation="horizontal"`、 keyboard ArrowLeft/Right、 Home/End
+
+**autosave**:
+
+- `useAutoSaveSync` (= localStorage 保存) は維持。 Preview に切り替えても autosave は走り続ける (= viewMode は autosave key に影響しない)
+
+**「画像を追加」 / drag&drop / paste**:
+
+- Write tab だけで有効 (= Preview tab では textarea が DOM に居ないので drop イベントは発火しない、 が安全策で view モードチェック)
+
+### やらない (別 Issue 候補)
+
+- アイキャッチ画像 (= OGP 画像) 編集
+- トピック (= tag) suggestion / autocomplete
+- 公開予約 (= schedule)
+- TOC sidebar / outline
+- code block 構文ハイライト preview 強化 (= 既に rehype-pygments 経由で対応済)
+- 「自動保存中」 indicator の visual upgrade
+- Zenn 風の「公開設定」 別画面 (= 現状の 1 form で完結する pattern を維持)
+
+---
+
+## 3. 実装方針
+
+### 3.1 `ArticleEditor.tsx`
+
+主要変更箇所:
+
+1. **state 追加**: `const [viewMode, setViewMode] = useState<"write" | "preview">("write");`
+2. **layout grid**: 既存 `<form>` の直下に
+   ```jsx
+   <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+   	<main className="min-w-0">…tab + panel…</main>
+   	<aside className="space-y-3">…title/slug/tags/status…</aside>
+   </div>
+   ```
+3. **tablist** (新 component or inline):
+   ```jsx
+   <div
+   	role="tablist"
+   	aria-label="エディタ表示モード"
+   	aria-orientation="horizontal"
+   	className="flex items-center gap-1 border-b border-border"
+   >
+   	<button
+   		role="tab"
+   		aria-selected={viewMode === "write"}
+   		aria-controls="editor-panel-write"
+   		id="editor-tab-write"
+   		onClick={() => setViewMode("write")}
+   		onKeyDown={handleTabKey}
+   		className="..."
+   	>
+   		Write
+   	</button>
+   	<button
+   		role="tab"
+   		aria-selected={viewMode === "preview"}
+   		aria-controls="editor-panel-preview"
+   		id="editor-tab-preview"
+   		onClick={() => setViewMode("preview")}
+   		onKeyDown={handleTabKey}
+   		className="..."
+   	>
+   		Preview
+   	</button>
+   	<div className="ml-auto flex gap-2">
+   		<button type="button" onClick={handleCancel}>
+   			キャンセル
+   		</button>
+   		<button type="submit" disabled={submitting}>
+   			保存
+   		</button>
+   	</div>
+   </div>
+   ```
+4. **tab key handler**:
+   ```ts
+   function handleTabKey(e: KeyboardEvent<HTMLButtonElement>) {
+   	if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+   		e.preventDefault();
+   		setViewMode((m) => (m === "write" ? "preview" : "write"));
+   	}
+   }
+   ```
+5. **tabpanel**: `viewMode==="write"` で textarea、 `"preview"` で `MarkdownPreview` を出す
+   ```jsx
+   <div role="tabpanel" id="editor-panel-write" aria-labelledby="editor-tab-write" hidden={viewMode!=="write"} className="...">
+     <textarea ref={textareaRef} ... className="h-[calc(100vh-220px)] w-full ..." />
+     {/* body-help, title-h1 warning, 画像 upload list */}
+   </div>
+   <div role="tabpanel" id="editor-panel-preview" aria-labelledby="editor-tab-preview" hidden={viewMode!=="preview"} className="h-[calc(100vh-220px)] overflow-y-auto ...">
+     <MarkdownPreview body={body} />
+   </div>
+   ```
+6. **sidebar** (右 col / mobile bottom):
+   - タイトル input (既存 maxLength=120)
+   - slug input (既存 pattern)
+   - タグ input (既存 max 5)
+   - 公開ステータス radio (既存 draft/published)
+   - **「画像を追加」 button は editor toolbar (= tablist 直下) に残す**、 sidebar には入れない
+7. **viewMode 切替時の focus management**: Write タブに切り替わったとき textarea に focus を戻す (= `useEffect` で `textareaRef.current?.focus()`)
+
+### 3.2 画像 upload 経路
+
+`handleFilesFromInput` / `handlePaste` / `handleDrop` / `handleDragOver` / `handleDragLeave` のハンドラはそのまま textarea に残す。 Preview tab 中は textarea が `hidden` でも DOM に存在するが、 drop イベントは visible 要素のみ取れる。 paste は document level で発生するが現状の handler は textarea bound なので問題なし。
+
+### 3.3 button 配置
+
+- Cancel / 保存 button を tablist の右端 inline に移動 (= form の bottom から削除して上部に)
+- mobile では tablist と button が縦に積まれる → `flex-wrap` で許容
+
+### 3.4 影響範囲
+
+- `client/src/components/articles/ArticleEditor.tsx` (= 主に layout 構造変更、 + viewMode state、 tab handler)
+- `client/src/components/articles/__tests__/ArticleEditor.test.tsx` (= 既存 test は layout 依存箇所を更新、 新規 tab 切替 test 追加)
+- 新 helper / file は追加しない (= scope 抑制)
+
+---
+
+## 4. テスト (4 系統)
+
+### 4.1 frontend vitest (`__tests__/ArticleEditor.test.tsx` に追加)
+
+#### Happy path
+
+- **HP-1**: 初期表示で Write tab が `aria-selected=true`、 textarea が visible、 preview pane が `hidden`
+- **HP-2**: Preview tab click → `aria-selected=true`、 textarea が `hidden`、 MarkdownPreview の中の HTML (= body の rendered) が visible
+- **HP-3**: Write タブに戻る click → textarea が visible + focused
+
+#### 境界
+
+- **BD-1**: ArrowRight キーで Preview tab に切替、 ArrowLeft で Write に戻る
+- **BD-2**: Home / End キーで最初 / 最後の tab に focus (= 既存挙動踏襲、 2 個しかないので結果的に Home=Write / End=Preview)
+
+#### 失敗系
+
+- **FF-1**: viewMode="preview" 中に form submit → 通常通り submit が走り API 呼び出し成功 (= タブ切替が submit を妨げない)
+
+#### 期待しない副作用
+
+- **SE-1**: Preview に切り替えても autosave key の値は変わらない (= localStorage 監視)
+- **SE-2**: Preview に切り替えても title / slug / tag input の入力中の値は維持される (= 右 sidebar の controlled component)
+- **SE-3**: 公開確認 dialog (= 既存) は引き続き「公開」 ステータスで submit したとき表示される
+
+#### 既存 test 更新
+
+- 既存「T-PUBLISH-2 create + published で『公開しました』 toast」 等は layout 変更で button 取得 selector が変わる場合がある → `getByRole("button", { name: "保存" })` または content match を update
+- 既存「本文 textarea が見える」 系の test → 初期 viewMode="write" 前提なので維持
+
+### 4.2 E2E Playwright (`client/e2e/article-editor-zenn.spec.ts` 新規)
+
+- **E2E-ZENN-1**: /articles/new アクセス → タイトル input が右 sidebar に visible / 本文 textarea が main col に visible
+- **E2E-ZENN-2**: 本文に Markdown 入力 → Preview tab click → preview pane に rendered HTML が visible (= 本文の `## heading` が `<h2>` で表示)
+- **E2E-ZENN-3**: keyboard ArrowRight で Preview にフォーカス + 切替
+- **E2E-ZENN-4 (デグレ防止)**: 「画像を追加」 button click → file picker 起動 (= existing behavior 維持、 file mock では skip でも OK)
+- **E2E-ZENN-5 (デグレ防止)**: 公開ステータス radio = published で「保存」 → 公開確認 dialog → OK → 公開成功 toast「公開しました」 が出て /articles/<slug> へ遷移
+
+実行:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test4@example.com \
+PLAYWRIGHT_USER1_PASSWORD=E5INn9EaBLG7WNPl \
+  npx playwright test e2e/article-editor-zenn.spec.ts --reporter=line
+```
+
+---
+
+## 5. 受け入れ基準 (DoD)
+
+- [ ] desktop で本文 editor が画面横幅の 65%+ を占める
+- [ ] タイトル / slug / タグ / 公開ステータス が右 sidebar (lg breakpoint) または bottom (sm) に配置
+- [ ] 上部に「Write」 / 「Preview」 タブが並ぶ
+- [ ] click / ArrowLeft / ArrowRight で tab 切替できる
+- [ ] aria-selected が tab に同期、 tabpanel に aria-labelledby が結ばれる
+- [ ] vitest 既存 + 追加 9 ケース 全 pass
+- [ ] Playwright spec E2E-ZENN-1〜5 stg で全 pass
+- [ ] typescript-reviewer / a11y-architect / code-reviewer 直列で CRITICAL/HIGH なし
+- [ ] gan-evaluator agent 採点: 「本文の書く範囲が広いか」 / 「Preview タブで切替動作するか」 / 「右 sidebar の metadata 配置が破綻していないか」
+
+---
+
+## 6. ロールバック
+
+- 1 file の layout 変更が中心なので、 PR revert で完全 rollback 可能
+- backward compat: API 変更なし、 vitest / E2E が pass する限り既存記事の編集に影響なし


### PR DESCRIPTION
## Summary

#780 (ハルナさん要望) の対応。 `ArticleEditor` を **Zenn 流の 2-col layout + Write/Preview タブ切替** に refine。

### 修正前
- `lg:grid-cols-2` で本文 50% / preview 50% → 本文の書く範囲が狭い
- タイトル / slug / タグ が上部に縦積み (スクロール必要)
- preview が常時並列表示 (= Zenn 流タブ切替ではない)

### 修正後
- `lg:grid-cols-[minmax(0,1fr)_320px]` で main col + 右 sidebar
- 本文 textarea: `h-[calc(100vh-220px)] min-h-[24rem]` = 画面縦いっぱい
- Write / Preview の **WAI-ARIA tabs** で排他切替 (click / ArrowLeft / ArrowRight / Home / End)
- 右 sidebar: タイトル / slug / タグ / 公開ステータス (fieldset)
- mobile (< lg) は sidebar が main 下に積み下がる responsive

### a11y
- `role="tablist"` / `aria-orientation="horizontal"` / `aria-selected` / `aria-controls` / `aria-labelledby` を完備
- 既存 `aria-label="本文 (Markdown)"` を textarea に明示 → 既存 vitest 互換
- WAI-ARIA tabs pattern (自動 activate モード) 準拠
- 画像 D&D の dashed border + ring (= 色だけでなく形状変化、 既存維持)

## Test plan

### vitest (5 ケース追加 + 1 既存更新)
- [ ] HP-1: 初期 Write tab `aria-selected=true` / Preview pane `hidden`
- [ ] HP-2: Preview click で aria-selected / hidden が切替
- [ ] BD-1: ArrowRight / ArrowLeft キーで切替
- [ ] SE-2: Preview に切替えても title input 値が維持される
- [ ] SE-3 (デグレ防止): Preview tab 中も form submit が走り createArticle 呼ばれる
- [ ] T-EDIT-2 (更新): Preview tab click 後に rendered heading が visible

### stg verify (= Claude 自身で踏む)
- [ ] /articles/new で本文が広いか実機確認
- [ ] Preview タブ click で切替動作
- [ ] mobile (responsive) で sidebar が main 下に積み下がる
- [ ] 公開ステータス radio で「公開」 → 「公開する」 button で confirm dialog → toast「公開しました」

### Review
- typescript-reviewer / a11y-architect / code-reviewer 直列
- gan-evaluator 採点 (本文書く範囲が広い / Preview タブで切替動作 / 右 sidebar 配置)

## Spec

`docs/specs/article-editor-zenn-refine-spec.md` (新規) に layout / a11y / test 計画を集約。

## 影響範囲

- `client/src/components/articles/ArticleEditor.tsx` (= layout 構造 + tab state + a11y)
- `client/src/components/articles/__tests__/ArticleEditor.test.tsx` (= 既存 T-EDIT-2 更新、 tab 切替 5 ケース追加)
- 新 helper / file は追加なし (= scope 抑制)

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)
