### PR TITLE
[refactor][search] 左 nav 「探索」 → 「検索」 + /search で右 rail 表示 (#795)

### DIFF
--- a/client/e2e/search-nav-rail.spec.ts
+++ b/client/e2e/search-nav-rail.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * #795 / search-nav-rename-rail
+ *
+ * 左 nav 「探索」 → 「検索」 + path /search に変更、 /search で右 rail を表示
+ * (ARightRail = TrendingTags + WhoToFollow)、 /explore route は維持。
+ *
+ * Login helper は #797 で共通化予定 (stg は日本語 UI で /メールアドレス/、 local
+ * docker fixture は英語 UI のため regex で両対応)。
+ *
+ * 実行 (stg):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     npx playwright test e2e/search-nav-rail.spec.ts --reporter=line
+ *
+ * 認証は anonymous OK の項目だけ用意してあるので credential 不要。
+ */
+
+import { expect, test } from "@playwright/test";
+
+test.describe("Search nav rename + right rail (#795)", () => {
+	test("desktop 1280: 左 nav 「検索」 click → /search 着地 + 右 rail 表示", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/");
+
+		const searchLink = page.getByRole("link", { name: "検索", exact: true });
+		await expect(searchLink).toBeVisible({ timeout: 15_000 });
+		await searchLink.click();
+		await page.waitForURL("**/search");
+
+		// /search ページの heading
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible();
+
+		// 右 rail (ARightRail) の 2 panel が見える
+		const rail = page.getByRole("complementary", { name: "右サイドバー" });
+		await expect(rail).toBeVisible();
+		await expect(rail.getByText(/Trending tags/i)).toBeVisible();
+		await expect(rail.getByText(/Who to follow/i)).toBeVisible();
+	});
+
+	test("desktop 1280: 左 nav に 「探索」 entry が存在しない (regression)", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/");
+		await expect(
+			page.getByRole("link", { name: "探索", exact: true }),
+		).toHaveCount(0);
+	});
+
+	test("desktop 1280: /explore 直叩きは 200 (route 維持)", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		const response = await page.goto("/explore");
+		expect(response?.status() ?? 0).toBeLessThan(400);
+		// /explore も同じ右 rail chrome を持っている
+		await expect(
+			page.getByRole("complementary", { name: "右サイドバー" }),
+		).toBeVisible({ timeout: 15_000 });
+	});
+
+	test("mobile 375: /search の右 rail は非表示 (lg:block のため)", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		await page.goto("/search");
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible({ timeout: 15_000 });
+
+		// rail は DOM 上は存在するが visible は false (display:none via lg:block)
+		const rail = page.getByRole("complementary", { name: "右サイドバー" });
+		await expect(rail).not.toBeVisible();
+	});
+
+	test("anonymous でも /search 200 + 右 rail 表示", async ({ browser }) => {
+		// fresh context (cookie / auth なし)。 baseURL は playwright.config 経由で
+		// 解決 (PLAYWRIGHT_BASE_URL 未設定時のデフォルト分岐を 1 箇所に集約)。
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		try {
+			await page.setViewportSize({ width: 1280, height: 800 });
+			const response = await page.goto("/search");
+			expect(response?.status() ?? 0).toBeLessThan(400);
+			await expect(
+				page.getByRole("heading", { name: "検索", level: 1 }),
+			).toBeVisible({ timeout: 15_000 });
+			await expect(
+				page.getByRole("complementary", { name: "右サイドバー" }),
+			).toBeVisible();
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -11,8 +11,10 @@
  *  - 全 NavItem / pod に `focus-visible:outline-2 outline-[var(--a-accent)]` (WCAG 2.4.7)
  *  - 非 active 時の `hover:bg-[var(--a-bg-muted)]` (現在 transparent で hover 無反応)
  *
- * #741 で「探索」 icon を Search (虫眼鏡) に変更、 「検索」 entry を削除。
- * Twitter 準拠 IA: search は /explore の component で、 nav 上は 1 entry のみ。
+ * #741 で「探索」 icon を Search (虫眼鏡) に変更、 「検索」 entry を削除して
+ * `/explore` に統一。 #795 で再調整: nav 入口を 「検索」 (/search) に変更し、
+ * `/explore` route は残るが nav からは外す。 rail に search panel は無い前提で
+ * duplication 問題なし。
  *
  * 既存 `LeftNavbar` とは別実装で並存 (POC、Phase B で統一予定)。
  */
@@ -61,9 +63,9 @@ interface NavItemDef {
 
 const NAV_ITEMS: NavItemDef[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
-	// #741: Twitter 準拠 IA — explore icon を Search (虫眼鏡) に統一、
-	// 「検索」 専用 entry は削除 (search box は /explore 最上部)。
-	{ href: "/explore", label: "探索", Icon: Search },
+	// #741 で 「探索」 (/explore) に統一 → #795 で nav 入口を 「検索」 (/search) に変更。
+	// `/explore` route は残るが nav には出さない。
+	{ href: "/search", label: "検索", Icon: Search },
 	{
 		href: "/notifications",
 		label: "通知",

--- a/client/src/components/layout-a/AMobileShell.tsx
+++ b/client/src/components/layout-a/AMobileShell.tsx
@@ -8,7 +8,7 @@
  *
  * - 上部 app bar: BrandMark + 「devstream」 + ハンバーガー
  * - ハンバーガー click で Sheet (左 drawer) が開き、ALeftNav と同 nav 内容
- * - 下部 bottom-tab bar: ホーム / 探索 / 通知 / メッセージ / プロフィール
+ * - 下部 bottom-tab bar: ホーム / 検索 / 通知 / メッセージ / プロフィール
  *   (auth に応じて表示)
  *
  * 表示条件: `< sm` (640px 未満)。`sm` 以上では ALayout のサイドカラムを使う。
@@ -45,11 +45,12 @@ interface BottomTabItem {
 	requiresAuth?: boolean;
 }
 
-// #741: Twitter 準拠 IA — explore icon を Search (虫眼鏡) に統一、
-// 「検索」 entry は削除 (search box は /explore 最上部に統合)。
+// #741: Twitter 準拠 IA — explore icon を Search (虫眼鏡) に統一。
+// #795: nav 入口を 「検索」 (/search) に変更。 `/explore` route は残るが
+// nav からは外す。 rail に search panel は無い前提で duplication 問題なし。
 const BOTTOM_TABS: BottomTabItem[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
-	{ href: "/explore", label: "探索", Icon: Search },
+	{ href: "/search", label: "検索", Icon: Search },
 	{ href: "/notifications", label: "通知", Icon: Bell, requiresAuth: true },
 	{
 		href: "/messages",
@@ -256,10 +257,10 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 	// ただし auth-scoped task (下書き等) は drawer に残し desktop main nav は profile
 	// menu 経由に分離する場合がある (#762: drafts は X mobile drawer 準拠で keep、
 	// desktop main nav からは削除 → profile DropdownMenu に移動)。
-	// #741: 「検索」 entry は削除 (Twitter 準拠 IA、 search box は /explore 最上部)。
+	// #741 で 「探索」 1 entry に統一 → #795 で nav 入口を 「検索」 (/search) に変更。
 	const items: BottomTabItem[] = [
 		{ href: "/", label: "ホーム", Icon: Home },
-		{ href: "/explore", label: "探索", Icon: Search },
+		{ href: "/search", label: "検索", Icon: Search },
 		{ href: "/notifications", label: "通知", Icon: Bell, requiresAuth: true },
 		{
 			href: "/messages",

--- a/client/src/components/layout-a/__tests__/ALeftNav.test.tsx
+++ b/client/src/components/layout-a/__tests__/ALeftNav.test.tsx
@@ -97,9 +97,9 @@ describe("ALeftNav (#557 Phase B-0-6)", () => {
 	it("非 active NavItem に hover:bg-[var(--a-bg-muted)] が付く", () => {
 		setupAuthed(0);
 		render(<ALeftNav />);
-		// "/" が active なので 「探索」 (非 active) を確認
-		const exploreLink = screen.getByRole("link", { name: /探索/ });
-		expect(exploreLink.className).toContain(
+		// "/" が active なので 「検索」 (#795 で 「探索」 から rename、 非 active) を確認
+		const searchLink = screen.getByRole("link", { name: /検索/ });
+		expect(searchLink.className).toContain(
 			"hover:bg-[color:var(--a-bg-muted)]",
 		);
 	});

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -3,14 +3,17 @@ import { LeftNavLink } from "@/types";
 /**
  * LeftNavbar / MobileNavbar に表示する link 一覧 (#297).
  *
- * 並び順は X (旧 Twitter) の左ナビに準拠: ホーム → 探索 → 通知 →
+ * 並び順は X (旧 Twitter) の左ナビに準拠: ホーム → 検索 → 通知 →
  * メッセージ → プロフィール。
  *
  * Phase 1 で導入した SVG 資産 (home.svg) は Home 行のみ後方互換維持のため
  * imgLocation に残し、他 link は lucide-react icon に揃える。
  *
- * #741 で「検索」 entry を削除、 「探索」 icon を Search (虫眼鏡) に統一。
- * Twitter 準拠 IA: search は /explore の component で、 nav 上は 1 entry のみ。
+ * #741 で「検索」 entry を削除して「探索」 (/explore) に統一したが、 #795 で
+ * ハルナさんの product 判断に基づき再調整: nav の入口は 「検索」 (path: /search)。
+ * `/explore` route は残るが nav からは外す。 rail に search panel は戻さない
+ * ため `/search` でも rail (TrendingTags + WhoToFollow) を出して surface
+ * duplication 問題は再発しない。
  */
 export const leftNavLinks: LeftNavLink[] = [
 	{
@@ -20,8 +23,10 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "Home",
 	},
 	{
-		path: "/explore",
-		label: "探索",
+		// #795: 「探索」 → 「検索」 rename + path /explore → /search。
+		// /explore route は残るが nav 入口は /search に。
+		path: "/search",
+		label: "検索",
 		iconName: "Search",
 	},
 	{

--- a/client/src/lib/layout/__tests__/focused-surfaces.test.ts
+++ b/client/src/lib/layout/__tests__/focused-surfaces.test.ts
@@ -26,11 +26,13 @@ describe("shouldHideRightRail", () => {
 		});
 	});
 
-	describe("surface duplication (#741): /search", () => {
+	describe("search surface (#795: 抑制解除、 rail を出す)", () => {
+		// #741 で `/search` 系を 「surface duplication 防止」 で抑制したが、
+		// rail の search panel は削除済みなので duplication 問題なし → #795 で解除。
 		it.each([["/search"], ["/search/users"], ["/search/anything"]])(
-			"returns true for %s",
+			"returns false for %s",
 			(pathname) => {
-				expect(shouldHideRightRail(pathname)).toBe(true);
+				expect(shouldHideRightRail(pathname)).toBe(false);
 			},
 		);
 	});
@@ -109,6 +111,9 @@ describe("shouldHideRightRail", () => {
 			["/drafts"],
 			["/follow-requests"],
 			["/explore"],
+			// #795: /search 系も rail を出す (search panel は rail に無いので duplication なし)
+			["/search"],
+			["/search/users"],
 		])("returns false for %s", (pathname) => {
 			expect(shouldHideRightRail(pathname)).toBe(false);
 		});

--- a/client/src/lib/layout/focused-surfaces.ts
+++ b/client/src/lib/layout/focused-surfaces.ts
@@ -1,20 +1,19 @@
 /**
- * Right rail 抑制対象 pathname 判定 (#741).
+ * Right rail 抑制対象 pathname 判定 (#741, #795).
  *
- * Spec: docs/specs/explore-search-rightrail-spec.md §3.4
+ * Spec: docs/specs/explore-search-rightrail-spec.md §3.4 / §9, search-nav-rename-rail-spec.md
  *
- * 右 rail (`ARightRail`) は「 trending + who-to-follow」 を出す chrome だが、
- * 以下の 6 カテゴリでは集中阻害 / surface 重複 / picker page の rail dominant
- * 問題で page purpose と矛盾するため抑制する:
+ * 履歴: #741 で「Surface duplication 防止」 として `/search` 系を category 2 に
+ * 入れたが、 ARightRail から search panel を削除した時点で duplication は
+ * 解消されていた。 #795 で抑制対象から外し、 `/search` でも rail を表示。
+ *
+ * 現役の抑制カテゴリは 5 つ (category 番号は historical):
  *
  *   1. **Composer / Edit form** — 元から抑制対象
  *      - `/settings/*`
  *      - `/articles/new` / `/articles/<slug>/edit`
  *      - `/mentor/wanted/new`
  *      - `/mentors/me/edit`
- *
- *   2. **Surface duplication 防止**
- *      - `/search` / `/search/*` (中央 SearchBox と rail search panel が重複)
  *
  *   3. **Focused single-task surface**
  *      - `/agent` / `/agent/*` (Claude Agent LLM chat workspace)
@@ -41,8 +40,9 @@
  *      将来の picker 以外 (例: `/mentors/<handle>` profile detail) も同じ category
  *      に乗せやすくする (code-reviewer #760 提案)。
  *
- * 採点根拠 (`ui-ux-tester` agent 2026-05-17 audit):
- *   - `/search` rail score: -2 (surface duplication 最悪)
+ * 採点根拠 (`ui-ux-tester` agent 2026-05-17 audit、 #795 で更新):
+ *   - ~~`/search` rail score: -2 (surface duplication 最悪)~~ → #795 で抑制解除。
+ *     rail に search panel が無い前提で duplication 問題は再発しない。
  *   - `/agent` rail score: -2 (LLM chat に discovery ノイズ)
  *   - `/messages/<id>` rail score: -1 (private chat に discovery 不適切)
  *   - `/articles/<slug>` rail score: -1 (長文読みに干渉)
@@ -63,8 +63,8 @@ export function shouldHideRightRail(pathname: string): boolean {
 	if (pathname === "/mentor/wanted/new") return true;
 	if (pathname === "/mentors/me/edit") return true;
 
-	// 2. Surface duplication (#741)
-	if (pathname === "/search" || pathname.startsWith("/search/")) return true;
+	// (category 2 は #741 の `/search` surface duplication 抑制だったが、 #795 で
+	// 解除して `/search` でも rail を表示する方針に変更。 番号は historical 維持。)
 
 	// 3. Focused single-task surface (#741)
 	if (pathname === "/agent" || pathname.startsWith("/agent/")) return true;

--- a/docs/specs/explore-search-rightrail-spec.md
+++ b/docs/specs/explore-search-rightrail-spec.md
@@ -327,3 +327,28 @@ PLAYWRIGHT_USER1_HANDLE=test4 \
 
 - 単一 file の差分 (`client/src/app/(template)/explore/page.tsx`) を revert すれば原状回復
 - DB / API 触らず、 既存 component 流用のみ
+
+## 9. follow-up: nav 「探索」 → 「検索」 + /search 抑制解除 (#795)
+
+ハルナさん指示 (2026-05-18) で #741 の決定を部分的に再調整。
+
+### 9.1 変更
+
+- 左 nav の label 「探索」 → 「検索」、 path `/explore` → `/search` (#795)
+- `shouldHideRightRail` 判定から `/search` 系を除外。 `/search` でも `ARightRail` (TrendingTags + WhoToFollow) を表示
+- 関連 spec doc: [search-nav-rename-rail-spec.md](./search-nav-rename-rail-spec.md)
+
+### 9.2 #741 との関係
+
+- §3.1 で「nav から検索 entry を削除して /explore に統一」 とした判断は #795 で逆転
+- §3.4.1 抑制リストの `/search` 行は #795 で削除 (現行コードは抑制対象から外れている)
+- §3.4.2 「search panel 削除」 は **継続**。 search panel は ARightRail に戻さない (`/search` 中央 SearchBox と rail search panel の重複懸念があったため)
+- `/explore` route は維持。 nav からは外れたが URL 直叩き / 既存 deep link は引き続き機能
+
+### 9.3 受け入れ基準
+
+- [ ] 左 nav 「検索」 entry が `/search` を指す
+- [ ] `/search` で `ARightRail` 表示、 中央 SearchBox との競合なし
+- [ ] `/explore` 直叩き 200、 同じ rail chrome
+- [ ] vitest: `shouldHideRightRail("/search")` / `("/search/users")` → false
+- [ ] Playwright: 上記すべて pass

--- a/docs/specs/search-nav-rename-rail-spec.md
+++ b/docs/specs/search-nav-rename-rail-spec.md
@@ -1,0 +1,210 @@
+# 左 nav 「探索」→「検索」 + /search 右 rail 追加
+
+> 関連: [Issue #795](https://github.com/haruna0712/claude-code/issues/795)
+> 既存 spec の更新: [explore-search-rightrail-spec.md](./explore-search-rightrail-spec.md) (§3.4 抑制リスト)
+> 経緯: [#741](https://github.com/haruna0712/claude-code/issues/741) の判断を一部再調整
+
+## 1. 背景
+
+ハルナさん指示 (2026-05-18):
+
+- 左 nav の 「探索」 を 「検索」 に rename
+- 左 nav の link 先を `/search` に変更
+- ただし `/explore` route は残す
+- `/search` の画面表示を `/explore` に合わせる (= 右 rail を追加)
+
+#741 で「nav は 1 entry (= 探索)、 rail に search panel を統合」 で X 準拠化したが、 ハルナさんの product 判断として 「検索」 を一級 entry にする方向に方針転換。 rail の search panel は #741 で既に削除済みなので、 `/search` で rail を出しても重複問題は再発しない。
+
+## 2. やること
+
+### 2.1 左 nav の rename + path 変更
+
+`client/src/constants/index.ts`:
+
+```diff
+@@ docstring 抜粋 @@
+- * #741 で「検索」 entry を削除、 「探索」 icon を Search (虫眼鏡) に統一。
+- * Twitter 準拠 IA: search は /explore の component で、 nav 上は 1 entry のみ。
++ * #741 で「検索」 entry を削除して「探索」 に統一したが、 #795 で再調整:
++ * nav の入口は 「検索」 (path: /search)。 /explore は route は残るが nav 外へ。
++ * rail に search panel を戻さないため `/search` に rail を出しても重複しない。
+
+  {
+-     path: "/explore",
+-     label: "探索",
++     path: "/search",
++     label: "検索",
+      iconName: "Search",
+  },
+```
+
+### 2.2 /search の右 rail 抑制を解除
+
+`client/src/lib/layout/focused-surfaces.ts` の `shouldHideRightRail` 判定から `/search` を外す:
+
+```diff
+- "/search",
+- "/search/*",
+```
+
+(具体 path に応じて。 ファイル内の正規表現 / startsWith 配列のスタイルに合わせる)
+
+合わせて関連 spec `docs/specs/explore-search-rightrail-spec.md` §3.4 の抑制リストから `/search` 行を削除し、 #795 の経緯を 1 行追記する。
+
+### 2.3 /search の page (`client/src/app/(template)/search/page.tsx`)
+
+- 既存 chrome (header / SearchBox / SearchModeTabs / TweetCardList) は維持
+- (template) layout から `ARightRail` が自動で挟まれるので **page 側の追加変更は不要**
+- 視認確認: `<div className="p-5">` 中央の幅が rail と重なって読みづらくないか (3.4 で検証)
+
+### 2.4 /explore は変更なし (path は残す)
+
+- route は削除しない。 既存 SearchBox + trending feed + (logged-out) HeroBanner はそのまま
+- docstring の #741 注記を 「nav からは /search を指すが /explore も維持」 と 1 行追記
+
+## 3. やらないこと
+
+- `/explore` / `/search` の SEO canonical 整理 (両 URL が同等 chrome で indexing 制御要する場合は別 Issue)
+- `/search` の q なし時に trending feed を出す統合案 (ハルナさん指示は rail 追加まで、 中央統合は scope 外)
+- ARightRail に search panel を戻す
+- `/explore` への redirect
+
+## 4. UI 振る舞い
+
+### 4.1 デスクトップ (1280+)
+
+```
+[Left nav]    [center: SearchBox / 結果 / SearchModeTabs]    [Right rail: TrendingTags + WhoToFollow]
+ホーム
+検索 ← click → /search 着地、 右 rail が見える
+通知
+...
+```
+
+### 4.2 モバイル (375)
+
+- 右 rail は `lg:block` で非表示 (既存挙動維持)
+- 中央 column のみ表示。 SearchBox / 結果 / SearchModeTabs はそのまま
+
+### 4.3 /explore (直叩き)
+
+- nav にはないが URL 直叩き可
+- 既存 chrome (SearchBox + trending feed + 右 rail + (logged-out) HeroBanner) は維持
+
+### 4.4 /search で空クエリ
+
+- 既存通り 「上のボックスにキーワードを入れて検索してください」 メッセージ
+- 右 rail (Trending + WhoToFollow) は表示される ← 本 Issue で新規
+
+### 4.5 未ログイン
+
+- /search も /explore も 200 (匿名閲覧可)
+- right rail の WhoToFollow は `isAuthenticated={false}` を受けて 「Login して見る」 系の表示に切り替わる (既存挙動)
+
+## 5. テスト
+
+### 5.1 vitest 単体
+
+- `constants/index.ts` を import して `leftNavLinks` を assertion:
+  - 「検索」 entry が存在し path は `/search`
+  - 「探索」 entry は存在しない
+- `focused-surfaces.test.ts` (なければ新設):
+  - `shouldHideRightRail('/search')` → `false`
+  - `shouldHideRightRail('/messages')` → `true` (regression 確認)
+
+### 5.2 Playwright E2E
+
+ファイル: `client/e2e/search-nav-rail.spec.ts` (新設)
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test.describe("Search nav rename + right rail (#795)", () => {
+	test("左 nav 「検索」 click → /search 着地 + 右 rail 表示", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/");
+		await page.getByRole("link", { name: "検索" }).click();
+		await page.waitForURL("**/search");
+		await expect(page.getByRole("heading", { name: "検索" })).toBeVisible();
+		// 右 rail の panel header が見える
+		await expect(page.getByText(/Trending tags/i)).toBeVisible();
+		await expect(page.getByText(/Who to follow/i)).toBeVisible();
+	});
+
+	test("左 nav に「探索」 entry が存在しない", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/");
+		await expect(page.getByRole("link", { name: "探索" })).toHaveCount(0);
+	});
+
+	test("/explore 直叩きは 200 (route 維持)", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/explore");
+		await expect(page.getByText(/トレンド|探索/)).toBeVisible({
+			timeout: 10_000,
+		});
+		// 右 rail も同じ chrome で出る
+		await expect(page.getByText(/Trending tags/i)).toBeVisible();
+	});
+
+	test("Mobile 375 で /search は中央のみ (rail 非表示)", async ({ page }) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		await page.goto("/search");
+		await expect(page.getByRole("heading", { name: "検索" })).toBeVisible();
+		// `aside[aria-label="右サイドバー"]` は `lg:block` なので 375 では DOM 上は
+		// あっても非表示 (display:none)。 visible 判定で false になるべき。
+		const rail = page.locator('aside[aria-label="右サイドバー"]');
+		await expect(rail).toHaveCount(1);
+		await expect(rail).not.toBeVisible();
+	});
+});
+```
+
+### 5.3 stg 実行コマンド
+
+```bash
+cd /workspace/client
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+  npx playwright test e2e/search-nav-rail.spec.ts --reporter=line
+```
+
+未ログインでも動くので credential 不要。
+
+### 5.4 ui-ux-tester 事後監査
+
+PR マージ + stg 反映後、 `ui-ux-tester` を呼んで:
+
+- ホーム → 「検索」 が 1 click で /search に着地
+- /search と /explore の chrome (右 rail 含む) が同じ見た目
+- 375px で rail が出ない (regression なし)
+
+### 5.5 gan-evaluator
+
+nav 入口変更 + 大きな chrome 変化なので必須。 採点項目:
+
+- 「検索」 entry がホームから 1 click 以内
+- 未ログインで /search / /explore が壊れない
+- 右 rail の content (Trending / Who to follow) が読める
+
+## 6. 受け入れ基準
+
+- [ ] 左 nav の label / path が変わっている
+- [ ] /search で右 rail が見える (1280px)
+- [ ] /search で中央が rail と被って読みづらくない (3.4 視認 OK)
+- [ ] /explore 直叩きは引き続き 200
+- [ ] Mobile 375 で /search が rail 非表示で動く
+- [ ] vitest pass / Playwright spec pass
+- [ ] reviewer 直列 (typescript / code / a11y / ui-ux) 全部 HIGH 以上なし
+- [ ] gan-evaluator pass
+- [ ] ROADMAP の該当行に check (もしあれば、 なければ無理に作らない)
+
+## 7. ロールアウト / リスク
+
+- リスク: SEO で /search / /explore が同等の content を indexing されると重複扱い
+  - 緩和策: 本 Issue scope 外、 必要なら別 Issue で canonical / robots noindex 整理
+- リスク: `/explore` への外部 link / bookmark は維持されるが、 nav からの導線が消えるので存在感が下がる
+  - 緩和策: 別 Issue で /explore を 「discover hub」 として明示的にリッチ化する判断を別途検討
+- リスク: `ARightRail` の幅 (320px) が中央 column を圧迫
+  - 緩和策: 既存挙動 (`hidden lg:block`) のままで他 page (/`/` / `/articles` 等) と同じ behavior、 新規問題ない見込み


### PR DESCRIPTION
Closes #795

## Summary

- 左 nav の label 「探索」 → 「検索」、 path \`/explore\` → \`/search\` (3 source 同時 rename)
- \`shouldHideRightRail\` から \`/search\` 系を抑制解除 → \`/search\` でも \`ARightRail\` (TrendingTags + WhoToFollow) を表示
- \`/explore\` route は維持。 nav からは外れるが URL 直叩き / deep link は引き続き機能

#741 で「nav 1 entry に統一 + /search 抑制」 した判断をハルナさん指示で部分的に再調整。 rail に search panel は戻さないので duplication 問題は再発しない。

## 変更ファイル (9)

| File | 変更 |
| - | - |
| \`client/src/constants/index.ts\` | leftNavLinks の 「探索」 entry rename |
| \`client/src/components/layout-a/ALeftNav.tsx\` | NAV_ITEMS の hardcoded entry rename + docstring |
| \`client/src/components/layout-a/AMobileShell.tsx\` | BOTTOM_TABS + drawer items の hardcoded entry rename |
| \`client/src/lib/layout/focused-surfaces.ts\` | \`/search\` 系の hide 判定削除 + JSDoc 整理 |
| \`client/src/components/layout-a/__tests__/ALeftNav.test.tsx\` | "探索" → "検索" |
| \`client/src/lib/layout/__tests__/focused-surfaces.test.ts\` | \`/search\` 系を rail 表示側 |
| \`client/e2e/search-nav-rail.spec.ts\` | 新規 (5 ケース) |
| \`docs/specs/search-nav-rename-rail-spec.md\` | 新規 spec doc |
| \`docs/specs/explore-search-rightrail-spec.md\` | §9 follow-up 追記 |

## レビュー結果

| Reviewer | Verdict | 対応 |
| - | - | - |
| typescript-reviewer | HIGH 1 (hardcoded nav 未追従) | ALeftNav / AMobileShell に rename を反映済 |
| code-reviewer | HIGH 1 (E2E BASE_URL 二重解決) + MEDIUM 2 + LOW 2 | HIGH/MEDIUM 反映済、 DRY 単一 source 化は #798 に follow-up |

## Test plan

- [x] vitest: **860 pass | 1 todo** (regression なし)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [ ] stg 反映後 Claude が 1280 / 375 で実画面確認
- [ ] ui-ux-tester で /search + /explore の chrome が揃っているか事後監査
- [ ] gan-evaluator で 「ホーム → 検索 1 click」 「未ログイン挙動」 採点

```bash
# stg E2E (anonymous OK のため credential 不要)
cd client
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
  npx playwright test e2e/search-nav-rail.spec.ts --reporter=line
```

## Follow-up

- #798: nav 配列の単一 source of truth 化 (本 PR で 3 箇所同時 rename の DRY 違反顕在化)

## 関連

- 仕様: [\`docs/specs/search-nav-rename-rail-spec.md\`](docs/specs/search-nav-rename-rail-spec.md)
- 関連 spec § 追記: [\`docs/specs/explore-search-rightrail-spec.md\`](docs/specs/explore-search-rightrail-spec.md) §9
- ハルナさん指示 2026-05-18 (本セッション、 #790 / #791 と並走)