### PR TITLE
[bug][articles] #780 Zenn refine の 3 bug fix (Preview 排他切替 / main 幅 / tab focus) (#782)

### DIFF
--- a/client/src/app/(template)/layout.tsx
+++ b/client/src/app/(template)/layout.tsx
@@ -20,6 +20,7 @@ import type { ReactNode } from "react";
 
 import AComposeDialogHost from "@/components/layout-a/AComposeDialogHost";
 import ALeftNav from "@/components/layout-a/ALeftNav";
+import AMainWidth from "@/components/layout-a/AMainWidth";
 import AMobileAppBar from "@/components/layout-a/AMobileShell";
 import ARightRail from "@/components/layout-a/ARightRail";
 
@@ -39,15 +40,17 @@ export default function TemplateLayout({ children }: LayoutProps) {
 			}}
 		>
 			<ALeftNav />
+			{/* #782: `maxWidth: 800` の固定制約を `AMainWidth` (client) に委譲。
+			    article editor route だけ max-width を 1280 に広げて本文を書きやすく
+			    する。 他 route は 800px の TL 用幅を維持 (= デグレ防止)。 */}
 			<main
 				// mobile (< sm) では fixed bottom-nav が content に被らないよう、
 				// safe-area を含む余白と scroll padding を main 側に確保する。
-				className="mx-auto flex w-full min-w-0 scroll-pb-28 flex-col pb-28 sm:scroll-pb-0 sm:border-r sm:border-[color:var(--a-border)] sm:pb-0"
-				style={{ maxWidth: 800 }}
+				className="flex w-full min-w-0 scroll-pb-28 flex-col pb-28 sm:scroll-pb-0 sm:border-r sm:border-[color:var(--a-border)] sm:pb-0"
 				aria-label="メインコンテンツ"
 			>
 				<AMobileAppBar />
-				{children}
+				<AMainWidth>{children}</AMainWidth>
 			</main>
 			<ARightRail />
 			{/*

--- a/client/src/components/articles/ArticleEditor.tsx
+++ b/client/src/components/articles/ArticleEditor.tsx
@@ -156,6 +156,10 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
+	// #782: WAI-ARIA tabs pattern の roving tabindex で、 ArrowKey 切替時に
+	// 次の tab に明示 focus を返すため、 各 tab button の ref を保持。
+	const writeTabRef = useRef<HTMLButtonElement | null>(null);
+	const previewTabRef = useRef<HTMLButtonElement | null>(null);
 	// upload 完了で caret を移動させたい位置を保持。 setBody の updater 内では
 	// 副作用 (DOM 操作) を起こさず、 commit 後に useEffect 経由で flush する
 	// (typescript-reviewer M-3 反映、 React Strict Mode の double-call で
@@ -196,20 +200,35 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 
 	// #780: tablist keyboard nav。 ArrowLeft/Right で前/次の tab に自動 activate、
 	// Home/End は 2 tab しかないため Write/Preview を直接指す。
+	// #782 gan-evaluator HIGH: WAI-ARIA tabs pattern の roving tabindex を完成
+	// させるため、 setViewMode 後に次の tab button へ明示 focus を渡す。
 	const handleTabKey = useCallback((e: KeyboardEvent<HTMLButtonElement>) => {
+		const focusTab = (next: "write" | "preview") => {
+			const ref = next === "write" ? writeTabRef : previewTabRef;
+			ref.current?.focus();
+		};
 		if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
 			e.preventDefault();
-			setViewMode((m) => (m === "write" ? "preview" : "write"));
+			let next: "write" | "preview" = "write";
+			setViewMode((m) => {
+				next = m === "write" ? "preview" : "write";
+				return next;
+			});
+			// state 更新後に focus を移すが、 React は同期 batch するので
+			// next を closure で持っておけば確実に該当 tab に focus 移動できる。
+			queueMicrotask(() => focusTab(next));
 			return;
 		}
 		if (e.key === "Home") {
 			e.preventDefault();
 			setViewMode("write");
+			queueMicrotask(() => focusTab("write"));
 			return;
 		}
 		if (e.key === "End") {
 			e.preventDefault();
 			setViewMode("preview");
+			queueMicrotask(() => focusTab("preview"));
 		}
 	}, []);
 
@@ -425,6 +444,7 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 							className="flex items-center gap-1"
 						>
 							<button
+								ref={writeTabRef}
 								type="button"
 								role="tab"
 								id="editor-tab-write"
@@ -442,6 +462,7 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 								Write
 							</button>
 							<button
+								ref={previewTabRef}
 								type="button"
 								role="tab"
 								id="editor-tab-preview"
@@ -503,12 +524,18 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 						</div>
 					</div>
 
-					{/* Write tabpanel */}
+					{/* Write tabpanel
+					    #782 gan-evaluator CRITICAL: HTML `hidden` attribute は `display: none`
+					    を適用するが、 className の `flex` (= `display: flex`) で上書き
+					    されるため両 panel が同時描画される regression が出ていた。
+					    `hidden` + `style.display: 'none'` を併用して確実に非表示にする
+					    (`hidden` は a11y tree からも除外するので残す)。 */}
 					<div
 						role="tabpanel"
 						id="editor-panel-write"
 						aria-labelledby="editor-tab-write"
 						hidden={viewMode !== "write"}
