### PR TITLE
[fix][search] /search/users 「おすすめユーザー」 h2 二重表示を修正 (#810 hotfix)

### DIFF
--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -217,7 +217,9 @@ export default async function UserSearchPage({
 						{/* #810: ハルナさん指示 — ユーザータブ + q なし のとき
 						    「おすすめユーザー」 を中央に表示 (投稿タブの 「最新の投稿」 と
 						    同じ pattern)。 WhoToFollow は anon でも popular fallback で
-						    動くので auth 分岐なしでそのまま使える。 */}
+						    動くので auth 分岐なしでそのまま使える。
+						    #810 hotfix: bare={true} で WhoToFollow 内蔵の h2
+						    「おすすめユーザー」 を抑制し、 外側の h2 と重複させない。 */}
 						<section
 							aria-labelledby="users-recommended-heading"
 							className="space-y-3"
@@ -228,7 +230,7 @@ export default async function UserSearchPage({
 							>
 								おすすめユーザー
 							</h2>
-							<WhoToFollow isAuthenticated={loggedIn} />
+							<WhoToFollow isAuthenticated={loggedIn} bare />
 						</section>
 					</>
 				)}


### PR DESCRIPTION
## Summary

#810 (PR #812) の stg 検証で発覚: 外側 h2「おすすめユーザー」 + WhoToFollow 内蔵 h2「おすすめユーザー」 が **2 重表示**。 WhoToFollow に bare={true} を渡して内蔵 heading を抑制。

## 変更

`client/src/app/(template)/search/users/page.tsx` の WhoToFollow 1 行に `bare` prop を追加。

## Test plan

- [x] vitest 874 pass | 1 todo (regression なし)
- [x] tsc / eslint clean
- [ ] stg 反映後 Playwright MCP で 「おすすめユーザー」 が 1 つだけ表示されることを確認

related: #810 / PR #812
