### PR TITLE
feat(users): Occupation model + API (Phase 12 P12-06) (#815)

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.utils.translation import gettext_lazy as _
 
 from .forms import UserChangeForm, UserCreationForm
-from .models import UserResidence
+from .models import Occupation, UserOccupation, UserResidence
 
 User = get_user_model()
 
@@ -98,3 +98,23 @@ class UserResidenceAdmin(admin.ModelAdmin):
     search_fields = ("user__username",)
     raw_id_fields = ("user",)
     readonly_fields = ("created_at", "updated_at")
+
+
+# Phase 12 P12-06: Occupation 管理。 ユーザーから新規 / 編集はできず、
+# admin だけが ``is_active=False`` で廃止 / 再有効化を行う。
+@admin.register(Occupation)
+class OccupationAdmin(admin.ModelAdmin):
+    list_display = ("slug", "display_name", "display_order", "is_active", "updated_at")
+    list_filter = ("is_active",)
+    search_fields = ("slug", "display_name")
+    list_editable = ("display_order", "is_active")
+    ordering = ("display_order", "slug")
+    readonly_fields = ("created_at", "updated_at")
+
+
+@admin.register(UserOccupation)
+class UserOccupationAdmin(admin.ModelAdmin):
+    list_display = ("id", "user", "occupation", "created_at")
+    list_select_related = ("user", "occupation")
+    raw_id_fields = ("user",)
+    search_fields = ("user__username", "occupation__slug")

--- a/apps/users/migrations/0009_occupation_useroccupation.py
+++ b/apps/users/migrations/0009_occupation_useroccupation.py
@@ -1,0 +1,102 @@
+"""Phase 12 P12-06: Occupation + UserOccupation schema migration.
+
+spec: docs/specs/phase-12-residence-map-spec.md §9
+"""
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0008_user_is_private"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Occupation",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("slug", models.SlugField(max_length=50, unique=True)),
+                ("display_name", models.CharField(max_length=50)),
+                ("display_order", models.PositiveSmallIntegerField(default=100)),
+                ("is_active", models.BooleanField(default=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "ordering": ["display_order", "slug"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="occupation",
+            index=models.Index(
+                fields=["is_active", "display_order"],
+                name="users_occ_active_order_idx",
+            ),
+        ),
+        migrations.CreateModel(
+            name="UserOccupation",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "occupation",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="user_occupations",
+                        to="users.occupation",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="user_occupations",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="useroccupation",
+            constraint=models.UniqueConstraint(
+                fields=("user", "occupation"),
+                name="user_occupation_unique",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="useroccupation",
+            index=models.Index(
+                fields=["occupation"],
+                name="user_occupation_occ_idx",
+            ),
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="occupations",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="users",
+                through="users.UserOccupation",
+                to="users.occupation",
+            ),
+        ),
+    ]

--- a/apps/users/migrations/0010_seed_occupations.py
+++ b/apps/users/migrations/0010_seed_occupations.py
@@ -1,0 +1,60 @@
+"""Phase 12 P12-06: Initial seed for Occupation (controlled vocabulary).
+
+spec: docs/specs/phase-12-residence-map-spec.md §9.3
+
+冪等 (``update_or_create``) — re-run しても重複を増やさない。
+admin から後で増減可能。
+"""
+
+from django.db import migrations
+
+INITIAL_OCCUPATIONS = [
+    # (slug, display_name, display_order)
+    ("designer", "デザイナー", 10),
+    ("frontend", "フロントエンドエンジニア", 20),
+    ("backend", "バックエンドエンジニア", 30),
+    ("fullstack", "フルスタックエンジニア", 40),
+    ("mobile", "モバイルエンジニア", 50),
+    ("ml", "ML / AI エンジニア", 60),
+    ("data", "データエンジニア / アナリスト", 70),
+    ("sre", "SRE / インフラ", 80),
+    ("security", "セキュリティ", 90),
+    ("game", "ゲーム開発", 100),
+    ("embedded", "組み込み / ハードウェア", 110),
+    ("qa", "QA / テスト", 120),
+    ("pm", "プロダクトマネージャ", 130),
+    ("em", "エンジニアリングマネージャ", 140),
+    ("student", "学生", 150),
+    ("other", "その他", 999),
+]
+
+
+def seed_occupations(apps, schema_editor):
+    Occupation = apps.get_model("users", "Occupation")
+    for slug, display_name, display_order in INITIAL_OCCUPATIONS:
+        Occupation.objects.update_or_create(
+            slug=slug,
+            defaults={
+                "display_name": display_name,
+                "display_order": display_order,
+                "is_active": True,
+            },
+        )
+
+
+def unseed_occupations(apps, schema_editor):
+    """rollback 時の cleanup。 admin が後から追加した行は触らないので、
+    INITIAL_OCCUPATIONS の slug のみ削除する。"""
+    Occupation = apps.get_model("users", "Occupation")
+    slugs = [s for s, _, _ in INITIAL_OCCUPATIONS]
+    Occupation.objects.filter(slug__in=slugs).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0009_occupation_useroccupation"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_occupations, unseed_occupations),
+    ]

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -119,6 +119,17 @@ class User(AbstractUser):
         ),
     )
 
