### PR TITLE
[feature][search] 検索結果に 「最新 / 注目」 sort tab を追加 (#811)

### DIFF
--- a/apps/search/services.py
+++ b/apps/search/services.py
@@ -10,8 +10,9 @@ ADR-0002 で pg_bigm + Lindera を仮採用しているので、Postgres 本番�
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta
+from typing import Literal
 
-from django.db.models import QuerySet
+from django.db.models import F, QuerySet
 from django.utils import timezone
 
 from apps.search.parser import ParsedQuery, parse_search_query
@@ -19,6 +20,24 @@ from apps.tweets.models import Tweet
 
 DEFAULT_LIMIT = 20
 MAX_LIMIT = 100
+
+SortOrder = Literal["latest", "top"]
+DEFAULT_SORT: SortOrder = "latest"
+
+# #811: 「注目」 tab の engagement 代理 score。 本物の impression_count は
+# 未実装のため、 既存 reaction / repost / reply の重み付け合算で代用。
+# 重み: repost=3 (拡散行動が最も信号強い) > reaction=2 (好印象) > reply=1 (議論)。
+# 将来 impression_count を導入したら別 sort 候補にできる。
+POPULARITY_REACTION_WEIGHT = 2
+POPULARITY_REPOST_WEIGHT = 3
+POPULARITY_REPLY_WEIGHT = 1
+
+
+def _normalize_sort(value: str | None) -> SortOrder:
+    """Query param からの sort 値を正規化。 不正値は default にフォールバック。"""
+    if value == "top":
+        return "top"
+    return "latest"
 
 
 def _apply_filters(qs: QuerySet[Tweet], parsed: ParsedQuery) -> QuerySet[Tweet]:
@@ -59,12 +78,23 @@ def _apply_filters(qs: QuerySet[Tweet], parsed: ParsedQuery) -> QuerySet[Tweet]:
     return qs
 
 
-def search_tweets(query: str, limit: int = DEFAULT_LIMIT, viewer=None) -> list[Tweet]:
+def search_tweets(
+    query: str,
+    limit: int = DEFAULT_LIMIT,
+    viewer=None,
+    sort: SortOrder = DEFAULT_SORT,
+) -> list[Tweet]:
     """Tweet を ``query`` で検索する。
 
     クエリ文字列は ``parse_search_query`` で operator + keywords に分解し、
     keywords は本文 (body) に対する icontains マッチ、operator は
     ``_apply_filters`` で QuerySet に適用する。空クエリは空リストを返す。
+
+    #811: ``sort`` parameter で結果の順序を切替:
+      - ``latest`` (default): ``-created_at, -id`` (X の 「最新」 相当)
+      - ``top``: popularity_score (reaction*2 + repost*3 + reply*1) DESC、
+        tie-break で ``-created_at`` (X の 「注目」 相当、 engagement 代理)
+    本物の impression_count は未実装 (#811 follow-up で別途設計)。
     """
     parsed = parse_search_query(query)
     has_filter = bool(
@@ -85,4 +115,16 @@ def search_tweets(query: str, limit: int = DEFAULT_LIMIT, viewer=None) -> list[T
     if parsed.keywords:
         qs = qs.filter(body__icontains=parsed.keywords)
 
-    return list(qs.order_by("-created_at", "-id")[:capped])
+    if sort == "top":
+        # popularity_score を annotate して降順、 同 score は最新優先。
+        qs = qs.annotate(
+            popularity_score=(
+                F("reaction_count") * POPULARITY_REACTION_WEIGHT
+                + F("repost_count") * POPULARITY_REPOST_WEIGHT
+                + F("reply_count") * POPULARITY_REPLY_WEIGHT
+            )
+        ).order_by("-popularity_score", "-created_at", "-id")
+    else:
+        qs = qs.order_by("-created_at", "-id")
+
+    return list(qs[:capped])

--- a/apps/search/tests/test_services.py
+++ b/apps/search/tests/test_services.py
@@ -99,3 +99,61 @@ class TestSearchTweets:
         )
 
         assert search_tweets("approved marker", viewer=follower) == [tweet]
+
+
+# --------------------------------------------------------------------------- #
+# #811: sort=latest|top の order 切替
+# --------------------------------------------------------------------------- #
+
+
+class TestSearchTweetsSort:
+    """sort=latest (default) は -created_at、 sort=top は popularity_score 順."""
+
+    @pytest.fixture
+    def author(self, db):
+        return User.objects.create_user(username="bob", email="bob@example.com", password="x")
+
+    @pytest.fixture
+    def graded_tweets(self, author):
+        # 古い順に作成、 engagement を後から update して 「最新」 と 「注目」 の
+        # 順序が異なるシナリオを作る。
+        old = Tweet.objects.create(author=author, body="hello world (oldest)")
+        mid = Tweet.objects.create(author=author, body="hello world (mid)")
+        new = Tweet.objects.create(author=author, body="hello world (newest)")
+        # popularity_score = reaction*2 + repost*3 + reply*1:
+        #   old: 10*2 + 0  + 0 = 20  ← 最高
+        #   mid:  0   + 0  + 0 = 0
+        #   new:  1*2 + 1*3 + 0 = 5
+        Tweet.objects.filter(pk=old.pk).update(reaction_count=10)
+        Tweet.objects.filter(pk=new.pk).update(reaction_count=1, repost_count=1)
+        return {"old": old, "mid": mid, "new": new}
+
+    def test_default_sort_is_latest(self, graded_tweets):
+        """sort 未指定なら -created_at 順 (new → mid → old)."""
+        results = search_tweets("hello world")
+        ids = [t.pk for t in results]
+        assert ids == [
+            graded_tweets["new"].pk,
+            graded_tweets["mid"].pk,
+            graded_tweets["old"].pk,
+        ]
+
+    def test_sort_latest_explicit(self, graded_tweets):
+        """sort='latest' は default と同じ -created_at 順."""
+        results = search_tweets("hello world", sort="latest")
+        ids = [t.pk for t in results]
+        assert ids == [
+            graded_tweets["new"].pk,
+            graded_tweets["mid"].pk,
+            graded_tweets["old"].pk,
+        ]
+
+    def test_sort_top_orders_by_popularity_score(self, graded_tweets):
+        """sort='top' は popularity_score DESC (old=20 → new=5 → mid=0)."""
+        results = search_tweets("hello world", sort="top")
+        ids = [t.pk for t in results]
+        assert ids == [
+            graded_tweets["old"].pk,
+            graded_tweets["new"].pk,
+            graded_tweets["mid"].pk,
+        ]

--- a/apps/search/tests/test_views.py
+++ b/apps/search/tests/test_views.py
@@ -41,3 +41,41 @@ def test_search_anon_blocked_regardless_of_query() -> None:
     assert client.get("/api/v1/search/").status_code == 401
     # q ありだが anon
     assert client.get("/api/v1/search/?q=anything").status_code == 401
+
+
+# --------------------------------------------------------------------------- #
+# #811: sort=latest|top の response body 反映 (services 詳細 test は test_services.py)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db(transaction=True)
+def test_search_response_includes_sort_default() -> None:
+    """sort 未指定なら response body に sort='latest' が含まれる."""
+    user = make_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/v1/search/?q=anything")
+    assert response.status_code == 200
+    assert response.json().get("sort") == "latest"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_search_response_includes_sort_top() -> None:
+    """sort=top を渡すと response body に sort='top'."""
+    user = make_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/v1/search/?q=anything&sort=top")
+    assert response.status_code == 200
+    assert response.json().get("sort") == "top"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_search_invalid_sort_falls_back_to_latest() -> None:
+    """不正な sort 値は latest に fallback (400 でなく安全側)."""
+    user = make_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/v1/search/?q=anything&sort=garbage")
+    assert response.status_code == 200
+    assert response.json().get("sort") == "latest"

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -17,7 +17,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.search.services import DEFAULT_LIMIT, MAX_LIMIT, search_tweets
+from apps.search.services import (
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+    _normalize_sort,
+    search_tweets,
+)
 from apps.tweets.serializers import TweetListSerializer
 
 
@@ -34,6 +39,9 @@ class SearchView(APIView):
         except (TypeError, ValueError):
             limit = DEFAULT_LIMIT
 
-        tweets = search_tweets(query, limit=limit, viewer=request.user)
+        # #811: sort=latest|top で検索結果の順序を切替。 不正値は latest にフォールバック。
+        sort = _normalize_sort(request.query_params.get("sort"))
+
+        tweets = search_tweets(query, limit=limit, viewer=request.user, sort=sort)
         data = TweetListSerializer(tweets, many=True, context={"request": request}).data
-        return Response({"query": query, "results": data, "count": len(data)})
+        return Response({"query": query, "sort": sort, "results": data, "count": len(data)})

--- a/client/e2e/search-sort-tabs.spec.ts
+++ b/client/e2e/search-sort-tabs.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * #811 / search-sort-tabs
+ *
+ * /search?q=... に 「最新 / 注目」 tab を追加。 click で URL `?sort=top` が
+ * 変わり、 backend の order が popularity_score DESC に切り替わる。
+ *
+ * 実行 (stg、 logged-in 必須なので credentials が要る):
+ *   PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \
+ *   PLAYWRIGHT_USER1_EMAIL=test4@example.com \
+ *   PLAYWRIGHT_USER1_PASSWORD=E5INn9EaBLG7WNPl \
+ *     npx playwright test e2e/search-sort-tabs.spec.ts --reporter=line
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+
+const USER1_EMAIL = process.env.PLAYWRIGHT_USER1_EMAIL ?? "";
+const USER1_PASSWORD = process.env.PLAYWRIGHT_USER1_PASSWORD ?? "";
+
+const CREDENTIALS_PRESENT = Boolean(USER1_EMAIL && USER1_PASSWORD);
+
+async function login(page: Page, email: string, password: string) {
+	await page.goto("/login");
+	// stg は日本語 UI、 local docker fixture は英語 UI で両対応 (#797 で共通化予定)。
+	await page.getByLabel(/メールアドレス|Email Address/i).fill(email);
+	await page.getByPlaceholder(/パスワード|Password/i).fill(password);
+	await page.getByRole("button", { name: /ログイン|Sign In/i }).click();
+	await page.waitForURL(/\/onboarding|\/$/);
+}
+
+test.describe("Search sort tabs (#811)", () => {
+	test.skip(
+		!CREDENTIALS_PRESENT,
+		"PLAYWRIGHT_USER1_EMAIL / PASSWORD が必要 (docs/local/e2e-stg.md)",
+	);
+
+	test("logged-in /search?q=django で 「最新」 / 「注目」 tab が表示される", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await login(page, USER1_EMAIL, USER1_PASSWORD);
+		await page.goto("/search?q=django");
+
+		const tablist = page.getByRole("tablist", { name: "検索結果の並び替え" });
+		await expect(tablist).toBeVisible({ timeout: 15_000 });
+		// 「最新」 は default で aria-selected=true
+		const latestTab = page.getByRole("tab", { name: "最新" });
+		const topTab = page.getByRole("tab", { name: "注目" });
+		await expect(latestTab).toHaveAttribute("aria-selected", "true");
+		await expect(topTab).toHaveAttribute("aria-selected", "false");
+	});
+
+	test("「注目」 タブ click で URL が ?sort=top に変わり、 aria-selected が反転", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await login(page, USER1_EMAIL, USER1_PASSWORD);
+		await page.goto("/search?q=django");
+
+		await page.getByRole("tab", { name: "注目" }).click();
+		await page.waitForURL(/\/search\?q=django.*sort=top/);
+
+		// 反転後の aria-selected
+		await expect(page.getByRole("tab", { name: "注目" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+		await expect(page.getByRole("tab", { name: "最新" })).toHaveAttribute(
+			"aria-selected",
+			"false",
+		);
+	});
+
+	test("anon /search?q=django では sort tab は出ない (promo が表示)", async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext();
+		const page = await ctx.newPage();
+		try {
+			await page.setViewportSize({ width: 1280, height: 800 });
+			await page.goto("/search?q=django");
+			await expect(
+				page.getByRole("heading", { name: "検索はログインが必要です" }),
+			).toBeVisible({ timeout: 15_000 });
+			// sort tab は q ありかつ logged-in でしか出ない
+			await expect(
+				page.getByRole("tablist", { name: "検索結果の並び替え" }),
+			).toHaveCount(0);
+		} finally {
+			await ctx.close();
+		}
+	});
+});

--- a/client/src/app/(template)/explore/page.tsx
+++ b/client/src/app/(template)/explore/page.tsx
@@ -19,10 +19,14 @@ import type { Metadata } from "next";
 
 import SearchExploreSurface from "@/components/search/SearchExploreSurface";
 import { fetchLatestTimeline } from "@/lib/api/explore";
-import { fetchSearch } from "@/lib/api/search";
+import { fetchSearch, type SearchSort } from "@/lib/api/search";
 import { serverFetch } from "@/lib/api/server";
 import type { CurrentUser } from "@/lib/api/users";
 import { stringifyJsonLd } from "@/lib/json-ld";
+
+function normalizeSort(value: string | undefined): SearchSort {
+	return value === "top" ? "top" : "latest";
+}
 
 export const metadata: Metadata = {
 	title: "探索 — エンジニア SNS",
@@ -54,19 +58,21 @@ async function loadCurrentUser(): Promise<CurrentUser | null> {
 }
 
 interface ExplorePageProps {
-	searchParams: { q?: string };
+	searchParams: { q?: string; sort?: string };
 }
 
 export default async function ExplorePage({ searchParams }: ExplorePageProps) {
 	const query = (searchParams.q ?? "").trim();
+	const sort = normalizeSort(searchParams.sort);
 	const [searchData, latestData, currentUser] = await Promise.all([
 		query
-			? fetchSearch(query).catch(() => ({
+			? fetchSearch(query, 20, sort).catch(() => ({
 					query,
+					sort,
 					results: [],
 					count: 0,
 				}))
-			: Promise.resolve({ query: "", results: [], count: 0 }),
+			: Promise.resolve({ query: "", sort, results: [], count: 0 }),
 		query
 			? Promise.resolve({ results: [], next_cursor: null, has_more: false })
 			: fetchLatestTimeline(20).catch(() => ({
@@ -89,6 +95,8 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
 				searchResults={searchData.results}
 				latestTweets={latestData.results}
 				currentUser={currentUser}
+				sort={sort}
+				basePathname="/explore"
 			/>
 		</>
 	);

--- a/client/src/app/(template)/search/page.tsx
+++ b/client/src/app/(template)/search/page.tsx
@@ -15,7 +15,7 @@ import type { Metadata } from "next";
 
 import SearchExploreSurface from "@/components/search/SearchExploreSurface";
 import { fetchLatestTimeline } from "@/lib/api/explore";
-import { fetchSearch } from "@/lib/api/search";
+import { fetchSearch, type SearchSort } from "@/lib/api/search";
 import { serverFetch } from "@/lib/api/server";
 import type { CurrentUser } from "@/lib/api/users";
 
@@ -27,8 +27,12 @@ async function loadCurrentUser(): Promise<CurrentUser | null> {
 	}
 }
 
+function normalizeSort(value: string | undefined): SearchSort {
+	return value === "top" ? "top" : "latest";
+}
+
 interface SearchPageProps {
-	searchParams: { q?: string };
+	searchParams: { q?: string; sort?: string };
 }
 
 export const metadata: Metadata = {
@@ -39,14 +43,16 @@ export const metadata: Metadata = {
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
 	const query = (searchParams.q ?? "").trim();
+	const sort = normalizeSort(searchParams.sort);
 	const [searchData, latestData, currentUser] = await Promise.all([
 		query
-			? fetchSearch(query).catch(() => ({
+			? fetchSearch(query, 20, sort).catch(() => ({
 					query,
+					sort,
 					results: [],
 					count: 0,
 				}))
-			: Promise.resolve({ query: "", results: [], count: 0 }),
+			: Promise.resolve({ query: "", sort, results: [], count: 0 }),
 		query
 			? Promise.resolve({ results: [], next_cursor: null, has_more: false })
 			: fetchLatestTimeline(20).catch(() => ({
@@ -64,6 +70,8 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 			searchResults={searchData.results}
 			latestTweets={latestData.results}
 			currentUser={currentUser}
+			sort={sort}
+			basePathname="/search"
 		/>
 	);
 }

--- a/client/src/components/search/SearchExploreSurface.tsx
+++ b/client/src/components/search/SearchExploreSurface.tsx
@@ -1,5 +1,5 @@
 /**
- * /explore と /search の共通 chrome (#806, #808).
+ * /explore と /search の共通 chrome (#806, #808, #811).
  *
  * ハルナさん指示 (2026-05-19): /explore と /search は「投稿を除いて完全に
  * 一致」 した layout。 URL は別だが見た目は同じ。 chrome (header + tabs +
@@ -13,6 +13,9 @@
  * IsAuthenticated 化したので anon SSR は 401 を受けて空結果になる前提。 UI
  * 側で promo に切り替えて acquisition funnel に流す。
  *
+ * #811: 検索結果に sort tab (最新 / 注目) を追加。 X の Top / Latest 切替に
+ * 倣う。 URL の `?sort=top` で navigate、 default は latest。
+ *
  * page.tsx 側で data fetch を済ませて props として渡す (server component
  * のままにするため)。
  */
@@ -22,6 +25,7 @@ import Link from "next/link";
 import SearchBox from "@/components/search/SearchBox";
 import SearchModeTabs from "@/components/search/SearchModeTabs";
 import TweetCardList from "@/components/timeline/TweetCardList";
+import type { SearchSort } from "@/lib/api/search";
 import type { TweetSummary } from "@/lib/api/tweets";
 import type { CurrentUser } from "@/lib/api/users";
 
@@ -36,6 +40,26 @@ interface SearchExploreSurfaceProps {
 	latestTweets: TweetSummary[];
 	/** ログイン中ユーザー (TweetCard の reaction state / 翻訳 prefs 用)。 */
 	currentUser: CurrentUser | null;
+	/**
+	 * #811: 検索結果 sort (latest / top)。 URL `?sort=...` から渡す。
+	 * default は "latest"。 q なしのときは無視 (最新の投稿 feed は常に時系列)。
+	 */
+	sort?: SearchSort;
+	/**
+	 * #811: tab href に使う pathname (例 `/search` / `/explore`)。
+	 * SearchModeTabs と同様、 現在の URL から page.tsx 側が渡す。
+	 */
+	basePathname?: string;
+}
+
+function buildSortHref(
+	pathname: string,
+	query: string,
+	sort: SearchSort,
+): string {
+	const params = new URLSearchParams({ q: query });
+	if (sort !== "latest") params.set("sort", sort);
+	return `${pathname}?${params.toString()}`;
 }
 
 export default function SearchExploreSurface({
@@ -44,6 +68,8 @@ export default function SearchExploreSurface({
 	searchResults,
 	latestTweets,
 	currentUser,
+	sort = "latest",
+	basePathname = "/search",
 }: SearchExploreSurfaceProps) {
 	return (
 		<>
@@ -123,6 +149,39 @@ export default function SearchExploreSurface({
 						</section>
 					) : (
 						<section aria-label="検索結果" className="space-y-3">
+							{/* #811: 最新 / 注目 タブ。 URL `?sort=top` で navigate、
+							    default は latest (sort param なし)。 click は Link 経由で
+							    server-side で再 fetch (small dataset 想定で client 切替なし)。 */}
+							<div
+								role="tablist"
+								aria-label="検索結果の並び替え"
+								className="mb-4 flex border-b border-[color:var(--a-border)]"
+							>
+								<Link
+									role="tab"
+									aria-selected={sort === "latest"}
+									href={buildSortHref(basePathname, query, "latest")}
+									className={`flex-1 py-2 text-center text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+										sort === "latest"
+											? "border-b-2 border-[color:var(--a-accent)] text-[color:var(--a-text)]"
+											: "border-b-2 border-transparent text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)]"
+									}`}
+								>
+									最新
+								</Link>
+								<Link
+									role="tab"
+									aria-selected={sort === "top"}
+									href={buildSortHref(basePathname, query, "top")}
+									className={`flex-1 py-2 text-center text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent)] ${
+										sort === "top"
+											? "border-b-2 border-[color:var(--a-accent)] text-[color:var(--a-text)]"
+											: "border-b-2 border-transparent text-[color:var(--a-text-muted)] hover:text-[color:var(--a-text)]"
+									}`}
+								>
+									注目
+								</Link>
+							</div>
 							<TweetCardList
 								tweets={searchResults}
 								ariaLabel={`「${query}」の検索結果`}

--- a/client/src/components/search/__tests__/SearchExploreSurface.test.tsx
+++ b/client/src/components/search/__tests__/SearchExploreSurface.test.tsx
@@ -131,6 +131,74 @@ describe("SearchExploreSurface", () => {
 		expect(screen.getByLabelText("「django」の検索結果")).toBeInTheDocument();
 	});
 
+	// #811: 検索結果に 「最新 / 注目」 sort tab。
+	it("logged-in + q あり: 「最新」 / 「注目」 sort tab + aria-selected", () => {
+		render(
+			<SearchExploreSurface
+				query="django"
+				searchCount={3}
+				searchResults={[SAMPLE_TWEET]}
+				latestTweets={[]}
+				currentUser={LOGGED_IN_USER}
+				sort="latest"
+				basePathname="/search"
+			/>,
+		);
+		expect(
+			screen.getByRole("tablist", { name: "検索結果の並び替え" }),
+		).toBeInTheDocument();
+		const latestTab = screen.getByRole("tab", { name: "最新" });
+		const topTab = screen.getByRole("tab", { name: "注目" });
+		expect(latestTab).toHaveAttribute("aria-selected", "true");
+		expect(topTab).toHaveAttribute("aria-selected", "false");
+		expect(latestTab).toHaveAttribute("href", "/search?q=django");
+		expect(topTab).toHaveAttribute("href", "/search?q=django&sort=top");
+	});
+
+	it("sort='top' で 「注目」 が aria-selected=true", () => {
+		render(
+			<SearchExploreSurface
+				query="django"
+				searchCount={3}
+				searchResults={[SAMPLE_TWEET]}
+				latestTweets={[]}
+				currentUser={LOGGED_IN_USER}
+				sort="top"
+				basePathname="/search"
+			/>,
+		);
+		expect(screen.getByRole("tab", { name: "最新" })).toHaveAttribute(
+			"aria-selected",
+			"false",
+		);
+		expect(screen.getByRole("tab", { name: "注目" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+	});
+
+	it("basePathname='/explore' で tab href が /explore?q=... を指す", () => {
+		render(
+			<SearchExploreSurface
+				query="rust"
+				searchCount={1}
+				searchResults={[SAMPLE_TWEET]}
+				latestTweets={[]}
+				currentUser={LOGGED_IN_USER}
+				sort="latest"
+				basePathname="/explore"
+			/>,
+		);
+		expect(screen.getByRole("tab", { name: "最新" })).toHaveAttribute(
+			"href",
+			"/explore?q=rust",
+		);
+		expect(screen.getByRole("tab", { name: "注目" })).toHaveAttribute(
+			"href",
+			"/explore?q=rust&sort=top",
+		);
+	});
+
 	// #808: anon + q あり → 検索結果ではなく 「ログインして検索」 promo を表示。
 	it("anon + q ありのとき: promo 表示、 件数行 / 検索結果 section は出ない", () => {
 		render(

--- a/client/src/lib/api/search.ts
+++ b/client/src/lib/api/search.ts
@@ -10,8 +10,13 @@
 import { serverFetch } from "@/lib/api/server";
 import type { TweetSummary } from "@/lib/api/tweets";
 
+/** #811: 検索結果 sort 切替。 latest = 新しい順、 top = 注目 (engagement 代理). */
+export type SearchSort = "latest" | "top";
+
 export interface SearchResponse {
 	query: string;
+	/** #811: backend が正規化した sort 値 (不正値は latest に fallback). */
+	sort?: SearchSort;
 	results: TweetSummary[];
 	count: number;
 }
@@ -21,11 +26,16 @@ const DEFAULT_LIMIT = 20;
 export async function fetchSearch(
 	query: string,
 	limit: number = DEFAULT_LIMIT,
+	sort: SearchSort = "latest",
 ): Promise<SearchResponse> {
 	const trimmed = (query ?? "").trim();
 	if (!trimmed) {
-		return { query: "", results: [], count: 0 };
+		return { query: "", sort, results: [], count: 0 };
 	}
-	const params = new URLSearchParams({ q: trimmed, limit: String(limit) });
+	const params = new URLSearchParams({
+		q: trimmed,
+		limit: String(limit),
+		sort,
+	});
 	return serverFetch<SearchResponse>(`/search/?${params.toString()}`);
 }


### PR DESCRIPTION
Closes #811

## Summary

ハルナさん指示 (2026-05-19): X の Top / Latest 切替に倣い、 検索結果に sort tab を追加。 本物の impression_count は未実装のため **engagement 代理指標** (reaction*2 + repost*3 + reply*1) で代用。

## 変更

### backend
- \`apps/search/services.py\`: \`search_tweets()\` に \`sort: Literal['latest', 'top']\` 追加。 \`top\` は \`popularity_score\` annotate で降順、 tie-break で \`-created_at\`。
- \`apps/search/views.py\`: query param \`sort\` 受け取り、 response に \`sort\` field を含める。 不正値は \`_normalize_sort\` で \`latest\` fallback。
- \`apps/search/tests/test_services.py\`: TestSearchTweetsSort 3 ケース (default=latest / sort=latest / sort=top の order)
- \`apps/search/tests/test_views.py\`: 3 ケース (sort field response / sort=top / 不正 sort fallback)

### frontend
- \`client/src/lib/api/search.ts\`: \`fetchSearch(query, limit, sort)\` + \`SearchSort\` type export
- \`client/src/components/search/SearchExploreSurface.tsx\`: 検索結果 section に \`role=tablist\` + 「最新」 / 「注目」 Link tab、 aria-selected で active state、 URL \`?sort=top\` を append/remove (basePathname prop で /search / /explore 両対応)
- \`client/src/app/(template)/search/page.tsx\` + \`/explore/page.tsx\`: searchParams.sort 受け取り、 fetchSearch + Surface に渡し
- vitest 3 ケース追加: tab 表示 / sort=top active 反転 / basePathname=/explore href

## Test plan

- [x] vitest 877 pass | 1 todo (regression なし)
- [x] tsc clean / eslint clean
- [x] backend pytest (services 3 + views 3) → CI で実行
- [ ] stg 反映後 Playwright MCP で 4 枚スクショ:
  - logged-in /search?q=django (default=latest、 最新 tab active)
  - logged-in /search?q=django&sort=top (注目 active、 順序が異なることを確認)
  - logged-in /explore?q=django&sort=top (chrome 共有確認)
  - anon /search?q=django (sort tab 出ない、 promo のみ regression)

\`\`\`bash
# stg E2E (logged-in 必須)
cd client
PLAYWRIGHT_BASE_URL=https://stg.codeplace.me \\
PLAYWRIGHT_USER1_EMAIL=test4@example.com \\
PLAYWRIGHT_USER1_PASSWORD=E5INn9EaBLG7WNPl \\
  npx playwright test e2e/search-sort-tabs.spec.ts --reporter=line
\`\`\`

## Follow-up

- 本物の impression_count トラッキング (TweetView model / Celery batch / cache invalidation) — 別 issue で設計。 本 PR の engagement 代理指標は MVP として ship、 本物が来たら sort='top' の logic だけ差し替え可能。

## 関連

- #806 (chrome 統合 / SearchExploreSurface)
- #808 (anon search gate、 本 PR でも維持)