### PR TITLE
fix(e2e): OCCUPATION-1 heading level mismatch (#818 hotfix)

### DIFF
--- a/client/e2e/occupation-edit.spec.ts
+++ b/client/e2e/occupation-edit.spec.ts
@@ -87,9 +87,11 @@ test.describe("Phase 12 P12-06b occupation chip edit + display (#818)", () => {
 		const page = await ctx.newPage();
 		await page.goto(`${BASE}/settings/profile`);
 
-		// chip picker section の見出しが出るまで待つ
+		// chip picker section の見出しが出るまで待つ。
+		// a11y-architect H2 修正で page h1 → h2 階層を維持するため h3 → h2 に
+		// 変更してある (#818 commit fe952fd) ので level: 2 で参照する。
 		await expect(
-			page.getByRole("heading", { name: /職業/, level: 3 }),
+			page.getByRole("heading", { name: /職業/, level: 2 }),
 		).toBeVisible({ timeout: 15000 });
 
 		// 「デザイナー」 と 「フロントエンドエンジニア」 を switch chip として選ぶ


### PR DESCRIPTION
## Summary

PR #820 で a11y-architect HIGH H2 (heading hierarchy: page h1 → section h2) のため OccupationChipPicker の見出しを h3 → h2 に変えた際、 E2E spec の `getByRole('heading', { level: 3 })` を更新し忘れた取りこぼし。

gan-evaluator の stg 採点 (#820 merge 後) で検出。

## 影響

- CI で OCCUPATION-1 が false-positive で fail する可能性。 1 行修正で解消。
- frontend / backend / a11y 挙動は変わらない (spec 修正のみ)。

## Test plan

- [ ] CI で frontend (Next.js) E2E が緑
