### PR TITLE
feat(profile): Occupation chip 多選択編集 UI + プロフィール表示 (#818)

### DIFF
--- a/client/e2e/occupation-edit.spec.ts
+++ b/client/e2e/occupation-edit.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 12 P12-06b 職業 chip 編集 + 表示 E2E spec (issue #818).
+ *
+ * spec: docs/specs/phase-12-residence-map-spec.md §9.5
+ *
+ * 検証シナリオ:
+ *   OCCUPATION-1 (golden):
+ *     USER1 が /settings/profile を開く → 「デザイナー」 chip を選択 →
+ *     「フロントエンドエンジニア」 chip を選択 → 「職業を保存」 → toast 通知 →
+ *     /u/<USER1> に遷移すると chip が 2 件表示される
+ *
+ *   OCCUPATION-2 (max enforce):
+ *     既に 3 件選択した状態で 4 件目 chip を click しても aria-checked が
+ *     true にならず、 「最大 3 件まで」 のヒントが出る
+ *
+ *   OCCUPATION-3 (anon view):
+ *     USER1 がセットした occupations は anon で /u/<USER1> を踏んでも
+ *     chip 表示される (公開プロフィール)
+ *
+ * env: docs/local/e2e-stg.md の test2 / test3 を使用。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	for (const [k, v] of Object.entries({
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	})) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+): Promise<{ csrf: string }> {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+	return { csrf };
+}
+
+async function clearOccupations(
+	request: APIRequestContext,
+	csrf: string,
+): Promise<void> {
+	const res = await request.put(`${BASE}/api/v1/users/me/occupations/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/settings/profile`,
+		},
+		data: { slugs: [] },
+	});
+	expect(res.status()).toBe(200);
+}
+
+test.describe("Phase 12 P12-06b occupation chip edit + display (#818)", () => {
+	test("OCCUPATION-1: chip 選択 → 保存 → /u/<self> に chip 表示", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const ctx = await browser.newContext();
+		const { csrf } = await loginViaApi(ctx.request, USER1);
+		await clearOccupations(ctx.request, csrf);
+
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/settings/profile`);
+
+		// chip picker section の見出しが出るまで待つ
+		await expect(
+			page.getByRole("heading", { name: /職業/, level: 3 }),
+		).toBeVisible({ timeout: 15000 });
+
+		// 「デザイナー」 と 「フロントエンドエンジニア」 を switch chip として選ぶ
+		const designer = page.getByRole("switch", { name: "デザイナー" });
+		const frontend = page.getByRole("switch", {
+			name: "フロントエンドエンジニア",
+		});
+		await expect(designer).toHaveAttribute("aria-checked", "false");
+		await designer.click();
+		await frontend.click();
+		await expect(designer).toHaveAttribute("aria-checked", "true");
+		await expect(frontend).toHaveAttribute("aria-checked", "true");
+
+		// 保存
+		await page.getByRole("button", { name: "職業を保存" }).click();
+
+		// 自分のプロフィールに行って chip が見える
+		await page.goto(`${BASE}/u/${USER1.handle}`);
+		const occSection = page.getByRole("region", { name: "職業" });
+		await expect(occSection).toBeVisible({ timeout: 15000 });
+		await expect(occSection.getByText("デザイナー")).toBeVisible();
+		await expect(
+			occSection.getByText("フロントエンドエンジニア"),
+		).toBeVisible();
+
+		await ctx.close();
+	});
+
+	test("OCCUPATION-2: 4 件目は disabled + hint 表示", async ({ browser }) => {
+		requireEnv();
+		const ctx = await browser.newContext();
+		const { csrf } = await loginViaApi(ctx.request, USER1);
+		// 事前に 3 件入れておく
+		const seed = await ctx.request.put(`${BASE}/api/v1/users/me/occupations/`, {
+			headers: {
+				"Content-Type": "application/json",
+				"X-CSRFToken": csrf,
+				Referer: `${BASE}/settings/profile`,
+			},
+			data: { slugs: ["designer", "frontend", "backend"] },
+		});
+		expect(seed.status()).toBe(200);
+
+		const page = await ctx.newPage();
+		await page.goto(`${BASE}/settings/profile`);
+
+		const fullstack = page.getByRole("switch", {
+			name: "フルスタックエンジニア",
+		});
+		await expect(fullstack).toBeDisabled();
+		await expect(page.getByTestId("occupation-limit-hint")).toBeVisible();
+
+		await ctx.close();
+	});
+
+	test("OCCUPATION-3: anon でも /u/<USER1> の chip が見える", async ({
+		browser,
+	}) => {
+		requireEnv();
+		// 事前条件: USER1 が designer + frontend を持っている (テスト #1 で設定済み、
+		// なくても anon で 200 が返ればよい)
+		const anon = await browser.newContext();
+		const anonPage = await anon.newPage();
+		await anonPage.goto(`${BASE}/u/${USER1.handle}`);
+
+		// occupation section が存在するか、 もしくは空でも 200 が返るかのいずれか。
+		// 設定済みなら section が見える。
+		const region = anonPage.getByRole("region", { name: "職業" });
+		if (await region.isVisible()) {
+			await expect(region).toBeVisible();
+		}
+		await anon.close();
+	});
+});

--- a/client/e2e/occupation-edit.spec.ts
+++ b/client/e2e/occupation-edit.spec.ts
@@ -149,18 +149,34 @@ test.describe("Phase 12 P12-06b occupation chip edit + display (#818)", () => {
 		browser,
 	}) => {
 		requireEnv();
-		// 事前条件: USER1 が designer + frontend を持っている (テスト #1 で設定済み、
-		// なくても anon で 200 が返ればよい)
+		// 自前で API seed して、 OCCUPATION-1 の実行順に依存しないようにする
+		// (typescript-reviewer MEDIUM: spec 間の暗黙依存を排除)。
+		const auth = await browser.newContext();
+		const { csrf } = await loginViaApi(auth.request, USER1);
+		const seed = await auth.request.put(
+			`${BASE}/api/v1/users/me/occupations/`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+					"X-CSRFToken": csrf,
+					Referer: `${BASE}/settings/profile`,
+				},
+				data: { slugs: ["designer", "frontend"] },
+			},
+		);
+		expect(seed.status()).toBe(200);
+		await auth.close();
+
+		// anon (cookie 無し) で公開プロフィールを踏む
 		const anon = await browser.newContext();
 		const anonPage = await anon.newPage();
 		await anonPage.goto(`${BASE}/u/${USER1.handle}`);
 
-		// occupation section が存在するか、 もしくは空でも 200 が返るかのいずれか。
-		// 設定済みなら section が見える。
 		const region = anonPage.getByRole("region", { name: "職業" });
-		if (await region.isVisible()) {
-			await expect(region).toBeVisible();
-		}
+		await expect(region).toBeVisible({ timeout: 15000 });
+		await expect(region.getByText("デザイナー")).toBeVisible();
+		await expect(region.getByText("フロントエンドエンジニア")).toBeVisible();
+
 		await anon.close();
 	});
 });

--- a/client/e2e/occupation-edit.spec.ts
+++ b/client/e2e/occupation-edit.spec.ts
@@ -148,13 +148,15 @@ test.describe("Phase 12 P12-06b occupation chip edit + display (#818)", () => {
 		const fullstack = page.getByRole("switch", {
 			name: "フルスタックエンジニア",
 		});
-		await expect(fullstack).toBeDisabled();
+		// a11y-architect HIGH 修正後: disabled 属性ではなく aria-disabled=true で
+		// focus 到達可能にしてある。
+		await expect(fullstack).toHaveAttribute("aria-disabled", "true");
 		await expect(page.getByTestId("occupation-limit-hint")).toBeVisible();
 
 		// boundary: 既選択 chip を 1 つ外すと 4 件目が再び enable になる
 		// (code-reviewer MEDIUM: 境界 test の対称性)
 		await page.getByRole("switch", { name: "バックエンドエンジニア" }).click();
-		await expect(fullstack).not.toBeDisabled();
+		await expect(fullstack).not.toHaveAttribute("aria-disabled", "true");
 		await expect(page.getByTestId("occupation-limit-hint")).not.toBeVisible();
 
 		await ctx.close();

--- a/client/e2e/occupation-edit.spec.ts
+++ b/client/e2e/occupation-edit.spec.ts
@@ -103,8 +103,17 @@ test.describe("Phase 12 P12-06b occupation chip edit + display (#818)", () => {
 		await expect(designer).toHaveAttribute("aria-checked", "true");
 		await expect(frontend).toHaveAttribute("aria-checked", "true");
 
-		// 保存
-		await page.getByRole("button", { name: "職業を保存" }).click();
+		// 保存 click → PUT 完了の signal を 2 つ待つ:
+		//   1. toast の「職業を保存しました」 が見える (完了シグナル)
+		//   2. 保存 button が再 disabled (savedSlugs と selected が一致した、 つまり PUT 反映済)
+		// この 2 つを揃えてから profile 遷移しないと stg ネットワーク遅延で flaky になる
+		// (code-reviewer HIGH 指摘)。
+		const saveButton = page.getByRole("button", { name: "職業を保存" });
+		await saveButton.click();
+		await expect(page.getByText("職業を保存しました")).toBeVisible({
+			timeout: 15000,
+		});
+		await expect(saveButton).toBeDisabled();
 
 		// 自分のプロフィールに行って chip が見える
 		await page.goto(`${BASE}/u/${USER1.handle}`);
@@ -141,6 +150,12 @@ test.describe("Phase 12 P12-06b occupation chip edit + display (#818)", () => {
 		});
 		await expect(fullstack).toBeDisabled();
 		await expect(page.getByTestId("occupation-limit-hint")).toBeVisible();
+
+		// boundary: 既選択 chip を 1 つ外すと 4 件目が再び enable になる
+		// (code-reviewer MEDIUM: 境界 test の対称性)
+		await page.getByRole("switch", { name: "バックエンドエンジニア" }).click();
+		await expect(fullstack).not.toBeDisabled();
+		await expect(page.getByTestId("occupation-limit-hint")).not.toBeVisible();
 
 		await ctx.close();
 	});

--- a/client/src/app/(template)/settings/profile/page.tsx
+++ b/client/src/app/(template)/settings/profile/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
+import OccupationChipPicker from "@/components/profile/OccupationChipPicker";
 import ProfileEditForm from "@/components/profile/ProfileEditForm";
+import type { Occupation } from "@/lib/api/occupation";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import type { CurrentUser } from "@/lib/api/users";
 
@@ -19,9 +21,36 @@ async function loadCurrentUser(): Promise<CurrentUser | null> {
 	}
 }
 
+async function loadOccupations(): Promise<Occupation[]> {
+	try {
+		return await serverFetch<Occupation[]>("/occupations/");
+	} catch {
+		// Phase 12 P12-06 backend が落ちていたら chip section は empty-state を出す。
+		return [];
+	}
+}
+
+async function loadMyOccupations(): Promise<string[]> {
+	try {
+		const res = await serverFetch<{ slugs: string[] }>(
+			"/users/me/occupations/",
+		);
+		return res.slugs;
+	} catch {
+		// 認証必須 endpoint。 ログイン後にこのページに到達しているので 401 は通常
+		// 起きないが、 念のため空配列で fail-safe。
+		return [];
+	}
+}
+
 export default async function ProfileSettingsPage() {
 	const currentUser = await loadCurrentUser();
 	if (!currentUser) redirect("/login");
+
+	const [occupations, myOccupationSlugs] = await Promise.all([
+		loadOccupations(),
+		loadMyOccupations(),
+	]);
 
 	return (
 		<>
@@ -44,12 +73,21 @@ export default async function ProfileSettingsPage() {
 						className="truncate text-[color:var(--a-text-subtle)]"
 						style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
 					>
-						表示名 / bio / 画像 / 外部リンク
+						表示名 / bio / 画像 / 外部リンク / 職業
 					</p>
 				</div>
 			</header>
-			<div className="p-5">
+			<div className="space-y-6 p-5">
 				<ProfileEditForm initialUser={currentUser} />
+				<div
+					className="rounded-lg border p-4"
+					style={{ borderColor: "var(--a-border)" }}
+				>
+					<OccupationChipPicker
+						allOccupations={occupations}
+						initialSelectedSlugs={myOccupationSlugs}
+					/>
+				</div>
 			</div>
 		</>
 	);

--- a/client/src/app/(template)/settings/profile/page.tsx
+++ b/client/src/app/(template)/settings/profile/page.tsx
@@ -24,8 +24,11 @@ async function loadCurrentUser(): Promise<CurrentUser | null> {
 async function loadOccupations(): Promise<Occupation[]> {
 	try {
 		return await serverFetch<Occupation[]>("/occupations/");
-	} catch {
-		// Phase 12 P12-06 backend が落ちていたら chip section は empty-state を出す。
+	} catch (error) {
+		// catalog 取得失敗時は empty-state を chip section が出す。
+		// auth は不要なので 401/403 は想定外、 5xx / network も catalog 全体の
+		// 機能停止に過ぎないため fail-safe する (個人データではない)。
+		console.error("loadOccupations failed", error);
 		return [];
 	}
 }
@@ -36,10 +39,18 @@ async function loadMyOccupations(): Promise<string[]> {
 			"/users/me/occupations/",
 		);
 		return res.slugs;
-	} catch {
-		// 認証必須 endpoint。 ログイン後にこのページに到達しているので 401 は通常
-		// 起きないが、 念のため空配列で fail-safe。
-		return [];
+	} catch (error) {
+		// 認証必須 endpoint。 401/403 は「未認証扱い → 空配列」 で安全に degrade。
+		// それ以外 (5xx / network) は **個人データ** を空で上書きしないよう必ず
+		// 投げる (typescript-reviewer HIGH: silent catch は picker が空の状態で
+		// 保存できてしまい既存 occupations を破壊する)。
+		if (
+			error instanceof ApiServerError &&
+			(error.status === 401 || error.status === 403)
+		) {
+			return [];
+		}
+		throw error;
 	}
 }
 

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -300,14 +300,20 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 
 				{profile.occupations && profile.occupations.length > 0 && (
 					<section aria-label="職業" className="mt-3 px-4">
-						<ul className="flex flex-wrap gap-2">
+						{/* a11y-architect C2: chip 形状を border のみで示すと token contrast が
+						    保証されないため、 ``--a-accent-bg`` (sky-100) を fill にして
+						    text-foreground と AA contrast (>=10:1) を満たす。 */}
+						<ul
+							aria-label={`職業 ${profile.occupations.length} 件`}
+							className="flex flex-wrap gap-2"
+						>
 							{profile.occupations.map((o) => (
 								<li key={o.slug}>
 									<span
-										className="inline-block rounded-full border px-3 py-1 text-xs"
+										className="inline-block rounded-full px-3 py-1 text-xs"
 										style={{
-											borderColor: "var(--a-border)",
-											background: "var(--a-surface-soft, transparent)",
+											background: "var(--a-accent-bg)",
+											color: "var(--a-accent-text)",
 										}}
 									>
 										{o.display_name}

--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -48,6 +48,9 @@ interface PublicProfile {
 	is_muting: boolean;
 	/** Phase 4B (#449): User UUID (ReportDialog の target_id 用) */
 	user_id: string;
+	/** Phase 12 P12-06: 職業 chip (controlled vocabulary)。 空配列なら未設定。
+	 *  backend `PublicProfileSerializer.get_occupations` 由来。 */
+	occupations: Array<{ slug: string; display_name: string }>;
 }
 
 type ProfileTab = "tweets" | "likes" | "favorites" | "mentor";
@@ -293,6 +296,26 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 
 				{profile.bio && (
 					<p className="mt-4 whitespace-pre-wrap px-4 text-sm">{profile.bio}</p>
+				)}
+
+				{profile.occupations && profile.occupations.length > 0 && (
+					<section aria-label="職業" className="mt-3 px-4">
+						<ul className="flex flex-wrap gap-2">
+							{profile.occupations.map((o) => (
+								<li key={o.slug}>
+									<span
+										className="inline-block rounded-full border px-3 py-1 text-xs"
+										style={{
+											borderColor: "var(--a-border)",
+											background: "var(--a-surface-soft, transparent)",
+										}}
+									>
+										{o.display_name}
+									</span>
+								</li>
+							))}
+						</ul>
+					</section>
 				)}
 
 				{residence && (

--- a/client/src/components/profile/OccupationChipPicker.tsx
+++ b/client/src/components/profile/OccupationChipPicker.tsx
@@ -13,9 +13,11 @@
  *   - success toast is shown via ``role=status`` (also polite)
  */
 
+import axios from "axios";
 import { useState } from "react";
 import { toast } from "react-toastify";
 
+import { parseDrfErrors } from "@/lib/api/errors";
 import {
 	OCCUPATION_MAX_PER_USER,
 	saveMyOccupations,
@@ -70,8 +72,15 @@ export default function OccupationChipPicker({
 			setSelected(nextSaved);
 			toast.success("職業を保存しました");
 		} catch (err: unknown) {
-			const message =
-				err instanceof Error ? err.message : "保存に失敗しました。";
+			// axios error (= サーバ応答あり) は DRF error parser で人間に読める
+			// メッセージを取り出す。 client-side early-throw (Error) は
+			// 既に日本語メッセージなのでそのまま使う。
+			let message = "保存に失敗しました。";
+			if (axios.isAxiosError(err)) {
+				message = parseDrfErrors(err).summary ?? message;
+			} else if (err instanceof Error && err.message) {
+				message = err.message;
+			}
 			setErrorMsg(message);
 		} finally {
 			setIsSaving(false);

--- a/client/src/components/profile/OccupationChipPicker.tsx
+++ b/client/src/components/profile/OccupationChipPicker.tsx
@@ -7,14 +7,23 @@
  * (= 3) chips can be active. After ``保存`` the server replaces the user's
  * occupations with the current selection (PUT semantics).
  *
- * a11y:
- *   - chips are ``role=switch`` with ``aria-checked``
- *   - count indicator uses ``aria-live=polite``
- *   - success toast is shown via ``role=status`` (also polite)
+ * a11y design:
+ *   - chips are ``role=switch`` + ``aria-checked``。 visible text 自身が
+ *     accessible name となるよう ``aria-label`` は付けない (重複ラベル回避)。
+ *   - 4 件目以降は ``aria-disabled="true"`` (focusable は維持)。 SR 経由で
+ *     「ここは disabled で、 なぜ disabled か」 を ``aria-describedby`` で説明。
+ *   - 件数 indicator は visible のみ。 max 境界遷移 (3 件到達 / 解除) のときだけ
+ *     別 ``role=status`` region で 1 回 polite アナウンス (連続更新の noise を抑制)。
+ *   - 限定 hint は ``role=status`` で polite。
+ *   - 保存失敗 inline message は ``role=status`` (assertive の `role=alert` は
+ *     session 切れ等の中断系に予約)。
+ *   - 保存中は ``aria-busy=true`` で SR に「処理中」 を伝える。
+ *   - 選択 chip の text 色は AA 4.5:1 を満たす ``--a-accent-deep`` + white、
+ *     さらに ``✓`` icon を併記して色のみ依存を回避。
  */
 
 import axios from "axios";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "react-toastify";
 
 import { parseDrfErrors } from "@/lib/api/errors";
@@ -29,6 +38,8 @@ interface OccupationChipPickerProps {
 	initialSelectedSlugs: string[];
 }
 
+const HINT_ID = "occupation-limit-hint";
+
 export default function OccupationChipPicker({
 	allOccupations,
 	initialSelectedSlugs,
@@ -41,6 +52,11 @@ export default function OccupationChipPicker({
 	);
 	const [isSaving, setIsSaving] = useState(false);
 	const [errorMsg, setErrorMsg] = useState<string | null>(null);
+	// max 境界遷移のときだけ polite に流すアナウンス。 通常の count 更新は visible 表示のみ。
+	const [boundaryAnnouncement, setBoundaryAnnouncement] = useState<string>("");
+	const prevReachedMaxRef = useRef<boolean>(
+		initialSelectedSlugs.length >= OCCUPATION_MAX_PER_USER,
+	);
 
 	const reachedMax = selected.size >= OCCUPATION_MAX_PER_USER;
 	const isDirty =
@@ -56,8 +72,24 @@ export default function OccupationChipPicker({
 			} else if (next.size < OCCUPATION_MAX_PER_USER) {
 				next.add(slug);
 			}
+			// max 境界の遷移 (達した / 解除した) を 1 回だけ polite に流す。
+			const nextReached = next.size >= OCCUPATION_MAX_PER_USER;
+			if (nextReached !== prevReachedMaxRef.current) {
+				setBoundaryAnnouncement(
+					nextReached
+						? `最大 ${OCCUPATION_MAX_PER_USER} 件選択しました。 これ以上は選択できません。`
+						: "最大選択を解除しました。 追加で選択できます。",
+				);
+				prevReachedMaxRef.current = nextReached;
+			}
 			return next;
 		});
+	};
+
+	const handleChipClick = (slug: string, isDisabled: boolean) => {
+		// aria-disabled でも DOM の onClick は発火するので明示的に early-return。
+		if (isDisabled) return;
+		toggleSlug(slug);
 	};
 
 	const handleSave = async () => {
@@ -72,9 +104,6 @@ export default function OccupationChipPicker({
 			setSelected(nextSaved);
 			toast.success("職業を保存しました");
 		} catch (err: unknown) {
-			// axios error (= サーバ応答あり) は DRF error parser で人間に読める
-			// メッセージを取り出す。 client-side early-throw (Error) は
-			// 既に日本語メッセージなのでそのまま使う。
 			let message = "保存に失敗しました。";
 			if (axios.isAxiosError(err)) {
 				message = parseDrfErrors(err).summary ?? message;
@@ -89,7 +118,7 @@ export default function OccupationChipPicker({
 
 	if (allOccupations.length === 0) {
 		return (
-			<p className="text-sm text-muted-foreground">
+			<p className="text-sm text-muted-foreground" role="status">
 				職業 catalog を取得できませんでした。
 			</p>
 		);
@@ -98,53 +127,68 @@ export default function OccupationChipPicker({
 	return (
 		<section aria-labelledby="occupation-picker-heading" className="space-y-3">
 			<div className="flex items-baseline justify-between">
-				<h3
+				<h2
 					id="occupation-picker-heading"
 					className="text-sm font-semibold tracking-tight"
 				>
 					職業 (最大 {OCCUPATION_MAX_PER_USER} 件)
-				</h3>
+				</h2>
 				<p
 					className="text-xs text-muted-foreground"
-					aria-live="polite"
 					data-testid="occupation-count"
 				>
 					{selected.size} / {OCCUPATION_MAX_PER_USER} 件選択中
 				</p>
 			</div>
 
-			<ul className="flex flex-wrap gap-2" role="group" aria-label="職業を選択">
+			{/* 閾値アナウンス用 polite live region。 通常 count 変更では更新せず、
+			    max 境界をまたいだ瞬間だけ 1 回だけ message を入れる (SR noise 抑制)。 */}
+			<p role="status" className="sr-only">
+				{boundaryAnnouncement}
+			</p>
+
+			<div
+				role="group"
+				aria-label="職業を選択"
+				className="flex flex-wrap gap-2"
+			>
 				{allOccupations.map((occ) => {
 					const isSelected = selected.has(occ.slug);
 					const isDisabled = !isSelected && reachedMax;
 					return (
-						<li key={occ.slug}>
-							<button
-								type="button"
-								role="switch"
-								aria-checked={isSelected}
-								aria-label={occ.display_name}
-								disabled={isDisabled}
-								onClick={() => toggleSlug(occ.slug)}
-								data-slug={occ.slug}
-								className={
-									"rounded-full border px-3 py-1 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
-									(isSelected
-										? "border-[color:var(--a-accent)] bg-[color:var(--a-accent)] text-white"
-										: isDisabled
-											? "cursor-not-allowed border-border text-muted-foreground opacity-50"
-											: "border-border bg-background text-foreground hover:bg-muted")
-								}
-							>
-								{occ.display_name}
-							</button>
-						</li>
+						<button
+							key={occ.slug}
+							type="button"
+							role="switch"
+							aria-checked={isSelected}
+							aria-disabled={isDisabled || undefined}
+							aria-describedby={isDisabled ? HINT_ID : undefined}
+							onClick={() => handleChipClick(occ.slug, isDisabled)}
+							data-slug={occ.slug}
+							className={
+								"inline-flex min-h-[28px] items-center gap-1 rounded-full border px-3 py-1 text-sm transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent-deep)] " +
+								(isSelected
+									? "border-[color:var(--a-accent-deep)] bg-[color:var(--a-accent-deep)] text-white"
+									: isDisabled
+										? "cursor-not-allowed border-border text-muted-foreground opacity-50"
+										: "border-border bg-background text-foreground hover:bg-muted")
+							}
+						>
+							{isSelected && (
+								<span aria-hidden="true" className="text-xs leading-none">
+									✓
+								</span>
+							)}
+							{occ.display_name}
+						</button>
 					);
 				})}
-			</ul>
+			</div>
 
 			{reachedMax && (
 				<p
+					id={HINT_ID}
+					role="status"
 					className="text-xs text-muted-foreground"
 					data-testid="occupation-limit-hint"
 				>
@@ -154,7 +198,7 @@ export default function OccupationChipPicker({
 			)}
 
 			{errorMsg && (
-				<p role="alert" className="text-sm text-red-600">
+				<p role="status" className="text-sm text-red-600">
 					{errorMsg}
 				</p>
 			)}
@@ -164,7 +208,8 @@ export default function OccupationChipPicker({
 					type="button"
 					onClick={handleSave}
 					disabled={!isDirty || isSaving}
-					className="rounded-full bg-[color:var(--a-accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+					aria-busy={isSaving || undefined}
+					className="rounded-full bg-[color:var(--a-accent-deep)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent-deep)] disabled:cursor-not-allowed disabled:opacity-50"
 				>
 					{isSaving ? "保存中…" : "職業を保存"}
 				</button>

--- a/client/src/components/profile/OccupationChipPicker.tsx
+++ b/client/src/components/profile/OccupationChipPicker.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * Occupation chip picker (Phase 12 P12-06b, issue #818).
+ *
+ * Multi-select chip picker for /settings/profile. Max ``OCCUPATION_MAX_PER_USER``
+ * (= 3) chips can be active. After ``保存`` the server replaces the user's
+ * occupations with the current selection (PUT semantics).
+ *
+ * a11y:
+ *   - chips are ``role=switch`` with ``aria-checked``
+ *   - count indicator uses ``aria-live=polite``
+ *   - success toast is shown via ``role=status`` (also polite)
+ */
+
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+import {
+	OCCUPATION_MAX_PER_USER,
+	saveMyOccupations,
+	type Occupation,
+} from "@/lib/api/occupation";
+
+interface OccupationChipPickerProps {
+	allOccupations: Occupation[];
+	initialSelectedSlugs: string[];
+}
+
+export default function OccupationChipPicker({
+	allOccupations,
+	initialSelectedSlugs,
+}: OccupationChipPickerProps) {
+	const [selected, setSelected] = useState<Set<string>>(
+		() => new Set(initialSelectedSlugs),
+	);
+	const [savedSlugs, setSavedSlugs] = useState<Set<string>>(
+		() => new Set(initialSelectedSlugs),
+	);
+	const [isSaving, setIsSaving] = useState(false);
+	const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+	const reachedMax = selected.size >= OCCUPATION_MAX_PER_USER;
+	const isDirty =
+		selected.size !== savedSlugs.size ||
+		Array.from(selected).some((s) => !savedSlugs.has(s));
+
+	const toggleSlug = (slug: string) => {
+		setErrorMsg(null);
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(slug)) {
+				next.delete(slug);
+			} else if (next.size < OCCUPATION_MAX_PER_USER) {
+				next.add(slug);
+			}
+			return next;
+		});
+	};
+
+	const handleSave = async () => {
+		if (!isDirty || isSaving) return;
+		setIsSaving(true);
+		setErrorMsg(null);
+		try {
+			const slugs = Array.from(selected);
+			const saved = await saveMyOccupations(slugs);
+			const nextSaved = new Set(saved);
+			setSavedSlugs(nextSaved);
+			setSelected(nextSaved);
+			toast.success("職業を保存しました");
+		} catch (err: unknown) {
+			const message =
+				err instanceof Error ? err.message : "保存に失敗しました。";
+			setErrorMsg(message);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	if (allOccupations.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground">
+				職業 catalog を取得できませんでした。
+			</p>
+		);
+	}
+
+	return (
+		<section aria-labelledby="occupation-picker-heading" className="space-y-3">
+			<div className="flex items-baseline justify-between">
+				<h3
+					id="occupation-picker-heading"
+					className="text-sm font-semibold tracking-tight"
+				>
+					職業 (最大 {OCCUPATION_MAX_PER_USER} 件)
+				</h3>
+				<p
+					className="text-xs text-muted-foreground"
+					aria-live="polite"
+					data-testid="occupation-count"
+				>
+					{selected.size} / {OCCUPATION_MAX_PER_USER} 件選択中
+				</p>
+			</div>
+
+			<ul className="flex flex-wrap gap-2" role="group" aria-label="職業を選択">
+				{allOccupations.map((occ) => {
+					const isSelected = selected.has(occ.slug);
+					const isDisabled = !isSelected && reachedMax;
+					return (
+						<li key={occ.slug}>
+							<button
+								type="button"
+								role="switch"
+								aria-checked={isSelected}
+								aria-label={occ.display_name}
+								disabled={isDisabled}
+								onClick={() => toggleSlug(occ.slug)}
+								data-slug={occ.slug}
+								className={
+									"rounded-full border px-3 py-1 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
+									(isSelected
+										? "border-[color:var(--a-accent)] bg-[color:var(--a-accent)] text-white"
+										: isDisabled
+											? "cursor-not-allowed border-border text-muted-foreground opacity-50"
+											: "border-border bg-background text-foreground hover:bg-muted")
+								}
+							>
+								{occ.display_name}
+							</button>
+						</li>
+					);
+				})}
+			</ul>
+
+			{reachedMax && (
+				<p
+					className="text-xs text-muted-foreground"
+					data-testid="occupation-limit-hint"
+				>
+					最大 {OCCUPATION_MAX_PER_USER} 件まで選択できます。
+					他を選ぶには既存の選択を外してください。
+				</p>
+			)}
+
+			{errorMsg && (
+				<p role="alert" className="text-sm text-red-600">
+					{errorMsg}
+				</p>
+			)}
+
+			<div>
+				<button
+					type="button"
+					onClick={handleSave}
+					disabled={!isDirty || isSaving}
+					className="rounded-full bg-[color:var(--a-accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+				>
+					{isSaving ? "保存中…" : "職業を保存"}
+				</button>
+			</div>
+		</section>
+	);
+}

--- a/client/src/components/profile/__tests__/OccupationChipPicker.test.tsx
+++ b/client/src/components/profile/__tests__/OccupationChipPicker.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * OccupationChipPicker tests (Phase 12 P12-06b, issue #818).
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import OccupationChipPicker from "@/components/profile/OccupationChipPicker";
+import type { Occupation } from "@/lib/api/occupation";
+
+const { saveMock, toastSuccessSpy } = vi.hoisted(() => ({
+	saveMock: vi.fn(),
+	toastSuccessSpy: vi.fn(),
+}));
+
+vi.mock("@/lib/api/occupation", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/api/occupation")>(
+		"@/lib/api/occupation",
+	);
+	return {
+		...actual,
+		saveMyOccupations: saveMock,
+	};
+});
+
+vi.mock("react-toastify", () => ({
+	toast: { success: toastSuccessSpy, error: vi.fn() },
+}));
+
+const CATALOG: Occupation[] = [
+	{ slug: "designer", display_name: "デザイナー", display_order: 10 },
+	{
+		slug: "frontend",
+		display_name: "フロントエンドエンジニア",
+		display_order: 20,
+	},
+	{
+		slug: "backend",
+		display_name: "バックエンドエンジニア",
+		display_order: 30,
+	},
+	{
+		slug: "fullstack",
+		display_name: "フルスタックエンジニア",
+		display_order: 40,
+	},
+];
+
+function chip(label: string) {
+	return screen.getByRole("switch", { name: label });
+}
+
+describe("OccupationChipPicker", () => {
+	beforeEach(() => {
+		saveMock.mockReset();
+		toastSuccessSpy.mockReset();
+	});
+
+	it("renders every catalog occupation as a switch chip", () => {
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={[]}
+			/>,
+		);
+		expect(screen.getAllByRole("switch")).toHaveLength(CATALOG.length);
+		expect(chip("デザイナー")).toHaveAttribute("aria-checked", "false");
+	});
+
+	it("reflects initial selected slugs as aria-checked=true", () => {
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={["designer", "frontend"]}
+			/>,
+		);
+		expect(chip("デザイナー")).toHaveAttribute("aria-checked", "true");
+		expect(chip("フロントエンドエンジニア")).toHaveAttribute(
+			"aria-checked",
+			"true",
+		);
+		expect(chip("バックエンドエンジニア")).toHaveAttribute(
+			"aria-checked",
+			"false",
+		);
+	});
+
+	it("toggles a chip and updates the count indicator", async () => {
+		const user = userEvent.setup();
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={[]}
+			/>,
+		);
+		await user.click(chip("デザイナー"));
+		expect(chip("デザイナー")).toHaveAttribute("aria-checked", "true");
+		expect(screen.getByTestId("occupation-count")).toHaveTextContent(
+			"1 / 3 件選択中",
+		);
+	});
+
+	it("disables unselected chips when 3 chips are selected", async () => {
+		const user = userEvent.setup();
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={["designer", "frontend", "backend"]}
+			/>,
+		);
+		// 4 件目 (fullstack) は disabled
+		expect(chip("フルスタックエンジニア")).toBeDisabled();
+		// 既選択は disable しない (off にできる必要)
+		expect(chip("デザイナー")).not.toBeDisabled();
+		// click しても aria-checked 変わらない
+		await user.click(chip("フルスタックエンジニア"));
+		expect(chip("フルスタックエンジニア")).toHaveAttribute(
+			"aria-checked",
+			"false",
+		);
+		expect(screen.getByTestId("occupation-limit-hint")).toBeInTheDocument();
+	});
+
+	it("save button is disabled when nothing changed", () => {
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={["designer"]}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "職業を保存" })).toBeDisabled();
+	});
+
+	it("calls saveMyOccupations on save and shows success toast", async () => {
+		const user = userEvent.setup();
+		saveMock.mockResolvedValueOnce(["designer", "frontend"]);
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={[]}
+			/>,
+		);
+
+		await user.click(chip("デザイナー"));
+		await user.click(chip("フロントエンドエンジニア"));
+		await user.click(screen.getByRole("button", { name: "職業を保存" }));
+
+		expect(saveMock).toHaveBeenCalledWith(
+			expect.arrayContaining(["designer", "frontend"]),
+		);
+		expect(toastSuccessSpy).toHaveBeenCalledWith("職業を保存しました");
+		// 保存後は dirty=false で button 再 disable
+		expect(screen.getByRole("button", { name: "職業を保存" })).toBeDisabled();
+	});
+
+	it("shows an error message when save fails", async () => {
+		const user = userEvent.setup();
+		saveMock.mockRejectedValueOnce(new Error("保存に失敗しました。"));
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={[]}
+			/>,
+		);
+		await user.click(chip("デザイナー"));
+		await user.click(screen.getByRole("button", { name: "職業を保存" }));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent("保存に失敗しました");
+		expect(toastSuccessSpy).not.toHaveBeenCalled();
+	});
+
+	it("renders an empty-state message when catalog is empty", () => {
+		render(
+			<OccupationChipPicker allOccupations={[]} initialSelectedSlugs={[]} />,
+		);
+		expect(screen.queryAllByRole("switch")).toHaveLength(0);
+		expect(
+			screen.getByText(/catalog を取得できませんでした/),
+		).toBeInTheDocument();
+	});
+});

--- a/client/src/components/profile/__tests__/OccupationChipPicker.test.tsx
+++ b/client/src/components/profile/__tests__/OccupationChipPicker.test.tsx
@@ -101,7 +101,7 @@ describe("OccupationChipPicker", () => {
 		);
 	});
 
-	it("disables unselected chips when 3 chips are selected", async () => {
+	it("marks unselected chips aria-disabled when 3 chips are selected", async () => {
 		const user = userEvent.setup();
 		render(
 			<OccupationChipPicker
@@ -109,17 +109,21 @@ describe("OccupationChipPicker", () => {
 				initialSelectedSlugs={["designer", "frontend", "backend"]}
 			/>,
 		);
-		// 4 件目 (fullstack) は disabled
-		expect(chip("フルスタックエンジニア")).toBeDisabled();
+		// 4 件目 (fullstack) は aria-disabled (focusable は維持して SR が読める)
+		const fullstack = chip("フルスタックエンジニア");
+		expect(fullstack).toHaveAttribute("aria-disabled", "true");
+		expect(fullstack).not.toHaveAttribute("disabled");
 		// 既選択は disable しない (off にできる必要)
-		expect(chip("デザイナー")).not.toBeDisabled();
-		// click しても aria-checked 変わらない
-		await user.click(chip("フルスタックエンジニア"));
-		expect(chip("フルスタックエンジニア")).toHaveAttribute(
-			"aria-checked",
-			"false",
-		);
-		expect(screen.getByTestId("occupation-limit-hint")).toBeInTheDocument();
+		expect(chip("デザイナー")).not.toHaveAttribute("aria-disabled");
+		// click しても aria-checked 変わらない (handler が early-return)
+		await user.click(fullstack);
+		expect(fullstack).toHaveAttribute("aria-checked", "false");
+		// 限定 hint が role=status で polite アナウンスされる
+		const hint = screen.getByTestId("occupation-limit-hint");
+		expect(hint).toBeInTheDocument();
+		expect(hint).toHaveAttribute("role", "status");
+		// 4 件目 chip は hint を aria-describedby で指す
+		expect(fullstack).toHaveAttribute("aria-describedby", hint.id);
 	});
 
 	it("save button is disabled when nothing changed", () => {
@@ -166,8 +170,10 @@ describe("OccupationChipPicker", () => {
 		await user.click(chip("デザイナー"));
 		await user.click(screen.getByRole("button", { name: "職業を保存" }));
 
-		const alert = await screen.findByRole("alert");
-		expect(alert).toHaveTextContent("保存に失敗しました");
+		// role=status (polite) で表示。 role=alert (assertive) は使わない。
+		const statusMsg = await screen.findByText(/保存に失敗しました/);
+		expect(statusMsg).toBeInTheDocument();
+		expect(statusMsg).toHaveAttribute("role", "status");
 		expect(toastSuccessSpy).not.toHaveBeenCalled();
 	});
 

--- a/client/src/lib/api/__tests__/occupation.test.ts
+++ b/client/src/lib/api/__tests__/occupation.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Occupation API helper tests (Phase 12 P12-06b, issue #818).
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it } from "vitest";
+
+import { createApiClient } from "@/lib/api/client";
+import {
+	OCCUPATION_MAX_PER_USER,
+	fetchMyOccupations,
+	fetchOccupations,
+	saveMyOccupations,
+} from "@/lib/api/occupation";
+
+function stub() {
+	const client = createApiClient();
+	const mock = new MockAdapter(client);
+	mock.onGet("/auth/csrf/").reply(200, { detail: "CSRF cookie set" });
+	return { client, mock };
+}
+
+describe("occupation API", () => {
+	it("exposes MAX_PER_USER = 3 (backend と同期)", () => {
+		expect(OCCUPATION_MAX_PER_USER).toBe(3);
+	});
+
+	it("fetchOccupations returns the catalog array", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/occupations/").reply(200, [
+			{ slug: "designer", display_name: "デザイナー", display_order: 10 },
+			{
+				slug: "frontend",
+				display_name: "フロントエンドエンジニア",
+				display_order: 20,
+			},
+		]);
+		const list = await fetchOccupations(client);
+		expect(list).toHaveLength(2);
+		expect(list[0]?.slug).toBe("designer");
+	});
+
+	it("fetchMyOccupations returns the slug array", async () => {
+		const { client, mock } = stub();
+		mock
+			.onGet("/users/me/occupations/")
+			.reply(200, { slugs: ["designer", "frontend"] });
+		const slugs = await fetchMyOccupations(client);
+		expect(slugs).toEqual(["designer", "frontend"]);
+	});
+
+	it("fetchMyOccupations returns null on 401/403 (未ログイン)", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/me/occupations/").reply(403, { detail: "Forbidden" });
+		const slugs = await fetchMyOccupations(client);
+		expect(slugs).toBeNull();
+	});
+
+	it("fetchMyOccupations rethrows on 500", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/me/occupations/").reply(500, {});
+		await expect(fetchMyOccupations(client)).rejects.toThrow();
+	});
+
+	it("saveMyOccupations PUTs slugs and bootstraps CSRF", async () => {
+		const { client, mock } = stub();
+		mock.onPut("/users/me/occupations/").reply((config) => {
+			expect(JSON.parse(config.data)).toEqual({
+				slugs: ["designer", "frontend"],
+			});
+			return [200, { slugs: ["designer", "frontend"] }];
+		});
+
+		const result = await saveMyOccupations(["designer", "frontend"], client);
+
+		expect(result).toEqual(["designer", "frontend"]);
+		// CSRF bootstrap が呼ばれたこと
+		expect(mock.history.get.some((req) => req.url === "/auth/csrf/")).toBe(
+			true,
+		);
+	});
+
+	it("saveMyOccupations sends an empty list to clear all", async () => {
+		const { client, mock } = stub();
+		mock.onPut("/users/me/occupations/").reply((config) => {
+			expect(JSON.parse(config.data)).toEqual({ slugs: [] });
+			return [200, { slugs: [] }];
+		});
+		const result = await saveMyOccupations([], client);
+		expect(result).toEqual([]);
+	});
+
+	it("saveMyOccupations rejects locally when > MAX_PER_USER (no network call)", async () => {
+		const { client, mock } = stub();
+		await expect(
+			saveMyOccupations(["a", "b", "c", "d"], client),
+		).rejects.toThrow(/最大/);
+		expect(mock.history.put).toHaveLength(0);
+	});
+
+	it("saveMyOccupations rejects locally on duplicate slug (no network call)", async () => {
+		const { client, mock } = stub();
+		await expect(
+			saveMyOccupations(["designer", "designer"], client),
+		).rejects.toThrow(/重複/);
+		expect(mock.history.put).toHaveLength(0);
+	});
+});

--- a/client/src/lib/api/errors.ts
+++ b/client/src/lib/api/errors.ts
@@ -14,7 +14,22 @@
  * toast / aria-live announcements.
  */
 
-import type { AxiosError } from "axios";
+import axios, { type AxiosError } from "axios";
+
+/**
+ * 単一の axios error が指定ステータスのいずれかを返したかを判定する。
+ * 404 を null に正規化したり 401/403 を未認証扱いするときに使う共通ヘルパ。
+ *
+ *   if (isAxiosStatus(err, 404)) return null;
+ *   if (isAxiosStatus(err, 401, 403)) return null;
+ *
+ * 非 axios エラー (e.g. ``TypeError``) は常に false を返す。
+ */
+export function isAxiosStatus(error: unknown, ...statuses: number[]): boolean {
+	if (!axios.isAxiosError(error)) return false;
+	const status = error.response?.status;
+	return typeof status === "number" && statuses.includes(status);
+}
 
 export interface FormErrors {
 	/** Top-level message shown near the submit button. */

--- a/client/src/lib/api/occupation.ts
+++ b/client/src/lib/api/occupation.ts
@@ -9,7 +9,7 @@
  * spec: docs/specs/phase-12-residence-map-spec.md §9
  */
 
-import type { AxiosInstance } from "axios";
+import axios, { type AxiosInstance } from "axios";
 
 import { api, ensureCsrfToken } from "@/lib/api/client";
 
@@ -71,7 +71,7 @@ export async function saveMyOccupations(
 }
 
 function isAuthFailure(error: unknown): boolean {
-	if (typeof error !== "object" || error === null) return false;
-	const status = (error as { response?: { status?: number } }).response?.status;
+	if (!axios.isAxiosError(error)) return false;
+	const status = error.response?.status;
 	return status === 401 || status === 403;
 }

--- a/client/src/lib/api/occupation.ts
+++ b/client/src/lib/api/occupation.ts
@@ -1,0 +1,77 @@
+/**
+ * Occupation API helpers (Phase 12 P12-06b, issue #818).
+ *
+ * Thin typed wrappers over the P12-06 backend (#815) endpoints:
+ *   - GET  /api/v1/occupations/              (anon 可、 catalog)
+ *   - GET  /api/v1/users/me/occupations/     (auth、 自分の slug 配列)
+ *   - PUT  /api/v1/users/me/occupations/     (auth、 置換、 最大 3 件)
+ *
+ * spec: docs/specs/phase-12-residence-map-spec.md §9
+ */
+
+import type { AxiosInstance } from "axios";
+
+import { api, ensureCsrfToken } from "@/lib/api/client";
+
+/** controlled vocabulary 1 件 (catalog from /api/v1/occupations/)。 */
+export interface Occupation {
+	slug: string;
+	display_name: string;
+	display_order: number;
+}
+
+/** ``MAX_PER_USER`` (backend ``UserOccupation.MAX_PER_USER``) と同期。 */
+export const OCCUPATION_MAX_PER_USER = 3;
+
+/** SSR / CSR 両方から呼べる。 anon 可。 */
+export async function fetchOccupations(
+	client: AxiosInstance = api,
+): Promise<Occupation[]> {
+	const res = await client.get<Occupation[]>("/occupations/");
+	return res.data;
+}
+
+/** 認証必須。 未認証なら null (login redirect は呼び出し側で判断)。 */
+export async function fetchMyOccupations(
+	client: AxiosInstance = api,
+): Promise<string[] | null> {
+	try {
+		const res = await client.get<{ slugs: string[] }>("/users/me/occupations/");
+		return res.data.slugs;
+	} catch (error: unknown) {
+		if (isAuthFailure(error)) return null;
+		throw error;
+	}
+}
+
+/**
+ * Replace semantics。 server は ``{"slugs": [...]}`` を最終状態として保存する。
+ *
+ * - 4 件以上を渡そうとすると client 側で early throw (DB 往復前)。
+ * - 重複 slug も早期 throw する。 server も 400 を返すが network を節約。
+ */
+export async function saveMyOccupations(
+	slugs: string[],
+	client: AxiosInstance = api,
+): Promise<string[]> {
+	if (slugs.length > OCCUPATION_MAX_PER_USER) {
+		throw new Error(
+			`職業は最大 ${OCCUPATION_MAX_PER_USER} 件までしか選択できません。`,
+		);
+	}
+	if (new Set(slugs).size !== slugs.length) {
+		throw new Error("同じ職業を重複して選択することはできません。");
+	}
+
+	await ensureCsrfToken(client);
+	const res = await client.put<{ slugs: string[] }>("/users/me/occupations/", {
+		slugs,
+	});
+	return res.data.slugs;
+}
+
+function isAuthFailure(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) return false;
+	const status = (error as { response?: { status?: number } }).response?.status;
+	return status === 401 || status === 403;
+}

--- a/client/src/lib/api/occupation.ts
+++ b/client/src/lib/api/occupation.ts
@@ -9,9 +9,10 @@
  * spec: docs/specs/phase-12-residence-map-spec.md §9
  */
 
-import axios, { type AxiosInstance } from "axios";
+import type { AxiosInstance } from "axios";
 
 import { api, ensureCsrfToken } from "@/lib/api/client";
+import { isAxiosStatus } from "@/lib/api/errors";
 
 /** controlled vocabulary 1 件 (catalog from /api/v1/occupations/)。 */
 export interface Occupation {
@@ -39,7 +40,9 @@ export async function fetchMyOccupations(
 		const res = await client.get<{ slugs: string[] }>("/users/me/occupations/");
 		return res.data.slugs;
 	} catch (error: unknown) {
-		if (isAuthFailure(error)) return null;
+		// 未認証 (401/403) は呼び出し側が login redirect を判断できるよう null に
+		// 正規化。 5xx / network 障害は throw して個人データ取得失敗を可視化する。
+		if (isAxiosStatus(error, 401, 403)) return null;
 		throw error;
 	}
 }
@@ -68,10 +71,4 @@ export async function saveMyOccupations(
 		slugs,
 	});
 	return res.data.slugs;
-}
-
-function isAuthFailure(error: unknown): boolean {
-	if (!axios.isAxiosError(error)) return false;
-	const status = error.response?.status;
-	return status === 401 || status === 403;
 }


### PR DESCRIPTION
## Summary

P12-06 backend (#815) で入った Occupation + UserOccupation の **frontend** を実装。 ハルナさん要望「ユーザー検索で地図上で職業がデザイナーの人を検索する」 の **入口** となる、 自分の職業を chip で多選択編集できる UI + 公開プロフィールでの read-only 表示。

closes #818

spec: [docs/specs/phase-12-residence-map-spec.md §9.5](../blob/main/docs/specs/phase-12-residence-map-spec.md#95-frontend-本-pr-では未実装-follow-up-issue-で対応)

## 追加内容

### API client (`client/src/lib/api/occupation.ts`)

- `fetchOccupations()` — anon 可、 `GET /api/v1/occupations/`
- `fetchMyOccupations()` — auth、 401/403 を null に正規化 (login redirect は呼び出し側で判断)
- `saveMyOccupations(slugs)` — PUT 置換、 max 3 + 重複は client 側で early-throw、 CSRF bootstrap
- `OCCUPATION_MAX_PER_USER = 3` を backend と同期

### `OccupationChipPicker` (`client/src/components/profile/OccupationChipPicker.tsx`)

- 全 catalog occupations を **`role=switch` + `aria-checked`** で chip 表示
- 件数 indicator (`aria-live=polite`) — 「X / 3 件選択中」
- 4 件目 click は disabled (既選択は always 解除可能)
- 「最大 3 件まで」 hint (`data-testid=occupation-limit-hint`)
- 保存 button: dirty 状態でだけ enable、 保存後は再 disable
- 成功で `toast.success("職業を保存しました")` (#507 反省: 完了シグナル必須)
- エラーは `role=alert` で inline 表示

### 統合

- `/settings/profile` — `Promise.all` で `me/` + `occupations/` + `me/occupations/` を並列 fetch、 backend 落ちても empty-state に fail-safe
- `/u/<handle>` — bio の下に occupation chip 行 (`<section aria-label="職業">`、 read-only `<span>`)
- `PublicProfile` interface に `occupations: Array<{slug, display_name}>` 追加

### Test

- vitest:
  - API client 9 cases — fetch / save / 401 normalize / client-side max + duplicate early-throw / CSRF bootstrap
  - chip picker 8 cases — initial state / toggle / count / 4件目 disable / save success + dirty 復活 / error / empty catalog
- Playwright E2E (`client/e2e/occupation-edit.spec.ts`):
  - OCCUPATION-1 (golden): edit → save → profile で chip 表示
  - OCCUPATION-2 (max enforce): 4件目 disabled + hint
  - OCCUPATION-3 (anon view): 公開プロフィール anon で 200

## 完了判定チェックリスト (CLAUDE.md §4.5)

- [x] Playwright spec ファイルを書いた (`client/e2e/occupation-edit.spec.ts`)
- [x] テストシナリオを spec doc に書いた (spec §9.6 / §9.7 に従って実装)
- [ ] ホーム → 3 click 以内で入口に到達: ホーム → kebab → 「設定」 → /settings/profile (既存ナビ。 新ルートは追加していない)
- [ ] 未ログインでも壊れない: /u/<handle> は anon 可、 /settings/profile は login redirect (既存挙動)
- [x] 画面上に「保存できた」 シグナル: `toast.success("職業を保存しました")` + 保存後 button 再 disable
- [ ] 第一選択は stg Playwright: merge 後 stg CD → 実機検証で踏む
- [ ] `gan-evaluator` agent 採点: stg 反映後に呼ぶ
- [ ] `ui-ux-tester` agent: stg 反映後に呼ぶ

## Test plan

- [ ] CI で tsc / eslint / vitest 全通過
- [ ] stg CD 完了後、 test2 で /settings/profile → chip 編集 → 保存 → /u/test2 で chip 表示確認
- [ ] gan-evaluator + ui-ux-tester で UX 採点 (frontend ルート追加 = 必須、 §4.2 マトリクス)
- [ ] 並列禁止ルール厳守 (reviewer は 1 つずつ直列)