### PR TITLE
[feature][search] /search/users (q なし) で 「おすすめユーザー」 を中央 inline 表示 (#810)

### DIFF
--- a/client/e2e/search-users-recommended.spec.ts
+++ b/client/e2e/search-users-recommended.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * #810 / search-users-recommended
+ *
+ * /search/users (q なし) で 「おすすめユーザー」 section を中央に表示する変更の
+ * E2E 確認。 anonymous OK のため credential 不要。
+ *
+ * 実行 (stg):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *     npx playwright test e2e/search-users-recommended.spec.ts --reporter=line
+ */
+
+import { expect, test } from "@playwright/test";
+
+test.describe("Users tab recommended (#810)", () => {
+	test("/search/users (q なし) で 「おすすめユーザー」 h2 + WhoToFollow が visible", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/search/users");
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible({ timeout: 15_000 });
+		await expect(
+			page.getByRole("heading", { name: "おすすめユーザー", level: 2 }),
+		).toBeVisible();
+	});
+
+	test("/search/users?q=alice (q あり) で 「おすすめユーザー」 は出ない (検索結果モード)", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/search/users?q=alice");
+		await expect(
+			page.getByRole("heading", { name: "検索", level: 1 }),
+		).toBeVisible({ timeout: 15_000 });
+		// q ありなので 「おすすめユーザー」 h2 は出ない (検索結果 or empty placeholder)
+		await expect(
+			page.getByRole("heading", { name: "おすすめユーザー", level: 2 }),
+		).toHaveCount(0);
+	});
+
+	test("anonymous でも /search/users 200 + 「おすすめユーザー」 visible", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		try {
+			await page.setViewportSize({ width: 1280, height: 800 });
+			const response = await page.goto("/search/users");
+			expect(response?.status() ?? 0).toBeLessThan(400);
+			await expect(
+				page.getByRole("heading", { name: "おすすめユーザー", level: 2 }),
+			).toBeVisible({ timeout: 15_000 });
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -16,6 +16,7 @@ import NearMeFilter from "@/components/search/NearMeFilter";
 import SearchModeTabs from "@/components/search/SearchModeTabs";
 import UserSearchBox from "@/components/search/UserSearchBox";
 import UserSearchResultCard from "@/components/search/UserSearchResultCard";
+import WhoToFollow from "@/components/sidebar/WhoToFollow";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import {
 	PROXIMITY_RADIUS_DEFAULT_KM,
@@ -208,10 +209,28 @@ export default async function UserSearchPage({
 				</div>
 
 				{!hasAnyQuery && (
-					<p className="text-sm text-[color:var(--a-text-muted)]">
-						ユーザー名 / 表示名 / 自己紹介 (bio) で部分一致検索できます。
-						ログイン中は「近所で絞り込む」 で居住地の近い人だけに絞れます。
-					</p>
+					<>
+						<p className="mb-6 text-sm text-[color:var(--a-text-muted)]">
+							ユーザー名 / 表示名 / 自己紹介 (bio) で部分一致検索できます。
+							ログイン中は「近所で絞り込む」 で居住地の近い人だけに絞れます。
+						</p>
+						{/* #810: ハルナさん指示 — ユーザータブ + q なし のとき
+						    「おすすめユーザー」 を中央に表示 (投稿タブの 「最新の投稿」 と
+						    同じ pattern)。 WhoToFollow は anon でも popular fallback で
+						    動くので auth 分岐なしでそのまま使える。 */}
+						<section
+							aria-labelledby="users-recommended-heading"
+							className="space-y-3"
+						>
+							<h2
+								id="users-recommended-heading"
+								className="mb-4 px-2 text-lg font-semibold text-foreground"
+							>
+								おすすめユーザー
+							</h2>
+							<WhoToFollow isAuthenticated={loggedIn} />
+						</section>
+					</>
 				)}
 
 				{outcome.kind === "missing_residence" && (


### PR DESCRIPTION
Closes #810

## Summary

ハルナさん指示 (2026-05-19): 投稿タブと同じく、 ユーザータブも q なしのときに中央 「おすすめユーザー」 を出してほしい。

#806 の投稿タブ 「最新の投稿」 pattern をユーザータブにも適用。 既存 WhoToFollow component (auth state 対応済) を流用、 最小変更で実現。

## 変更

- `client/src/app/(template)/search/users/page.tsx`: `!hasAnyQuery` branch に `<h2>おすすめユーザー</h2>` + `<WhoToFollow isAuthenticated={loggedIn} />` を追加。 既存の説明文は維持 (mb-6 で間隔)。
- `client/e2e/search-users-recommended.spec.ts`: 新規 3 ケース (q なし / q あり regression / anonymous)

## 挙動

| URL | persona | 中央 content |
| - | - | - |
| `/search/users` | anon | 説明文 + 「おすすめユーザー」 (popular fallback) |
| `/search/users` | logged-in | 説明文 + 「おすすめユーザー」 (personalised) |
| `/search/users?q=alice` | 両方 | 検索結果 (おすすめは出ない、 regression なし) |
| `/search/users?near_me=1` | logged-in | near-me 結果 (おすすめは出ない) |

## Test plan

- [x] vitest 874 pass | 1 todo (regression なし)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] stg 反映後 Playwright MCP で 2 枚スクショ (anon /search/users / logged-in /search/users) + 「おすすめユーザー」 表示確認

## 関連

- #806 (投稿タブの 「最新の投稿」 pattern 起点)
- #808 (anon search gate)