### PR TITLE
[feature][search] search response に residence/occupations + bbox filter (P12-08a) (#817)

### DIFF
--- a/apps/users/tests/test_user_search_bbox.py
+++ b/apps/users/tests/test_user_search_bbox.py
@@ -1,0 +1,224 @@
+"""
+ユーザー検索 API の bbox filter + residence/occupations response (Phase 12 P12-08a, #817)。
+
+対象エンドポイント: ``GET /api/v1/users/search/?bbox=south,west,north,east&...``
+
+ルール (spec §11.3):
+- bbox = south,west,north,east の 4 float。 residence center が矩形内の user のみ
+- **bbox は auth 必須** (地理的総ざらい列挙の privacy 防御、 anon は 401)
+- residence 未設定 user は bbox から除外 (INNER JOIN)
+- occupation / q との併用は AND
+- near_me / near 併用時は near を優先 (bbox 無視)
+- 不正 bbox は 400 (auth 通過後)
+- response に residence ({lat,lng,radius_m} or null) と occupations 配列を含む
+- residence は select_related、 occupations は prefetch_related で N+1 回避
+
+spec: docs/specs/phase-12-residence-map-spec.md §11
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.users.models import Occupation, UserOccupation, UserResidence
+
+# 東京駅周辺 (bbox 内に入れる) / 大阪 (bbox 外)
+TOKYO = ("35.681236", "139.767125")
+SHINJUKU = ("35.689634", "139.700565")
+OSAKA = ("34.702485", "135.495951")
+
+# 東京都心をすっぽり覆う bbox (south,west,north,east)
+TOKYO_BBOX = "35.5,139.5,35.8,139.9"
+
+
+@pytest.fixture
+def search_url() -> str:
+    return reverse("users-fulltext-search")
+
+
+@pytest.fixture
+def occupations(db):
+    designer, _ = Occupation.objects.get_or_create(
+        slug="designer",
+        defaults={"display_name": "デザイナー", "display_order": 10},
+    )
+    backend, _ = Occupation.objects.get_or_create(
+        slug="backend",
+        defaults={"display_name": "バックエンドエンジニア", "display_order": 30},
+    )
+    return {"designer": designer, "backend": backend}
+
+
+def _set_residence(user, lat: str, lng: str, radius_m: int = 500) -> UserResidence:
+    return UserResidence.objects.create(user=user, latitude=lat, longitude=lng, radius_m=radius_m)
+
+
+def _attach(user, *occ) -> None:
+    for o in occ:
+        UserOccupation.objects.create(user=user, occupation=o)
+
+
+@pytest.fixture
+def viewer(api_client: APIClient, user_factory):
+    """bbox は地理的総ざらい列挙なので auth 必須 (P12-08a privacy)。 residence 不要の
+    閲覧者で ``api_client`` を認証する副作用 fixture。 これを引数に取った test は
+    ログイン済みとして bbox を叩ける。"""
+    api_client.force_authenticate(user=user_factory(username="bbox_viewer"))
+    return None
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestUserSearchBbox:
+    def test_bbox_requires_auth(self, api_client: APIClient, search_url: str) -> None:
+        """anon の bbox sweep は 401 (near_me と同じ privacy 方針)。"""
+        res = api_client.get(search_url, {"bbox": TOKYO_BBOX})
+        assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_bbox_returns_users_inside_rect(
+        self, api_client: APIClient, user_factory, viewer, search_url: str
+    ) -> None:
+        inside = user_factory(username="inside_tokyo")
+        _set_residence(inside, *TOKYO)
+        outside = user_factory(username="outside_osaka")
+        _set_residence(outside, *OSAKA)
+
+        res = api_client.get(search_url, {"bbox": TOKYO_BBOX})
+
+        assert res.status_code == status.HTTP_200_OK
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "inside_tokyo" in usernames
+        assert "outside_osaka" not in usernames
+
+    def test_bbox_excludes_users_without_residence(
+        self, api_client: APIClient, user_factory, viewer, search_url: str
+    ) -> None:
+        with_res = user_factory(username="has_residence")
+        _set_residence(with_res, *TOKYO)
+        user_factory(username="no_residence")
+
+        res = api_client.get(search_url, {"bbox": TOKYO_BBOX})
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "has_residence" in usernames
+        assert "no_residence" not in usernames
+
+    def test_bbox_and_occupation_is_and(
+        self, api_client: APIClient, user_factory, occupations, viewer, search_url: str
+    ) -> None:
+        designer_in = user_factory(username="designer_tokyo")
+        _set_residence(designer_in, *SHINJUKU)
+        _attach(designer_in, occupations["designer"])
+
+        backend_in = user_factory(username="backend_tokyo")
+        _set_residence(backend_in, *SHINJUKU)
+        _attach(backend_in, occupations["backend"])
+
+        res = api_client.get(search_url, {"bbox": TOKYO_BBOX, "occupation": "designer"})
+
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "designer_tokyo" in usernames
+        assert "backend_tokyo" not in usernames
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "35.5,139.5,35.8",  # 3 値
+            "a,b,c,d",  # 非数値
+            "100,139,35,140",  # 緯度 > 90
+            "35.5,200,35.8,139.9",  # 経度 > 180
+            "35.8,139.5,35.5,139.9",  # south > north (上下反転)
+            "",  # 空
+        ],
+    )
+    def test_invalid_bbox_returns_400(
+        self, api_client: APIClient, user_factory, viewer, search_url: str, bad: str
+    ) -> None:
+        # auth 済み (viewer) なので auth check は通過し、 parse 失敗で 400 になる。
+        res = api_client.get(search_url, {"bbox": bad})
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_near_me_takes_priority_over_bbox(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        """near_me と bbox 併用時は near_me 優先 (distance 順 + self 除外)。"""
+        me = user_factory(username="me_near")
+        _set_residence(me, *TOKYO)
+        api_client.force_authenticate(user=me)
+        nearby = user_factory(username="nearby")
+        _set_residence(nearby, *SHINJUKU)
+
+        # bbox は大阪を指す矩形 (Tokyo の me/nearby は範囲外) だが near_me 優先なので
+        # 近所 (Tokyo 中心) の nearby が出る、 bbox は無視される。
+        res = api_client.get(
+            search_url,
+            {"near_me": "1", "radius_km": "10", "bbox": "34.5,135.3,34.9,135.7"},
+        )
+
+        assert res.status_code == status.HTTP_200_OK
+        usernames = [r["username"] for r in res.data["results"]]
+        assert "nearby" in usernames  # near_me が効いている
+        assert "me_near" not in usernames  # near は self 除外
+        # distance_km annotation が付く = near 経路を通った証拠
+        nearby_row = next(r for r in res.data["results"] if r["username"] == "nearby")
+        assert nearby_row["distance_km"] is not None
+        # near 経路でも residence / occupations field が serialize される
+        # (select_related / prefetch が共通 queryset にあること、 python-reviewer LOW)
+        assert nearby_row["residence"] is not None
+        assert isinstance(nearby_row["occupations"], list)
+
+    def test_response_includes_residence_and_occupations(
+        self, api_client: APIClient, user_factory, occupations, viewer, search_url: str
+    ) -> None:
+        u = user_factory(username="rich_row")
+        _set_residence(u, *TOKYO, radius_m=1500)
+        _attach(u, occupations["designer"])
+
+        res = api_client.get(search_url, {"bbox": TOKYO_BBOX})
+
+        row = next(r for r in res.data["results"] if r["username"] == "rich_row")
+        assert row["residence"] is not None
+        assert set(row["residence"].keys()) >= {"latitude", "longitude", "radius_m"}
+        assert row["residence"]["radius_m"] == 1500
+        # lat/lng は文字列で返す契約 (frontend Leaflet 用、 DecimalField→str)
+        assert isinstance(row["residence"]["latitude"], str)
+        assert isinstance(row["residence"]["longitude"], str)
+        assert {"slug": "designer", "display_name": "デザイナー"} in row["occupations"]
+
+    def test_residence_null_when_unset_in_text_search(
+        self, api_client: APIClient, user_factory, search_url: str
+    ) -> None:
+        """text 検索 (bbox 無し) では residence 未設定 user も出るが residence=null。"""
+        user_factory(username="plain_textonly", display_name="Plain")
+
+        res = api_client.get(search_url, {"q": "plain_textonly"})
+
+        row = next(r for r in res.data["results"] if r["username"] == "plain_textonly")
+        assert row["residence"] is None
+        assert row["occupations"] == []
+
+    def test_bbox_no_n_plus_one(
+        self,
+        api_client: APIClient,
+        user_factory,
+        occupations,
+        viewer,
+        search_url: str,
+        django_assert_max_num_queries,
+    ) -> None:
+        """residence (select_related) / occupations (prefetch_related) で
+        user 数に比例した追加 query が出ないこと。"""
+        for i in range(5):
+            u = user_factory(username=f"map_user_{i}")
+            _set_residence(u, *SHINJUKU)
+            _attach(u, occupations["designer"])
+
+        # pagination count + main query + occupations prefetch + (cursor) で
+        # 数本に収まる。 user 数 (5) に比例しない上限を置く。
+        with django_assert_max_num_queries(8):
+            res = api_client.get(search_url, {"bbox": TOKYO_BBOX})
+            # response をシリアライズさせるため results を評価
+            assert len(res.data["results"]) == 5

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -826,6 +826,10 @@ class UserFullTextSerializer(serializers.ModelSerializer):
 
     user_id = serializers.UUIDField(source="id", read_only=True)
     distance_km = serializers.SerializerMethodField()
+    # P12-08: 地図 view 用。 residence は select_related、 occupations は
+    # prefetch_related を view 側で入れて N+1 を防ぐ。 list view は無視するだけ。
+    residence = serializers.SerializerMethodField()
+    occupations = serializers.SerializerMethodField()
 
     def get_distance_km(self, obj: User) -> float | None:
         # annotation 値 (Decimal / float) を float に正規化。 annotation 無しなら None。
@@ -833,6 +837,26 @@ class UserFullTextSerializer(serializers.ModelSerializer):
         if value is None:
             return None
         return round(float(value), 2)
+
+    def get_residence(self, obj: User) -> dict | None:
+        """自分で設定した居住地の円 (中心 + 半径)。 未設定は None。
+        ピンポイントではなく min 500m の円なので公開してよい
+        (spec: docs/specs/phase-12-residence-map-spec.md §11.2)。"""
+        try:
+            res = obj.residence
+        except UserResidence.DoesNotExist:
+            return None
+        return {
+            "latitude": str(res.latitude),
+            "longitude": str(res.longitude),
+            "radius_m": res.radius_m,
+        }
+
+    def get_occupations(self, obj: User) -> list[dict[str, str]]:
+        """user の職業 chip (slug + display_name)。 地図 Circle の配色 / popup 用。
+        M2M は Occupation.Meta.ordering (display_order) を継承。
+        view が prefetch_related("occupations") を入れるので N+1 にならない。"""
+        return [{"slug": o.slug, "display_name": o.display_name} for o in obj.occupations.all()]
 
     class Meta:
         model = User
@@ -843,6 +867,8 @@ class UserFullTextSerializer(serializers.ModelSerializer):
             "bio",
             "avatar_url",
             "distance_km",
+            "residence",
+            "occupations",
         )
         read_only_fields = fields
 
@@ -911,6 +937,30 @@ def _parse_radius_km(value: str | None) -> float:
     except (ValueError, TypeError):
         r = _NEAR_RADIUS_KM_DEFAULT
     return max(0.0, min(r, _NEAR_RADIUS_KM_MAX))
+
+
+def _parse_bbox(value: str) -> tuple[float, float, float, float] | None:
+    """``"south,west,north,east"`` → (south, west, north, east)。 不正は None (P12-08)。
+
+    4 値 float、 緯度 ∈ [-90,90] / 経度 ∈ [-180,180]、 ``south ≤ north`` を要求。
+    経度の日付変更線跨ぎ (west > east) は MVP 非対応 — そのまま BETWEEN し結果 0 で可。
+    """
+    try:
+        parts = value.split(",")
+        if len(parts) != 4:
+            return None
+        south, west, north, east = (float(p) for p in parts)
+    except (ValueError, AttributeError, OverflowError):
+        return None
+    if not all(math.isfinite(v) for v in (south, west, north, east)):
+        return None
+    if not (-90.0 <= south <= 90.0 and -90.0 <= north <= 90.0):
+        return None
+    if not (-180.0 <= west <= 180.0 and -180.0 <= east <= 180.0):
+        return None
+    if south > north:
+        return None
+    return (south, west, north, east)
 
 
 class UserFullTextSearchView(ListAPIView):
@@ -991,6 +1041,7 @@ class UserFullTextSearchView(ListAPIView):
         q = (params.get("q") or "").strip()
         near_me = params.get("near_me") == "1"
         near_raw = params.get("near")
+        bbox_raw = params.get("bbox")
         occupation_slugs = self._valid_occupation_slugs()
 
         center: tuple[float, float] | None = None
@@ -1020,11 +1071,36 @@ class UserFullTextSearchView(ListAPIView):
                 )
             center = parsed
 
-        if center is None and not q and not occupation_slugs:
-            # q / near / occupation のどれも無ければ空配列 (P12-04 既存挙動)
+        # bbox は near 系が無いときだけ評価する (near 優先、 §11.3)。 near と併用された
+        # bbox は黙って無視 (malformed でも 400 にしない — 使われないので)。
+        bbox: tuple[float, float, float, float] | None = None
+        if center is None and bbox_raw is not None:
+            # bbox は「矩形内の全 user の residence を一括取得」 する地理的総ざらい
+            # 列挙なので、 near_me と同様 **auth 必須** にする (privacy、 owner 判断
+            # 2026-05: anon の drive-by / scraper sweep を遮断。 occupation/text 検索は
+            # anon のまま)。 auth check を parse より先に置き、 anon は 401。
+            if not self.request.user.is_authenticated:
+                raise NotAuthenticated("bbox 検索には認証が必要です")
+            bbox = _parse_bbox(bbox_raw)
+            if bbox is None:
+                raise ValidationError(
+                    {
+                        "bbox": "bbox は 'south,west,north,east' の 4 値で、 "
+                        "lat∈[-90,90] / lng∈[-180,180] / south≤north が必要です"
+                    }
+                )
+
+        if center is None and not q and not occupation_slugs and bbox is None:
+            # q / near / occupation / bbox のどれも無ければ空配列 (P12-04 既存挙動)
             return User.objects.none()
 
-        qs = User.objects.filter(is_active=True)
+        # P12-08: serializer の residence / occupations field 用に JOIN/prefetch を
+        # 入れて N+1 を防ぐ。 全 branch (text / near / bbox) 共通。
+        qs = (
+            User.objects.filter(is_active=True)
+            .select_related("residence")
+            .prefetch_related("occupations")
+        )
         if q:
             qs = qs.filter(
                 Q(username__icontains=q) | Q(display_name__icontains=q) | Q(bio__icontains=q)
@@ -1036,6 +1112,19 @@ class UserFullTextSearchView(ListAPIView):
             qs = qs.filter(occupations__slug__in=occupation_slugs).distinct()
 
         if center is None:
+            # 地図 view (P12-08): bbox 内の residence を持つ user に絞る。
+            # lat/lng の範囲 lookup が residence を INNER JOIN するので未設定 user は
+            # 自動的に除外される (residence__isnull=False は冗長なので付けない、
+            # python-reviewer MEDIUM)。 self 除外は near と違い行わない (自分も地図に
+            # 出てよい)。 経度跨ぎは BETWEEN で結果 0 になるだけ。
+            if bbox is not None:
+                south, west, north, east = bbox
+                qs = qs.filter(
+                    residence__latitude__gte=south,
+                    residence__latitude__lte=north,
+                    residence__longitude__gte=west,
+                    residence__longitude__lte=east,
+                )
             return qs.order_by("username")
 
         # 近所検索: haversine SQL で distance を annotation

--- a/docs/specs/phase-12-residence-map-spec.md
+++ b/docs/specs/phase-12-residence-map-spec.md
@@ -293,7 +293,7 @@ PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/onboarding-
 5. ✅ **P12-03** (merged): signup wizard step 2 (居住地 prompt)
 6. ✅ **P12-06** (#815 backend / #818 frontend merged): `Occupation` model + 多選択編集 UI (本 spec §9)
 7. ✅ **P12-07** (#816 merged / PR #823, E2E hotfix #826): `/api/v1/users/search/?occupation=` filter + chip filter UI (本 spec §10、 stg E2E 4/4 pass、 gan-evaluator 8.0/10、 ui-ux-tester CRITICAL 0 → follow-up #827 / #828)
-8. **P12-08** (#817): `/search/users` に Leaflet 地図 view toggle (job filter と組み合わせ可能)
+8. **P12-08** (#817): `/search/users` に Leaflet 地図 view toggle + bbox query (本 spec §11、 backend=P12-08a / frontend=P12-08b の 2 PR)
 
 各段階で `gan-evaluator` agent に採点させて UX を確認 (新 route 追加なので Phase 11 同様の必須運用)。
 
@@ -557,4 +557,136 @@ filter できるようにする。 ハルナさん要望「職業がデザイナ
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/user-search-occupation.spec.ts
+```
+
+---
+
+## 11. 地図 view toggle + bbox query — P12-08 (#817)
+
+### 11.1 背景
+
+ハルナさん要望の最終形:「ユーザー検索で地図上で検索できる。 地図の上に検索欄があって、 職業がデザイナーの人を検索する」。 P12-06 (職業 model) / P12-07 (職業 filter) が揃ったので、 `/search/users` に **地図 view** を載せる。 地図上で職業 chip + bbox pan が効く。
+
+スコープを 2 PR に分割 (500 行 guideline + review 量):
+
+- **P12-08a (backend)**: search response に `residence` / `occupations` を追加 + `?bbox=` filter
+- **P12-08b (frontend)**: `UserMapView` + `SearchViewToggle` + page 統合 + E2E
+
+### 11.2 プライバシー設計 (最重要)
+
+- 地図に出すのは各 user が **自分で設定した residence の円** (中心 + 半径、 min 500m)。 P12-01 で既にピンポイント漏れは防いである (DB CheckConstraint で radius ≥ 500m)。
+- **中心 marker (ピン) は描かない**。 Circle (塗り) のみ。 ピンを描くと「ここに住んでいる」 と誤読されるため。 円の中心は user が粗く設定した点であって自宅ではない、 という P12-02 の設計を踏襲。
+- residence 未設定 user は **地図 view から除外** (bbox filter は residence INNER JOIN)。 list view には従来通り出る。
+
+### 11.3 API 仕様 (P12-08a)
+
+#### search response に residence / occupations を追加
+
+`UserFullTextSerializer` (`GET /api/v1/users/search/`) に nested field を追加:
+
+```jsonc
+{
+	"user_id": "...",
+	"username": "...",
+	"display_name": "...",
+	"bio": "...",
+	"avatar_url": "...",
+	"distance_km": null,
+	"residence": {
+		"latitude": "35.681236",
+		"longitude": "139.767125",
+		"radius_m": 500,
+	}, // 未設定なら null
+	"occupations": [{ "slug": "designer", "display_name": "デザイナー" }], // 空配列可
+}
+```
+
+- `residence` は `select_related("residence")` で N+1 回避。 未設定は `null`。
+- `occupations` は `prefetch_related("occupations")` で N+1 回避。 map の Circle 配色 + popup chip 用。
+- list view (既存) はこの 2 field を無視するだけ。 後方互換。
+
+#### `?bbox=south,west,north,east` filter
+
+> **privacy 判断 (council 2026-05)**: bbox は「矩形内の全 user の residence を一括取得」 する
+> **地理的総ざらい列挙**。 個々の円は 500m で粗いが、 occupation filter + 矩形 sweep で
+> 「この界隈の designer を全部出す」 ができてしまう。 anon の drive-by / scraper sweep を
+> 防ぐため、 **bbox は near_me と同様 auth 必須** にする (occupation/text 検索は anon のまま)。
+> 「profile で公開済」 ≠ 「地図で sweep 列挙可」。
+
+| query                              | 意味                                                                    |
+| ---------------------------------- | ----------------------------------------------------------------------- |
+| `bbox=sw_lat,sw_lng,ne_lat,ne_lng` | residence center が矩形内の user のみ。 **auth 必須** (anon は 401)     |
+| `occupation` との併用              | AND (bbox 内 **かつ** その職業)                                         |
+| `q` との併用                       | AND                                                                     |
+| `near_me` / `near` との併用        | **near 系を優先** (bbox は無視)。 両方 distance/矩形 は UX 上両立しない |
+
+ルール:
+
+- **auth check を最優先**: anon が bbox を付けたら parse 前に **401** (near_me と一貫)。
+- 4 値 comma 区切り、 各 float、 `south ≤ north` / 緯度 ∈ [-90,90] / 経度 ∈ [-180,180]。 不正は **400**。
+- 経度の日付変更線跨ぎ (west > east) は MVP では非対応 (400 でなく east<west も許容し単純 `BETWEEN`、 跨ぎは結果 0 でよい)。 → シンプルに `latitude BETWEEN south AND north AND longitude BETWEEN west AND east`。
+- residence INNER JOIN (lat/lng の範囲 lookup が自動で INNER JOIN するので未設定 user は除外)、 self 除外は near と異なり **しない** (bbox は自分も地図に出てよい)。
+- `bbox` 単独 (q / near / occupation 無し) でも検索成立 (ただし auth 済み)。
+- 並びは `username` (距離概念が無いので proximity paginator は使わない)。
+- 結果上限の注意: bbox が広いと大量 hit しうる。 pagination (cursor, page_size=20) はそのまま効く。 frontend は「50 件超なら zoom in 促し」 を出すが、 **backend は通常 pagination で返す** (count を別途返さず、 frontend は 1 page 目 + `next` 有無で「多すぎ」 を判定)。
+
+### 11.4 frontend 設計 (P12-08b)
+
+- **`SearchViewToggle.tsx`**: list ↔ map の切替。 `role=switch` ではなく **2 つの `role=tab` / もしくは aria-pressed の toggle button 2 個** が素直 (#824 の議論を踏まえ button + `aria-pressed`)。 `?view=map` / `?view=list` (default list) を URL 同期。 keyboard 操作可。
+
+  > **scope 判断 (council 2026-05)**: **pan-to-update (地図 pan/zoom → `?bbox=` 再取得) は P12-08b では作らない**。
+  > MVP は「occupation chip で絞る → 該当 user の residence 円を地図に出す → tap でプロフィール」。
+  > 地図は**現在の検索結果 (text/occupation filter) を別レンダリングしたもの**で、 anon のまま動く
+  > (= owner 要望「地図で designer を探す」 を満たす)。 pan で矩形を sweep する「この area を検索」 機能は
+  > bbox endpoint (auth 必須) を使う **follow-up issue** に切り出す (debounce/race の複雑さ + privacy の
+  > sweep 面を分離)。 PR A の bbox endpoint は follow-up までは dormant (auth-gated)。
+
+- **`UserMapView.tsx`** (`next/dynamic` + `ssr:false`、 Leaflet):
+  - 描画対象は**現在の検索結果**(occupation/text filter 済み) のうち residence を持つ user。 bbox は使わない。
+  - 地図中心 / zoom は描画する円に **auto-fit** (`fitBounds`)。 結果 0 なら東京駅 default + 空 state 文言。
+  - 各 user の residence を `Circle` で描画。 配色は先頭 occupation の slug→色 (固定 palette、 無職業は neutral gray)。 **中心 marker は描かない** (§11.2)。
+  - Circle click → popup (display_name / @handle / occupation chip / 「プロフィールを見る」 link)。 ESC で閉じる。
+  - 職業 chip filter (`OccupationFilter`) は list/map 共通で上部に出す → map でも Circle が増減。
+- **`SearchViewToggle.tsx`**: list ↔ map の切替。 `aria-pressed` の toggle button 2 個。 `?view=map` / `?view=list` (default list) を URL 同期、 keyboard 操作可。
+- **a11y**: 地図は keyboard-only user に厳しいので **list view を常に並存** (toggle で戻れる)。 map view でも「一覧で見る」 link を出す (dead-end 回避)。
+- **TileLayer (`map/MapTileLayer.tsx` で集約)**: OSM 標準 URL を **env var (`NEXT_PUBLIC_MAP_TILE_URL` / attribution) で差し替え可能**にして 1 箇所に集約する (council 全員一致 — prod で OSM 規約に当たる前に MapTiler/Protomaps 等へ env 変更だけで swap できる seam を今作る)。 既存 `ResidenceCircleMap` のインライン URL も将来この集約に寄せる (本 PR では新規 map view のみ)。
+
+### 11.5 OSM タイル使用ポリシー
+
+OSM 公式タイルは production heavy traffic で規約違反になりうる。 MVP / stg は OSM 標準で OK。 prod DAU 増加時に Carto / Stadia / 自前 tile server に切替 (follow-up issue)。
+
+### 11.6 テスト
+
+#### backend pytest — `apps/users/tests/test_user_search_bbox.py` (P12-08a)
+
+| case                                      | 期待                                                    |
+| ----------------------------------------- | ------------------------------------------------------- |
+| anon の `?bbox=`                          | **401** (auth 必須、 sweep 列挙の privacy 防御)         |
+| (auth) `?bbox=` 内の residence user のみ  | 矩形内 user が出る、 矩形外は出ない                     |
+| (auth) residence 未設定 user は除外       | 未設定は結果に出ない                                    |
+| (auth) `?bbox=...&occupation=designer`    | bbox 内 AND designer                                    |
+| (auth) 不正 bbox (3値/非数値/範囲外/反転) | 400                                                     |
+| `?bbox=` + `?near_me=1`                   | near_me 優先 (bbox 無視、 distance 順)                  |
+| response に residence / occupations 含む  | residence={lat,lng,radius_m} or null、 occupations 配列 |
+| residence の N+1 が無い                   | `django_assert_max_num_queries` で query 数を bound     |
+
+#### frontend vitest (P12-08b)
+
+- `SearchViewToggle`: list/map click で `?view=` 同期、 `aria-pressed` 反映
+- `userSearch.ts`: `bbox` / `view` を query に織り込む (buildUserSearchParams 拡張)
+- `UserMapView`: react-leaflet を mock し、 residence ありの user 数だけ Circle、 未設定は描かない、 occupation 配色
+
+#### E2E — `client/e2e/user-search-map.spec.ts` (P12-08b)
+
+| ID    | 誰が | 何をする                                    | 何が見える                                     |
+| ----- | ---- | ------------------------------------------- | ---------------------------------------------- |
+| MAP-1 | anon | `/search/users?view=map` を開く             | `.leaflet-container` が描画される              |
+| MAP-2 | anon | list ↔ map toggle を keyboard で操作       | `?view=map` / `?view=list` が URL 同期         |
+| MAP-3 | anon | map view で職業 chip を選ぶ                 | `?occupation=` + `view=map` 維持、 Circle 増減 |
+| MAP-4 | anon | 地図 view から「一覧で見る」 で list へ戻る | list view に戻れる (dead-end 無し)             |
+
+実行:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://stg.codeplace.me npx playwright test e2e/user-search-map.spec.ts
 ```


### PR DESCRIPTION
## 概要

#817 (地図 view) の **backend 半分** (P12-08a)。 frontend 地図 view は後続 PR (P12-08b) で。 2 PR 分割は 500 行 guideline + review 量のため (P12-06 の #815/#818 と同じ方針)。

spec: [docs/specs/phase-12-residence-map-spec.md §11](https://github.com/haruna0712/claude-code/blob/main/docs/specs/phase-12-residence-map-spec.md)

## backend

- `UserFullTextSerializer` に `residence` ({lat,lng,radius_m} or null) と `occupations` ([{slug,display_name}]) を追加
  - `select_related("residence")` + `prefetch_related("occupations")` で N+1 回避 (全 path 共通)
  - list view は無視するだけ (後方互換)
- `?bbox=south,west,north,east` filter: residence center が矩形内の user (anon 可)
  - `q` / `occupation` とは AND、 不正 bbox は 400、 residence 未設定 user は除外 (INNER JOIN)
  - `near_me` / `near` 併用時は **near 優先** (bbox 無視)
- プライバシー: residence は min 500m の円。 ピンポイントではない (frontend で Circle のみ描画、 中心 marker 無し)

## テスト

- pytest `test_user_search_bbox.py` (9 case): 矩形内/外、 residence 未設定除外、 bbox AND occupation、 不正 bbox 400 (6 variant)、 near 優先、 residence/occupations response、 N+1 bound

## サブエージェントレビュー (直列)

- python-reviewer: **APPROVE** — 冗長 `residence__isnull=False` 削除、 str-type + near-path field の test 追加
- database-reviewer: **all NONE/LOW** — JOIN alias 単一 / DISTINCT+ORDER BY valid / N+1 無し / parameterized 確認。 lat/lng index は #825 に defer
- code-reviewer: **APPROVE** — `south>north` test case + docstring 追加

## follow-up

- bbox の btree index (residence > 5k 行時) → #825 に追記候補
- 地図 view 本体 (UserMapView / SearchViewToggle / E2E) → P12-08b で #817 を close

#817 (backend 部分)