### PR TITLE
[feature][search] ユーザー検索に occupation filter + chip UI (P12-07) (#816)

### DIFF
--- a/apps/users/tests/test_user_search_occupation.py
+++ b/apps/users/tests/test_user_search_occupation.py
@@ -1,0 +1,313 @@
+"""
+ユーザー検索 API の occupation filter (Phase 12 P12-07, issue #816)。
+
+対象エンドポイント: ``GET /api/v1/users/search/?occupation=<slug>&...``
+
+ルール (spec §10):
+- ``occupation=<slug>`` は繰り返し可、 複数指定は **OR 結合**
+- ``q`` / ``near_me`` / ``near`` との併用は **AND**
+- 未知 slug / ``is_active=False`` slug は **無視**
+- M2M JOIN の重複 user は ``.distinct()`` で 1 件に
+- occupation 単独 (q / near 無し) でも検索成立
+- occupation も q も near も無ければ空配列 (従来挙動)
+
+spec: docs/specs/phase-12-residence-map-spec.md §10
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.users.models import Occupation, UserOccupation, UserResidence
+from apps.users.views import UserFullTextSearchView
+
+TOKYO = ("35.681236", "139.767125")
+SHINJUKU = ("35.689634", "139.700565")
+OSAKA = ("34.702485", "135.495951")
+
+
+@pytest.fixture
+def search_url() -> str:
+    return reverse("users-fulltext-search")
+
+
+@pytest.fixture
+def occupations(db):
+    """seed migration (0010) と共存するため ``get_or_create`` で subset 取得。
+    廃止職業は test 専用 slug で新規作成 (seed と衝突しない)。"""
+    # display_name は seed migration 0010 と一致させる (get_or_create は seed が
+    # 先行すると defaults を適用しないため、 ズレると latent な maintenance trap に
+    # なる — python-reviewer MEDIUM 指摘)。
+    designer, _ = Occupation.objects.get_or_create(
+        slug="designer",
+        defaults={"display_name": "デザイナー", "display_order": 10},
+    )
+    frontend, _ = Occupation.objects.get_or_create(
+        slug="frontend",
+        defaults={"display_name": "フロントエンドエンジニア", "display_order": 20},
+    )
+    backend, _ = Occupation.objects.get_or_create(
+        slug="backend",
+        defaults={"display_name": "バックエンドエンジニア", "display_order": 30},
+    )
+    deprecated, _ = Occupation.objects.get_or_create(
+        slug="zz_deprecated_test",
+        defaults={
+            "display_name": "廃止職業 (test)",
+            "display_order": 999,
+            "is_active": False,
+        },
+    )
+    return {
+        "designer": designer,
+        "frontend": frontend,
+        "backend": backend,
+        "deprecated": deprecated,
+    }
+
+
+def _attach(user, *occ) -> None:
+    for o in occ:
+        UserOccupation.objects.create(user=user, occupation=o)
+
+
+def _set_residence(user, lat: str, lng: str, radius_m: int = 500) -> UserResidence:
+    return UserResidence.objects.create(user=user, latitude=lat, longitude=lng, radius_m=radius_m)
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUserSearchOccupationFilter:
+    def test_single_occupation_filters(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        d = user_factory(username="designer_user")
+        _attach(d, occupations["designer"])
+        b = user_factory(username="backend_user")
+        _attach(b, occupations["backend"])
+
+        res = api_client.get(search_url, {"occupation": "designer"})
+
+        assert res.status_code == status.HTTP_200_OK
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "designer_user" in usernames
+        assert "backend_user" not in usernames
+
+    def test_multiple_occupation_is_or(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        d = user_factory(username="designer_only")
+        _attach(d, occupations["designer"])
+        f = user_factory(username="frontend_only")
+        _attach(f, occupations["frontend"])
+        b = user_factory(username="backend_only")
+        _attach(b, occupations["backend"])
+
+        res = api_client.get(search_url, {"occupation": ["designer", "frontend"]})
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "designer_only" in usernames
+        assert "frontend_only" in usernames
+        assert "backend_only" not in usernames
+
+    def test_user_with_multiple_matching_occupations_not_duplicated(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """designer + frontend 両方持つ user は OR filter で 2 回 JOIN するが
+        ``.distinct()`` で結果に 1 回だけ出る。"""
+        both = user_factory(username="multi_occ")
+        _attach(both, occupations["designer"], occupations["frontend"])
+
+        res = api_client.get(search_url, {"occupation": ["designer", "frontend"]})
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert usernames.count("multi_occ") == 1
+
+    def test_unknown_slug_only_returns_empty(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """未知 slug だけ (q/near 無し) は「有効な検索条件なし」 扱いで空配列。
+        spec §10.2: 検索成立は q / near / 有効 occupation のいずれか。 stale な
+        bookmark URL で全 user を吐き出さないための挙動。"""
+        d = user_factory(username="any_designer")
+        _attach(d, occupations["designer"])
+        user_factory(username="plain_user")
+
+        res = api_client.get(search_url, {"occupation": "nonexistent_slug"})
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["results"] == []
+
+    def test_inactive_slug_only_returns_empty(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """is_active=False の occupation は採用しない → 有効 slug 0 件 → 空配列。"""
+        dep = user_factory(username="deprecated_user")
+        _attach(dep, occupations["deprecated"])
+        user_factory(username="plain_user2")
+
+        res = api_client.get(search_url, {"occupation": "zz_deprecated_test"})
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["results"] == []
+
+    def test_mixed_valid_and_invalid_slugs_uses_valid(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """valid + invalid 混在時は valid slug だけで filter する (invalid は drop)。"""
+        d = user_factory(username="mixed_designer")
+        _attach(d, occupations["designer"])
+        b = user_factory(username="mixed_backend")
+        _attach(b, occupations["backend"])
+
+        res = api_client.get(search_url, {"occupation": ["nonexistent_slug", "designer"]})
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "mixed_designer" in usernames
+        assert "mixed_backend" not in usernames
+
+    def test_occupation_and_q_is_and(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        match = user_factory(username="react_designer", bio="React が好き")
+        _attach(match, occupations["designer"])
+        # designer だが bio に react 無し
+        no_q = user_factory(username="vue_designer", bio="Vue 派")
+        _attach(no_q, occupations["designer"])
+        # react あるが designer 無し
+        no_occ = user_factory(username="react_backend", bio="React も触る")
+        _attach(no_occ, occupations["backend"])
+
+        res = api_client.get(search_url, {"q": "React", "occupation": "designer"})
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "react_designer" in usernames
+        assert "vue_designer" not in usernames
+        assert "react_backend" not in usernames
+
+    def test_occupation_and_near_me_is_and(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        me = user_factory(username="me_occ")
+        _set_residence(me, *TOKYO)
+        api_client.force_authenticate(user=me)
+
+        nearby_designer = user_factory(username="nearby_designer")
+        _set_residence(nearby_designer, *SHINJUKU)
+        _attach(nearby_designer, occupations["designer"])
+
+        nearby_backend = user_factory(username="nearby_backend")
+        _set_residence(nearby_backend, *SHINJUKU)
+        _attach(nearby_backend, occupations["backend"])
+
+        far_designer = user_factory(username="far_designer")
+        _set_residence(far_designer, *OSAKA)
+        _attach(far_designer, occupations["designer"])
+
+        res = api_client.get(
+            search_url,
+            {"near_me": "1", "radius_km": "10", "occupation": "designer"},
+        )
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "nearby_designer" in usernames  # 近い AND designer
+        assert "nearby_backend" not in usernames  # 近いが designer でない
+        assert "far_designer" not in usernames  # designer だが遠い
+
+    def test_near_me_occupation_requires_auth(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        res = api_client.get(search_url, {"near_me": "1", "occupation": "designer"})
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_explicit_near_and_occupation_is_and_anon(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """``?near=lat,lng`` (anon 可) + occupation も AND。 near_me と別経路だが
+        同じ haversine + .distinct() を通るので独立に検証する。"""
+        nearby_designer = user_factory(username="anon_nearby_designer")
+        _set_residence(nearby_designer, *SHINJUKU)
+        _attach(nearby_designer, occupations["designer"])
+
+        nearby_backend = user_factory(username="anon_nearby_backend")
+        _set_residence(nearby_backend, *SHINJUKU)
+        _attach(nearby_backend, occupations["backend"])
+
+        far_designer = user_factory(username="anon_far_designer")
+        _set_residence(far_designer, *OSAKA)
+        _attach(far_designer, occupations["designer"])
+
+        res = api_client.get(
+            search_url,
+            {
+                "near": f"{TOKYO[0]},{TOKYO[1]}",
+                "radius_km": "10",
+                "occupation": "designer",
+            },
+        )
+
+        assert res.status_code == status.HTTP_200_OK
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "anon_nearby_designer" in usernames  # 近い AND designer
+        assert "anon_nearby_backend" not in usernames  # 近いが designer でない
+        assert "anon_far_designer" not in usernames  # designer だが遠い
+
+    def test_occupation_only_search_succeeds(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """q も near も無く occupation だけでも検索成立する。"""
+        d = user_factory(username="solo_designer")
+        _attach(d, occupations["designer"])
+
+        res = api_client.get(search_url, {"occupation": "designer"})
+
+        assert res.status_code == status.HTTP_200_OK
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "solo_designer" in usernames
+
+    def test_no_params_returns_empty(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """occupation も q も near も無ければ従来通り空配列。"""
+        d = user_factory(username="lonely")
+        _attach(d, occupations["designer"])
+
+        res = api_client.get(search_url)
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data["results"] == []
+
+    def test_occupation_excludes_inactive_users(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        active = user_factory(username="active_designer")
+        _attach(active, occupations["designer"])
+        hidden = user_factory(username="hidden_designer", is_active=False)
+        _attach(hidden, occupations["designer"])
+
+        res = api_client.get(search_url, {"occupation": "designer"})
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "active_designer" in usernames
+        assert "hidden_designer" not in usernames
+
+    def test_occupation_filter_caps_slug_count(
+        self, api_client: APIClient, user_factory, occupations, search_url: str
+    ) -> None:
+        """MAX_OCCUPATION_FILTER (=20) を超える slug は頭打ちで drop される。
+        先頭 20 件をすべて invalid にし、 21 件目に唯一の valid slug (designer) を
+        置くと、 cap で designer が落ちて「有効 slug 0 件」 → 空配列になる
+        (DB 照合より前に truncate される証明)。"""
+        d = user_factory(username="capped_designer")
+        _attach(d, occupations["designer"])
+
+        cap = UserFullTextSearchView.MAX_OCCUPATION_FILTER
+        slugs = [f"invalid_{i}" for i in range(cap)] + ["designer"]
+        res = api_client.get(search_url, {"occupation": slugs})
+
+        assert res.status_code == status.HTTP_200_OK
+        # designer は 21 件目で cap 外 → filter に採用されず → 検索条件なし扱い
+        assert res.data["results"] == []

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -24,7 +24,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from apps.common.cookie_auth import CookieAuthentication, CSRFEnforcingAuthentication
-from apps.users.models import UserResidence
+from apps.users.models import Occupation, UserResidence
 from apps.users.s3_presign import generate_presigned_upload_url
 from apps.users.serializers import (
     CustomUserSerializer,
@@ -957,11 +957,41 @@ class UserFullTextSearchView(ListAPIView):
                 self._cached_paginator = UserSearchCursorPagination()
         return self._cached_paginator
 
+    # 1 リクエストで受け付ける occupation slug の上限。 catalog は ~16 件なので
+    # 全選択しても余裕がある一方、 AllowAny endpoint に巨大 IN を投げる abuse を
+    # 防ぐ (python-reviewer HIGH 指摘)。
+    MAX_OCCUPATION_FILTER = 20
+
+    def _valid_occupation_slugs(self) -> list[str]:
+        """``?occupation=`` で渡された slug を **存在 + is_active=True** に正規化。
+
+        未知 slug / 廃止 (is_active=False) slug は落とす (bookmark URL を将来の
+        vocabulary 変更で壊さないため、 P12-07 spec §10.2)。 空白除去 + 重複排除し、
+        ``MAX_OCCUPATION_FILTER`` 件で頭打ちにしてから 1 回だけ DB 照合する。
+        1 件も渡されなければ空 list (DB 照合もしない)。
+        """
+        raw = self.request.query_params.getlist("occupation")
+        # 順序を保ったまま重複排除 → 上限でクランプ。
+        seen: dict[str, None] = {}
+        for s in raw:
+            trimmed = s.strip()
+            if trimmed:
+                seen.setdefault(trimmed)
+        cleaned = list(seen)[: self.MAX_OCCUPATION_FILTER]
+        if not cleaned:
+            return []
+        return list(
+            Occupation.objects.filter(slug__in=cleaned, is_active=True).values_list(
+                "slug", flat=True
+            )
+        )
+
     def get_queryset(self) -> QuerySet:
         params = self.request.query_params
         q = (params.get("q") or "").strip()
         near_me = params.get("near_me") == "1"
         near_raw = params.get("near")
+        occupation_slugs = self._valid_occupation_slugs()
 
         center: tuple[float, float] | None = None
         if near_me:
@@ -990,8 +1020,8 @@ class UserFullTextSearchView(ListAPIView):
                 )
             center = parsed
 
-        if center is None and not q:
-            # 何も指定が無ければ空配列 (P12-04 既存挙動)
+        if center is None and not q and not occupation_slugs:
+            # q / near / occupation のどれも無ければ空配列 (P12-04 既存挙動)
             return User.objects.none()
 
         qs = User.objects.filter(is_active=True)
@@ -999,6 +1029,11 @@ class UserFullTextSearchView(ListAPIView):
             qs = qs.filter(
                 Q(username__icontains=q) | Q(display_name__icontains=q) | Q(bio__icontains=q)
             )
+
+        if occupation_slugs:
+            # 複数 slug は OR 結合 (__in)。 M2M JOIN で同一 user が複数行になるので
+            # .distinct() で重複排除。 q / near との併用は AND (filter の連鎖)。
+            qs = qs.filter(occupations__slug__in=occupation_slugs).distinct()
 
         if center is None:
             return qs.order_by("username")

--- a/client/e2e/user-search-occupation.spec.ts
+++ b/client/e2e/user-search-occupation.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * Phase 12 P12-07 ユーザー検索 occupation filter E2E spec (issue #816).
+ *
+ * spec: docs/specs/phase-12-residence-map-spec.md §10
+ *
+ * 検証シナリオ:
+ *   OCCSEARCH-1 (single filter):
+ *     USER1 を designer に seed → anon が /search/users で「デザイナー」 chip を
+ *     click → URL に ?occupation=designer → USER1 が結果に出る / backend の
+ *     USER2 は出ない
+ *
+ *   OCCSEARCH-2 (multi OR):
+ *     USER1=designer, USER2=backend を seed → anon が 2 chip 選択 → URL に
+ *     occupation 2 件 → USER1 / USER2 両方が出る (OR 和集合)
+ *
+ *   OCCSEARCH-3 (reload preserves selection):
+ *     anon が /search/users?occupation=designer を直接開く → 「デザイナー」 chip が
+ *     aria-checked=true で復元される
+ *
+ *   OCCSEARCH-4 (q AND occupation):
+ *     anon が ?q=<USER1 handle>&occupation=designer → USER1 が出る。
+ *     occupation を USER1 が持たない backend にすると USER1 は出ない (AND)。
+ *
+ * env: docs/local/e2e-stg.md の test2 (USER1) / test3 (USER2)。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+const USER2 = {
+	email: process.env.PLAYWRIGHT_USER2_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER2_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER2_HANDLE ?? "",
+};
+
+function requireEnv() {
+	for (const [k, v] of Object.entries({
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+		PLAYWRIGHT_USER2_EMAIL: USER2.email,
+		PLAYWRIGHT_USER2_PASSWORD: USER2.password,
+		PLAYWRIGHT_USER2_HANDLE: USER2.handle,
+	})) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+): Promise<{ csrf: string }> {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+	return { csrf };
+}
+
+/** USER の occupations を置換 (PUT semantics)。 spec 間の暗黙依存を避けるため
+ *  各 test が自前で seed する。 */
+async function setOccupations(
+	request: APIRequestContext,
+	csrf: string,
+	slugs: string[],
+): Promise<void> {
+	const res = await request.put(`${BASE}/api/v1/users/me/occupations/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/settings/profile`,
+		},
+		data: { slugs },
+	});
+	expect(res.status()).toBe(200);
+}
+
+async function seedUser(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+	slugs: string[],
+): Promise<void> {
+	const { csrf } = await loginViaApi(request, user);
+	await setOccupations(request, csrf, slugs);
+}
+
+test.describe("Phase 12 P12-07 user search occupation filter (#816)", () => {
+	test("OCCSEARCH-1: chip click filters by occupation + syncs URL", async ({
+		browser,
+	}) => {
+		requireEnv();
+		// USER1=designer, USER2=backend を seed (別 context で逐次)
+		const seedCtx = await browser.newContext();
+		await seedUser(seedCtx.request, USER1, ["designer"]);
+		await seedCtx.close();
+		const seedCtx2 = await browser.newContext();
+		await seedUser(seedCtx2.request, USER2, ["backend"]);
+		await seedCtx2.close();
+
+		// anon で検索 page を開く
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+		await page.goto(`${BASE}/search/users`);
+
+		const designerChip = page.getByRole("switch", { name: "デザイナー" });
+		await expect(designerChip).toBeVisible({ timeout: 15000 });
+		await expect(designerChip).toHaveAttribute("aria-checked", "false");
+		await designerChip.click();
+
+		// URL が ?occupation=designer に同期する
+		await expect(page).toHaveURL(/[?&]occupation=designer/);
+
+		// designer の USER1 は出る、 backend の USER2 は出ない
+		const results = page.getByRole("region", { name: "検索結果" });
+		await expect(results).toBeVisible({ timeout: 15000 });
+		await expect(page.locator(`a[href="/u/${USER1.handle}"]`)).toBeVisible();
+		await expect(page.locator(`a[href="/u/${USER2.handle}"]`)).toHaveCount(0);
+
+		await anon.close();
+	});
+
+	test("OCCSEARCH-2: two chips give OR union", async ({ browser }) => {
+		requireEnv();
+		const seedCtx = await browser.newContext();
+		await seedUser(seedCtx.request, USER1, ["designer"]);
+		await seedCtx.close();
+		const seedCtx2 = await browser.newContext();
+		await seedUser(seedCtx2.request, USER2, ["backend"]);
+		await seedCtx2.close();
+
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+		await page.goto(`${BASE}/search/users?occupation=designer`);
+
+		// designer は既に選択済 (URL 復元)。 backend chip を足す
+		await expect(
+			page.getByRole("switch", { name: "デザイナー" }),
+		).toHaveAttribute("aria-checked", "true");
+		await page.getByRole("switch", { name: "バックエンドエンジニア" }).click();
+
+		await expect(page).toHaveURL(/occupation=designer/);
+		await expect(page).toHaveURL(/occupation=backend/);
+
+		// OR 和集合: USER1 (designer) も USER2 (backend) も出る
+		await expect(page.locator(`a[href="/u/${USER1.handle}"]`)).toBeVisible({
+			timeout: 15000,
+		});
+		await expect(page.locator(`a[href="/u/${USER2.handle}"]`)).toBeVisible();
+
+		await anon.close();
+	});
+
+	test("OCCSEARCH-3: reloading a filtered URL restores chip selection", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const seedCtx = await browser.newContext();
+		await seedUser(seedCtx.request, USER1, ["designer"]);
+		await seedCtx.close();
+
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+		// URL 直接 (= reload と同じ初期 state)
+		await page.goto(`${BASE}/search/users?occupation=designer`);
+
+		const designerChip = page.getByRole("switch", { name: "デザイナー" });
+		await expect(designerChip).toBeVisible({ timeout: 15000 });
+		await expect(designerChip).toHaveAttribute("aria-checked", "true");
+		// 他 chip は未選択
+		await expect(
+			page.getByRole("switch", { name: "バックエンドエンジニア" }),
+		).toHaveAttribute("aria-checked", "false");
+
+		await anon.close();
+	});
+
+	test("OCCSEARCH-4: q AND occupation narrows results", async ({ browser }) => {
+		requireEnv();
+		const seedCtx = await browser.newContext();
+		await seedUser(seedCtx.request, USER1, ["designer"]);
+		await seedCtx.close();
+
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+
+		// q=<USER1 handle> AND occupation=designer → USER1 が出る
+		await page.goto(
+			`${BASE}/search/users?q=${encodeURIComponent(USER1.handle)}&occupation=designer`,
+		);
+		await expect(page.locator(`a[href="/u/${USER1.handle}"]`)).toBeVisible({
+			timeout: 15000,
+		});
+
+		// 同じ q だが USER1 が持たない occupation=backend → USER1 は出ない (AND)
+		await page.goto(
+			`${BASE}/search/users?q=${encodeURIComponent(USER1.handle)}&occupation=backend`,
+		);
+		// 検索は走るが該当無し (USER1 は backend を持たない)
+		await expect(page.locator(`a[href="/u/${USER1.handle}"]`)).toHaveCount(0);
+
+		await anon.close();
+	});
+});

--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -13,12 +13,16 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import NearMeFilter from "@/components/search/NearMeFilter";
+import OccupationFilter from "@/components/search/OccupationFilter";
 import SearchModeTabs from "@/components/search/SearchModeTabs";
 import UserSearchBox from "@/components/search/UserSearchBox";
 import UserSearchResultCard from "@/components/search/UserSearchResultCard";
 import WhoToFollow from "@/components/sidebar/WhoToFollow";
+import type { Occupation } from "@/lib/api/occupation";
 import { ApiServerError, serverFetch } from "@/lib/api/server";
 import {
+	buildUserSearchHref,
+	buildUserSearchParams,
 	PROXIMITY_RADIUS_DEFAULT_KM,
 	PROXIMITY_RADIUS_MAX_KM,
 	PROXIMITY_RADIUS_MIN_KM,
@@ -32,6 +36,8 @@ interface SearchPageProps {
 		cursor?: string;
 		near_me?: string;
 		radius_km?: string;
+		/** Next.js は重複 query key を string[] に、 単一を string にする。 */
+		occupation?: string | string[];
 	};
 }
 
@@ -45,6 +51,20 @@ interface SearchQuery {
 	cursor?: string;
 	nearMe: boolean;
 	radiusKm: number;
+	/** P12-07: URL ``?occupation=`` で復元した職業 slug (重複排除済)。 */
+	occupations: string[];
+}
+
+/** ``occupation`` query を string[] に正規化 (単一 string / 配列 / 未指定)。
+ *  空文字を落とし、 重複は除く (URL 安定 + filter の意味は集合)。 */
+function parseOccupations(raw: string | string[] | undefined): string[] {
+	const list = raw === undefined ? [] : Array.isArray(raw) ? raw : [raw];
+	const seen = new Set<string>();
+	for (const slug of list) {
+		const trimmed = slug.trim();
+		if (trimmed) seen.add(trimmed);
+	}
+	return Array.from(seen);
 }
 
 function parseSearchParams(sp: SearchPageProps["searchParams"]): SearchQuery {
@@ -58,7 +78,24 @@ function parseSearchParams(sp: SearchPageProps["searchParams"]): SearchQuery {
 					PROXIMITY_RADIUS_MAX_KM,
 				)
 			: PROXIMITY_RADIUS_DEFAULT_KM;
-	return { q, cursor: sp.cursor, nearMe, radiusKm };
+	return {
+		q,
+		cursor: sp.cursor,
+		nearMe,
+		radiusKm,
+		occupations: parseOccupations(sp.occupation),
+	};
+}
+
+/** SSR で職業 catalog を取得。 失敗しても検索自体は動かすため fail-safe で
+ *  空配列に倒す (filter UI だけ消える)。 silent にしないよう console.error は残す。 */
+async function loadOccupations(): Promise<Occupation[]> {
+	try {
+		return await serverFetch<Occupation[]>("/occupations/");
+	} catch (error) {
+		console.error("[search/users] failed to load occupations catalog", error);
+		return [];
+	}
 }
 
 async function loadCurrentUser(): Promise<CurrentUser | null> {
@@ -77,14 +114,13 @@ type SearchOutcome =
 	| { kind: "error"; message: string };
 
 async function loadUserSearch(query: SearchQuery): Promise<SearchOutcome> {
-	const params = new URLSearchParams();
-	if (query.q) params.set("q", query.q);
-	if (query.cursor) params.set("cursor", query.cursor);
-	if (query.nearMe) {
-		params.set("near_me", "1");
-		params.set("radius_km", String(query.radiusKm));
-	}
-	const qs = params.toString();
+	const qs = buildUserSearchParams({
+		q: query.q,
+		cursor: query.cursor,
+		nearMe: query.nearMe,
+		radiusKm: query.radiusKm,
+		occupations: query.occupations,
+	}).toString();
 	const url = qs ? `/users/search/?${qs}` : "/users/search/";
 	try {
 		const page = await serverFetch<UserSearchPageData>(url);
@@ -125,26 +161,27 @@ function buildSearchHref(
 	query: SearchQuery,
 	overrides: { cursor?: string | null } = {},
 ): string {
-	const params = new URLSearchParams();
-	if (query.q) params.set("q", query.q);
-	if (query.nearMe) {
-		params.set("near_me", "1");
-		params.set("radius_km", String(query.radiusKm));
-	}
-	const cursor = overrides.cursor;
-	if (cursor) params.set("cursor", cursor);
-	const qs = params.toString();
-	return qs ? `/search/users?${qs}` : "/search/users";
+	return buildUserSearchHref({
+		q: query.q,
+		nearMe: query.nearMe,
+		radiusKm: query.radiusKm,
+		occupations: query.occupations,
+		cursor: overrides.cursor,
+	});
 }
 
 export default async function UserSearchPage({
 	searchParams,
 }: SearchPageProps) {
 	const query = parseSearchParams(searchParams);
-	const currentUser = await loadCurrentUser();
+	const [currentUser, occupationCatalog] = await Promise.all([
+		loadCurrentUser(),
+		loadOccupations(),
+	]);
 	const loggedIn = currentUser !== null;
-	// 何も指定がなければ検索しない
-	const hasAnyQuery = query.q.length > 0 || query.nearMe;
+	// 何も指定がなければ検索しない (occupation 選択も検索成立条件)
+	const hasAnyQuery =
+		query.q.length > 0 || query.nearMe || query.occupations.length > 0;
 	const outcome = hasAnyQuery
 		? await loadUserSearch(query)
 		: ({
@@ -156,6 +193,15 @@ export default async function UserSearchPage({
 		outcome.kind === "results" ? extractCursor(outcome.page.next) : null;
 	const prevCursor =
 		outcome.kind === "results" ? extractCursor(outcome.page.previous) : null;
+
+	// header subtitle / 表示用: 選択 occupation slug を display_name に解決。
+	// catalog に無い slug (取得失敗時など) は slug をそのまま見せる。
+	// 表示有無は hasAnyQuery と一致する (occupationLabels.length === query.occupations.length)
+	// ので別 flag を作らず hasAnyQuery を再利用する (typescript-reviewer 指摘の二重管理回避)。
+	const occupationLabels = query.occupations.map(
+		(slug) =>
+			occupationCatalog.find((o) => o.slug === slug)?.display_name ?? slug,
+	);
 
 	return (
 		<>
@@ -174,13 +220,15 @@ export default async function UserSearchPage({
 					>
 						検索
 					</h1>
-					{(query.q || query.nearMe) && (
+					{hasAnyQuery && (
 						<p
 							className="truncate text-[color:var(--a-text-subtle)]"
 							style={{ fontFamily: "var(--a-font-mono)", fontSize: 11 }}
 						>
 							{query.q && `「${query.q}」`}
 							{query.nearMe && ` · 半径 ${query.radiusKm}km`}
+							{occupationLabels.length > 0 &&
+								` · ${occupationLabels.join(" / ")}`}
 						</p>
 					)}
 				</div>
@@ -200,11 +248,25 @@ export default async function UserSearchPage({
 					    (typescript-reviewer HIGH 修正、 client component が
 					    Server Component の re-render で remount されない問題)。 */}
 					<NearMeFilter
-						key={`${query.nearMe}-${query.radiusKm}`}
+						key={`${query.nearMe}-${query.radiusKm}-${query.occupations.join(",")}`}
 						query={query.q}
 						initialNearMe={query.nearMe}
 						initialRadiusKm={query.radiusKm}
 						loggedIn={loggedIn}
+						occupations={query.occupations}
+					/>
+				</div>
+
+				{/* P12-07: 職業 chip filter。 catalog は SSR で取得 (失敗時は
+				    OccupationFilter が null を返して filter UI が消える)。
+				    selected は props から直接導出するので remount 用 key は不要。 */}
+				<div className="mb-6">
+					<OccupationFilter
+						occupations={occupationCatalog}
+						selected={query.occupations}
+						query={query.q}
+						nearMe={query.nearMe}
+						radiusKm={query.radiusKm}
 					/>
 				</div>
 

--- a/client/src/components/search/NearMeFilter.tsx
+++ b/client/src/components/search/NearMeFilter.tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import {
+	buildUserSearchHref,
 	PROXIMITY_RADIUS_DEFAULT_KM,
 	PROXIMITY_RADIUS_MAX_KM,
 	PROXIMITY_RADIUS_MIN_KM,
@@ -29,6 +30,9 @@ interface NearMeFilterProps {
 	initialRadiusKm: number;
 	/** 「ログイン必須」 を出す必要があるかどうか。 page 側で current user を見て判定。 */
 	loggedIn: boolean;
+	/** P12-07: 併存する職業 filter。 near_me toggle / slider 操作で取りこぼさず
+	 *  URL を維持する (code-reviewer HIGH: cross-filter state loss 対策)。 */
+	occupations?: string[];
 }
 
 export default function NearMeFilter({
@@ -36,20 +40,21 @@ export default function NearMeFilter({
 	initialNearMe,
 	initialRadiusKm,
 	loggedIn,
+	occupations = [],
 }: NearMeFilterProps) {
 	const router = useRouter();
 	const [nearMe, setNearMe] = useState(initialNearMe);
 	const [radiusKm, setRadiusKm] = useState(initialRadiusKm);
 
 	function navigate(next: { nearMe: boolean; radiusKm: number }) {
-		const params = new URLSearchParams();
-		if (query) params.set("q", query);
-		if (next.nearMe) {
-			params.set("near_me", "1");
-			params.set("radius_km", String(next.radiusKm));
-		}
-		const qs = params.toString();
-		router.push(qs ? `/search/users?${qs}` : "/search/users");
+		router.push(
+			buildUserSearchHref({
+				q: query,
+				nearMe: next.nearMe,
+				radiusKm: next.radiusKm,
+				occupations,
+			}),
+		);
 	}
 
 	return (
@@ -82,7 +87,7 @@ export default function NearMeFilter({
 				{!loggedIn && (
 					<Link
 						href={`/login?next=${encodeURIComponent(
-							query ? `/search/users?q=${query}` : "/search/users",
+							buildUserSearchHref({ q: query, occupations }),
 						)}`}
 						className="rounded-md border border-[color:var(--a-border)] px-2 py-1 text-[color:var(--a-text-muted)] underline-offset-2 hover:underline"
 						style={{ fontSize: 11.5 }}

--- a/client/src/components/search/OccupationFilter.tsx
+++ b/client/src/components/search/OccupationFilter.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+/**
+ * 職業 (occupation) chip filter (Phase 12 P12-07, issue #816)。
+ *
+ * `/search/users` で職業 slug を toggle して URL に同期する。 選択は
+ * ``?occupation=designer&occupation=frontend`` の形で複数 (backend で OR 結合)。
+ * 既存の q / near_me / radius_km は維持したまま navigate する。
+ *
+ * a11y design (OccupationChipPicker と一貫):
+ *   - chip は ``role=switch`` + ``aria-checked``。 visible text 自身が
+ *     accessible name となるよう ``aria-label`` は付けない。
+ *   - 選択 chip は ``--a-accent-deep`` 塗り + ``✓`` icon (色のみ依存を回避)。
+ *   - filter 変更は即 URL navigate (保存 button は無い、 検索 filter なので)。
+ *   - 1 件以上選択中のとき「すべて解除」 link を出す。
+ *   - 見出しは heading 要素にせず、 visible label ``<p id>`` を chips の
+ *     ``role=group`` から ``aria-labelledby`` で 1 回だけ参照する (兄弟の
+ *     NearMeFilter と同じく page の h1→h2 階層に余計な heading を挿さない、
+ *     かつ label 文字列の二重アナウンスを避ける — typescript-reviewer 指摘)。
+ */
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import type { Occupation } from "@/lib/api/occupation";
+import { buildUserSearchHref } from "@/lib/api/userSearch";
+
+interface OccupationFilterProps {
+	/** GET /api/v1/occupations/ の catalog (is_active のみ、 display_order 順)。 */
+	occupations: Occupation[];
+	/** URL から復元した現在の選択 slug。 */
+	selected: string[];
+	/** 併存する text query (URL 維持用)。 */
+	query: string;
+	/** 併存する近所検索 state (URL 維持用)。 */
+	nearMe: boolean;
+	radiusKm: number;
+}
+
+export default function OccupationFilter({
+	occupations,
+	selected,
+	query,
+	nearMe,
+	radiusKm,
+}: OccupationFilterProps) {
+	const router = useRouter();
+
+	// toggle / 解除で router.push すると server component が再 render され、
+	// keyboard / SR の focus が body に落ちる (a11y-architect H-1)。 直前に操作した
+	// chip の slug を覚えておき、 navigation 後 (selected prop が変わった後) に
+	// その chip へ focus を戻す。 stable key 由来で DOM が保持される場合は no-op、
+	// 落ちた場合の保険。
+	const refocusSlugRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		const slug = refocusSlugRef.current;
+		if (!slug) return;
+		refocusSlugRef.current = null;
+		document
+			.querySelector<HTMLElement>(
+				`[data-occupation-chip="${CSS.escape(slug)}"]`,
+			)
+			?.focus();
+	}, [selected]);
+
+	// catalog が取れなかった (SSR fetch 失敗) ときは何も描画しない。
+	// q / near 検索は従来通り動くので filter UI だけ消す。
+	if (occupations.length === 0) return null;
+
+	const selectedSet = new Set(selected);
+
+	const navigate = (nextOccupations: string[]) => {
+		// filter を変えたら cursor は無効になるので引き継がない (1 page 目に戻す)。
+		// scroll:false で navigation 時の viewport jump を防ぐ (a11y-architect H-1)。
+		router.push(
+			buildUserSearchHref({
+				q: query,
+				nearMe,
+				radiusKm,
+				occupations: nextOccupations,
+			}),
+			{ scroll: false },
+		);
+	};
+
+	const toggle = (slug: string) => {
+		refocusSlugRef.current = slug;
+		const next = new Set(selectedSet);
+		if (next.has(slug)) {
+			next.delete(slug);
+		} else {
+			next.add(slug);
+		}
+		// catalog の表示順 (display_order) を維持して URL を安定させる。
+		navigate(occupations.map((o) => o.slug).filter((s) => next.has(s)));
+	};
+
+	const clearAll = () => {
+		// 全解除後は「すべて解除」 button が消えるので、 focus を先頭 chip へ逃がす。
+		refocusSlugRef.current = occupations[0]?.slug ?? null;
+		navigate([]);
+	};
+
+	const hasSelection = selectedSet.size > 0;
+
+	return (
+		<div
+			className="rounded-md border border-[color:var(--a-border)] px-3 py-2"
+			style={{ background: "var(--a-bg-muted)" }}
+		>
+			<div className="mb-2 flex items-baseline justify-between">
+				<p
+					id="occupation-filter-label"
+					className="text-[color:var(--a-text-muted)]"
+					style={{ fontSize: 12, fontWeight: 600 }}
+				>
+					職業で絞り込む
+				</p>
+				{hasSelection && (
+					<button
+						type="button"
+						onClick={clearAll}
+						className="text-[color:var(--a-text-muted)] underline-offset-2 hover:underline"
+						style={{ fontSize: 11.5 }}
+					>
+						すべて解除
+					</button>
+				)}
+			</div>
+
+			<div
+				role="group"
+				aria-labelledby="occupation-filter-label"
+				className="flex flex-wrap gap-2"
+			>
+				{occupations.map((occ) => {
+					const isSelected = selectedSet.has(occ.slug);
+					return (
+						<button
+							key={occ.slug}
+							type="button"
+							role="switch"
+							aria-checked={isSelected}
+							onClick={() => toggle(occ.slug)}
+							data-occupation-chip={occ.slug}
+							className={
+								"inline-flex min-h-[28px] items-center gap-1 rounded-full border px-3 py-1 text-sm transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent-deep)] " +
+								(isSelected
+									? "border-[color:var(--a-accent-deep)] bg-[color:var(--a-accent-deep)] text-white"
+									: "border-border bg-background text-foreground hover:bg-muted")
+							}
+						>
+							{isSelected && (
+								<span aria-hidden="true" className="text-xs leading-none">
+									✓
+								</span>
+							)}
+							{occ.display_name}
+						</button>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/client/src/components/search/__tests__/NearMeFilter.test.tsx
+++ b/client/src/components/search/__tests__/NearMeFilter.test.tsx
@@ -121,4 +121,39 @@ describe("NearMeFilter", () => {
 			"/search/users?near_me=1&radius_km=30",
 		);
 	});
+
+	it("preserves occupation filter when toggling near_me (P12-07 cross-filter)", () => {
+		render(
+			<NearMeFilter
+				query="rust"
+				initialNearMe={false}
+				initialRadiusKm={10}
+				loggedIn={true}
+				occupations={["designer", "frontend"]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox"));
+		expect(mockPush).toHaveBeenCalledWith(
+			"/search/users?q=rust&near_me=1&radius_km=10&occupation=designer&occupation=frontend",
+		);
+	});
+
+	it("keeps occupation in login next= link when not logged in", () => {
+		render(
+			<NearMeFilter
+				query=""
+				initialNearMe={false}
+				initialRadiusKm={10}
+				loggedIn={false}
+				occupations={["designer"]}
+			/>,
+		);
+		const loginLink = screen.getByRole("link", {
+			name: "ログインして近い順に探す",
+		});
+		expect(loginLink).toHaveAttribute(
+			"href",
+			`/login?next=${encodeURIComponent("/search/users?occupation=designer")}`,
+		);
+	});
 });

--- a/client/src/components/search/__tests__/OccupationFilter.test.tsx
+++ b/client/src/components/search/__tests__/OccupationFilter.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for OccupationFilter (Phase 12 P12-07, issue #816)。
+ *
+ * chip toggle → URL navigate / 選択状態の aria-checked / すべて解除 を検証。
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import OccupationFilter from "@/components/search/OccupationFilter";
+import type { Occupation } from "@/lib/api/occupation";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush }),
+	usePathname: () => "/search/users",
+}));
+
+const CATALOG: Occupation[] = [
+	{ slug: "designer", display_name: "デザイナー", display_order: 10 },
+	{ slug: "frontend", display_name: "フロントエンド", display_order: 20 },
+	{ slug: "backend", display_name: "バックエンド", display_order: 30 },
+];
+
+function renderFilter(
+	overrides: Partial<Parameters<typeof OccupationFilter>[0]> = {},
+) {
+	return render(
+		<OccupationFilter
+			occupations={CATALOG}
+			selected={[]}
+			query=""
+			nearMe={false}
+			radiusKm={10}
+			{...overrides}
+		/>,
+	);
+}
+
+describe("OccupationFilter", () => {
+	beforeEach(() => {
+		mockPush.mockClear();
+	});
+
+	it("renders a switch chip per catalog entry", () => {
+		renderFilter();
+		expect(
+			screen.getByRole("switch", { name: "デザイナー" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("switch", { name: "フロントエンド" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("switch", { name: "バックエンド" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders nothing when catalog is empty", () => {
+		const { container } = renderFilter({ occupations: [] });
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("marks selected slugs with aria-checked=true", () => {
+		renderFilter({ selected: ["frontend"] });
+		expect(
+			screen.getByRole("switch", { name: "フロントエンド" }),
+		).toHaveAttribute("aria-checked", "true");
+		expect(screen.getByRole("switch", { name: "デザイナー" })).toHaveAttribute(
+			"aria-checked",
+			"false",
+		);
+	});
+
+	it("navigates with ?occupation=slug when an unselected chip is clicked", () => {
+		renderFilter();
+		fireEvent.click(screen.getByRole("switch", { name: "デザイナー" }));
+		expect(mockPush).toHaveBeenCalledWith("/search/users?occupation=designer", {
+			scroll: false,
+		});
+	});
+
+	it("adds a second occupation while keeping the first (OR set)", () => {
+		renderFilter({ selected: ["designer"] });
+		fireEvent.click(screen.getByRole("switch", { name: "フロントエンド" }));
+		// catalog 表示順 (designer→frontend) で URL が安定する
+		expect(mockPush).toHaveBeenCalledWith(
+			"/search/users?occupation=designer&occupation=frontend",
+			{ scroll: false },
+		);
+	});
+
+	it("removes an occupation when a selected chip is clicked again", () => {
+		renderFilter({ selected: ["designer", "frontend"] });
+		fireEvent.click(screen.getByRole("switch", { name: "デザイナー" }));
+		expect(mockPush).toHaveBeenCalledWith("/search/users?occupation=frontend", {
+			scroll: false,
+		});
+	});
+
+	it("preserves q and near_me/radius when toggling occupation", () => {
+		renderFilter({
+			selected: [],
+			query: "react",
+			nearMe: true,
+			radiusKm: 25,
+		});
+		fireEvent.click(screen.getByRole("switch", { name: "フロントエンド" }));
+		expect(mockPush).toHaveBeenCalledWith(
+			"/search/users?q=react&near_me=1&radius_km=25&occupation=frontend",
+			{ scroll: false },
+		);
+	});
+
+	it("shows すべて解除 only when something is selected and clears all", () => {
+		const { rerender } = render(
+			<OccupationFilter
+				occupations={CATALOG}
+				selected={[]}
+				query="react"
+				nearMe={false}
+				radiusKm={10}
+			/>,
+		);
+		expect(screen.queryByRole("button", { name: "すべて解除" })).toBeNull();
+
+		rerender(
+			<OccupationFilter
+				occupations={CATALOG}
+				selected={["designer"]}
+				query="react"
+				nearMe={false}
+				radiusKm={10}
+			/>,
+		);
+		const clear = screen.getByRole("button", { name: "すべて解除" });
+		fireEvent.click(clear);
+		// occupation を全部外して q は維持
+		expect(mockPush).toHaveBeenCalledWith("/search/users?q=react", {
+			scroll: false,
+		});
+	});
+});

--- a/client/src/lib/api/__tests__/userSearch.test.ts
+++ b/client/src/lib/api/__tests__/userSearch.test.ts
@@ -1,7 +1,12 @@
 /**
- * userSearch helper tests (Phase 12 P12-04).
+ * userSearch helper tests (Phase 12 P12-04 / P12-07).
+ *
+ * P12-07 で ``fetchUserSearch`` の params 組み立てが ``Record<string,string>``
+ * から ``URLSearchParams`` に変わった (occupation の同名 key 繰り返しを
+ * サポートするため)。 アサーションは URLSearchParams を介して検証する。
  */
 
+import type { AxiosRequestConfig } from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { describe, expect, it } from "vitest";
 
@@ -15,11 +20,27 @@ function stub() {
 	return { client, mock };
 }
 
+/** config.params (URLSearchParams) を単一値の plain object に潰す。
+ *  occupation のような複数値 key は getAll で別途検証する。
+ *  誤って複数値 key にこの helper を使うと last-wins で false-green になるため、
+ *  重複 key を検出したら明示的に throw する (typescript-reviewer HIGH 指摘)。 */
+function scalarParams(config: AxiosRequestConfig): Record<string, string> {
+	const params = config.params as URLSearchParams;
+	const keys = Array.from(params.keys());
+	const dupes = keys.filter((k, i) => keys.indexOf(k) !== i);
+	if (dupes.length > 0) {
+		throw new Error(
+			`scalarParams() received duplicate keys [${dupes.join(", ")}]; use getAll() instead`,
+		);
+	}
+	return Object.fromEntries(params.entries());
+}
+
 describe("userSearch API", () => {
 	it("fetchUserSearch sends ?q= when query is non-empty", async () => {
 		const { client, mock } = stub();
 		mock.onGet("/users/search/").reply((config) => {
-			expect(config.params).toEqual({ q: "alice" });
+			expect(scalarParams(config)).toEqual({ q: "alice" });
 			return [
 				200,
 				{
@@ -46,7 +67,7 @@ describe("userSearch API", () => {
 	it("fetchUserSearch trims whitespace and omits empty q", async () => {
 		const { client, mock } = stub();
 		mock.onGet("/users/search/").reply((config) => {
-			expect(config.params).toEqual({});
+			expect(scalarParams(config)).toEqual({});
 			return [200, { results: [], next: null, previous: null }];
 		});
 		const page = await fetchUserSearch("   ", {}, client);
@@ -56,7 +77,7 @@ describe("userSearch API", () => {
 	it("fetchUserSearch forwards cursor for pagination", async () => {
 		const { client, mock } = stub();
 		mock.onGet("/users/search/").reply((config) => {
-			expect(config.params).toEqual({ q: "bob", cursor: "abc123" });
+			expect(scalarParams(config)).toEqual({ q: "bob", cursor: "abc123" });
 			return [200, { results: [], next: null, previous: "prev=xyz" }];
 		});
 		const page = await fetchUserSearch("bob", { cursor: "abc123" }, client);
@@ -94,7 +115,7 @@ describe("userSearch API", () => {
 	it("fetchUserSearch sends near_me=1 + radius_km when proximity enabled", async () => {
 		const { client, mock } = stub();
 		mock.onGet("/users/search/").reply((config) => {
-			expect(config.params).toEqual({ near_me: "1", radius_km: "15" });
+			expect(scalarParams(config)).toEqual({ near_me: "1", radius_km: "15" });
 			return [200, { results: [], next: null, previous: null }];
 		});
 		await fetchUserSearch("", { nearMe: true, radiusKm: 15 }, client);
@@ -103,7 +124,7 @@ describe("userSearch API", () => {
 	it("fetchUserSearch combines q + near_me + cursor", async () => {
 		const { client, mock } = stub();
 		mock.onGet("/users/search/").reply((config) => {
-			expect(config.params).toEqual({
+			expect(scalarParams(config)).toEqual({
 				q: "rust",
 				cursor: "abc",
 				near_me: "1",
@@ -121,9 +142,55 @@ describe("userSearch API", () => {
 	it("fetchUserSearch defaults radiusKm to 10 when nearMe with no radius", async () => {
 		const { client, mock } = stub();
 		mock.onGet("/users/search/").reply((config) => {
-			expect(config.params).toEqual({ near_me: "1", radius_km: "10" });
+			expect(scalarParams(config)).toEqual({ near_me: "1", radius_km: "10" });
 			return [200, { results: [], next: null, previous: null }];
 		});
 		await fetchUserSearch("", { nearMe: true }, client);
+	});
+
+	it("fetchUserSearch appends one occupation param per slug (P12-07)", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply((config) => {
+			const params = config.params as URLSearchParams;
+			expect(params.getAll("occupation")).toEqual(["designer", "frontend"]);
+			return [200, { results: [], next: null, previous: null }];
+		});
+		await fetchUserSearch(
+			"",
+			{ occupations: ["designer", "frontend"] },
+			client,
+		);
+	});
+
+	it("fetchUserSearch omits occupation param when array empty/undefined", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply((config) => {
+			const params = config.params as URLSearchParams;
+			expect(params.getAll("occupation")).toEqual([]);
+			expect(scalarParams(config)).toEqual({ q: "go" });
+			return [200, { results: [], next: null, previous: null }];
+		});
+		await fetchUserSearch("go", { occupations: [] }, client);
+	});
+
+	it("fetchUserSearch combines q + occupation (AND on backend)", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply((config) => {
+			const params = config.params as URLSearchParams;
+			expect(params.get("q")).toBe("react");
+			expect(params.getAll("occupation")).toEqual(["frontend"]);
+			return [200, { results: [], next: null, previous: null }];
+		});
+		await fetchUserSearch("react", { occupations: ["frontend"] }, client);
+	});
+
+	it("fetchUserSearch skips empty / whitespace-only slugs in occupations", async () => {
+		const { client, mock } = stub();
+		mock.onGet("/users/search/").reply((config) => {
+			const params = config.params as URLSearchParams;
+			expect(params.getAll("occupation")).toEqual(["designer"]);
+			return [200, { results: [], next: null, previous: null }];
+		});
+		await fetchUserSearch("", { occupations: ["designer", "", "   "] }, client);
 	});
 });

--- a/client/src/lib/api/userSearch.ts
+++ b/client/src/lib/api/userSearch.ts
@@ -36,25 +36,72 @@ export interface UserSearchOptions {
 	nearMe?: boolean;
 	/** P12-05: 近所検索の半径 (km, 1〜200 で clamp は backend 側で行う)。 */
 	radiusKm?: number;
+	/** P12-07: 職業 slug で絞り込む。 複数指定は backend で OR 結合。 */
+	occupations?: string[];
 }
 
 export const PROXIMITY_RADIUS_MIN_KM = 1;
 export const PROXIMITY_RADIUS_MAX_KM = 100;
 export const PROXIMITY_RADIUS_DEFAULT_KM = 10;
 
-/** ``GET /users/search/?q=`` を呼ぶ。 cursor を渡せば next/prev page。 */
+/** ``/search/users`` (frontend route) と ``/users/search/`` (API) 双方の
+ *  query string を組み立てる単一の正本。 q / near_me / radius_km / occupation[] /
+ *  cursor を一貫した順序・形式 (occupation は同名 key を append) で出す。
+ *  これを共有することで NearMeFilter / OccupationFilter / page が filter を
+ *  取りこぼさず相互に維持できる (code-reviewer HIGH: cross-filter state loss 対策)。 */
+export interface UserSearchQueryState {
+	q?: string;
+	nearMe?: boolean;
+	radiusKm?: number;
+	occupations?: string[];
+	cursor?: string | null;
+}
+
+export function buildUserSearchParams(
+	state: UserSearchQueryState,
+): URLSearchParams {
+	const params = new URLSearchParams();
+	const q = state.q?.trim();
+	if (q) params.set("q", q);
+	if (state.nearMe) {
+		params.set("near_me", "1");
+		params.set(
+			"radius_km",
+			String(state.radiusKm ?? PROXIMITY_RADIUS_DEFAULT_KM),
+		);
+	}
+	for (const slug of state.occupations ?? []) {
+		const trimmed = slug.trim();
+		if (trimmed) params.append("occupation", trimmed);
+	}
+	if (state.cursor) params.set("cursor", state.cursor);
+	return params;
+}
+
+/** frontend route href (`/search/users?...`)。 query が空なら base path のみ。 */
+export function buildUserSearchHref(state: UserSearchQueryState): string {
+	const qs = buildUserSearchParams(state).toString();
+	return qs ? `/search/users?${qs}` : "/search/users";
+}
+
+/** ``GET /users/search/?q=`` を呼ぶ。 cursor を渡せば next/prev page。
+ *
+ * occupation は同名 key を繰り返す (``?occupation=a&occupation=b``) ので
+ * ``Record<string,string>`` ではなく ``URLSearchParams`` で組み立てる
+ * (axios の array シリアライズは ``occupation[]=`` 形式になり backend の
+ * ``getlist("occupation")`` と噛み合わないため、 明示的に append する)。 */
 export async function fetchUserSearch(
 	query: string,
 	options: UserSearchOptions = {},
 	client: AxiosInstance = api,
 ): Promise<UserSearchPage> {
-	const params: Record<string, string> = {};
-	if (query.trim()) params.q = query.trim();
-	if (options.cursor) params.cursor = options.cursor;
-	if (options.nearMe) {
-		params.near_me = "1";
-		params.radius_km = String(options.radiusKm ?? PROXIMITY_RADIUS_DEFAULT_KM);
-	}
+	const params = buildUserSearchParams({
+		q: query,
+		cursor: options.cursor,
+		nearMe: options.nearMe,
+		radiusKm: options.radiusKm,
+		occupations: options.occupations,
+	});
 	const res = await client.get<UserSearchPage>("/users/search/", { params });
 	return res.data;
 }

--- a/docs/specs/phase-12-residence-map-spec.md
+++ b/docs/specs/phase-12-residence-map-spec.md
@@ -291,8 +291,8 @@ PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/onboarding-
 3. ✅ **P12-04** (#680 merged): 汎用 user search page (full-text、 cursor pagination)
 4. ✅ **P12-05** (#681 merged): 近所検索 (haversine SQL, near_me=1 / near=lat,lng)
 5. ✅ **P12-03** (merged): signup wizard step 2 (居住地 prompt)
-6. **P12-06** (#815): `Occupation` model + 多選択編集 UI (本 spec §9 / 本 PR は backend、 frontend は follow-up)
-7. **P12-07** (#816): `/api/v1/users/search/?occupation=` filter + chip filter UI
+6. ✅ **P12-06** (#815 backend / #818 frontend merged): `Occupation` model + 多選択編集 UI (本 spec §9)
+7. **P12-07** (#816): `/api/v1/users/search/?occupation=` filter + chip filter UI (本 spec §10)
 8. **P12-08** (#817): `/search/users` に Leaflet 地図 view toggle (job filter と組み合わせ可能)
 
 各段階で `gan-evaluator` agent に採点させて UX を確認 (新 route 追加なので Phase 11 同様の必須運用)。
@@ -457,3 +457,104 @@ docker compose -f local.yml exec api pytest apps/users/tests/test_occupation.py 
 ### 9.7 frontend テスト (P12-06 follow-up)
 
 follow-up issue で実装。 概要は P12-07 / P12-08 と同様の chip 多選択 vitest + Playwright E2E。
+
+---
+
+## 10. 検索 API の occupation filter + chip UI — P12-07 (#816)
+
+### 10.1 背景
+
+P12-06 (#815 / #818) で User に `Occupation` M2M が入った。 これを **ユーザー検索 API + UI** から
+filter できるようにする。 ハルナさん要望「職業がデザイナーの人を検索する」 の中核。
+
+既存 `UserFullTextSearchView` (`GET /api/v1/users/search/`, §7.4 / §7.5) に occupation filter を
+**追加** する。 地図 view は P12-08 (#817) で別 PR、 本 PR は **list 表示のままの chip filter** に閉じる。
+
+### 10.2 API 仕様
+
+`GET /api/v1/users/search/?occupation=designer&occupation=frontend`
+
+| query                 | 意味                                                               |
+| --------------------- | ------------------------------------------------------------------ |
+| `occupation=<slug>`   | 繰り返し可。 **複数指定は OR 結合** (designer **または** frontend) |
+| `q` との併用          | AND (`q` 部分一致 **かつ** いずれかの occupation を持つ)           |
+| `near_me=1` / `near=` | AND (近所 **かつ** occupation)                                     |
+
+ルール:
+
+- **未知 slug は無視** (存在 + `is_active=True` の slug だけ採用)。 bookmark URL を将来の vocabulary 変更で壊さないため。
+- 有効な occupation slug が **1 件も無ければ occupation filter は適用しない** (q / near 単独検索と同じ挙動)。
+- M2M JOIN で同一 user が重複しうるので **`.distinct()`** で重複排除。
+- occupation だけ指定 (q も near も無し) でも検索成立 → `is_active=True` user を `username` 順で返す。
+- 検索成立条件は「`q` あり **or** `near` 系あり **or** 有効な occupation slug が 1 件以上」。 どれも無ければ従来通り空配列。
+
+レスポンス形は §7.4 の `UserFullTextSerializer` をそのまま流用 (occupation を列に増やさない。 表示は frontend が catalog と突き合わせる必要が無いので最小に保つ)。
+
+### 10.3 実装方針 (backend)
+
+`UserFullTextSearchView.get_queryset`:
+
+1. `params.getlist("occupation")` で slug 配列を取得 (DRF `query_params` は `QueryDict`)。
+2. `Occupation.objects.filter(slug__in=raw_slugs, is_active=True).values_list("slug", flat=True)` で
+   **有効 slug に正規化** (未知 / inactive を落とす)。
+3. 検索成立判定に「有効 occupation slug が 1 件以上」 を OR で加える。
+4. `qs = qs.filter(occupations__slug__in=valid_slugs).distinct()` で OR filter。
+   - near 検索 (haversine annotate) と併用する場合も `.distinct()` を最後に維持する。
+   - 既存 `order_by` の前に `.distinct()` を挟んでも cursor pagination は安定 (ordering 列は username / distance のまま)。
+
+### 10.4 実装方針 (frontend)
+
+- `lib/api/userSearch.ts`: `UserSearchOptions` に `occupations?: string[]` 追加。 `fetchUserSearch` で
+  `occupations.forEach((slug) => params.append("occupation", slug))` (URLSearchParams は append で繰り返し可)。
+- **新規** `components/search/OccupationFilter.tsx` (client component):
+  - props: `occupations: Occupation[]` (catalog), `selected: string[]`, `query`, `nearMe`, `radiusKm`。
+  - chip を `role="group"`、 各 chip は `<button role="switch" aria-checked>` (OccupationChipPicker と同じ a11y パターンを踏襲)。
+  - toggle で `router.push("/search/users?...&occupation=slug")` に URL 同期。 既存 q / near_me / radius_km は維持。
+  - 選択 chip は `--a-accent-deep` 塗り + ✓、 未選択は border のみ (OccupationChipPicker と一貫)。
+- `app/(template)/search/users/page.tsx`:
+  - `searchParams.occupation` は string | string[] (Next.js は重複 key を配列化)。 正規化 helper で `string[]` に。
+  - SSR で `fetchOccupations()` を呼んで catalog を取得 (fail-safe: 失敗時 console.error + [], filter UI 非表示)。
+  - `loadUserSearch` / `buildSearchHref` に occupation を織り込む。 hasAnyQuery 判定に occupation を追加。
+  - `OccupationFilter` を `NearMeFilter` の下に配置。
+- catalog が空 (取得失敗) のとき chip UI は描画しない (q / near は従来通り動く)。
+
+### 10.5 テスト (P12-07)
+
+#### backend pytest — `apps/users/tests/test_user_search_occupation.py`
+
+| case                                 | 期待                                                              |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| `?occupation=designer`               | designer を持つ user のみ、 持たない user は出ない                |
+| `?occupation=designer&=frontend`     | designer **OR** frontend を持つ user (和集合)、 重複 user は 1 件 |
+| 複数 occupation 持つ user の重複排除 | designer+frontend 両方の user が結果に 1 回だけ (`.distinct()`)   |
+| `?q=react&occupation=frontend`       | bio/handle/name に react を含み **かつ** frontend (AND)           |
+| `?near_me=1&occupation=designer`     | auth 必須 + 近所 **かつ** designer (AND)、 anon は 401            |
+| `?near=lat,lng&occupation=designer`  | anon 可 + 近所 **かつ** designer (AND)                            |
+| 未知 slug 単独 `?occupation=xxx`     | 有効 slug 0 件 + q/near 無し → **空配列** (検索条件なし扱い)      |
+| inactive slug 単独                   | 採用しない → 有効 slug 0 件 → **空配列**                          |
+| valid + invalid 混在                 | invalid を drop し valid slug だけで filter                       |
+| occupation 単独 (有効 slug あり)     | 検索成立、 該当 user を username 順                               |
+| 何も指定無し (occupation も無し)     | 空配列 (従来挙動維持)                                             |
+
+#### frontend vitest — `lib/api/__tests__/userSearch.test.ts` (追記) + `components/search/__tests__/OccupationFilter.test.tsx`
+
+- `fetchUserSearch` が `occupations: ["designer","frontend"]` を `?occupation=designer&occupation=frontend` に展開
+- 空配列 / 未指定なら occupation param を付けない
+- OccupationFilter: chip click で `router.push` が呼ばれ URL に occupation slug が入る
+- 選択済み chip 再 click で URL から外れる
+- selected prop の chip が `aria-checked="true"`
+
+#### E2E — `client/e2e/user-search-occupation.spec.ts`
+
+| ID          | 誰が | 何をする                                       | 何が見える                                                 |
+| ----------- | ---- | ---------------------------------------------- | ---------------------------------------------------------- |
+| OCCSEARCH-1 | anon | `/search/users` で「デザイナー」 chip を click | URL に `?occupation=designer`、 designer user が結果に出る |
+| OCCSEARCH-2 | anon | designer + frontend の 2 chip を選択           | 両方の OR 和集合が出る、 URL に 2 つの occupation          |
+| OCCSEARCH-3 | anon | chip 選択した URL を直接 reload                | chip が選択状態を保持 (URL → 初期 selected 復元)           |
+| OCCSEARCH-4 | anon | `?q=...&occupation=designer` で q と併用       | q AND occupation で絞られる                                |
+
+実行:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/user-search-occupation.spec.ts
+```


### PR DESCRIPTION
## 概要

ユーザー検索 (`/search/users`) に **職業 (occupation) filter** を追加。 ハルナさん要望「職業がデザイナーの人を検索する」 の中核 (#816 / P12-07)。 地図 view は P12-08 (#817) で別 PR。

spec: [docs/specs/phase-12-residence-map-spec.md §10](https://github.com/haruna0712/claude-code/blob/main/docs/specs/phase-12-residence-map-spec.md)

## backend (`apps/users/views.py`)

- `UserFullTextSearchView` に `?occupation=<slug>` filter (複数指定は **OR 結合**)
- `q` / `near_me` / `near` との併用は **AND**、 M2M JOIN 重複は `.distinct()` で排除
- 未知 slug / `is_active=False` slug は無視。 有効 slug 0 件 + q/near 無しは空配列 (stale bookmark が全 user を吐かない)
- `MAX_OCCUPATION_FILTER=20` で slug 件数を頭打ち (AllowAny endpoint の abuse 対策)

## frontend

- `userSearch.ts`: `buildUserSearchParams` / `buildUserSearchHref` を URL 組み立ての**共有正本**として追加 → NearMeFilter / OccupationFilter / page が filter を取りこぼさず相互維持
- `OccupationFilter.tsx` (新規): `role=switch` chip、 toggle で URL 同期、「すべて解除」、 navigation 後の focus 復元 + `scroll:false`
- `NearMeFilter.tsx`: `occupations` pass-through (near_me toggle / login link で occupation を維持)
- `/search/users` page: SSR で catalog fetch (fail-safe) + filter mount + header summary

## テスト

- backend pytest `test_user_search_occupation.py` (14 case): single / OR / distinct / q AND / near_me AND / near= AND (anon) / 未知・inactive・mixed slug / cap / 空配列
- frontend vitest: userSearch 12 / OccupationFilter 8 / NearMeFilter 9
- E2E `client/e2e/user-search-occupation.spec.ts` (4 case): chip filter / OR / reload 復元 / q AND
  - `PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/user-search-occupation.spec.ts`

## サブエージェントレビュー (直列、 §4.2)

- python-reviewer: spec/test 矛盾 (空配列挙動) 修正、 cap 追加、 near= test / mixed-slug test 追加
- database-reviewer: cap 追加、 `DISTINCT + ORDER BY annotation` が Postgres で valid 確認
- typescript-reviewer: test helper 強化、 trim、 重複 flag 削除、 label 単一化
- a11y-architect (WCAG 2.2 AA): **CRITICAL 0**。 focus 復元 + scroll:false 追加。 selected chip 白文字 on `#0369a1` = 5.93:1 PASS
- code-reviewer: **cross-filter state loss (HIGH)** = NearMeFilter が occupation を落とす問題を共有 URL builder で修正

## follow-up (別 issue 予定、本 PR スコープ外)

- chip の `role=switch` → `aria-pressed` 化を OccupationChipPicker と揃えて再評価 (a11y-architect H-2)
- `UserOccupation(occupation_id, user_id)` 複合 index / `EXISTS` subquery 化 (database-reviewer、 規模拡大時)

## 実機検証

stg は main merge → CD で自動デプロイ。 反映後に E2E (stg Playwright) + `gan-evaluator` + `ui-ux-tester` を回す。

Closes #816