### PR TITLE
[fix][dm] /messages mobile 375 で room list 最終 row がボトムナビと重なる修正 (#791)

### DIFF
--- a/client/e2e/messages-mobile-bottomnav-padding.spec.ts
+++ b/client/e2e/messages-mobile-bottomnav-padding.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * #791 / messages-mobile-bottomnav-padding
+ *
+ * 375x812 viewport で `/messages` の room list 最終アイテムがボトムナビ
+ * (aria-label="モバイルタブ" の <nav>) と重ならないことを assertion。
+ *
+ * 実行 (stg):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=test4@example.com \
+ *   PLAYWRIGHT_USER1_PASSWORD=E5INn9EaBLG7WNPl \
+ *   PLAYWRIGHT_USER1_HANDLE=test4 \
+ *     npx playwright test e2e/messages-mobile-bottomnav-padding.spec.ts --reporter=line
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+
+const USER1_EMAIL = process.env.PLAYWRIGHT_USER1_EMAIL ?? "";
+const USER1_PASSWORD = process.env.PLAYWRIGHT_USER1_PASSWORD ?? "";
+
+const CREDENTIALS_PRESENT = Boolean(USER1_EMAIL && USER1_PASSWORD);
+
+async function login(page: Page, email: string, password: string) {
+	await page.goto("/login");
+	await page.getByLabel("Email Address").fill(email);
+	await page.getByPlaceholder("Password").fill(password);
+	await page.getByRole("button", { name: /Sign In/i }).click();
+	await page.waitForURL(/\/onboarding|\/$/);
+}
+
+test.describe("messages mobile bottom nav padding (#791)", () => {
+	test.skip(
+		!CREDENTIALS_PRESENT,
+		"PLAYWRIGHT_USER1_EMAIL / PASSWORD が必要 (docs/local/e2e-stg.md)",
+	);
+
+	test("375x812 で room list 最終アイテムがボトムナビと重ならない", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		await login(page, USER1_EMAIL, USER1_PASSWORD);
+		await page.goto("/messages");
+		await page.waitForLoadState("networkidle");
+
+		// room list が render されるまで待つ (RoomList component の wrapper)
+		const roomListWrapper = page.locator('[data-testid="room-list"]');
+		await expect(roomListWrapper).toBeVisible({ timeout: 15_000 });
+
+		// ボトムナビ (fixed inset-x-0 bottom-0、 sm 以下のみ表示)
+		const bottomNav = page.getByRole("navigation", { name: "モバイルタブ" });
+		await expect(bottomNav).toBeVisible();
+
+		// RoomList は direct child として <ul> (or <Link> 招待 + <ul>) or empty
+		// state <div> を持つ。 全 child の bottom がボトムナビ上端を超えないこと
+		// (= 一番下の content がナビと重ならない) を確認する。 個別 <li> ではなく
+		// list container の bottom rect で検証 (code-reviewer LOW 反映)。
+		const items = roomListWrapper.locator("> *");
+		const itemCount = await items.count();
+		test.skip(
+			itemCount === 0,
+			"room list が空。 fixture を追加するか別 user で踏んで再実行",
+		);
+
+		const lastContent = items.last();
+		const lastContentBox = await lastContent.boundingBox();
+		const bottomNavBox = await bottomNav.boundingBox();
+
+		expect(
+			lastContentBox,
+			"room list 内の最終 content の bounding box が取れる",
+		).not.toBeNull();
+		expect(bottomNavBox, "ボトムナビの bounding box が取れる").not.toBeNull();
+
+		// 「最終 content 下端」 ≤ 「ボトムナビ上端」 で重なりなし
+		const lastContentBottom = lastContentBox!.y + lastContentBox!.height;
+		expect(lastContentBottom).toBeLessThanOrEqual(bottomNavBox!.y);
+	});
+});