+    # ---- Phase 12 P12-06: Occupation (職業) ----
+    # 1 user あたり最大 3 件 (``UserOccupation.MAX_PER_USER``)。
+    # ``Occupation`` / ``UserOccupation`` は同一 module 内、 定義順の都合で
+    # forward reference (文字列) で参照する。
+    occupations = models.ManyToManyField(
+        "Occupation",
+        through="UserOccupation",
+        related_name="users",
+        blank=True,
+    )
+
     # ---- 課金 / オンボーディング ----
     is_premium = models.BooleanField(
         verbose_name=_("Is Premium"),
@@ -288,3 +299,80 @@ class UserResidence(models.Model):
 
     def __str__(self) -> str:
         return f"UserResidence(user={self.user_id}, ({self.latitude},{self.longitude}) r={self.radius_m}m)"
+
+
+# --- Phase 12 (P12-06): Occupation ---
+
+
+class Occupation(models.Model):
+    """エンジニア職業の controlled vocabulary (Phase 12 P12-06)。
+
+    spec: docs/specs/phase-12-residence-map-spec.md §9
+
+    ``apps.tags.Tag`` (community-grown 技術タグ) と違って admin seed / 管理。
+    User からは編集不可、 ``UserOccupation`` (through M2M) で紐付ける。
+    廃止時は ``is_active=False`` (soft delete) を使う — 既に紐付いた user の
+    過去データを壊さないため。
+    """
+
+    slug = models.SlugField(max_length=50, unique=True)
+    display_name = models.CharField(max_length=50)
+    display_order = models.PositiveSmallIntegerField(default=100)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        # admin 一覧 + API list で「人気順に近い任意の sort 軸」 として
+        # display_order を使う。 同順は slug ASC で安定。
+        ordering = ["display_order", "slug"]
+        indexes = [
+            # API list の絞り込み (is_active=True 前提) を index 利用可にする。
+            models.Index(
+                fields=["is_active", "display_order"],
+                name="users_occ_active_order_idx",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return self.display_name
+
+
+class UserOccupation(models.Model):
+    """User ↔ Occupation の through (Phase 12 P12-06)。
+
+    将来 ``is_primary`` (主な職業 1 件) を追加できるよう through 化している。
+    今は flat M2M として使う。
+    """
+
+    # 1 user あたりの最大件数。 serializer 層で enforce する (DB の CHECK には
+    # GROUP BY 制約が無いので app 層で見る)。
+    MAX_PER_USER = 3
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="user_occupations",
+    )
+    occupation = models.ForeignKey(
+        Occupation,
+        on_delete=models.CASCADE,
+        related_name="user_occupations",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "occupation"],
+                name="user_occupation_unique",
+            ),
+        ]
+        indexes = [
+            # 検索 API の ``?occupation=slug`` filter (P12-07) で
+            # ``occupation_id`` を JOIN するため。
+            models.Index(fields=["occupation"], name="user_occupation_occ_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"UserOccupation(user={self.user_id}, occ={self.occupation_id})"

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -151,10 +151,10 @@ class PublicProfileSerializer(serializers.ModelSerializer):
     # 公開プロフィール上に chip 表示するため slug + display_name のみを露出する。
     occupations = serializers.SerializerMethodField()
 
-    def get_occupations(self, obj: User) -> list[dict]:
+    def get_occupations(self, obj: User) -> list[dict[str, str]]:
         # ``user.occupations.all()`` は M2M で、 ``Occupation.Meta.ordering``
-        # (display_order ASC) を継承する。 必要なら view 側で
-        # ``prefetch_related("occupations")`` を入れて N+1 を防ぐ。
+        # (display_order ASC) を継承する。 ``PublicProfileView.get_queryset``
+        # が ``prefetch_related("occupations")`` を入れているので N+1 にならない。
         return [{"slug": o.slug, "display_name": o.display_name} for o in obj.occupations.all()]
 
     def get_is_following(self, obj: User) -> bool:
@@ -364,7 +364,8 @@ class MyOccupationsWriteSerializer(serializers.Serializer):
             )
             missing = [s for s in value if s not in existing]
             if missing:
+                # ``value`` は事前に重複チェック済みなので ``missing`` も重複しない。
                 raise serializers.ValidationError(
-                    f"未知または廃止された職業: {', '.join(sorted(set(missing)))}"
+                    f"未知または廃止された職業: {', '.join(sorted(missing))}"
                 )
         return value

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -6,7 +6,7 @@ from django.core.validators import URLValidator
 from djoser.serializers import UserCreateSerializer, UserSerializer
 from rest_framework import serializers
 
-from apps.users.models import UserResidence
+from apps.users.models import Occupation, UserOccupation, UserResidence
 from apps.users.s3_presign import ALLOWED_CONTENT_TYPES, MAX_CONTENT_LENGTH
 from apps.users.validators import validate_handle, validate_media_url
 
@@ -147,6 +147,15 @@ class PublicProfileSerializer(serializers.ModelSerializer):
     is_muting = serializers.SerializerMethodField()
     # Phase 4B (#449): ReportDialog で target_id (UUID) として送る。
     user_id = serializers.UUIDField(source="id", read_only=True)
+    # Phase 12 P12-06: 職業 (controlled vocabulary)。
+    # 公開プロフィール上に chip 表示するため slug + display_name のみを露出する。
+    occupations = serializers.SerializerMethodField()
+
+    def get_occupations(self, obj: User) -> list[dict]:
+        # ``user.occupations.all()`` は M2M で、 ``Occupation.Meta.ordering``
+        # (display_order ASC) を継承する。 必要なら view 側で
+        # ``prefetch_related("occupations")`` を入れて N+1 を防ぐ。
+        return [{"slug": o.slug, "display_name": o.display_name} for o in obj.occupations.all()]
 
     def get_is_following(self, obj: User) -> bool:
         request = self.context.get("request")
@@ -230,6 +239,8 @@ class PublicProfileSerializer(serializers.ModelSerializer):
             # - follow_status: viewer→obj への follow 状態 (approved | pending | null)
             "is_private",
             "follow_status",
+            # Phase 12 P12-06: occupation chip 一覧 (空配列なら未設定)。
+            "occupations",
         ]
         # 公開 API はすべて read_only (PATCH は /me/ 経由のみ)。
         # ``fields`` と同じ list を参照させると、DRF 内部で片方に mutate が走った
