### PR TITLE
[fix][search] nav 「検索」 を /search に戻す + anon の検索クエリを IsAuthenticated で禁止 (#808)

### DIFF
--- a/apps/search/tests/test_views.py
+++ b/apps/search/tests/test_views.py
@@ -1,0 +1,43 @@
+"""SearchView API tests (#808).
+
+GET /api/v1/search/ permission gating: anon は 401、 logged-in は 200。
+"""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from apps.follows.tests._factories import make_user
+
+
+@pytest.mark.django_db(transaction=True)
+def test_search_anon_returns_401() -> None:
+    """#808: anon (未認証) は /api/v1/search/ を叩けない (401)."""
+    client = APIClient()
+    response = client.get("/api/v1/search/?q=django")
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db(transaction=True)
+def test_search_logged_in_returns_200() -> None:
+    """logged-in は従来通り 200 (空クエリでも results=[] / count=0 で返す)."""
+    user = make_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/v1/search/?q=django")
+    assert response.status_code == 200
+    body = response.json()
+    assert "query" in body
+    assert "results" in body
+    assert "count" in body
+
+
+@pytest.mark.django_db(transaction=True)
+def test_search_anon_blocked_regardless_of_query() -> None:
+    """q なし / 不正 q でも anon は 401 (実行前に permission で弾く)."""
+    client = APIClient()
+    # q 空
+    assert client.get("/api/v1/search/").status_code == 401
+    # q ありだが anon
+    assert client.get("/api/v1/search/?q=anything").status_code == 401

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -2,12 +2,17 @@
 
 GET /api/v1/search/?q=...&limit=N
 
-未ログインでも検索可。フィルタ演算子は P2-12 (#206) で拡張。
+#808 (2026-05-19): permission を IsAuthenticated に変更。 ハルナさん指示で
+anon の検索クエリ実行を禁止する (search?q=... での lurker 検索を遮断、
+acquisition funnel として 「検索したいなら登録して」 と促す)。 anon は frontend
+の SearchExploreSurface 側で 「検索はログインが必要です」 promo を見るだけ。
+
+フィルタ演算子は P2-12 (#206) で拡張。
 """
 
 from __future__ import annotations
 
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -17,7 +22,7 @@ from apps.tweets.serializers import TweetListSerializer
 
 
 class SearchView(APIView):
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request: Request) -> Response:
         query = (request.query_params.get("q") or "").strip()

--- a/client/e2e/search-nav-anon-gate.spec.ts
+++ b/client/e2e/search-nav-anon-gate.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * #808 / search-nav-anon-gate
+ *
+ * - nav 「検索」 click → /search 着地 (#803 → #808 で逆転、 path /search 固定)
+ * - /explore 直叩きは引き続き 200 (deep link 維持)
+ * - anon + /search?q=django: chrome + 「検索はログインが必要です」 promo
+ * - anon + /search (q なし): 「最新の投稿」 feed (現状維持)
+ *
+ * anonymous OK のため credential 不要。
+ *
+ * 実行 (stg):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     npx playwright test e2e/search-nav-anon-gate.spec.ts --reporter=line
+ */
+
+import { expect, test } from "@playwright/test";
+
+test.describe("Search nav back to /search + anon query gate (#808)", () => {
+	test("desktop 1280: nav 「検索」 click → /search に着地 (/explore でなく)", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/");
+
+		const searchLink = page.getByRole("link", { name: "検索", exact: true });
+		await expect(searchLink).toBeVisible({ timeout: 15_000 });
+		await searchLink.click();
+		await page.waitForURL("**/search");
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible();
+	});
+
+	test("/explore 直叩きは引き続き 200 (deep link 維持、 chrome は /search と共有)", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		const response = await page.goto("/explore");
+		expect(response?.status() ?? 0).toBeLessThan(400);
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible({ timeout: 15_000 });
+	});
+
+	test("anon + /search?q=django: 「検索はログインが必要です」 promo 表示", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		try {
+			await page.setViewportSize({ width: 1280, height: 800 });
+			await page.goto("/search?q=django");
+			// chrome は visible
+			await expect(
+				page.getByRole("heading", { name: "検索", level: 1 }),
+			).toBeVisible({ timeout: 15_000 });
+			// promo h2 + button
+			await expect(
+				page.getByRole("heading", {
+					name: "検索はログインが必要です",
+					level: 2,
+				}),
+			).toBeVisible();
+			await expect(page.getByRole("link", { name: "ログイン" })).toBeVisible();
+			await expect(page.getByRole("link", { name: "新規登録" })).toBeVisible();
+			// 件数行 / 検索結果は出ない
+			await expect(page.getByText(/「django」 — /)).toHaveCount(0);
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test("anon + /search (q なし): 「最新の投稿」 feed 表示 (現状維持)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		try {
+			await page.setViewportSize({ width: 1280, height: 800 });
+			await page.goto("/search");
+			await expect(
+				page.getByRole("heading", { name: "最新の投稿", level: 2 }),
+			).toBeVisible({ timeout: 15_000 });
+			// promo は出ない (q なしのため)
+			await expect(
+				page.getByRole("heading", { name: "検索はログインが必要です" }),
+			).toHaveCount(0);
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/client/src/components/layout-a/ALeftNav.tsx
+++ b/client/src/components/layout-a/ALeftNav.tsx
@@ -63,9 +63,9 @@ interface NavItemDef {
 
 const NAV_ITEMS: NavItemDef[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
-	// #741 で /explore 統一 → #795 で /search → #803 で /explore に戻す。
-	// label 「検索」 は維持、 /explore は SearchBox + 最新の投稿 feed の 2 段構成 (#803)。
-	{ href: "/explore", label: "検索", Icon: Search },
+	// path 変遷: #741 /explore → #795 /search → #803 /explore → #808 /search 固定。
+	// #806 chrome 統合後の tab URL 跳び問題回避のため nav は /search に集約。
+	{ href: "/search", label: "検索", Icon: Search },
 	{
 		href: "/notifications",
 		label: "通知",

--- a/client/src/components/layout-a/AMobileShell.tsx
+++ b/client/src/components/layout-a/AMobileShell.tsx
@@ -45,12 +45,12 @@ interface BottomTabItem {
 	requiresAuth?: boolean;
 }
 
-// #741: Twitter 準拠 IA — explore icon を Search (虫眼鏡) に統一。
-// #795 で path を /search に変えたが、 #803 で /explore に戻す。 /explore page は
-// #803 で 「SearchBox + 最新の投稿 feed」 の 2 段構成にリデザイン済。
+// path 変遷: #741 /explore → #795 /search → #803 /explore → #808 /search。
+// #806 chrome 統合後にタブ URL 跳び問題が出たため #808 で /search に固定。
+// /explore は route 維持 (deep link)、 nav からは外す。
 const BOTTOM_TABS: BottomTabItem[] = [
 	{ href: "/", label: "ホーム", Icon: Home },
-	{ href: "/explore", label: "検索", Icon: Search },
+	{ href: "/search", label: "検索", Icon: Search },
 	{ href: "/notifications", label: "通知", Icon: Bell, requiresAuth: true },
 	{
 		href: "/messages",
@@ -257,11 +257,11 @@ function DrawerNav({ onItemClick }: { onItemClick: () => void }) {
 	// ただし auth-scoped task (下書き等) は drawer に残し desktop main nav は profile
 	// menu 経由に分離する場合がある (#762: drafts は X mobile drawer 準拠で keep、
 	// desktop main nav からは削除 → profile DropdownMenu に移動)。
-	// #741 で 「探索」 1 entry に統一 → #795 で /search に変更 → #803 で /explore に戻す。
-	// /explore は SearchBox + 最新の投稿 feed の 2 段構成 (#803)。
+	// path 変遷: #741 /explore → #795 /search → #803 /explore → #808 /search 固定。
+	// #806 chrome 統合後の tab URL 跳び問題回避のため nav は /search に集約。
 	const items: BottomTabItem[] = [
 		{ href: "/", label: "ホーム", Icon: Home },
-		{ href: "/explore", label: "検索", Icon: Search },
+		{ href: "/search", label: "検索", Icon: Search },
 		{ href: "/notifications", label: "通知", Icon: Bell, requiresAuth: true },
 		{
 			href: "/messages",

--- a/client/src/components/search/SearchExploreSurface.tsx
+++ b/client/src/components/search/SearchExploreSurface.tsx
@@ -1,16 +1,23 @@
 /**
- * /explore と /search の共通 chrome (#806).
+ * /explore と /search の共通 chrome (#806, #808).
  *
  * ハルナさん指示 (2026-05-19): /explore と /search は「投稿を除いて完全に
  * 一致」 した layout。 URL は別だが見た目は同じ。 chrome (header + tabs +
  * 説明 + SearchBox + フィルタ) を 1 component に集約し、 中央の投稿リスト
  * 部分だけ q の有無で切り替える:
- *   - q あり: 検索結果 (SearchResultTweet[])
+ *   - q あり: 検索結果 (TweetSummary[])
  *   - q なし: 「最新の投稿」 feed (TweetSummary[])
+ *
+ * #808: anon (currentUser=null) + q あり のとき、 検索結果ではなく 「検索は
+ * ログインが必要です」 promo を中央に出す。 backend /api/v1/search/ を
+ * IsAuthenticated 化したので anon SSR は 401 を受けて空結果になる前提。 UI
+ * 側で promo に切り替えて acquisition funnel に流す。
  *
  * page.tsx 側で data fetch を済ませて props として渡す (server component
  * のままにするため)。
  */
+
+import Link from "next/link";
 
 import SearchBox from "@/components/search/SearchBox";
 import SearchModeTabs from "@/components/search/SearchModeTabs";
@@ -55,7 +62,10 @@ export default function SearchExploreSurface({
 					>
 						検索
 					</h1>
-					{query && (
+					{/* #808: anon は検索を実行できないので件数行 (= 「『q』 — N 件」) は
+					    出さない (searchCount=0 だが anon の 0 と logged-in の 0 件 hit を
+					    UI で混同させないため)。 */}
+					{query && currentUser !== null && (
 						<p
 							className="truncate text-[color:var(--a-text-subtle)]"
 							style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
@@ -76,16 +86,53 @@ export default function SearchExploreSurface({
 				</div>
 
 				{query ? (
-					<section aria-label="検索結果" className="space-y-3">
-						<TweetCardList
-							tweets={searchResults}
-							ariaLabel={`「${query}」の検索結果`}
-							emptyMessage="一致するツイートはありません。"
-							currentUserHandle={currentUser?.username}
-							currentUserPreferredLanguage={currentUser?.preferred_language}
-							currentUserAutoTranslate={currentUser?.auto_translate}
-						/>
-					</section>
+					currentUser === null ? (
+						// #808: anon + q あり → 検索は IsAuthenticated。 結果を出さず
+						// 「ログインして検索」 promo を中央に出して acquisition funnel に流す。
+						// chrome (h1 + 件数行 + tabs + 説明 + box) は visible で残す。
+						<section
+							role="status"
+							aria-labelledby="anon-search-gate-heading"
+							className="rounded-md border border-[color:var(--a-border)] bg-[color:var(--a-bg-subtle)] px-5 py-8 text-center"
+						>
+							<h2
+								id="anon-search-gate-heading"
+								className="mb-2 text-base font-semibold text-[color:var(--a-text)]"
+							>
+								検索はログインが必要です
+							</h2>
+							<p className="mb-4 text-sm text-[color:var(--a-text-muted)]">
+								アカウントを作成またはログインすると、
+								投稿・タグ・ユーザーを検索できます。
+							</p>
+							<div className="flex justify-center gap-3">
+								<Link
+									href={`/login?next=${encodeURIComponent(`/search?q=${query}`)}`}
+									className="rounded-md px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+									style={{ background: "var(--a-accent)" }}
+								>
+									ログイン
+								</Link>
+								<Link
+									href="/register"
+									className="rounded-md border border-[color:var(--a-border)] px-4 py-2 text-sm font-medium text-[color:var(--a-text)] transition-colors hover:bg-[color:var(--a-bg-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)]"
+								>
+									新規登録
+								</Link>
+							</div>
+						</section>
+					) : (
+						<section aria-label="検索結果" className="space-y-3">
+							<TweetCardList
+								tweets={searchResults}
+								ariaLabel={`「${query}」の検索結果`}
+								emptyMessage="一致するツイートはありません。"
+								currentUserHandle={currentUser?.username}
+								currentUserPreferredLanguage={currentUser?.preferred_language}
+								currentUserAutoTranslate={currentUser?.auto_translate}
+							/>
+						</section>
+					)
 				) : (
 					<section
 						aria-labelledby="explore-latest-heading"

--- a/client/src/components/search/__tests__/SearchExploreSurface.test.tsx
+++ b/client/src/components/search/__tests__/SearchExploreSurface.test.tsx
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import SearchExploreSurface from "@/components/search/SearchExploreSurface";
 import type { TweetSummary } from "@/lib/api/tweets";
+import type { CurrentUser } from "@/lib/api/users";
 
 // SearchBox is a client component that wires next/navigation; mock to render
 // a simple stub so we can assert the surrounding chrome without a full router.
@@ -62,6 +63,28 @@ const SAMPLE_TWEET: TweetSummary = {
 	edit_count: 0,
 };
 
+const LOGGED_IN_USER = {
+	id: "u-1",
+	email: "alice@example.com",
+	username: "alice",
+	full_name: "Alice",
+	display_name: "Alice",
+	bio: "",
+	avatar_url: "",
+	header_url: "",
+	is_premium: false,
+	needs_onboarding: false,
+	github_url: "",
+	x_url: "",
+	zenn_url: "",
+	qiita_url: "",
+	note_url: "",
+	linkedin_url: "",
+	preferred_language: "ja",
+	auto_translate: false,
+	is_private: false,
+} as unknown as CurrentUser;
+
 describe("SearchExploreSurface", () => {
 	it("q なしのとき: h1 '検索' + tabs + 説明 + box + 「最新の投稿」 h2", () => {
 		render(
@@ -88,14 +111,14 @@ describe("SearchExploreSurface", () => {
 		expect(screen.queryByText(/件$/)).not.toBeInTheDocument();
 	});
 
-	it("q ありのとき: 件数行 + 検索結果 section、 「最新の投稿」 は出ない", () => {
+	it("logged-in + q ありのとき: 件数行 + 検索結果 section、 「最新の投稿」 は出ない", () => {
 		render(
 			<SearchExploreSurface
 				query="django"
 				searchCount={42}
 				searchResults={[SAMPLE_TWEET, SAMPLE_TWEET]}
 				latestTweets={[]}
-				currentUser={null}
+				currentUser={LOGGED_IN_USER}
 			/>,
 		);
 		expect(
@@ -106,6 +129,48 @@ describe("SearchExploreSurface", () => {
 			screen.queryByRole("heading", { name: "最新の投稿", level: 2 }),
 		).not.toBeInTheDocument();
 		expect(screen.getByLabelText("「django」の検索結果")).toBeInTheDocument();
+	});
+
+	// #808: anon + q あり → 検索結果ではなく 「ログインして検索」 promo を表示。
+	it("anon + q ありのとき: promo 表示、 件数行 / 検索結果 section は出ない", () => {
+		render(
+			<SearchExploreSurface
+				query="django"
+				searchCount={0}
+				searchResults={[]}
+				latestTweets={[]}
+				currentUser={null}
+			/>,
+		);
+		// chrome は visible
+		expect(
+			screen.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeInTheDocument();
+		expect(screen.getByTestId("search-mode-tabs")).toBeInTheDocument();
+		expect(screen.getByTestId("search-box")).toBeInTheDocument();
+		// promo の h2 + button
+		expect(
+			screen.getByRole("heading", {
+				name: "検索はログインが必要です",
+				level: 2,
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "ログイン" })).toHaveAttribute(
+			"href",
+			expect.stringContaining("/login?next="),
+		);
+		expect(screen.getByRole("link", { name: "新規登録" })).toHaveAttribute(
+			"href",
+			"/register",
+		);
+		// 件数行 / 検索結果 / 「最新の投稿」 は出ない
+		expect(screen.queryByText(/「django」 — /)).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText("「django」の検索結果"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: "最新の投稿", level: 2 }),
+		).not.toBeInTheDocument();
 	});
 
 	it("chrome (h1 + tabs + 説明 + box) は q ありなしに関わらず常に表示", () => {

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -23,10 +23,12 @@ export const leftNavLinks: LeftNavLink[] = [
 		iconName: "Home",
 	},
 	{
-		// #795 で path を /search に向けたが、 #803 でハルナさん指示により /explore
-		// に戻す。 label 「検索」 は維持。 /explore page は #803 で SearchBox +
-		// 最新の投稿 feed の 2 段構成にリデザイン (旧トレンドツイートは廃止)。
-		path: "/explore",
+		// path の変遷: #741 /explore → #795 /search → #803 /explore → #808 /search。
+		// #806 で chrome を統合した後、 /explore でタブ click すると /search に
+		// 飛ぶ URL 跳びが顕在化したため、 ハルナさん指示で nav は /search 固定に
+		// 統一 (タブ問題が起きない pathname に nav を集約)。 label 「検索」 維持。
+		// /explore route は deep link 維持のため残す (nav から見えないだけで 200)。
+		path: "/search",
 		label: "検索",
 		iconName: "Search",
 	},


### PR DESCRIPTION
Closes #808

## Summary

ハルナさん指示 (2026-05-19):
- #806 で /explore と /search の chrome を統合した後、 /explore でタブ click すると /search に飛ぶ URL 跳びが顕在化 → nav 「検索」 は **/search に戻す** (#803 を再度逆転)
- anon が `search?q=...` で実検索するのを避けたい → backend を **IsAuthenticated**、 frontend で anon は **「検索はログインが必要です」 promo** を見る

## 変更内容

### A. nav 「検索」 → /search 固定 (3 source 同期)

| File | 変更 |
| - | - |
| `client/src/constants/index.ts` | leftNavLinks の path: /explore → /search |
| `client/src/components/layout-a/ALeftNav.tsx` | NAV_ITEMS 同期 |
| `client/src/components/layout-a/AMobileShell.tsx` | BOTTOM_TABS + drawer items 同期 |

`/explore` route は **維持** (deep link 保護、 ハルナさん明示)。 nav からだけ消える。

### B. backend: SearchView を IsAuthenticated

| File | 変更 |
| - | - |
| `apps/search/views.py` | `permission_classes = [AllowAny]` → `[IsAuthenticated]` |
| `apps/search/tests/test_views.py` | 新規 3 ケース (anon 401 / logged-in 200 / q なし anon も 401) |

### C. frontend: SearchExploreSurface に anon + q あり promo

| File | 変更 |
| - | - |
| `client/src/components/search/SearchExploreSurface.tsx` | anon (currentUser=null) + q あり → 検索結果でなく 「検索はログインが必要です」 promo (h2 + ログイン / 新規登録 button)。 件数行も anon では suppress |
| `client/src/components/search/__tests__/SearchExploreSurface.test.tsx` | logged-in / anon の分岐 case を追加 (5 ケース) |
| `client/e2e/search-nav-anon-gate.spec.ts` | 新規 4 ケース (anonymous OK) |

## Test plan

- [x] vitest 全 **874 pass | 1 todo** (regression なし)
- [x] backend pytest 新規 3 ケース (CI で実行)
- [x] `npx tsc --noEmit` clean / `npx eslint` clean
- [ ] stg 反映後 Playwright MCP で **4 枚スクショ並列比較**:
  - anon /search (q なし) — 「最新の投稿」 feed
  - anon /search?q=django — 「検索はログインが必要です」 promo
  - logged-in /search (q なし) — 「最新の投稿」 feed (現状維持)
  - logged-in /search?q=django — 検索結果 (現状維持)
- [ ] **ハルナさんに 4 枚提示して chrome 一致 + anon promo 動作を確認**

```bash
# stg E2E (anonymous OK)
cd client
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
  npx playwright test e2e/search-nav-anon-gate.spec.ts --reporter=line
```

## Follow-up

- **#809 (次起票予定)**: 「ユーザー」 タブの q なしで 「おすすめユーザー」 (WhoToFollow) を中央に表示 (本セッションで追加指示、 別 PR で対応)

## 関連

- #803 (nav を /explore に変えた経緯)
- #806 (chrome 共通化、 本 PR でも維持)
- #735 (鍵アカ visibility contract、 IsAuthenticated 拡大の隣接設計)