--- a/client/src/app/(template)/messages/page.tsx
+++ b/client/src/app/(template)/messages/page.tsx
@@ -136,7 +136,16 @@ export default function MessagesPage() {
 					</Dialog>
 				</div>
 			</header>
-			<div className="p-5">
+			{/*
+				#791: 内側 wrapper にも mobile 用 padding-bottom を持たせる。
+				(template) layout 側の `pb-28` は外側 scroll container のため、
+				room list が overflow して長くなったときに最終 row 下端の
+				余白を確保できない。 ui-ux-tester が 375x812 で実機重なりを
+				検出したのもこのシナリオ。 内側に `pb-20` を持たせて 最終 row
+				下にナビ高さ分の clearance を作る。 sm+ では `pb-5` (= 元の p-5)
+				に戻して desktop で余分な空白が出ないようにする。
+			*/}
+			<div className="p-5 pb-20 sm:pb-5">
 				<RoomList currentUserId={profile.pkid} />
 			</div>
 		</>

--- a/docs/specs/messages-mobile-bottomnav-padding-spec.md
+++ b/docs/specs/messages-mobile-bottomnav-padding-spec.md
@@ -1,0 +1,114 @@
+# /messages モバイル ボトムナビ重なり修正
+
+> 関連: [Issue #791](https://github.com/haruna0712/claude-code/issues/791), ui-ux-tester 監査 2026-05-18
+
+## 1. 背景
+
+`ui-ux-tester` agent の `/messages` IA 監査 (Playwright MCP / 375x812 viewport) で発掘。 mobile viewport で `/messages` を開くと、 room list の最終アイテムがボトムナビ (高さ約 60px) の下に潜り、 初期表示で切れる。 スクロール可能なので機能不全ではないが、 \"最後の room まで見えている\" シグナルが失われる典型的な mobile safe-area 不足。
+
+evidence: `/workspace/uxaudit-messages-ia-375.png`
+
+## 2. 原因
+
+`client/src/app/(template)/messages/page.tsx:139`:
+
+```tsx
+<div className="p-5">
+	<RoomList currentUserId={profile.pkid} />
+</div>
+```
+
+`p-5` (= 1.25rem 四方) しかなく、 mobile のボトムナビ分の余白がない。
+
+## 3. やること
+
+### 3.1 frontend 変更
+
+`client/src/app/(template)/messages/page.tsx:139` の 1 行 + 経緯コメント:
+
+```tsx
+- <div className="p-5">
++ <div className="p-5 pb-20 sm:pb-5">
+```
+
+- `pb-20` = `padding-bottom: 5rem (80px)` で ボトムナビ 60px + 余裕 20px をカバー
+- `sm:pb-5` で sm 以上 (= ボトムナビ非表示) では `p-5` 相当に戻し、 desktop で余分な空白を作らない
+- (template) layout (`client/src/app/(template)/layout.tsx`) の `pb-28 sm:pb-0` は **外側 main column の scroll container** に対する padding-bottom。 短いリストで viewport を超えないときに余白を担保。 一方 wrapper 内側の `pb-20 sm:pb-5` は **room list が長くなって overflow したとき**、 最終アイテム下にナビ高さ分の余白を確保する。 効くシナリオが違うため重複ではない (code-reviewer MEDIUM 反映)
+
+### 3.2 backend 変更
+
+なし。
+
+## 4. やらないこと
+
+- `/messages` 以外のページで同種の問題があるか全件監査 (別 Issue、 ui-ux-tester に渡す)
+- ボトムナビ高さの design token 化 (別 Issue、 phase 10 設計取り込みで扱う想定)
+- safe-area-inset (iOS notch) 対応 (別 Issue、 必要になったら)
+
+## 5. テスト
+
+### 5.1 Playwright E2E
+
+ファイル: `client/e2e/messages-mobile-bottomnav-padding.spec.ts` (新設)
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test("375px で room list 最終アイテムがボトムナビと重ならない (#791)", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 375, height: 812 });
+	// login (env で test4 / E5INn9EaBLG7WNPl など onboarding 完了済を渡す)
+	await page.goto("/messages");
+	await page.waitForLoadState("networkidle");
+
+	// RoomList component の wrapper には既存 data-testid="room-list" がある
+	const roomList = page.locator('[data-testid="room-list"]');
+	// ボトムナビは AMobileShell の <nav aria-label="モバイルタブ">
+	const bottomNav = page.getByRole("navigation", { name: "モバイルタブ" });
+
+	await expect(roomList).toBeVisible();
+	const lastItem = roomList.locator("> *").last();
+	const lastRoomBox = await lastItem.boundingBox();
+	const bottomNavBox = await bottomNav.boundingBox();
+
+	expect(lastRoomBox).not.toBeNull();
+	expect(bottomNavBox).not.toBeNull();
+
+	// 最終 room の bottom がボトムナビの top より上にあること
+	expect(lastRoomBox!.y + lastRoomBox!.height).toBeLessThanOrEqual(
+		bottomNavBox!.y,
+	);
+});
+```
+
+`RoomList` には既に `data-testid="room-list"` がある。 ボトムナビは `<nav aria-label="モバイルタブ">` (AMobileShell) で取得。
+
+### 5.2 stg 実行コマンド
+
+test3 / test2 は onboarding 未完了の場合があるので、 stg では test4 以降の onboarding 完了済ユーザーを推奨:
+
+```bash
+cd /workspace/client
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+PLAYWRIGHT_USER1_EMAIL=test4@example.com \
+PLAYWRIGHT_USER1_PASSWORD=E5INn9EaBLG7WNPl \
+  npx playwright test e2e/messages-mobile-bottomnav-padding.spec.ts --reporter=line
+```
+
+### 5.3 視覚回帰の確認
+
+- desktop 1280x800 で `/messages` に余分な底パディングが見えるが、 機能影響なし
+- ui-ux-tester 監査の再実行 (本 Issue 完了後) で 375 px のスクショを撮り直し、 重なり解消を確認
+
+## 6. 受け入れ基準
+
+- [ ] `client/src/app/(template)/messages/page.tsx` の wrapper に `pb-20 sm:pb-5` 追加
+- [ ] `client/e2e/messages-mobile-bottomnav-padding.spec.ts` 新設、 375x812 で pass
+- [ ] desktop 1280x800 での regression なし (余白が下に増えるだけ)
+- [ ] stg 反映後 Claude が 375 viewport で踏んで確認
+- [ ] `code-reviewer` レビュー pass (HIGH/CRITICAL なし)
+
+## 7. リスク
+
+- 低。 class 1 個追加のみ。 spacing が好みに合わなければ `pb-[calc(...)]` で微調整可


### PR DESCRIPTION
Closes #791

## Summary

- ui-ux-tester が `/messages` の 375x812 viewport で発掘した room list overflow 時の重なり bug を修正
- 内側 wrapper の `p-5` → `p-5 pb-20 sm:pb-5` で mobile 時のみ clearance を確保

## 経緯

(template) layout (`client/src/app/(template)/layout.tsx`) の main column には既に `pb-28 sm:pb-0` が effetcive だが、 これは **外側 scroll container** の padding。 短いリストで viewport を超えないシナリオには効くが、 room list が overflow して長くなったときに 最終 row の下に nav 分の余白を確保できない。 ui-ux-tester が 375x812 で実機重なりを検出。

修正は内側 wrapper にも mobile 専用 padding-bottom を持たせる。 sm+ では従来通りに戻すので desktop / tablet では余分な空白なし。

## レビュー結果

- **code-reviewer**: APPROVE (HIGH/CRITICAL なし)。 MEDIUM 2 件 (docs / コメントの説明 accuracy) と LOW 2 件 (locator コメント) を反映済。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Playwright spec を新設 (env 未設定で skip)
- [ ] stg 反映後 Claude が 375 viewport で実画面確認
- [ ] ui-ux-tester 事後監査で 重なり解消を確認

```bash
# stg E2E
cd client
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
PLAYWRIGHT_USER1_EMAIL=test4@example.com \
PLAYWRIGHT_USER1_PASSWORD=E5INn9EaBLG7WNPl \
  npx playwright test e2e/messages-mobile-bottomnav-padding.spec.ts --reporter=line
```

## 関連

- 仕様: [`docs/specs/messages-mobile-bottomnav-padding-spec.md`](docs/specs/messages-mobile-bottomnav-padding-spec.md)
- ui-ux-tester 監査 2026-05-18 (本セッション)
- evidence: `/workspace/uxaudit-messages-ia-375.png`
- 同シリーズ: #790 (group 0-member、 マージ済 #793) / #792 (招待 inline 化、 未着手)