### PR TITLE
[refactor][explore] /explore = 検索 box + 最新の投稿 feed の 2 段構成 + nav 「検索」 → /explore (#803)

### DIFF
--- a/apps/timeline/services.py
+++ b/apps/timeline/services.py
@@ -299,6 +299,36 @@ def invalidate_home_tl(user) -> None:
     cache.delete(TL_HOME_CACHE_KEY.format(user_id=user.pk))
 
 
+def build_latest_tl(viewer, limit: int = TL_DEFAULT_PAGE_SIZE) -> list[Tweet]:
+    """最新の投稿 feed (#803): 全 public tweets を -created_at で並べる.
+
+    /explore page の中央 column 用。 anonymous OK、 viewer がいれば Block 除外
+    post-filter。 cache 無し (latest は秒単位で変わるため短時間 cache でも
+    刻一刻ずれる)。 buffer で hard limit して大量データを引かないよう保護。
+
+    type filter: ORIGINAL / QUOTE のみ (REPOST は最新の投稿 feed では noise)。
+
+    sec HIGH (#735 contract): 鍵アカ (is_private=True) の tweet は anonymous /
+    非 follower viewer に漏らさない。 `_query_global` と同じく `author__is_private=False`
+    で base filter。 viewer が approved follower であっても本 endpoint では公開
+    feed として一律 hide (鍵アカ tweet は home TL で別経路から見せる、 #735)。
+    """
+    qs = (
+        Tweet.objects.select_related("author")
+        .filter(
+            type__in=[TweetType.ORIGINAL, TweetType.QUOTE],
+            author__is_private=False,
+        )
+        .order_by("-created_at", "-id")[:TL_BUFFER_SIZE]
+    )
+    tweets = list(qs)
+    if viewer is not None and getattr(viewer, "is_authenticated", False):
+        blocked = _exclude_blocked_users_qs(viewer)
+        if blocked:
+            tweets = [t for t in tweets if t.author_id not in blocked]
+    return tweets[:limit]
+
+
 def build_explore_tl(viewer, limit: int = TL_DEFAULT_PAGE_SIZE) -> list[Tweet]:
     """未ログイン用 explore: 24h 内 reaction 数上位.
 

--- a/apps/timeline/tests/test_services.py
+++ b/apps/timeline/tests/test_services.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
+from django.utils import timezone
 
 from apps.follows.tests._factories import make_follow, make_user
 from apps.timeline.services import (
@@ -11,6 +14,7 @@ from apps.timeline.services import (
     _interleave_70_30,
     build_explore_tl,
     build_home_tl,
+    build_latest_tl,
 )
 from apps.tweets.models import Tweet, TweetType
 from apps.tweets.tests._factories import make_tweet
@@ -139,6 +143,93 @@ def test_build_explore_tl_returns_only_with_reactions() -> None:
     pks = {t.pk for t in result}
     assert with_reaction.pk in pks
     assert no_reaction.pk not in pks
+
+
+# --------------------------------------------------------------------------- #
+# build_latest_tl (#803): 最新の投稿 feed
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_latest_tl_orders_by_created_at_desc() -> None:
+    """latest feed は -created_at で並ぶ (最新が先頭)."""
+    a = make_user()
+    b = make_user()
+    old = make_tweet(author=a, body="old")
+    new = make_tweet(author=b, body="new")
+    # code-reviewer MEDIUM 反映: created_at を強制設定して時刻差を確実に作る。
+    # auto_now_add は同一 transaction 内で sub-ms 差になり順序保証が弱い。
+    now = timezone.now()
+    Tweet.objects.filter(pk=old.pk).update(created_at=now - timedelta(seconds=10))
+    Tweet.objects.filter(pk=new.pk).update(created_at=now)
+
+    result = build_latest_tl(viewer=None, limit=20)
+    pks_in_order = [t.pk for t in result]
+    assert new.pk in pks_in_order
+    assert old.pk in pks_in_order
+    # 最新の new が old より前
+    assert pks_in_order.index(new.pk) < pks_in_order.index(old.pk)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_latest_tl_excludes_private_account_tweets() -> None:
+    """#735 contract: 鍵アカ (is_private=True) の tweet は latest feed に出ない."""
+    public_author = make_user()
+    private_author = make_user()
+    private_author.is_private = True
+    private_author.save(update_fields=["is_private"])
+
+    public_t = make_tweet(author=public_author, body="public")
+    private_t = make_tweet(author=private_author, body="private")
+
+    # anonymous viewer
+    result = build_latest_tl(viewer=None, limit=20)
+    pks = {t.pk for t in result}
+    assert public_t.pk in pks
+    assert private_t.pk not in pks
+
+    # authenticated viewer でも同じ (本 endpoint は公開 feed なので一律 hide)
+    viewer = make_user()
+    result_authed = build_latest_tl(viewer=viewer, limit=20)
+    pks_authed = {t.pk for t in result_authed}
+    assert public_t.pk in pks_authed
+    assert private_t.pk not in pks_authed
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_latest_tl_includes_zero_reaction_tweets() -> None:
+    """trending と違い、 reaction_count=0 でも latest には含まれる."""
+    author = make_user()
+    no_reaction = make_tweet(author=author, body="no reactions yet")
+
+    result = build_latest_tl(viewer=None, limit=20)
+    assert no_reaction.pk in {t.pk for t in result}
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_latest_tl_excludes_repost_type() -> None:
+    """REPOST は最新の投稿 feed では noise になるため除外."""
+    a = make_user()
+    b = make_user()
+    original = make_tweet(author=a, body="original")
+    repost = Tweet.objects.create(author=b, body="", type=TweetType.REPOST, repost_of=original)
+
+    result = build_latest_tl(viewer=None, limit=20)
+    pks = {t.pk for t in result}
+    assert original.pk in pks
+    assert repost.pk not in pks
+
+
+@pytest.mark.django_db(transaction=True)
+def test_build_latest_tl_anonymous_viewer_sees_all() -> None:
+    """anonymous (viewer=None) で Block filter を skip し全 tweet が見える."""
+    a = make_user()
+    # python-reviewer HIGH 反映: 変数名 `t` だと set comprehension の loop 変数と
+    # shadowing する。 `tweet` に rename。
+    tweet = make_tweet(author=a, body="hello world")
+
+    result = build_latest_tl(viewer=None, limit=20)
+    assert tweet.pk in {t.pk for t in result}
 
 
 @pytest.mark.django_db(transaction=True)

--- a/apps/timeline/urls.py
+++ b/apps/timeline/urls.py
@@ -6,10 +6,13 @@ from apps.timeline.views import (
     ExploreTimelineView,
     FollowingTimelineView,
     HomeTimelineView,
+    LatestTimelineView,
 )
 
 urlpatterns = [
     path("home/", HomeTimelineView.as_view(), name="timeline-home"),
     path("following/", FollowingTimelineView.as_view(), name="timeline-following"),
     path("explore/", ExploreTimelineView.as_view(), name="timeline-explore"),
+    # #803: 最新の投稿 feed (/explore page 中央 column 用)。
+    path("latest/", LatestTimelineView.as_view(), name="timeline-latest"),
 ]

--- a/apps/timeline/views.py
+++ b/apps/timeline/views.py
@@ -15,7 +15,9 @@ from rest_framework.views import APIView
 
 from apps.timeline.cursor import decode_cursor, encode_cursor
 from apps.timeline.services import (
+    TL_BUFFER_SIZE,
     build_explore_tl,
+    build_latest_tl,
     get_or_build_home_tl,
 )
 from apps.tweets.models import Tweet, TweetType
@@ -174,6 +176,38 @@ class ExploreTimelineView(APIView):
 
         viewer = None if isinstance(request.user, AnonymousUser) else request.user
         full = build_explore_tl(viewer=viewer, limit=limit * 5)
+        page, next_cursor, has_more = _slice_with_cursor(full, cursor.id if cursor else None, limit)
+
+        data = TweetListSerializer(
+            page,
+            many=True,
+            context={
+                "request": request,
+                "viewer_repost_ids": _viewer_repost_ids(request, page),
+            },
+        ).data
+        return Response({"results": data, "next_cursor": next_cursor, "has_more": has_more})
+
+
+class LatestTimelineView(APIView):
+    """GET /api/v1/timeline/latest/?cursor=...&limit=N (#803).
+
+    最新の投稿 feed。 anonymous OK、 ordering は -created_at。 auth 時は viewer の
+    双方向 Block で除外。 cache なし (秒単位で更新されるため)。 REPOST は除外し
+    ORIGINAL / QUOTE のみ。
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request: Request) -> Response:
+        limit = _parse_limit(request)
+        cursor = decode_cursor(request.query_params.get("cursor"))
+
+        viewer = None if isinstance(request.user, AnonymousUser) else request.user
+        # code-reviewer HIGH 反映: build_latest_tl 内部の `[:TL_BUFFER_SIZE]` で
+        # 結局 200 件 cap なので、 `limit * 5` を渡しても無意味。 services 側に
+        # TL_BUFFER_SIZE を直接渡して buffer 全件取得 → 後段で cursor slice する。
+        full = build_latest_tl(viewer=viewer, limit=TL_BUFFER_SIZE)
         page, next_cursor, has_more = _slice_with_cursor(full, cursor.id if cursor else None, limit)
 
         data = TweetListSerializer(

--- a/client/e2e/explore-latest.spec.ts
+++ b/client/e2e/explore-latest.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * #803 / explore-latest
+ *
+ * 左 nav 「検索」 アイコン click → /explore 着地、 中央 column が SearchBox +
+ * 「最新の投稿」 feed の 2 段構成、 右 rail (ARightRail) も同時表示。
+ *
+ * シナリオ (anonymous OK のため credential 不要):
+ *   1. desktop 1280: 左 nav 「検索」 → /explore 着地 + h2 「最新の投稿」 visible
+ *   2. /explore に SearchBox が表示される (submit すると /search に遷移)
+ *   3. 右 rail (TrendingTags + WhoToFollow) が表示される
+ *   4. mobile 375: 中央 column のみ、 right rail 非表示
+ *   5. /search は別 page として残り、 q クエリで検索結果表示 (regression)
+ *
+ * 実行 (stg):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     npx playwright test e2e/explore-latest.spec.ts --reporter=line
+ */
+
+import { expect, test } from "@playwright/test";
+
+test.describe("Explore latest feed (#803)", () => {
+	test("desktop 1280: 左 nav 「検索」 → /explore + 「最新の投稿」 + 右 rail", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/");
+
+		const searchLink = page.getByRole("link", { name: "検索", exact: true });
+		await expect(searchLink).toBeVisible({ timeout: 15_000 });
+		await searchLink.click();
+		await page.waitForURL("**/explore");
+
+		// h2 「最新の投稿」 が見える
+		await expect(
+			page.getByRole("heading", { name: "最新の投稿", level: 2 }),
+		).toBeVisible();
+
+		// 右 rail (ARightRail) の panel が見える
+		const rail = page.getByRole("complementary", { name: "右サイドバー" });
+		await expect(rail).toBeVisible();
+		await expect(rail.getByText(/Trending tags/i)).toBeVisible();
+	});
+
+	test("/explore に SearchBox が表示され、 submit で /search に遷移", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/explore");
+
+		// SearchBox の入力欄が見える
+		const searchInput = page.getByRole("searchbox").first();
+		await expect(searchInput).toBeVisible({ timeout: 15_000 });
+
+		// 適当なキーワードで submit → /search?q=... に遷移
+		await searchInput.fill("django");
+		await searchInput.press("Enter");
+		await page.waitForURL(/\/search\?q=django/);
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible();
+	});
+
+	test("mobile 375: /explore は中央のみ表示、 右 rail 非表示", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		await page.goto("/explore");
+
+		await expect(
+			page.getByRole("heading", { name: "最新の投稿", level: 2 }),
+		).toBeVisible({ timeout: 15_000 });
+
+		const rail = page.getByRole("complementary", { name: "右サイドバー" });
+		await expect(rail).not.toBeVisible();
+	});
+
+	test("anonymous でも /explore 200 + 最新の投稿 visible", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		try {
+			await page.setViewportSize({ width: 1280, height: 800 });
+			const response = await page.goto("/explore");
+			expect(response?.status() ?? 0).toBeLessThan(400);
+			await expect(
+				page.getByRole("heading", { name: "最新の投稿", level: 2 }),
+			).toBeVisible({ timeout: 15_000 });
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test("/search は別 page として残る (regression、 q クエリで結果表示)", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/search?q=django");
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible({ timeout: 15_000 });
+		// /search は 「最新の投稿」 h2 を持たない (現状維持)
+		await expect(
+			page.getByRole("heading", { name: "最新の投稿", level: 2 }),
+		).toHaveCount(0);
+	});
+});

--- a/client/src/app/(template)/explore/page.tsx
+++ b/client/src/app/(template)/explore/page.tsx
@@ -1,54 +1,40 @@
 /**
  * /explore — discovery surface for both anonymous AND authenticated visitors.
  *
- * Spec: docs/specs/explore-search-rightrail-spec.md
+ * Spec: docs/specs/explore-search-rightrail-spec.md, explore-latest-feed-spec.md
  *
- * Twitter / X 準拠 IA (#741):
- *   - 全 persona でアクセス可能 (logged-in も redirect しない)
- *   - 最上部に SearchBox 常置 (submit → /search?q=...)
- *   - 本文は trending tweets feed
- *   - logged-out 時のみ HeroBanner + StickyLoginBanner を出す
+ * 構成 (#803 で再設計):
+ *   - 最上部に SearchBox (sticky bar)、 submit → /search?q=...
+ *   - 本文は 「最新の投稿」 feed (-created_at 順、 GET /api/v1/timeline/latest/)
+ *   - 右 rail (ARightRail = TrendingTags + WhoToFollow) は (template) layout が自動配置
  *
- * 関連 SPEC: §16.2 (discovery / acquisition)。
+ * #803 で削除した要素:
+ *   - 旧 「トレンドツイート」 (24h reaction 数上位、 fetchExploreTimeline)
+ *     → 別 surface で再利用する場合は backend endpoint は残してあるので可
+ *   - logged-in 空 trending 時の WhoToFollow inline (#746)
+ *     → 右 rail に同じ component あり
+ *   - HeroBanner / StickyLoginBanner (logged-out 用 CTA)
+ *     → A direction では anon でも 中央 column は SearchBox + latest だけのシンプル構成
  */
 
 import type { Metadata } from "next";
 
-import HeroBanner from "@/components/explore/HeroBanner";
-import StickyLoginBanner from "@/components/explore/StickyLoginBanner";
 import SearchBox from "@/components/search/SearchBox";
-import WhoToFollow from "@/components/sidebar/WhoToFollow";
 import TweetCardList from "@/components/timeline/TweetCardList";
-import { ApiServerError, serverFetch } from "@/lib/api/server";
-import { fetchExploreTimeline } from "@/lib/api/explore";
+import { fetchLatestTimeline } from "@/lib/api/explore";
 import { stringifyJsonLd } from "@/lib/json-ld";
 
 export const metadata: Metadata = {
 	title: "探索 — エンジニア SNS",
 	description:
-		"トレンドのツイートを見つけ、 技術タグや人を検索する discovery surface。",
+		"最新の投稿を時系列で眺め、 ツイート・タグ・ユーザーを検索する discovery surface。",
 	openGraph: {
 		title: "探索 — エンジニア SNS",
 		description:
-			"トレンドのツイートを見つけ、 技術タグや人を検索する discovery surface。",
+			"最新の投稿を時系列で眺め、 ツイート・タグ・ユーザーを検索する discovery surface。",
 		type: "website",
 	},
 };
-
-interface CurrentUser {
-	id: string;
-	username: string;
-}
-
-async function isAuthenticated(): Promise<boolean> {
-	try {
-		await serverFetch<CurrentUser>("/users/me/");
-		return true;
-	} catch (err) {
-		if (err instanceof ApiServerError && err.status === 401) return false;
-		return false;
-	}
-}
 
 const websiteJsonLd = {
 	"@context": "https://schema.org",
@@ -60,19 +46,12 @@ const websiteJsonLd = {
 };
 
 export default async function ExplorePage() {
-	const authed = await isAuthenticated();
-
-	// #746: fetchExploreTimeline が throw した (network / 5xx / timeout) 場合、
-	// 空 page を返して下流の empty-state branch に流す。 「trending tweets が
-	// 集計されてない」 と「 backend エラー」 は UI 上 区別せず、 どちらでも
-	// WhoToFollow fallback を出す (blank page よりは discovery surface を見せる
-	// 方が UX が良い)。 観測性は別途 Sentry / structlog が拾うので、 UI で
-	// distinguish しない方針。
-	const page = await fetchExploreTimeline(20).catch(() => ({
+	// #803: 最新の投稿 feed を fetch。 fail 時は空 page (empty state branch に流す)。
+	// 観測性は Sentry / structlog 側で拾うので UI 上は区別しない。
+	const page = await fetchLatestTimeline(20).catch(() => ({
 		results: [],
-		count: 0,
-		next: null,
-		previous: null,
+		next_cursor: null,
+		has_more: false,
 	}));
 
 	return (
@@ -82,10 +61,7 @@ export default async function ExplorePage() {
 				dangerouslySetInnerHTML={{ __html: stringifyJsonLd(websiteJsonLd) }}
 			/>
 
-			{/*
-			 * Sticky context bar with search box.
-			 * Twitter analog: /explore 最上部の search field。
-			 */}
+			{/* sticky 検索 box (Twitter analog: /explore 最上部 search field)。 */}
 			<div
 				className="sticky top-0 z-10 px-5 py-3"
 				style={{
@@ -109,10 +85,9 @@ export default async function ExplorePage() {
 					</span>
 				</div>
 				{/*
-				 * #741 a11y M-1: /search route (default "ツイート検索") よりも広い
-				 * 検索対象 (tweet/tag/user) を表現する label を渡す。 同じ component
-				 * が異なる文脈で使われるとき screen reader が「ここで何ができるか」 を
-				 * 正しく伝えるための差分。
+				 * #741 a11y M-1: /search route の SearchBox より広い検索対象を表す
+				 * label を渡す。 同じ component が異なる文脈で使われるときに SR が
+				 * 「ここで何ができるか」 を正しく伝えるための差分。
 				 */}
 				<SearchBox formAriaLabel="サイト内検索 (ツイート・タグ・ユーザー)" />
 			</div>
@@ -121,53 +96,23 @@ export default async function ExplorePage() {
 			 * #741 a11y H-2 (WCAG 2.4.11 Focus Not Obscured Minimum):
 			 * 上の sticky 80-100px bar が tab focus した focusable を覆わないよう、
 			 * descendant の focusable 要素に scroll-margin-top を当てる。
-			 * Tailwind arbitrary descendant `[&_a]:scroll-mt-24` 等で focusable
-			 * (link / button / input) のみ対象 (text 全体に当てると意図しない動作)。
 			 */}
 			<article className="min-w-0 [&_a]:scroll-mt-28 [&_button]:scroll-mt-28 [&_input]:scroll-mt-28">
-				{!authed && <HeroBanner />}
-
-				<section aria-labelledby="explore-feed-heading" className="mt-8 px-5">
+				<section aria-labelledby="explore-latest-heading" className="mt-8 px-5">
 					<h2
-						id="explore-feed-heading"
+						id="explore-latest-heading"
 						className="mb-4 px-2 text-lg font-semibold text-foreground"
 					>
-						トレンドツイート
+						最新の投稿
 					</h2>
 
 					<TweetCardList
 						tweets={page.results}
-						ariaLabel="トレンドツイート"
-						emptyMessage="今は表示できるツイートがありません。"
+						ariaLabel="最新の投稿"
+						emptyMessage="まだ投稿がありません。"
 					/>
 				</section>
-
-				{/*
-				 * #746: trending tweets が空のとき (まだ集計されていない、
-				 * 一時的に backend がデータを返せない、 等)、 ページが「壊れて見える」
-				 * ほどスパースになるのを防ぐため、 既存 `WhoToFollow` を inline で
-				 * fallback render する。 logged-in なら personalised recommendations、
-				 * anon なら popular users (component 内で auth state 判定済)。
-				 *
-				 * 右 rail にも WhoToFollow があるが、 (a) 右 rail は lg+ のみ表示
-				 * (mobile/tablet で消える)、 (b) 中央 column の inline 表示は
-				 * desktop でも「次の action はこれ」 として導線強化になる、 ので
-				 * 重複を許容。
-				 *
-				 * 見出しは WhoToFollow 内蔵 h2「おすすめユーザー」 をそのまま使う:
-				 * - 外側に「代わりに…」 のような追加 h2 を置くと nested heading 重複
-				 *   + 「primary content が壊れた」 と読ませる framing になる
-				 *   (code-reviewer 指摘)
-				 * - bare=false (default) で card style も維持
-				 */}
-				{page.results.length === 0 && (
-					<div className="mt-6 px-5">
-						<WhoToFollow isAuthenticated={authed} />
-					</div>
-				)}
 			</article>
-
-			{!authed && <StickyLoginBanner />}
 		</>
 	);
 }

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -63,9 +63,9 @@ interface NavItemDef {
 
 const NAV_ITEMS: NavItemDef[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
-	// #741 で 「探索」 (/explore) に統一 → #795 で nav 入口を 「検索」 (/search) に変更。
-	// `/explore` route は残るが nav には出さない。
-	{ href: "/search", label: "検索", Icon: Search },
+	// #741 で /explore 統一 → #795 で /search → #803 で /explore に戻す。
+	// label 「検索」 は維持、 /explore は SearchBox + 最新の投稿 feed の 2 段構成 (#803)。
+	{ href: "/explore", label: "検索", Icon: Search },
 	{
 		href: "/notifications",
 		label: "通知",

--- a/client/src/components/layout-a/AMobileShell.tsx
+++ b/client/src/components/layout-a/AMobileShell.tsx
@@ -46,11 +46,11 @@ interface BottomTabItem {
 }
 
 // #741: Twitter 準拠 IA — explore icon を Search (虫眼鏡) に統一。
-// #795: nav 入口を 「検索」 (/search) に変更。 `/explore` route は残るが
-// nav からは外す。 rail に search panel は無い前提で duplication 問題なし。
+// #795 で path を /search に変えたが、 #803 で /explore に戻す。 /explore page は
+// #803 で 「SearchBox + 最新の投稿 feed」 の 2 段構成にリデザイン済。
 const BOTTOM_TABS: BottomTabItem[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
-	{ href: "/search", label: "検索", Icon: Search },
+	{ href: "/explore", label: "検索", Icon: Search },
 	{ href: "/notifications", label: "通知", Icon: Bell, requiresAuth: true },
 	{
 		href: "/messages",
@@ -257,10 +257,11 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 	// ただし auth-scoped task (下書き等) は drawer に残し desktop main nav は profile
 	// menu 経由に分離する場合がある (#762: drafts は X mobile drawer 準拠で keep、
 	// desktop main nav からは削除 → profile DropdownMenu に移動)。
-	// #741 で 「探索」 1 entry に統一 → #795 で nav 入口を 「検索」 (/search) に変更。
+	// #741 で 「探索」 1 entry に統一 → #795 で /search に変更 → #803 で /explore に戻す。
+	// /explore は SearchBox + 最新の投稿 feed の 2 段構成 (#803)。
 	const items: BottomTabItem[] = [
 		{ href: "/", label: "ホーム", Icon: Home },
-		{ href: "/search", label: "検索", Icon: Search },
+		{ href: "/explore", label: "検索", Icon: Search },
 		{ href: "/notifications", label: "通知", Icon: Bell, requiresAuth: true },
 		{
 			href: "/messages",

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -23,9 +23,10 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "Home",
 	},
 	{
-		// #795: 「探索」 → 「検索」 rename + path /explore → /search。
-		// /explore route は残るが nav 入口は /search に。
-		path: "/search",
+		// #795 で path を /search に向けたが、 #803 でハルナさん指示により /explore
+		// に戻す。 label 「検索」 は維持。 /explore page は #803 で SearchBox +
+		// 最新の投稿 feed の 2 段構成にリデザイン (旧トレンドツイートは廃止)。
+		path: "/explore",
 		label: "検索",
 		iconName: "Search",
 	},

--- a/client/src/lib/api/__tests__/explore.test.ts
+++ b/client/src/lib/api/__tests__/explore.test.ts
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiServerError } from "@/lib/api/server";
 import {
 	fetchExploreTimeline,
+	fetchLatestTimeline,
 	type ExploreTimelinePage,
+	type LatestTimelinePage,
 } from "@/lib/api/explore";
 import type { TweetSummary } from "@/lib/api/tweets";
 
@@ -213,5 +215,95 @@ describe("fetchExploreTimeline", () => {
 
 		const result = await fetchExploreTimeline(20);
 		expect(result.results.map((t) => t.id)).toEqual([3, 1, 2]);
+	});
+});
+
+// --------------------------------------------------------------------------- //
+// fetchLatestTimeline (#803)                                                  //
+// --------------------------------------------------------------------------- //
+
+describe("fetchLatestTimeline", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		cookiesMock.mockReturnValue([]);
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.clearAllMocks();
+	});
+
+	it("GETs /api/v1/timeline/latest/ with default limit=20 and no cursor", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					results: [SAMPLE_TWEET],
+					next_cursor: null,
+					has_more: false,
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
+		);
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+		const result = await fetchLatestTimeline();
+
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		const [url] = fetchSpy.mock.calls[0]!;
+		expect(url).toContain("/timeline/latest/");
+		expect(url).toContain("limit=20");
+		expect(url).not.toContain("cursor=");
+		const typed: LatestTimelinePage = result;
+		expect(typed.has_more).toBe(false);
+	});
+
+	it("forwards cursor query param when provided", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					results: [],
+					next_cursor: "eyJpZCI6OTl9",
+					has_more: true,
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
+		);
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+		await fetchLatestTimeline(50, "abc123");
+
+		const [url] = fetchSpy.mock.calls[0]!;
+		expect(url).toContain("limit=50");
+		expect(url).toContain("cursor=abc123");
+	});
+
+	it("throws ApiServerError on 500", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ detail: "Server Error" }), {
+				status: 500,
+				headers: { "content-type": "application/json" },
+			}),
+		) as unknown as typeof fetch;
+
+		await expect(fetchLatestTimeline(20)).rejects.toBeInstanceOf(
+			ApiServerError,
+		);
+	});
+
+	it("propagates network errors (TypeError)", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockRejectedValue(
+				new TypeError("Failed to fetch"),
+			) as unknown as typeof fetch;
+
+		await expect(fetchLatestTimeline(20)).rejects.toThrow();
 	});
 });

--- a/client/src/lib/api/explore.ts
+++ b/client/src/lib/api/explore.ts
@@ -1,8 +1,9 @@
 /**
- * Explore timeline API helper (P2-19 / Issue #191).
+ * Explore / Latest timeline API helpers (P2-19 / Issue #191, #803).
  *
- * Public, no auth required. Backed by GET /api/v1/timeline/explore/ which
- * returns the trending public feed for unauthenticated visitors.
+ * Public, no auth required. Backed by:
+ *  - GET /api/v1/timeline/explore/ — 24h trending (reaction 数上位)
+ *  - GET /api/v1/timeline/latest/ — 全 public tweets 最新順 (#803)
  */
 
 import { serverFetch } from "@/lib/api/server";
@@ -15,10 +16,37 @@ export interface ExploreTimelinePage {
 	previous: string | null;
 }
 
+/**
+ * #803: 最新の投稿 feed は cursor-based pagination (next_cursor + has_more)。
+ * 既存 ExploreTimelinePage の DRF default shape (count + next + previous) とは
+ * 別 (view 実装の差異)。 explore.ts に同居しているが shape は独立。
+ */
+export interface LatestTimelinePage {
+	results: TweetSummary[];
+	next_cursor: string | null;
+	has_more: boolean;
+}
+
 const DEFAULT_LIMIT = 20;
 
 export async function fetchExploreTimeline(
 	limit: number = DEFAULT_LIMIT,
 ): Promise<ExploreTimelinePage> {
 	return serverFetch<ExploreTimelinePage>(`/timeline/explore/?limit=${limit}`);
+}
+
+/**
+ * 最新の投稿 feed を取得 (#803、 /explore page の中央 column 用)。
+ * cursor を渡すと次 page を取得 (本 PR では initial page のみ呼び出し、
+ * infinite scroll は将来検討)。
+ */
+export async function fetchLatestTimeline(
+	limit: number = DEFAULT_LIMIT,
+	cursor: string | null = null,
+): Promise<LatestTimelinePage> {
+	const params = new URLSearchParams({ limit: String(limit) });
+	if (cursor) params.set("cursor", cursor);
+	return serverFetch<LatestTimelinePage>(
+		`/timeline/latest/?${params.toString()}`,
+	);
 }

--- a/docs/specs/explore-latest-feed-spec.md
+++ b/docs/specs/explore-latest-feed-spec.md
@@ -1,0 +1,245 @@
+# /explore = 検索 box + 最新の投稿 feed の 2 段構成
+
+> 関連: [Issue #803](https://github.com/haruna0712/issues/803), ハルナさん指示 2026-05-18
+> 経緯: [#741 / #746 / #795](https://github.com/haruna0712/claude-code/) の判断を再度調整
+
+## 1. 背景
+
+#795 で 「探索」 → 「検索」 + nav path /explore → /search に変えたが、 ハルナさんの mental model としては:
+
+- 検索アイコン (nav 「検索」) → **/explore** に遷移したい
+- /explore の中央は 「検索 box (現在の /search 風) + 最新の投稿 feed」 の 2 段
+- 既存 /explore の「トレンドツイート」 / 「おすすめユーザー」 inline は削除
+
+#795 の判断を逆転して /explore に戻すが、 /explore の中身を 「検索 box + 最新の投稿」 にリデザインする。
+
+## 2. やること
+
+### 2.1 nav の path を /explore に戻す (label 「検索」 維持)
+
+3 箇所同期 (DRY 違反は [#798](https://github.com/haruna0712/claude-code/issues/798) で別途解消):
+
+- `client/src/constants/index.ts` の leftNavLinks
+- `client/src/components/layout-a/ALeftNav.tsx` の NAV_ITEMS
+- `client/src/components/layout-a/AMobileShell.tsx` の BOTTOM_TABS + drawer items
+
+```diff
+- { path: "/search", label: "検索", iconName: "Search" }
++ { path: "/explore", label: "検索", iconName: "Search" }
+```
+
+### 2.2 backend: 新 endpoint `/api/v1/timeline/latest/`
+
+`apps/timeline/services.py` に `build_latest_tl` 追加:
+
+```python
+def build_latest_tl(viewer, limit: int = TL_DEFAULT_PAGE_SIZE) -> list[Tweet]:
+    \"\"\"全 public tweets を `-created_at, -id` で並べる anonymous-OK feed.
+
+    type filter は trending と同じ ORIGINAL / QUOTE。 REPOST は除外 (タイムラインの
+    重複ノイズになるので minimal 構成では出さない、 必要なら別 issue)。
+    viewer がいる場合は Block 双方向除外。 cache は使わず (latest は秒単位で
+    変わるため、 短時間 cache だと刻一刻ずれる)。\"\"\"
+    qs = (
+        Tweet.objects.select_related(\"author\")
+        .filter(type__in=[TweetType.ORIGINAL, TweetType.QUOTE])
+        .order_by(\"-created_at\", \"-id\")[:TL_BUFFER_SIZE]
+    )
+    tweets = list(qs)
+    if viewer is not None and getattr(viewer, \"is_authenticated\", False):
+        blocked = _exclude_blocked_users_qs(viewer)
+        if blocked:
+            tweets = [t for t in tweets if t.author_id not in blocked]
+    return tweets[:limit]
+```
+
+`apps/timeline/views.py` に `LatestTimelineView` 追加 (ExploreTimelineView と同形):
+
+```python
+class LatestTimelineView(APIView):
+    \"\"\"GET /api/v1/timeline/latest/?cursor=...&limit=N
+
+    Anonymous OK。 全 public tweets を最新順 (-created_at)。 viewer がいれば
+    Block 除外 post-filter。 cache 無し。\"\"\"
+    permission_classes = [AllowAny]
+
+    def get(self, request: Request) -> Response:
+        limit = _parse_limit(request)
+        cursor = decode_cursor(request.query_params.get(\"cursor\"))
+        viewer = None if isinstance(request.user, AnonymousUser) else request.user
+        full = build_latest_tl(viewer=viewer, limit=limit * 5)
+        page, next_cursor, has_more = _slice_with_cursor(full, cursor.id if cursor else None, limit)
+        data = TweetListSerializer(
+            page,
+            many=True,
+            context={
+                \"request\": request,
+                \"viewer_repost_ids\": _viewer_repost_ids(request, page),
+            },
+        ).data
+        return Response({\"results\": data, \"next_cursor\": next_cursor, \"has_more\": has_more})
+```
+
+`apps/timeline/urls.py` に URL 追加:
+
+```python
+path(\"timeline/latest/\", LatestTimelineView.as_view(), name=\"timeline-latest\"),
+```
+
+### 2.3 frontend: api helper
+
+`client/src/lib/api/explore.ts` に追加 (新 file でなく既存ファイルに統合):
+
+```ts
+export interface LatestTimelinePage {
+	results: ExploreTimelineItem[]; // 既存 type 流用 (同じ serializer)
+	next_cursor: string | null;
+	has_more: boolean;
+}
+
+export async function fetchLatestTimeline(
+	limit = TL_DEFAULT_LIMIT,
+): Promise<LatestTimelinePage> {
+	return serverFetch<LatestTimelinePage>(`/timeline/latest/?limit=${limit}`);
+}
+```
+
+### 2.4 frontend: /explore page refactor
+
+`client/src/app/(template)/explore/page.tsx`:
+
+- **維持**: SearchBox (最上部、 submit → /search?q=...)
+- **削除**: trending tweets (fetchExploreTimeline + TweetCardList for trending)
+- **削除**: 「おすすめユーザー」 inline (logged-in 空 trending 時の WhoToFollow)
+- **削除**: HeroBanner / StickyLoginBanner (logged-out)
+- **追加**: 「最新の投稿」 heading + TweetCardList (fetchLatestTimeline 経由)
+- 右 rail は (template) layout が自動で挟むので page 変更なし
+
+最終構造:
+
+```tsx
+return (
+    <>
+        <header /* sticky 検索 box */>
+            <h1>探索</h1>
+            <SearchBox />
+        </header>
+        <section aria-labelledby="latest-heading" className="p-5">
+            <h2 id="latest-heading">最新の投稿</h2>
+            <TweetCardList tweets={data.results} ... />
+        </section>
+    </>
+);
+```
+
+### 2.5 test
+
+- backend: `apps/timeline/tests/test_latest_endpoint.py`
+  - anonymous で 200
+  - authenticated で 200
+  - ordering: 新しい順 (-created_at)
+  - block されたユーザーの tweet が non-blocked viewer に見えて、 blocking viewer に見えない
+  - REPOST は除外
+  - pagination: cursor 渡して次 page 取得
+- frontend: `client/src/lib/api/__tests__/latest.test.ts` (or explore.test.ts に追加)
+  - fetchLatestTimeline が /api/v1/timeline/latest/ を hit
+  - response shape の整合
+- frontend: /explore page の vitest (もしあれば、 なければ Playwright で代替)
+- Playwright (新規): `client/e2e/explore-latest.spec.ts`
+  - nav 「検索」 click → /explore 着地
+  - heading 「最新の投稿」 visible
+  - 右 rail visible
+  - anonymous 200 + 最新の投稿 表示
+
+## 3. やらないこと
+
+- 既存 `/timeline/explore/` (24h trending) endpoint の削除 (別 route で再利用可能性、 本 PR では touch しない)
+- REPOST を最新の投稿 feed に含める (将来検討、 別 issue)
+- /explore の infinite scroll 改修 (既存挙動継承)
+- 最新ツイートの cache 戦略 (現状 no cache、 stg 性能を見て別途)
+- /search page の中央 column 変更 (検索結果専用として維持)
+
+## 4. UI 振る舞い
+
+### 4.1 logged-in + 最新 tweets あり
+
+```
+[Left nav]                 [center]                          [Right rail]
+ホーム                      ┌─────────────────────────┐      Trending tags
+検索 ← active              │  探索                   │      Who to follow
+通知                        │  [検索 box]             │
+メッセージ                  └─────────────────────────┘
+記事                        最新の投稿
+...                         ┌─────────────────────────┐
+                            │ TweetCard A             │
+                            │ TweetCard B             │
+                            │ ...                     │
+```
+
+### 4.2 anonymous
+
+- 上記と同じ (auth gate なし)
+- 右 rail の WhoToFollow は `isAuthenticated=false` で 「Login して見る」 文言に切り替わる
+- HeroBanner / StickyLoginBanner は削除されているので anon に CTA は出ない (本 PR scope)
+
+### 4.3 最新 tweets 0 件
+
+「最新の投稿はまだありません。」 の placeholder。
+
+### 4.4 nav 「検索」 click
+
+- /explore に遷移 (#795 で /search に向けたのを逆転)
+- label は 「検索」 維持 (ハルナさん指示)
+
+### 4.5 検索 box submit
+
+- /search?q=... に遷移 (現状維持)
+- /search page で 検索結果のみ表示 (現状維持)
+
+## 5. テスト実行コマンド
+
+### 5.1 backend
+
+```bash
+docker compose -f local.yml exec api pytest apps/timeline/tests/test_latest_endpoint.py -v
+```
+
+### 5.2 frontend vitest
+
+```bash
+cd /workspace/client
+npx vitest run src/lib/api/__tests__/
+```
+
+### 5.3 Playwright (stg)
+
+```bash
+cd /workspace/client
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+  npx playwright test e2e/explore-latest.spec.ts --reporter=line
+```
+
+anonymous 動作確認なので credential 不要。
+
+## 6. 受け入れ基準
+
+CLAUDE.md §4.5 step 6 準拠:
+
+- [ ] nav 「検索」 click → `/explore` 着地
+- [ ] /explore 中央が 【検索 box】 + 【最新の投稿】 の 2 段のみ
+- [ ] 「最新の投稿」 heading が `<h2>` で visible
+- [ ] 右 rail (TrendingTags + WhoToFollow) は表示
+- [ ] /search は q クエリで検索結果 (現状維持)
+- [ ] anonymous でも /explore 200 + 最新の投稿 visible
+- [ ] block されたユーザーの tweet は authenticated viewer から非表示 (backend test pass)
+- [ ] vitest + Playwright spec pass
+- [ ] reviewer 直列: typescript-reviewer + code-reviewer + python-reviewer + database-reviewer + a11y-architect で CRITICAL/HIGH なし
+- [ ] stg 反映後 Claude が Playwright MCP で confirm + gan-evaluator 採点
+
+## 7. ロールアウト / リスク
+
+- リスク: `/timeline/latest/` が無 cache で全 tweets を毎回 select → 大量データで遅い可能性
+  - 緩和策: `LIMIT TL_BUFFER_SIZE` (既存 explore と同じ 100 件 buffer) で hard limit。 必要なら別 issue で cache 検討
+- リスク: REPOST 除外で 「最新の投稿」 が ORIGINAL/QUOTE しか出ない
+  - 緩和策: spec doc 通り、 必要なら別 issue
+- リスク: nav rename で再度 3 source 同期 → #798 (DRY 統合) でいずれ解消


### PR DESCRIPTION
Closes #803

## Summary

ハルナさん指示で /explore page をリデザイン:
- nav 「検索」 アイコン click の遷移先を /search → **/explore** に戻す (#795 を逆転、 label 「検索」 維持)
- /explore の中央 column を **【検索 box】 + 【最新の投稿 feed】** の 2 段構成に変更
- 旧 トレンドツイート / おすすめユーザー inline / HeroBanner / StickyLoginBanner は削除
- backend に新 endpoint `/api/v1/timeline/latest/` を追加

## 変更ファイル (12)

| Layer | File | 変更 |
| - | - | - |
| backend | `apps/timeline/services.py` | `build_latest_tl` 新規 (-created_at order、 is_private=False、 Block post-filter、 REPOST 除外) |
| backend | `apps/timeline/views.py` | `LatestTimelineView` 新規 (anonymous OK、 keyset cursor pagination、 TL_BUFFER_SIZE 直接渡し) |
| backend | `apps/timeline/urls.py` | `/timeline/latest/` 追加 |
| backend | `apps/timeline/tests/test_services.py` | 5 ケース (-created_at order / reaction=0 inclusion / REPOST 除外 / anonymous / 鍵アカ除外) |
| frontend | `client/src/app/(template)/explore/page.tsx` | 大幅 refactor: SearchBox + h2 「最新の投稿」 + TweetCardList のみに |
| frontend | `client/src/lib/api/explore.ts` | `fetchLatestTimeline` + `LatestTimelinePage` type 追加 |
| frontend | `client/src/lib/api/__tests__/explore.test.ts` | 4 ケース (limit / cursor / 500 / network error) |
| frontend | `client/src/constants/index.ts` | nav path /search → /explore |
| frontend | `client/src/components/layout-a/ALeftNav.tsx` | NAV_ITEMS 同期 |
| frontend | `client/src/components/layout-a/AMobileShell.tsx` | BOTTOM_TABS + drawer items 同期 |
| frontend | `client/e2e/explore-latest.spec.ts` | 新規 5 ケース (anonymous OK) |
| docs | `docs/specs/explore-latest-feed-spec.md` | 新規 spec doc |

## レビュー結果

| Reviewer | Verdict | 対応 |
| - | - | - |
| typescript-reviewer | HIGH x1 (fetchLatestTimeline unit test 不足) | 4 ケース追加 |
| code-reviewer | HIGH x2 (is_private filter 漏れ / limit*5 無意味化) | 反映済 |
| python-reviewer | HIGH x2 (inline import / 変数 shadowing) | 反映済、 MEDIUM 1 件 (Block query unbounded) は #804 |

## Test plan

- [x] frontend vitest: **869 pass | 1 todo** (regression なし)
- [x] `npx tsc --noEmit` clean / `npx eslint` clean
- [ ] backend pytest: build_latest_tl 5 ケース → CI で実行
- [ ] stg 反映後 Claude が Playwright MCP で確認
- [ ] frontend ルート大幅変更 = `gan-evaluator` で採点
- [ ] `ui-ux-tester` で /explore IA 監査再走

```bash
# stg E2E (anonymous OK のため credential 不要)
cd client
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
  npx playwright test e2e/explore-latest.spec.ts --reporter=line
```

## Follow-up

- **#804**: `_exclude_blocked_users_qs` の Block query を bounded に + `ExploreTimelineView` の `limit*5` を `TL_BUFFER_SIZE` 渡しに揃える (本 PR で latest だけ修正、 explore も同じ問題が pre-existing)
- **#798**: nav 配列の単一 source of truth 化 (3 ファイル同期作業の根本解消)

## 関連

- 仕様: [`docs/specs/explore-latest-feed-spec.md`](docs/specs/explore-latest-feed-spec.md)
- ハルナさん指示 2026-05-18 (#790-#792 + #795 + #803 の連続 session)
- #735 (鍵アカ tweet 漏洩防止 contract)