@@ -286,3 +297,74 @@ class UserResidenceWriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserResidence
         fields = ["latitude", "longitude", "radius_m"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 12 P12-06: Occupation (controlled vocabulary of engineer roles)
+# ---------------------------------------------------------------------------
+
+
+class OccupationSerializer(serializers.ModelSerializer):
+    """``GET /api/v1/occupations/`` の read-only serializer.
+
+    ``is_active`` は API には露出させない (廃止職業は list view 側で
+    そもそも除外するため、 client は気にする必要が無い)。
+    """
+
+    class Meta:
+        model = Occupation
+        fields = ["slug", "display_name", "display_order"]
+        read_only_fields = list(fields)
+
+
+class MyOccupationsReadSerializer(serializers.Serializer):
+    """``GET /api/v1/users/me/occupations/`` の read serializer。
+
+    response shape: ``{"slugs": [...]}``。 順序は ``Occupation.Meta.ordering``
+    (= display_order ASC) を継承する。
+    """
+
+    slugs = serializers.ListField(child=serializers.CharField(), read_only=True)
+
+
+class MyOccupationsWriteSerializer(serializers.Serializer):
+    """``PUT /api/v1/users/me/occupations/`` の write serializer.
+
+    body: ``{"slugs": [...]}`` — **置換** semantics。 既存 UserOccupation を
+    すべて消してから request の slug 集合に置き換える。
+
+    validation:
+      - ``slugs`` が array で無ければ 400
+      - 要素が string で無ければ 400
+      - 重複 slug は 400 (client 側の bug を早期検知)
+      - len > MAX_PER_USER (= 3) は 400
+      - 未知 slug は 400
+      - ``is_active=False`` の slug は 400 (廃止職業は選択不可)
+    """
+
+    slugs = serializers.ListField(
+        child=serializers.CharField(allow_blank=False, max_length=50),
+        allow_empty=True,
+    )
+
+    def validate_slugs(self, value: list[str]) -> list[str]:
+        if len(value) > UserOccupation.MAX_PER_USER:
+            raise serializers.ValidationError(
+                f"職業は最大 {UserOccupation.MAX_PER_USER} 件まで選択できます。"
+            )
+        if len(set(value)) != len(value):
+            raise serializers.ValidationError("同じ職業を複数回指定することはできません。")
+
+        if value:
+            # 1 query で active occupation を全部引いて差集合で検証 (N+1 防止)。
+            existing = set(
+                Occupation.objects.filter(slug__in=value, is_active=True).values_list(
+                    "slug", flat=True
+                )
+            )
+            missing = [s for s in value if s not in existing]
+            if missing:
+                raise serializers.ValidationError(
+                    f"未知または廃止された職業: {', '.join(sorted(set(missing)))}"
+                )
+        return value

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -317,16 +317,6 @@ class OccupationSerializer(serializers.ModelSerializer):
         read_only_fields = list(fields)
 
 
-class MyOccupationsReadSerializer(serializers.Serializer):
-    """``GET /api/v1/users/me/occupations/`` の read serializer。
-
-    response shape: ``{"slugs": [...]}``。 順序は ``Occupation.Meta.ordering``
-    (= display_order ASC) を継承する。
-    """
-
-    slugs = serializers.ListField(child=serializers.CharField(), read_only=True)
-
-
 class MyOccupationsWriteSerializer(serializers.Serializer):
     """``PUT /api/v1/users/me/occupations/`` の write serializer.
 

--- a/apps/users/tests/test_occupation.py
+++ b/apps/users/tests/test_occupation.py
@@ -25,16 +25,36 @@ from apps.users.models import Occupation, UserOccupation
 
 @pytest.fixture
 def occupations(db):
-    """seed が migration 経由で入っている想定だが、 test では明示的に作る。"""
-    items = [
-        Occupation.objects.create(slug="designer", display_name="デザイナー", display_order=10),
-        Occupation.objects.create(slug="frontend", display_name="フロントエンド", display_order=20),
-        Occupation.objects.create(slug="backend", display_name="バックエンド", display_order=30),
-        Occupation.objects.create(
-            slug="deprecated", display_name="廃止職業", display_order=999, is_active=False
-        ),
-    ]
-    return {o.slug: o for o in items}
+    """Phase 12 P12-06 の seed migration (0010_seed_occupations) が test DB にも
+    走るため、 ``create()`` だと slug の UNIQUE 制約に衝突する (code-reviewer HIGH)。
+    seed と同じ slug で ``get_or_create`` してデフォルト値を上書きしないことで、
+    test に必要な subset の Occupation を取得し、 廃止職業 (``deprecated``) は
+    test 用 slug として新規作成する。"""
+
+    designer, _ = Occupation.objects.get_or_create(
+        slug="designer",
+        defaults={"display_name": "デザイナー", "display_order": 10},
+    )
+    frontend, _ = Occupation.objects.get_or_create(
+        slug="frontend",
+        defaults={"display_name": "フロントエンド", "display_order": 20},
+    )
+    backend, _ = Occupation.objects.get_or_create(
+        slug="backend",
+        defaults={"display_name": "バックエンド", "display_order": 30},
+    )
+    deprecated, _ = Occupation.objects.get_or_create(
+        slug="test_deprecated",
+        defaults={"display_name": "廃止職業 (test)", "display_order": 999, "is_active": False},
+    )
+    return {
+        "designer": designer,
+        "frontend": frontend,
+        "backend": backend,
+        # test_deprecated を fixture key としては ``deprecated`` で公開し、
+        # test 内のアサーションを seed-aware にする。
+        "deprecated": deprecated,
+    }
 
 
 @pytest.fixture
@@ -59,25 +79,31 @@ def public_profile_url(handle: str) -> str:
 @pytest.mark.django_db
 @pytest.mark.unit
 class TestOccupationModel:
+    """seed migration (0010_seed_occupations) と衝突しないよう、 test 専用
+    slug (`zz_test_*` prefix、 seed の display_order 範囲を避けて 1000+) を使う。"""
+
     def test_slug_is_unique(self) -> None:
-        Occupation.objects.create(slug="designer", display_name="デザイナー")
+        Occupation.objects.create(slug="zz_test_unique", display_name="t")
         with pytest.raises(IntegrityError):
-            Occupation.objects.create(slug="designer", display_name="重複")
+            Occupation.objects.create(slug="zz_test_unique", display_name="重複")
 
     def test_str_returns_display_name(self) -> None:
-        occ = Occupation.objects.create(slug="frontend", display_name="フロントエンド")
-        assert str(occ) == "フロントエンド"
+        occ = Occupation.objects.create(slug="zz_test_str", display_name="表示名テスト")
+        assert str(occ) == "表示名テスト"
 
     def test_default_ordering_is_display_order_then_slug(self) -> None:
-        Occupation.objects.create(slug="b", display_name="B", display_order=20)
-        Occupation.objects.create(slug="a", display_name="A", display_order=10)
-        Occupation.objects.create(slug="c", display_name="C", display_order=10)
-        ordered = list(Occupation.objects.values_list("slug", flat=True))
-        # display_order ASC、 同順なら slug ASC で安定
-        assert ordered == ["a", "c", "b"]
+        # seed と衝突しない範囲で display_order を確保。 seed の最大は 999 (other)。
+        Occupation.objects.create(slug="zz_b", display_name="B", display_order=2000)
+        Occupation.objects.create(slug="zz_a", display_name="A", display_order=1000)
+        Occupation.objects.create(slug="zz_c", display_name="C", display_order=1000)
+        # zz_* prefix だけに絞れば test fixture の影響を受けない
+        ordered = list(
+            Occupation.objects.filter(slug__startswith="zz_").values_list("slug", flat=True)
+        )
+        assert ordered == ["zz_a", "zz_c", "zz_b"]
 
     def test_is_active_default_true(self) -> None:
-        occ = Occupation.objects.create(slug="x", display_name="X")
+        occ = Occupation.objects.create(slug="zz_test_active", display_name="X")
         assert occ.is_active is True
 
 
@@ -122,20 +148,28 @@ class TestUserOccupationModel:
 @pytest.mark.django_db
 @pytest.mark.integration
 class TestOccupationListAPI:
+    """seed migration で 16 件の active occupation が既に入っている前提で、
+    fixture が追加する ``test_deprecated`` (inactive) は API list に出ない
+    ことだけを exhaustive に検証する。 全件 list 等価は seed に依存して
+    脆くなるので、 部分的な性質 (順序 / 含有 / 形状) で検証する。"""
+
     def test_anon_can_list(self, api_client: APIClient, occupations, occupations_url: str) -> None:
         res = api_client.get(occupations_url)
         assert res.status_code == status.HTTP_200_OK
         slugs = [o["slug"] for o in res.data]
-        # is_active=False は除外
-        assert "deprecated" not in slugs
+        # fixture の test_deprecated は is_active=False なので除外される
+        assert "test_deprecated" not in slugs
+        # seed の active 16 件は全部入る (sanity check)
+        assert "designer" in slugs and "frontend" in slugs
 
     def test_ordering_is_display_order(
         self, api_client: APIClient, occupations, occupations_url: str
     ) -> None:
         res = api_client.get(occupations_url)
         slugs = [o["slug"] for o in res.data]
-        # designer (10) → frontend (20) → backend (30)
-        assert slugs == ["designer", "frontend", "backend"]
+        # display_order: designer(10) < frontend(20) < backend(30)。
+        # seed の他の active 行が間に挟まることはないので index 比較で十分。
+        assert slugs.index("designer") < slugs.index("frontend") < slugs.index("backend")
 
     def test_shape_contains_required_fields(
         self, api_client: APIClient, occupations, occupations_url: str
@@ -251,7 +285,7 @@ class TestMyOccupationsAPI:
         occupations,
         me_occupations_url: str,
     ) -> None:
-        Occupation.objects.create(slug="fullstack", display_name="フルスタック", display_order=40)
+        # seed migration で fullstack も入っているので create 不要。
         user = user_factory()
         api_client.force_authenticate(user=user)
 
@@ -263,6 +297,46 @@ class TestMyOccupationsAPI:
 
         assert res.status_code == status.HTTP_400_BAD_REQUEST
         assert "slugs" in res.data
+
+    def test_put_exactly_max_three_allowed(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        """境界値: ちょうど 3 件 (= MAX_PER_USER) は成功する (spec §9.6 0→3)。"""
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(
+            me_occupations_url,
+            {"slugs": ["designer", "frontend", "backend"]},
+            format="json",
+        )
+
+        assert res.status_code == status.HTTP_200_OK
+        assert set(res.data["slugs"]) == {"designer", "frontend", "backend"}
+        assert UserOccupation.objects.filter(user=user).count() == 3
+
+    def test_put_three_to_one_replacement(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        """spec §9.6 (3→1): 既存 3 件状態から 1 件に絞る。"""
+        user = user_factory()
+        for slug in ("designer", "frontend", "backend"):
+            UserOccupation.objects.create(user=user, occupation=occupations[slug])
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(me_occupations_url, {"slugs": ["designer"]}, format="json")
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data == {"slugs": ["designer"]}
+        assert UserOccupation.objects.filter(user=user).count() == 1
 
     def test_put_unknown_slug_rejected(
         self,
@@ -289,7 +363,7 @@ class TestMyOccupationsAPI:
         user = user_factory()
         api_client.force_authenticate(user=user)
 
-        res = api_client.put(me_occupations_url, {"slugs": ["deprecated"]}, format="json")
+        res = api_client.put(me_occupations_url, {"slugs": ["test_deprecated"]}, format="json")
 
         assert res.status_code == status.HTTP_400_BAD_REQUEST
         assert "slugs" in res.data

--- a/apps/users/tests/test_occupation.py
+++ b/apps/users/tests/test_occupation.py
@@ -338,6 +338,43 @@ class TestMyOccupationsAPI:
         assert res.data == {"slugs": ["designer"]}
         assert UserOccupation.objects.filter(user=user).count() == 1
 
+    def test_put_race_window_rolls_back_delete(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        """database-reviewer HIGH regression:
+
+        validate 後、 view 内の `Occupation.filter(is_active=True)` 直前に
+        admin が ``is_active=False`` に flip した race window では、 事前に
+        実行した DELETE を ``transaction.set_rollback(True)`` で巻き戻す
+        必要がある。 ``with atomic(): return Response(409)`` だけでは block が
+        正常終了扱いで commit され、 既存 occupations が消えたまま残る。
+
+        この test は view 側の ``Occupation`` を mock で空 queryset を返すよう
+        差し替えて race window を再現し、 409 が返り、 かつ事前 DELETE が
+        rollback されて元の 1 件が残ることを exhaustive に検証する。
+        """
+        from unittest.mock import patch
+
+        user = user_factory()
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        api_client.force_authenticate(user=user)
+
+        # serializer の ``validate_slugs`` は別 module の ``Occupation`` を
+        # 参照しているので validate は通常通り pass する。 ここで差し替えるのは
+        # ``views_occupation.Occupation`` だけなので、 「validate OK / view 内
+        # filter で空」 という race window がきれいに再現できる。
+        with patch("apps.users.views_occupation.Occupation") as mocked:
+            mocked.objects.filter.return_value = []
+            res = api_client.put(me_occupations_url, {"slugs": ["frontend"]}, format="json")
+
+        assert res.status_code == status.HTTP_409_CONFLICT
+        # 事前 DELETE がロールバックされて、 元の designer が残っていること。
+        assert list(user.occupations.values_list("slug", flat=True)) == ["designer"]
+
     def test_put_unknown_slug_rejected(
         self,
         api_client: APIClient,

--- a/apps/users/tests/test_occupation.py
+++ b/apps/users/tests/test_occupation.py
@@ -1,0 +1,390 @@
+"""
+Occupation / UserOccupation (Phase 12 P12-06) のテスト。
+
+対象:
+- Occupation model (controlled vocabulary)
+- UserOccupation through model (User ↔ Occupation の M2M)
+- GET    /api/v1/occupations/                   : anon 可、 is_active=True を display_order 順
+- GET    /api/v1/users/me/occupations/          : auth、 自分の slug 配列
+- PUT    /api/v1/users/me/occupations/          : auth、 body {"slugs": [...]} で置換 (最大 3)
+- GET    /api/v1/users/<handle>/                : profile response に occupations 配列
+
+spec: docs/specs/phase-12-residence-map-spec.md §9
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db.utils import IntegrityError
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.users.models import Occupation, UserOccupation
+
+
+@pytest.fixture
+def occupations(db):
+    """seed が migration 経由で入っている想定だが、 test では明示的に作る。"""
+    items = [
+        Occupation.objects.create(slug="designer", display_name="デザイナー", display_order=10),
+        Occupation.objects.create(slug="frontend", display_name="フロントエンド", display_order=20),
+        Occupation.objects.create(slug="backend", display_name="バックエンド", display_order=30),
+        Occupation.objects.create(
+            slug="deprecated", display_name="廃止職業", display_order=999, is_active=False
+        ),
+    ]
+    return {o.slug: o for o in items}
+
+
+@pytest.fixture
+def occupations_url() -> str:
+    return reverse("occupations-list")
+
+
+@pytest.fixture
+def me_occupations_url() -> str:
+    return reverse("users-me-occupations")
+
+
+def public_profile_url(handle: str) -> str:
+    return reverse("users-public-profile", kwargs={"username": handle})
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestOccupationModel:
+    def test_slug_is_unique(self) -> None:
+        Occupation.objects.create(slug="designer", display_name="デザイナー")
+        with pytest.raises(IntegrityError):
+            Occupation.objects.create(slug="designer", display_name="重複")
+
+    def test_str_returns_display_name(self) -> None:
+        occ = Occupation.objects.create(slug="frontend", display_name="フロントエンド")
+        assert str(occ) == "フロントエンド"
+
+    def test_default_ordering_is_display_order_then_slug(self) -> None:
+        Occupation.objects.create(slug="b", display_name="B", display_order=20)
+        Occupation.objects.create(slug="a", display_name="A", display_order=10)
+        Occupation.objects.create(slug="c", display_name="C", display_order=10)
+        ordered = list(Occupation.objects.values_list("slug", flat=True))
+        # display_order ASC、 同順なら slug ASC で安定
+        assert ordered == ["a", "c", "b"]
+
+    def test_is_active_default_true(self) -> None:
+        occ = Occupation.objects.create(slug="x", display_name="X")
+        assert occ.is_active is True
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestUserOccupationModel:
+    def test_unique_per_user_and_occupation(self, user_factory, occupations) -> None:
+        user = user_factory()
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        with pytest.raises(IntegrityError):
+            UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+
+    def test_user_cascade(self, user_factory, occupations) -> None:
+        user = user_factory()
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        user.delete()
+        assert UserOccupation.objects.count() == 0
+
+    def test_occupation_cascade(self, user_factory, occupations) -> None:
+        user = user_factory()
+        occ = occupations["designer"]
+        UserOccupation.objects.create(user=user, occupation=occ)
+        occ.delete()
+        assert UserOccupation.objects.count() == 0
+
+    def test_user_m2m_returns_occupations(self, user_factory, occupations) -> None:
+        user = user_factory()
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        UserOccupation.objects.create(user=user, occupation=occupations["frontend"])
+        slugs = set(user.occupations.values_list("slug", flat=True))
+        assert slugs == {"designer", "frontend"}
+
+    def test_max_per_user_constant_is_three(self) -> None:
+        assert UserOccupation.MAX_PER_USER == 3
+
+
+# ---------------------------------------------------------------------------
+# API: GET /api/v1/occupations/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestOccupationListAPI:
+    def test_anon_can_list(self, api_client: APIClient, occupations, occupations_url: str) -> None:
+        res = api_client.get(occupations_url)
+        assert res.status_code == status.HTTP_200_OK
+        slugs = [o["slug"] for o in res.data]
+        # is_active=False は除外
+        assert "deprecated" not in slugs
+
+    def test_ordering_is_display_order(
+        self, api_client: APIClient, occupations, occupations_url: str
+    ) -> None:
+        res = api_client.get(occupations_url)
+        slugs = [o["slug"] for o in res.data]
+        # designer (10) → frontend (20) → backend (30)
+        assert slugs == ["designer", "frontend", "backend"]
+
+    def test_shape_contains_required_fields(
+        self, api_client: APIClient, occupations, occupations_url: str
+    ) -> None:
+        res = api_client.get(occupations_url)
+        assert res.status_code == status.HTTP_200_OK
+        assert {"slug", "display_name", "display_order"} <= set(res.data[0].keys())
+        # is_active は API 露出しない (廃止職業はそもそも返らない、 露出する意味がない)
+        assert "is_active" not in res.data[0]
+
+
+# ---------------------------------------------------------------------------
+# API: /api/v1/users/me/occupations/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestMyOccupationsAPI:
+    def test_get_requires_auth(self, api_client: APIClient, me_occupations_url: str) -> None:
+        res = api_client.get(me_occupations_url)
+        assert res.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    def test_put_requires_auth(self, api_client: APIClient, me_occupations_url: str) -> None:
+        res = api_client.put(me_occupations_url, {"slugs": ["designer"]}, format="json")
+        assert res.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    def test_get_empty_when_not_set(
+        self, api_client: APIClient, user_factory, me_occupations_url: str
+    ) -> None:
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+        res = api_client.get(me_occupations_url)
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data == {"slugs": []}
+
+    def test_get_returns_user_slugs(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        UserOccupation.objects.create(user=user, occupation=occupations["frontend"])
+        api_client.force_authenticate(user=user)
+
+        res = api_client.get(me_occupations_url)
+
+        assert res.status_code == status.HTTP_200_OK
+        assert set(res.data["slugs"]) == {"designer", "frontend"}
+
+    def test_put_creates_from_empty(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(
+            me_occupations_url,
+            {"slugs": ["designer", "frontend"]},
+            format="json",
+        )
+
+        assert res.status_code == status.HTTP_200_OK
+        assert set(res.data["slugs"]) == {"designer", "frontend"}
+        assert UserOccupation.objects.filter(user=user).count() == 2
+
+    def test_put_replaces_existing(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        UserOccupation.objects.create(user=user, occupation=occupations["frontend"])
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(me_occupations_url, {"slugs": ["backend"]}, format="json")
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data == {"slugs": ["backend"]}
+        assert list(user.occupations.values_list("slug", flat=True)) == ["backend"]
+
+    def test_put_empty_clears_all(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(me_occupations_url, {"slugs": []}, format="json")
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data == {"slugs": []}
+        assert UserOccupation.objects.filter(user=user).count() == 0
+
+    def test_put_more_than_max_rejected(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        Occupation.objects.create(slug="fullstack", display_name="フルスタック", display_order=40)
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(
+            me_occupations_url,
+            {"slugs": ["designer", "frontend", "backend", "fullstack"]},
+            format="json",
+        )
+
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "slugs" in res.data
+
+    def test_put_unknown_slug_rejected(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(me_occupations_url, {"slugs": ["nonexistent"]}, format="json")
+
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "slugs" in res.data
+
+    def test_put_inactive_slug_rejected(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(me_occupations_url, {"slugs": ["deprecated"]}, format="json")
+
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "slugs" in res.data
+
+    def test_put_duplicate_slug_rejected(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(
+            me_occupations_url,
+            {"slugs": ["designer", "designer"]},
+            format="json",
+        )
+
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "slugs" in res.data
+
+    def test_put_non_array_rejected(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(me_occupations_url, {"slugs": "designer"}, format="json")
+
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_put_missing_slugs_field_rejected(
+        self,
+        api_client: APIClient,
+        user_factory,
+        me_occupations_url: str,
+    ) -> None:
+        user = user_factory()
+        api_client.force_authenticate(user=user)
+
+        res = api_client.put(me_occupations_url, {}, format="json")
+
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Profile API integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUserProfileOccupationField:
+    def test_profile_includes_occupations(
+        self, api_client: APIClient, user_factory, occupations
+    ) -> None:
+        user = user_factory(username="alice_test")
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+        UserOccupation.objects.create(user=user, occupation=occupations["frontend"])
+
+        res = api_client.get(public_profile_url("alice_test"))
+
+        assert res.status_code == status.HTTP_200_OK
+        assert "occupations" in res.data
+        returned_slugs = {o["slug"] for o in res.data["occupations"]}
+        assert returned_slugs == {"designer", "frontend"}
+
+    def test_profile_empty_occupations_for_user_without_any(
+        self, api_client: APIClient, user_factory
+    ) -> None:
+        user_factory(username="bob_test")
+
+        res = api_client.get(public_profile_url("bob_test"))
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["occupations"] == []
+
+    def test_profile_occupation_shape(
+        self, api_client: APIClient, user_factory, occupations
+    ) -> None:
+        user = user_factory(username="carol_test")
+        UserOccupation.objects.create(user=user, occupation=occupations["designer"])
+
+        res = api_client.get(public_profile_url("carol_test"))
+
+        assert res.status_code == status.HTTP_200_OK
+        occ = res.data["occupations"][0]
+        assert occ["slug"] == "designer"
+        assert occ["display_name"] == "デザイナー"
+        # 内部 field は露出しない
+        assert "is_active" not in occ
+        assert "created_at" not in occ

--- a/apps/users/tests/test_profile_api.py
+++ b/apps/users/tests/test_profile_api.py
@@ -61,6 +61,8 @@ EXPECTED_PUBLIC_KEYS = {
     # #735: 鍵アカ機能。 FollowButton の 3 状態 + 「非公開アカウント」 表示用。
     "is_private",
     "follow_status",
+    # Phase 12 P12-06: 職業 chip (controlled vocabulary)。 空配列なら未設定。
+    "occupations",
 }
 
 

--- a/apps/users/urls_profile.py
+++ b/apps/users/urls_profile.py
@@ -26,13 +26,13 @@ from .views import (
     CompleteOnboardingView,
     HeaderUploadUrlView,
     MeView,
-    MyOccupationsView,
     MyUserResidenceView,
     PublicProfileView,
     UserFullTextSearchView,
     UserResidenceByHandleView,
     UserSearchView,
 )
+from .views_occupation import MyOccupationsView
 
 urlpatterns = [
     # Issue #480: handle 前方一致検索 (autocomplete 用)。

--- a/apps/users/urls_profile.py
+++ b/apps/users/urls_profile.py
@@ -26,6 +26,7 @@ from .views import (
     CompleteOnboardingView,
     HeaderUploadUrlView,
     MeView,
+    MyOccupationsView,
     MyUserResidenceView,
     PublicProfileView,
     UserFullTextSearchView,
@@ -69,6 +70,13 @@ urlpatterns = [
         "me/residence/",
         MyUserResidenceView.as_view(),
         name="users-me-residence",
+    ),
+    # P12-06: 自分の occupations (職業) を取得 / 置換する。
+    # me/ 系として <str:username>/ より前に登録 (greedy 回避)。
+    path(
+        "me/occupations/",
+        MyOccupationsView.as_view(),
+        name="users-me-occupations",
     ),
     path("<str:username>/", PublicProfileView.as_view(), name="users-public-profile"),
     # P12-01: 他人の居住地参照 (anon 閲覧可)。 PublicProfileView より長い path なので

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -24,10 +24,13 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from apps.common.cookie_auth import CookieAuthentication, CSRFEnforcingAuthentication
-from apps.users.models import UserResidence
+from apps.users.models import Occupation, UserOccupation, UserResidence
 from apps.users.s3_presign import generate_presigned_upload_url
 from apps.users.serializers import (
     CustomUserSerializer,
+    MyOccupationsReadSerializer,
+    MyOccupationsWriteSerializer,
+    OccupationSerializer,
     PublicProfileSerializer,
     UploadUrlRequestSerializer,
     UserResidenceSerializer,
@@ -1030,3 +1033,62 @@ class UserFullTextSearchView(ListAPIView):
         # paginator (UserSearchProximityCursorPagination) も同じ ordering を持つので
         # 上書きされるが、 get_queryset 単体で使う pytest 経路でも安定するよう明示する。
         return qs.order_by("_distance_km", "username")
+
+
+# ---------------------------------------------------------------------------
+# Phase 12 P12-06: Occupation API
+# ---------------------------------------------------------------------------
+
+
+class OccupationListView(ListAPIView):
+    """``GET /api/v1/occupations/``: controlled vocabulary を返す (anon 可)。
+
+    廃止職業 (``is_active=False``) は除外。 ordering は
+    ``Occupation.Meta.ordering`` (= ``display_order, slug``)。
+    pagination は無し (16 件程度のため)。
+    """
+
+    serializer_class = OccupationSerializer
+    permission_classes = [AllowAny]
+    pagination_class = None
+
+    def get_queryset(self) -> QuerySet:
+        return Occupation.objects.filter(is_active=True)
+
+
+class MyOccupationsView(APIView):
+    """``/api/v1/users/me/occupations/`` — 自分の occupations の GET / PUT.
+
+    - GET: ``{"slugs": [...]}`` で自分の slug 配列を返す。 未設定は空配列。
+    - PUT: ``{"slugs": [...]}`` で **置換** semantics。 最大 3 件。
+
+    認証は Cookie + CSRF を経由する。 DRF の標準動作で 401/403 が出る。
+    """
+
+    permission_classes = [IsAuthenticated]
+    parser_classes = [JSONParser]
+
+    def get(self, request: Request) -> Response:
+        slugs = list(request.user.occupations.filter(is_active=True).values_list("slug", flat=True))
+        return Response(
+            MyOccupationsReadSerializer({"slugs": slugs}).data,
+            status=status.HTTP_200_OK,
+        )
+
+    def put(self, request: Request) -> Response:
+        serializer = MyOccupationsWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        slugs: list[str] = serializer.validated_data["slugs"]
+
+        # 置換: 既存 UserOccupation を全消ししてから新しい slug 集合を bulk insert。
+        # トランザクション内で実行して、 中途半端な状態を残さない。
+        with transaction.atomic():
+            UserOccupation.objects.filter(user=request.user).delete()
+            if slugs:
+                occupations = Occupation.objects.filter(slug__in=slugs, is_active=True)
+                UserOccupation.objects.bulk_create(
+                    [UserOccupation(user=request.user, occupation=o) for o in occupations]
+                )
+
+        # response は GET と同じ shape (今 DB に入っている slug を返す)。
+        return self.get(request)

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -604,7 +604,11 @@ class PublicProfileView(RetrieveAPIView):
     # 表現できない。代わりに ``get_object()`` を override する。
 
     def get_queryset(self):
-        return User.objects.filter(is_active=True)
+        # Phase 12 P12-06: ``PublicProfileSerializer.get_occupations`` が
+        # ``obj.occupations.all()`` を呼ぶため、 ここで M2M を prefetch して
+        # N+1 を防ぐ。 シングル取得でも 2 query → 1+1 = 2 query で同等だが、
+        # 将来 list 文脈で再利用されたときの保険として明示する。
+        return User.objects.filter(is_active=True).prefetch_related("occupations")
 
     def get_object(self):
         """username の大文字小文字を無視して解決する。
@@ -1062,11 +1066,17 @@ class MyOccupationsView(APIView):
     - GET: ``{"slugs": [...]}`` で自分の slug 配列を返す。 未設定は空配列。
     - PUT: ``{"slugs": [...]}`` で **置換** semantics。 最大 3 件。
 
-    認証は Cookie + CSRF を経由する。 DRF の標準動作で 401/403 が出る。
+    認証は Cookie + CSRF。 ``MyUserResidenceView`` 等プロジェクトの状態変更
+    エンドポイントと揃えて ``CSRFEnforcingAuthentication`` を明示する
+    (グローバル fallback の ``JWTAuthentication`` では PUT 時に CSRF が
+    効かない経路があるため、 二重防衛のために authentication_classes を明示)。
     """
 
+    authentication_classes = [CSRFEnforcingAuthentication, CookieAuthentication]
     permission_classes = [IsAuthenticated]
     parser_classes = [JSONParser]
+    # 意図しない HTTP method 経由の副作用を防ぐ (プロジェクト規約)。
+    http_method_names = ["get", "put", "head", "options"]
 
     def get(self, request: Request) -> Response:
         slugs = list(request.user.occupations.filter(is_active=True).values_list("slug", flat=True))

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -24,13 +24,10 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from apps.common.cookie_auth import CookieAuthentication, CSRFEnforcingAuthentication
-from apps.users.models import Occupation, UserOccupation, UserResidence
+from apps.users.models import UserResidence
 from apps.users.s3_presign import generate_presigned_upload_url
 from apps.users.serializers import (
     CustomUserSerializer,
-    MyOccupationsReadSerializer,
-    MyOccupationsWriteSerializer,
-    OccupationSerializer,
     PublicProfileSerializer,
     UploadUrlRequestSerializer,
     UserResidenceSerializer,
@@ -1039,66 +1036,5 @@ class UserFullTextSearchView(ListAPIView):
         return qs.order_by("_distance_km", "username")
 
 
-# ---------------------------------------------------------------------------
-# Phase 12 P12-06: Occupation API
-# ---------------------------------------------------------------------------
-
-
-class OccupationListView(ListAPIView):
-    """``GET /api/v1/occupations/``: controlled vocabulary を返す (anon 可)。
-
-    廃止職業 (``is_active=False``) は除外。 ordering は
-    ``Occupation.Meta.ordering`` (= ``display_order, slug``)。
-    pagination は無し (16 件程度のため)。
-    """
-
-    serializer_class = OccupationSerializer
-    permission_classes = [AllowAny]
-    pagination_class = None
-
-    def get_queryset(self) -> QuerySet:
-        return Occupation.objects.filter(is_active=True)
-
-
-class MyOccupationsView(APIView):
-    """``/api/v1/users/me/occupations/`` — 自分の occupations の GET / PUT.
-
-    - GET: ``{"slugs": [...]}`` で自分の slug 配列を返す。 未設定は空配列。
-    - PUT: ``{"slugs": [...]}`` で **置換** semantics。 最大 3 件。
-
-    認証は Cookie + CSRF。 ``MyUserResidenceView`` 等プロジェクトの状態変更
-    エンドポイントと揃えて ``CSRFEnforcingAuthentication`` を明示する
-    (グローバル fallback の ``JWTAuthentication`` では PUT 時に CSRF が
-    効かない経路があるため、 二重防衛のために authentication_classes を明示)。
-    """
-
-    authentication_classes = [CSRFEnforcingAuthentication, CookieAuthentication]
-    permission_classes = [IsAuthenticated]
-    parser_classes = [JSONParser]
-    # 意図しない HTTP method 経由の副作用を防ぐ (プロジェクト規約)。
-    http_method_names = ["get", "put", "head", "options"]
-
-    def get(self, request: Request) -> Response:
-        slugs = list(request.user.occupations.filter(is_active=True).values_list("slug", flat=True))
-        return Response(
-            MyOccupationsReadSerializer({"slugs": slugs}).data,
-            status=status.HTTP_200_OK,
-        )
-
-    def put(self, request: Request) -> Response:
-        serializer = MyOccupationsWriteSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        slugs: list[str] = serializer.validated_data["slugs"]
-
-        # 置換: 既存 UserOccupation を全消ししてから新しい slug 集合を bulk insert。
-        # トランザクション内で実行して、 中途半端な状態を残さない。
-        with transaction.atomic():
-            UserOccupation.objects.filter(user=request.user).delete()
-            if slugs:
-                occupations = Occupation.objects.filter(slug__in=slugs, is_active=True)
-                UserOccupation.objects.bulk_create(
-                    [UserOccupation(user=request.user, occupation=o) for o in occupations]
-                )
-
-        # response は GET と同じ shape (今 DB に入っている slug を返す)。
-        return self.get(request)
+# Phase 12 P12-06: Occupation 系 view は views_occupation.py に分離した
+# (apps/users/views.py が 800 行上限を超えるため。 code-reviewer HIGH 指摘)。

--- a/apps/users/views_occupation.py
+++ b/apps/users/views_occupation.py
@@ -1,0 +1,108 @@
+"""Phase 12 P12-06: Occupation 関連 view を分離するモジュール.
+
+``apps/users/views.py`` が 800 行上限を超えるため、 Occupation 系を別ファイルに
+切り出している (code-reviewer HIGH 指摘)。 内容としては:
+
+- ``OccupationListView``  : ``GET /api/v1/occupations/`` (anon 可)
+- ``MyOccupationsView``   : ``GET / PUT /api/v1/users/me/occupations/`` (auth)
+
+spec: docs/specs/phase-12-residence-map-spec.md §9
+"""
+
+from __future__ import annotations
+
+from django.db import transaction
+from django.db.models import QuerySet
+from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.common.cookie_auth import CookieAuthentication, CSRFEnforcingAuthentication
+from apps.users.models import Occupation, UserOccupation
+from apps.users.serializers import (
+    MyOccupationsWriteSerializer,
+    OccupationSerializer,
+)
+
+
+class OccupationListView(ListAPIView):
+    """``GET /api/v1/occupations/``: controlled vocabulary を返す (anon 可)。
+
+    廃止職業 (``is_active=False``) は除外。 ordering は
+    ``Occupation.Meta.ordering`` (= ``display_order, slug``)。
+    pagination は無し (16 件程度のため)。
+    """
+
+    serializer_class = OccupationSerializer
+    permission_classes = [AllowAny]
+    pagination_class = None
+
+    def get_queryset(self) -> QuerySet:
+        return Occupation.objects.filter(is_active=True)
+
+
+class MyOccupationsView(APIView):
+    """``/api/v1/users/me/occupations/`` — 自分の occupations の GET / PUT.
+
+    - GET: ``{"slugs": [...]}`` で自分の slug 配列を返す。 未設定は空配列。
+    - PUT: ``{"slugs": [...]}`` で **置換** semantics。 最大 3 件。
+
+    認証は Cookie + CSRF。 ``MyUserResidenceView`` 等プロジェクトの状態変更
+    エンドポイントと揃えて ``CSRFEnforcingAuthentication`` を明示する
+    (グローバル fallback の ``JWTAuthentication`` では PUT 時に CSRF が
+    効かない経路があるため、 二重防衛のために authentication_classes を明示)。
+    """
+
+    authentication_classes = [CSRFEnforcingAuthentication, CookieAuthentication]
+    permission_classes = [IsAuthenticated]
+    parser_classes = [JSONParser]
+    # 意図しない HTTP method 経由の副作用を防ぐ (プロジェクト規約)。
+    http_method_names = ["get", "put", "head", "options"]
+
+    def _current_slugs(self, request: Request) -> list[str]:
+        return list(request.user.occupations.filter(is_active=True).values_list("slug", flat=True))
+
+    def get(self, request: Request) -> Response:
+        return Response(
+            {"slugs": self._current_slugs(request)},
+            status=status.HTTP_200_OK,
+        )
+
+    def put(self, request: Request) -> Response:
+        serializer = MyOccupationsWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        slugs: list[str] = serializer.validated_data["slugs"]
+
+        # 置換: 既存 UserOccupation を全消ししてから新しい slug 集合を bulk insert。
+        # トランザクション内で実行して、 中途半端な状態を残さない。 admin が
+        # トランザクション中に ``is_active=False`` に切り替えても、 ``filter()``
+        # が再評価するので「 validate 時は active だったが insert 時は inactive」
+        # の極小レース窓は ``bulk_create`` 後に件数チェックで吸収する。
+        with transaction.atomic():
+            UserOccupation.objects.filter(user=request.user).delete()
+            if slugs:
+                occupations = list(Occupation.objects.filter(slug__in=slugs, is_active=True))
+                if len(occupations) != len(slugs):
+                    # validate 後に admin 操作で is_active=False になった race window。
+                    # 既に DELETE は実行済みだが atomic でロールバックされる。
+                    missing = sorted(set(slugs) - {o.slug for o in occupations})
+                    return Response(
+                        {
+                            "slugs": [
+                                f"職業が一時的に利用できません。 再試行してください: {', '.join(missing)}"
+                            ]
+                        },
+                        status=status.HTTP_409_CONFLICT,
+                    )
+                UserOccupation.objects.bulk_create(
+                    [UserOccupation(user=request.user, occupation=o) for o in occupations]
+                )
+
+        return Response(
+            {"slugs": self._current_slugs(request)},
+            status=status.HTTP_200_OK,
+        )

--- a/apps/users/views_occupation.py
+++ b/apps/users/views_occupation.py
@@ -79,30 +79,32 @@ class MyOccupationsView(APIView):
 
         # 置換: 既存 UserOccupation を全消ししてから新しい slug 集合を bulk insert。
         # トランザクション内で実行して、 中途半端な状態を残さない。 admin が
-        # トランザクション中に ``is_active=False`` に切り替えても、 ``filter()``
-        # が再評価するので「 validate 時は active だったが insert 時は inactive」
-        # の極小レース窓は ``bulk_create`` 後に件数チェックで吸収する。
+        # トランザクション中に ``is_active=False`` に切り替える race window では、
+        # ``bulk_create`` 直前の件数チェックで検知し、 ``set_rollback`` で DELETE
+        # も巻き戻す (database-reviewer HIGH: ``with atomic(): return`` だけだと
+        # block は正常終了扱いで commit されてしまうため明示 rollback が必須)。
+        race_missing: list[str] = []
         with transaction.atomic():
             UserOccupation.objects.filter(user=request.user).delete()
             if slugs:
                 occupations = list(Occupation.objects.filter(slug__in=slugs, is_active=True))
                 if len(occupations) != len(slugs):
-                    # validate 後に admin 操作で is_active=False になった race window。
-                    # 既に DELETE は実行済みだが atomic でロールバックされる。
-                    missing = sorted(set(slugs) - {o.slug for o in occupations})
-                    return Response(
-                        {
-                            "slugs": [
-                                f"職業が一時的に利用できません。 再試行してください: {', '.join(missing)}"
-                            ]
-                        },
-                        status=status.HTTP_409_CONFLICT,
+                    race_missing = sorted(set(slugs) - {o.slug for o in occupations})
+                    transaction.set_rollback(True)
+                else:
+                    UserOccupation.objects.bulk_create(
+                        [UserOccupation(user=request.user, occupation=o) for o in occupations]
                     )
-                UserOccupation.objects.bulk_create(
-                    [UserOccupation(user=request.user, occupation=o) for o in occupations]
-                )
 
-        return Response(
-            {"slugs": self._current_slugs(request)},
-            status=status.HTTP_200_OK,
-        )
+        if race_missing:
+            return Response(
+                {
+                    "slugs": [
+                        f"職業が一時的に利用できません。 再試行してください: {', '.join(race_missing)}"
+                    ]
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        # 成功時は validate 済みの slug を直接返す (race window が無いので確定的)。
+        return Response({"slugs": slugs}, status=status.HTTP_200_OK)

--- a/config/urls.py
+++ b/config/urls.py
@@ -11,6 +11,7 @@ from rest_framework import permissions
 
 from apps.common.views import csrf_token as csrf_token_view
 from apps.common.views import health as health_view
+from apps.users.views import OccupationListView
 from config.openapi import api_info
 
 schema_view = get_schema_view(
@@ -65,6 +66,14 @@ urlpatterns = [
     # /api/v1/users/me/ (GET/PATCH) と /api/v1/users/<handle>/ (GET) を提供。
     # 認証系 (/api/v1/auth/) と分離するため apps.users.urls_profile として別登録。
     path("api/v1/users/", include("apps.users.urls_profile")),
+    # Phase 12 P12-06: 職業 (controlled vocabulary) list endpoint。
+    # ``/api/v1/users/<handle>/`` の greedy 回避のため、 users prefix の
+    # 外側に置く (occupations は user-scoped ではない global resource)。
+    path(
+        "api/v1/occupations/",
+        OccupationListView.as_view(),
+        name="occupations-list",
+    ),
     # Phase 0 scaffold (P0-04). Each app ships empty urlpatterns until
     # the owning phase adds real endpoints (see docs/ROADMAP.md).
     path("api/v1/tweets/", include("apps.tweets.urls")),

--- a/config/urls.py
+++ b/config/urls.py
@@ -11,7 +11,7 @@ from rest_framework import permissions
 
 from apps.common.views import csrf_token as csrf_token_view
 from apps.common.views import health as health_view
-from apps.users.views import OccupationListView
+from apps.users.views_occupation import OccupationListView
 from config.openapi import api_info
 
 schema_view = get_schema_view(

--- a/docs/specs/phase-12-residence-map-spec.md
+++ b/docs/specs/phase-12-residence-map-spec.md
@@ -290,6 +290,170 @@ PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/onboarding-
 2. ✅ **P12-02** (#679 merged): 設定 UI + プロフィール map 表示 (Leaflet + OSM)
 3. ✅ **P12-04** (#680 merged): 汎用 user search page (full-text、 cursor pagination)
 4. ✅ **P12-05** (#681 merged): 近所検索 (haversine SQL, near_me=1 / near=lat,lng)
-5. **P12-03** (本 PR): signup wizard step 2 (居住地 prompt) — Phase 12 完了
+5. ✅ **P12-03** (merged): signup wizard step 2 (居住地 prompt)
+6. **P12-06** (#815): `Occupation` model + 多選択編集 UI (本 spec §9 / 本 PR は backend、 frontend は follow-up)
+7. **P12-07** (#816): `/api/v1/users/search/?occupation=` filter + chip filter UI
+8. **P12-08** (#817): `/search/users` に Leaflet 地図 view toggle (job filter と組み合わせ可能)
 
 各段階で `gan-evaluator` agent に採点させて UX を確認 (新 route 追加なので Phase 11 同様の必須運用)。
+
+---
+
+## 9. 職業 (Occupation) model — P12-06
+
+### 9.1 背景
+
+ハルナさん要望: 「ユーザー検索で地図上で検索できるようにならないかな？地図の上に検索欄があって、職業がデザイナーの人を検索する」
+
+地図 view (P12-08) と職業フィルタ (P12-07) を実装する前提として、 **そもそも User に「職業」 フィールドが無い**。 これを最初に整える。
+
+設計判断:
+
+- 自由 string では「フロントエンド」 「Frontend」 「frontend」 が一致せず検索品質が低い
+- 既存 `apps.tags.Tag` (技術タグ用、 user-proposed + moderator approval) とは目的が違う
+  - `Tag` = community-grown taxonomy (TypeScript / Next.js 等、 何百件にもなる)
+  - `Occupation` = curated, fixed vocabulary (~16 件、 admin が seed/管理)
+- → **別 model `Occupation` (apps/users) + User との M2M** で実装
+
+### 9.2 データモデル
+
+```python
+# apps/users/models.py
+class Occupation(models.Model):
+    """エンジニア職業の controlled vocabulary (P12-06)。
+
+    Tag (apps.tags) と違って admin seed/管理で、 ユーザー側からは作成・編集不可。
+    M2M で User と紐付ける (1 user あたり最大 3 件)。
+    """
+
+    slug          = SlugField(max_length=50, unique=True)
+    display_name  = CharField(max_length=50)
+    display_order = PositiveSmallIntegerField(default=100)
+    is_active     = BooleanField(default=True)
+    created_at    = DateTimeField(auto_now_add=True)
+    updated_at    = DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["display_order", "slug"]
+        indexes = [
+            models.Index(fields=["is_active", "display_order"], name="users_occ_active_order_idx"),
+        ]
+
+
+class UserOccupation(models.Model):
+    """User ↔ Occupation の through (P12-06)。
+
+    将来「主な職業 (1件)」 を強調するための ``is_primary`` を追加できるよう through 化。
+    """
+
+    MAX_PER_USER = 3
+
+    user        = ForeignKey(User, on_delete=CASCADE, related_name="user_occupations")
+    occupation  = ForeignKey(Occupation, on_delete=CASCADE, related_name="user_occupations")
+    created_at  = DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            UniqueConstraint(fields=["user", "occupation"], name="user_occupation_unique"),
+        ]
+        indexes = [
+            models.Index(fields=["occupation"], name="user_occupation_occ_idx"),
+        ]
+
+
+# User に M2M 追加
+class User(AbstractUser):
+    ...
+    occupations = models.ManyToManyField(
+        Occupation,
+        through="UserOccupation",
+        related_name="users",
+        blank=True,
+    )
+```
+
+**制約**:
+
+- 1 user あたり **最大 3 件** (serializer 層で enforce)
+- `Occupation.is_active=False` は API list / PUT で除外
+- User 削除 → `UserOccupation` も CASCADE
+- Occupation 削除 → `UserOccupation` も CASCADE (admin は soft delete `is_active=False` を推奨)
+
+### 9.3 初期 seed (data migration)
+
+```python
+INITIAL_OCCUPATIONS = [
+    ("designer",   "デザイナー",                    10),
+    ("frontend",   "フロントエンドエンジニア",       20),
+    ("backend",    "バックエンドエンジニア",         30),
+    ("fullstack",  "フルスタックエンジニア",         40),
+    ("mobile",     "モバイルエンジニア",             50),
+    ("ml",         "ML / AI エンジニア",             60),
+    ("data",       "データエンジニア / アナリスト",  70),
+    ("sre",        "SRE / インフラ",                 80),
+    ("security",   "セキュリティ",                   90),
+    ("game",       "ゲーム開発",                    100),
+    ("embedded",   "組み込み / ハードウェア",       110),
+    ("qa",         "QA / テスト",                   120),
+    ("pm",         "プロダクトマネージャ",          130),
+    ("em",         "エンジニアリングマネージャ",    140),
+    ("student",    "学生",                          150),
+    ("other",      "その他",                        999),
+]
+```
+
+seed は **冪等** (`update_or_create`)。 将来 admin から増減可能。
+
+### 9.4 API
+
+| Method | Path                            | 認証 | 内容                                                                |
+| ------ | ------------------------------- | ---- | ------------------------------------------------------------------- |
+| GET    | `/api/v1/occupations/`          | anon | `is_active=True` を `display_order` 順で返す                        |
+| GET    | `/api/v1/users/me/occupations/` | auth | 自分の slug 配列                                                    |
+| PUT    | `/api/v1/users/me/occupations/` | auth | body `{"slugs": [...]}` で **置換** (最大 3、 4 件以上は 400)       |
+| GET    | `/api/v1/users/<handle>/`       | anon | 既存 profile response に `occupations: [{slug, display_name}, ...]` |
+
+PUT を **置換** にする理由: M2M の add/remove を逐次 API で叩くより、 client が「最終的にこの 3 つ」 を declarative に渡せる方がシンプル + 競合に強い。
+
+**バリデーション**:
+
+- `slugs` が array でない / non-string element / 空文字混入 → 400
+- `len(slugs) > 3` → 400
+- 未知 slug → 400 (`{slugs: ["unknown slug: ..."]}`)
+- `is_active=False` slug → 400 (廃止済み職業は選択不可)
+- 重複 slug (`["a", "a"]`) → 400
+
+### 9.5 frontend (本 PR では未実装、 follow-up issue で対応)
+
+P12-06 の frontend (`/settings/profile` chip 多選択 + `/u/<handle>` 表示) は backend が緑になった後の follow-up PR で実装する。 backend PR を軽く保つ + frontend は a11y / E2E のレビュー量が backend と独立で大きいため。
+
+### 9.6 backend テスト (P12-06)
+
+`apps/users/tests/test_occupation.py`:
+
+- `TestOccupationModel`: slug unique / `__str__` / ordering (display_order ASC)
+- `TestUserOccupationModel`: 同一 (user, occupation) は IntegrityError / User CASCADE / Occupation CASCADE
+- `TestOccupationListAPI`: anon 200 / is_active=False 除外 / display_order 順 / shape = `[{slug, display_name, display_order}]`
+- `TestMyOccupationsAPI`:
+  - GET 認証必須 (401/403)
+  - GET 未設定 → 空配列 `{"slugs": []}`
+  - GET 設定済み → slug 配列
+  - PUT 認証必須
+  - PUT で置換 (既存 0 → 2、 2 → 3、 3 → 1)
+  - PUT 空配列で全消し
+  - PUT 4 件で 400
+  - PUT 未知 slug で 400
+  - PUT is_active=False slug で 400
+  - PUT 重複 slug で 400
+  - PUT non-array で 400
+- `TestUserProfileOccupationField`: GET `/api/v1/users/<handle>/` で `occupations` 配列が含まれる、 未設定 user は空配列
+
+実行:
+
+```bash
+docker compose -f local.yml exec api pytest apps/users/tests/test_occupation.py -v --no-cov
+```
+
+### 9.7 frontend テスト (P12-06 follow-up)
+
+follow-up issue で実装。 概要は P12-07 / P12-08 と同様の chip 多選択 vitest + Playwright E2E。


### PR DESCRIPTION
## Summary

ハルナさん要望「ユーザー検索で地図上で検索できるようにならないかな？地図の上に検索欄があって、職業がデザイナーの人を検索する」 の **基盤** となる **職業 (Occupation) controlled vocabulary** を新設。 P12-07 (#816、 検索 filter) / P12-08 (#817、 地図 view) の前提となる model + API。

closes #815 (backend portion — frontend は #818 で follow-up)

spec: [docs/specs/phase-12-residence-map-spec.md §9](../blob/feature/issue-815-occupation/docs/specs/phase-12-residence-map-spec.md#9-職業-occupation-model--p12-06)

## 含まれるもの (backend のみ)

- `Occupation` model: slug / display_name / display_order / is_active
  - `apps.tags.Tag` (community-grown) と違って admin seed/管理の curated 16 件
- `UserOccupation` through M2M: User ↔ Occupation
  - 1 user あたり最大 3 件 (serializer 層で enforce)
  - `UniqueConstraint(user, occupation)` + `occupation` index (検索 join 用 P12-07)
- migration 0009 (schema) + 0010 (initial seed 16 件、 designer / frontend / backend / fullstack / mobile / ml / data / sre / security / game / embedded / qa / pm / em / student / other)
- API:
  - `GET  /api/v1/occupations/`            — anon、 `is_active=True` を `display_order` 順
  - `GET  /api/v1/users/me/occupations/`   — auth、 `{"slugs": [...]}`
  - `PUT  /api/v1/users/me/occupations/`   — **置換** semantics、 4件以上は 400 / 未知 slug は 400 / `is_active=False` slug は 400 / 重複は 400
  - `GET  /api/v1/users/<handle>/` の response に `occupations` 配列追加 (空配列なら未設定)
- admin: `Occupation` (soft delete via `is_active`) + `UserOccupation` (raw_id_fields)
- pytest (28 cases): model invariants / list API / me API (auth/validation 境界) / profile API integration
- spec §8 rollout 更新 + §9 (P12-06) 詳細追加 + §10/§11 (P12-07/P12-08) 仕様プレビュー

## 含まれないもの (follow-up)

- frontend chip 編集 UI + profile chip 表示 → #818 (P12-06b)
- 検索 API `?occupation=` filter → #816 (P12-07)
- 地図 view toggle → #817 (P12-08)

## Test plan

- [ ] CI で `ruff check` / `ruff format --check` / `mypy` 通過
- [ ] CI で `pytest apps/users/tests/test_occupation.py` 28 cases 緑
- [ ] CI で 既存 `pytest apps/users/tests/test_profile_api.py` (occupations field 追加で `EXPECTED_PUBLIC_KEYS` 更新済) 緑
- [ ] merge 後 stg に CD → admin で 16 件 seed 確認 + `curl https://stg.codeplace.me/api/v1/occupations/` で 200 + list 確認
- [ ] merge 後 stg で test2 login → `PUT /api/v1/users/me/occupations/ {"slugs":["designer","frontend"]}` → `GET /api/v1/users/test2/` で `occupations: [{slug:"designer",...},{slug:"frontend",...}]`
- [ ] follow-up #818 (frontend) / #816 (search filter) / #817 (map view) の依存解消

## 並列禁止ルール遵守 (CLAUDE.md §4.5)

レビューエージェントは push 後 sequential に呼び出し (python-reviewer → code-reviewer → database-reviewer)。