### PR TITLE
fix(profile): ui-ux-tester 4 MEDIUM polish (#818 follow-up)

### DIFF
--- a/client/src/app/(template)/u/[handle]/page.tsx
+++ b/client/src/app/(template)/u/[handle]/page.tsx
@@ -299,7 +299,10 @@ export default async function ProfilePage({ params, searchParams }: PageProps) {
 				)}
 
 				{profile.occupations && profile.occupations.length > 0 && (
-					<section aria-label="職業" className="mt-3 px-4">
+					<section aria-label="職業" className="mt-4 px-4">
+						{/* ui-ux-tester polish #818: 居住地 section と同じ
+						    visible <h2>職業</h2> + mt-4 で並べて縦リズム / heading 揃え。 */}
+						<h2 className="mb-2 text-sm font-semibold">職業</h2>
 						{/* a11y-architect C2: chip 形状を border のみで示すと token contrast が
 						    保証されないため、 ``--a-accent-bg`` (sky-100) を fill にして
 						    text-foreground と AA contrast (>=10:1) を満たす。 */}

--- a/client/src/components/profile/OccupationChipPicker.tsx
+++ b/client/src/components/profile/OccupationChipPicker.tsx
@@ -127,10 +127,7 @@ export default function OccupationChipPicker({
 	return (
 		<section aria-labelledby="occupation-picker-heading" className="space-y-3">
 			<div className="flex items-baseline justify-between">
-				<h2
-					id="occupation-picker-heading"
-					className="text-sm font-semibold tracking-tight"
-				>
+				<h2 id="occupation-picker-heading" className="text-base font-semibold">
 					職業 (最大 {OCCUPATION_MAX_PER_USER} 件)
 				</h2>
 				<p
@@ -185,7 +182,7 @@ export default function OccupationChipPicker({
 				})}
 			</div>
 
-			{reachedMax && (
+			{reachedMax && isDirty && (
 				<p
 					id={HINT_ID}
 					role="status"

--- a/client/src/components/profile/__tests__/OccupationChipPicker.test.tsx
+++ b/client/src/components/profile/__tests__/OccupationChipPicker.test.tsx
@@ -118,11 +118,32 @@ describe("OccupationChipPicker", () => {
 		// click しても aria-checked 変わらない (handler が early-return)
 		await user.click(fullstack);
 		expect(fullstack).toHaveAttribute("aria-checked", "false");
-		// 限定 hint が role=status で polite アナウンスされる
+		// 初期 (= 保存済み clean state) では hint は出さない
+		// (ui-ux-tester polish #818: 「設定済の状態で常時 hint 表示は視覚 noise」)
+		expect(
+			screen.queryByTestId("occupation-limit-hint"),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows limit hint only after user reaches max with a dirty change", async () => {
+		const user = userEvent.setup();
+		render(
+			<OccupationChipPicker
+				allOccupations={CATALOG}
+				initialSelectedSlugs={["designer", "frontend"]}
+			/>,
+		);
+		expect(
+			screen.queryByTestId("occupation-limit-hint"),
+		).not.toBeInTheDocument();
+
+		// 3 件目を選ぶと dirty + reachedMax で hint が現れる
+		await user.click(chip("バックエンドエンジニア"));
 		const hint = screen.getByTestId("occupation-limit-hint");
-		expect(hint).toBeInTheDocument();
 		expect(hint).toHaveAttribute("role", "status");
-		// 4 件目 chip は hint を aria-describedby で指す
+
+		const fullstack = chip("フルスタックエンジニア");
+		expect(fullstack).toHaveAttribute("aria-disabled", "true");
 		expect(fullstack).toHaveAttribute("aria-describedby", hint.id);
 	});
 


### PR DESCRIPTION
## Summary

PR #820 merge 後の stg 採点で ui-ux-tester が検出した 4 MEDIUM を一括消化。 機能挙動は不変、 visual polish + a11y rhythm のみ。

closes 関連: ui-ux-tester report for #818

## 修正内容

1. **M1 — heading hierarchy 視覚整合** (`OccupationChipPicker.tsx`)
   - <h2> を `text-sm font-semibold tracking-tight` → `text-base font-semibold`
   - ProfileEditForm の他 h2 (リンク / 翻訳設定) と揃え。 tracking-tight も解消 (日本語 text-sm に negative tracking は cramped)

2. **M2 — post-save 視覚 noise** (`OccupationChipPicker.tsx`)
   - limit hint の出現条件を `reachedMax` → `reachedMax && isDirty` に変更
   - 保存済 (clean state) では hint を出さない。 user が 3 件目を click して dirty + reachedMax になったときだけ表示

3. **M3 — profile 公開ページ heading 非対称** (`u/[handle]/page.tsx`)
   - /u/<handle> の 職業 section に visible `<h2 className="mb-2 text-sm font-semibold">職業</h2>` 追加
   - 既存の 居住地 section と完全に同じ pattern (sighted user にも label が見える)

4. **M4 — 縦リズム不揃い** (`u/[handle]/page.tsx`)
   - /u/<handle> の 職業 section を `mt-3` → `mt-4`
   - bio (mt-4) / 居住地 (mt-4) と統一

## Test 更新

`OccupationChipPicker.test.tsx`: M2 挙動変更を反映:
- 「3 件 initial で hint が出る」 旧 assertion を「clean state では出ない」 に変更
- 「3 件目 click で dirty にすると出る」 を新 case として追加
- vitest 18 cases (17 → 18) all green

## Test plan

- [ ] CI で tsc / eslint / vitest 全通過
- [ ] stg merge 後、 test2 のプロフィールで visible 「職業」 heading + chip + mt-4 リズム確認
- [ ] /settings/profile で OccupationChipPicker h2 が「リンク」 「翻訳設定」 と同じ font-size に揃って見える
- [ ] 3 件選択した状態で「保存」 → toast 後 hint が消えて clean state、 chip 1 つを click で deselect → hint は出ない、 再度 3 件目を click で hint 復活