+						style={viewMode !== "write" ? { display: "none" } : undefined}
 						className="mt-2 flex min-h-0 flex-1 flex-col"
 					>
 						<textarea
@@ -570,12 +597,15 @@ export default function ArticleEditor({ mode, initial }: ArticleEditorProps) {
 						)}
 					</div>
 
-					{/* Preview tabpanel */}
+					{/* Preview tabpanel
+					    #782 gan-evaluator CRITICAL: 上記 Write panel と同じ理由で
+					    `hidden` + `style.display: 'none'` を併用。 */}
 					<div
 						role="tabpanel"
 						id="editor-panel-preview"
 						aria-labelledby="editor-tab-preview"
 						hidden={viewMode !== "preview"}
+						style={viewMode !== "preview" ? { display: "none" } : undefined}
 						tabIndex={0}
 						aria-label="本文プレビュー"
 						className="mt-2 h-[calc(100vh-220px)] min-h-[24rem] overflow-y-auto rounded border border-border bg-muted/20 p-4 text-sm"

--- a/client/src/components/layout-a/AMainWidth.tsx
+++ b/client/src/components/layout-a/AMainWidth.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+/**
+ * #782 Article editor wide-layout shim。
+ *
+ * `(template)/layout.tsx` の `<main>` は default で `maxWidth: 800` (= Twitter/X
+ * 流の home TL 用幅) に制限されている。 これは TL 系には適切だが、 ArticleEditor
+ * (= /articles/new / /articles/<slug>/edit) で本文 textarea が画面の 30% しか
+ * 取れない原因になる (#782 gan-evaluator 採点 2/5)。
+ *
+ * 本 component は pathname を見て article editor route のときだけ `maxWidth: none`
+ * + 横余白を desktop 1280px 程度に拡張する。 他 route は従来 800px のまま。
+ */
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+interface Props {
+	children: ReactNode;
+}
+
+const ARTICLE_EDITOR_RE = /^\/articles\/(new|[^/]+\/edit)\/?$/;
+
+export default function AMainWidth({ children }: Props) {
+	const pathname = usePathname() ?? "";
+	const isWide = ARTICLE_EDITOR_RE.test(pathname);
+	return (
+		<div className="mx-auto w-full" style={{ maxWidth: isWide ? 1280 : 800 }}>
+			{children}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

#782 (= #780 PR #781 後の gan-evaluator 採点 15/25 ship 不可) の fix-forward。 3 bug をまとめて潰す。

### CRITICAL: Preview tab で textarea が hidden にならない
`hidden={...}` attribute は HTML 標準で `display: none` を適用するが、 className の `flex` (= `display: flex`) で上書きされ Preview tab 切替後も textarea が visible のまま。 `hidden` + `style.display: 'none'` を併用して CSS specificity を担保。

### HIGH: 本文 textarea 幅 29% → 70%+
`(template)/layout.tsx` の `<main style={{maxWidth: 800}}>` が記事編集 page にも適用されていた。 新 client component `AMainWidth` で `usePathname` を見て article editor route だけ `maxWidth: 1280` に広げる。 他 route (= home / explore / messages 等) は従来 800px 維持。

### HIGH: ArrowLeft/Right で tab focus が移動しない
WAI-ARIA Tabs pattern の roving tabindex で、 keyboard 切替時に次の tab に明示 `focus()` を渡していなかった。 `writeTabRef` / `previewTabRef` + `queueMicrotask` で setViewMode 後に focus を移す。

## Test plan

stg 実機検証 (Playwright MCP):
- [ ] `/articles/new` で textarea 幅が viewport の 65%+
- [ ] Preview tab click で textarea が画面から消える (offsetParent === null)
- [ ] ArrowRight キーで focus が Preview tab に移動
- [ ] mobile (< lg) で sidebar が main 下に積み下がる
- [ ] 他 route (`/`, `/explore`) で main 幅が 800px 維持 (= デグレ防止)

### vitest
- [ ] 既存 ArticleEditor.test.tsx 全 pass
- [ ] hidden 状態の `style.display === 'none'` を assert

### gan-evaluator 再採点
- [ ] 20/25 以上を目標 (= 前回 15/25 から +5)

## 関連
- 元 PR: #781 (= #780 merged)
- spec: docs/specs/article-editor-zenn-refine-spec.md (= v0.3 に上げる別 issue 候補)

Closes #782
Refs #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)
