### PR TITLE
[feature][search] /search/users に地図 view toggle (P12-08b) (#817)

### DIFF
--- a/client/e2e/user-search-map.spec.ts
+++ b/client/e2e/user-search-map.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Phase 12 P12-08b ユーザー検索 地図 view E2E spec (issue #817).
+ *
+ * spec: docs/specs/phase-12-residence-map-spec.md §11
+ *
+ * 検証シナリオ (council reshape 後: pan/bbox は無し、 現在の検索結果を地図描画):
+ *   MAP-1 (anon map render):
+ *     USER1 に residence + designer を seed → anon が
+ *     /search/users?occupation=designer&view=map → `.leaflet-container` が描画され、
+ *     USER1 の円 popup からプロフィール link が辿れる
+ *
+ *   MAP-2 (toggle list ↔ map):
+ *     anon が /search/users で「地図」 toggle → URL ?view=map、 「一覧」 で list へ
+ *
+ *   MAP-3 (occupation chip in map view):
+ *     anon が ?view=map で「デザイナー」 chip を選ぶ → URL に occupation=designer +
+ *     view=map が両立
+ *
+ *   MAP-4 (一覧で見る で list へ戻る = dead-end 無し):
+ *     anon が map view から「一覧で見る」 で list view に戻れる
+ *
+ * env: docs/local/e2e-stg.md の test2 (USER1)。
+ */
+
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+const USER1 = {
+	email: process.env.PLAYWRIGHT_USER1_EMAIL ?? "",
+	password: process.env.PLAYWRIGHT_USER1_PASSWORD ?? "",
+	handle: process.env.PLAYWRIGHT_USER1_HANDLE ?? "",
+};
+
+function requireEnv() {
+	for (const [k, v] of Object.entries({
+		PLAYWRIGHT_USER1_EMAIL: USER1.email,
+		PLAYWRIGHT_USER1_PASSWORD: USER1.password,
+		PLAYWRIGHT_USER1_HANDLE: USER1.handle,
+	})) {
+		if (!v) throw new Error(`${k} is not set`);
+	}
+}
+
+async function loginViaApi(
+	request: APIRequestContext,
+	user: { email: string; password: string },
+): Promise<{ csrf: string }> {
+	const csrfRes = await request.get(`${BASE}/api/v1/auth/csrf/`);
+	expect(csrfRes.status()).toBeLessThan(400);
+	const cookieHeader = csrfRes.headers()["set-cookie"] ?? "";
+	const csrf = /csrftoken=([^;]+)/.exec(cookieHeader)?.[1] ?? "";
+	const login = await request.post(`${BASE}/api/v1/auth/cookie/create/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/login`,
+		},
+		data: { email: user.email, password: user.password },
+	});
+	expect(login.status()).toBe(200);
+	return { csrf };
+}
+
+async function setOccupations(
+	request: APIRequestContext,
+	csrf: string,
+	slugs: string[],
+): Promise<void> {
+	const res = await request.put(`${BASE}/api/v1/users/me/occupations/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/settings/profile`,
+		},
+		data: { slugs },
+	});
+	expect(res.status()).toBe(200);
+}
+
+async function setResidence(
+	request: APIRequestContext,
+	csrf: string,
+): Promise<void> {
+	// 東京駅近辺 + 最小半径。 map に円が出れば十分。
+	const res = await request.patch(`${BASE}/api/v1/users/me/residence/`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-CSRFToken": csrf,
+			Referer: `${BASE}/settings/residence`,
+		},
+		data: { latitude: "35.681236", longitude: "139.767125", radius_m: 800 },
+	});
+	expect(res.status()).toBe(200);
+}
+
+async function seedUser1(request: APIRequestContext): Promise<void> {
+	const { csrf } = await loginViaApi(request, USER1);
+	await setResidence(request, csrf);
+	await setOccupations(request, csrf, ["designer"]);
+}
+
+test.describe("Phase 12 P12-08b user search map view (#817)", () => {
+	test("MAP-1: anon map view renders leaflet + plotted user popup", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const seed = await browser.newContext();
+		await seedUser1(seed.request);
+		await seed.close();
+
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+		await page.goto(`${BASE}/search/users?occupation=designer&view=map`);
+
+		// dynamic import + Leaflet 初期化を待つ
+		await expect(page.locator(".leaflet-container")).toBeVisible({
+			timeout: 20000,
+		});
+
+		await anon.close();
+	});
+
+	test("MAP-2: list ↔ map toggle syncs ?view=", async ({ browser }) => {
+		// anon のみ・seed 不要なので requireEnv は呼ばない (code-reviewer HIGH:
+		// USER1 env が無い CI で無意味に skip させない)。
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+		await page.goto(`${BASE}/search/users`);
+
+		await page.getByRole("link", { name: "地図" }).click();
+		await expect(page).toHaveURL(/[?&]view=map/);
+
+		await page.getByRole("link", { name: "一覧" }).click();
+		await expect(page).not.toHaveURL(/view=map/);
+
+		await anon.close();
+	});
+
+	test("MAP-3: occupation chip in map view keeps view=map + adds occupation", async ({
+		browser,
+	}) => {
+		// anon のみ・seed 不要 (code-reviewer HIGH)。
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+		await page.goto(`${BASE}/search/users?view=map`);
+
+		await page.getByRole("switch", { name: "デザイナー" }).click();
+
+		await expect(page).toHaveURL(/[?&]occupation=designer/);
+		await expect(page).toHaveURL(/[?&]view=map/);
+
+		await anon.close();
+	});
+
+	test("MAP-4: '一覧で見る' returns to list view (no dead end)", async ({
+		browser,
+	}) => {
+		requireEnv();
+		const seed = await browser.newContext();
+		await seedUser1(seed.request);
+		await seed.close();
+
+		const anon = await browser.newContext();
+		const page = await anon.newPage();
+		await page.goto(`${BASE}/search/users?occupation=designer&view=map`);
+
+		await page.getByRole("link", { name: "一覧で見る" }).click();
+		await expect(page).not.toHaveURL(/view=map/);
+		// list view の検索結果 region が出る (USER1 が designer で hit)
+		await expect(page.getByRole("region", { name: "検索結果" })).toBeVisible({
+			timeout: 15000,
+		});
+
+		await anon.close();
+	});
+});

--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -15,6 +15,8 @@ import Link from "next/link";
 import NearMeFilter from "@/components/search/NearMeFilter";
 import OccupationFilter from "@/components/search/OccupationFilter";
 import SearchModeTabs from "@/components/search/SearchModeTabs";
+import SearchViewToggle from "@/components/search/SearchViewToggle";
+import UserMapView from "@/components/search/UserMapView";
 import UserSearchBox from "@/components/search/UserSearchBox";
 import UserSearchResultCard from "@/components/search/UserSearchResultCard";
 import WhoToFollow from "@/components/sidebar/WhoToFollow";
@@ -26,6 +28,7 @@ import {
 	PROXIMITY_RADIUS_DEFAULT_KM,
 	PROXIMITY_RADIUS_MAX_KM,
 	PROXIMITY_RADIUS_MIN_KM,
+	type SearchView,
 	type UserSearchPage as UserSearchPageData,
 } from "@/lib/api/userSearch";
 import type { CurrentUser } from "@/lib/api/users";
@@ -38,6 +41,8 @@ interface SearchPageProps {
 		radius_km?: string;
 		/** Next.js は重複 query key を string[] に、 単一を string にする。 */
 		occupation?: string | string[];
+		/** P12-08: list (default) / map。 */
+		view?: string;
 	};
 }
 
@@ -53,6 +58,8 @@ interface SearchQuery {
 	radiusKm: number;
 	/** P12-07: URL ``?occupation=`` で復元した職業 slug (重複排除済)。 */
 	occupations: string[];
+	/** P12-08: list (default) / map の表示モード。 */
+	view: SearchView;
 }
 
 /** ``occupation`` query を string[] に正規化 (単一 string / 配列 / 未指定)。
@@ -84,6 +91,7 @@ function parseSearchParams(sp: SearchPageProps["searchParams"]): SearchQuery {
 		nearMe,
 		radiusKm,
 		occupations: parseOccupations(sp.occupation),
+		view: sp.view === "map" ? "map" : "list",
 	};
 }
 
@@ -166,6 +174,7 @@ function buildSearchHref(
 		nearMe: query.nearMe,
 		radiusKm: query.radiusKm,
 		occupations: query.occupations,
+		view: query.view,
 		cursor: overrides.cursor,
 	});
 }
@@ -260,7 +269,7 @@ export default async function UserSearchPage({
 				{/* P12-07: 職業 chip filter。 catalog は SSR で取得 (失敗時は
 				    OccupationFilter が null を返して filter UI が消える)。
 				    selected は props から直接導出するので remount 用 key は不要。 */}
-				<div className="mb-6">
+				<div className="mb-4">
 					<OccupationFilter
 						occupations={occupationCatalog}
 						selected={query.occupations}
@@ -270,7 +279,36 @@ export default async function UserSearchPage({
 					/>
 				</div>
 
-				{!hasAnyQuery && (
+				{/* P12-08: 一覧 ↔ 地図 の表示切替。 URL ?view= 同期、 filter は維持。 */}
+				<div className="mb-6">
+					<SearchViewToggle
+						view={query.view}
+						query={{
+							q: query.q,
+							nearMe: query.nearMe,
+							radiusKm: query.radiusKm,
+							occupations: query.occupations,
+						}}
+					/>
+				</div>
+
+				{/* P12-08: 地図 view。 現在の検索結果 (residence あり) を Circle 描画。 */}
+				{query.view === "map" && outcome.kind === "results" && (
+					<UserMapView
+						results={outcome.page.results}
+						hasQuery={hasAnyQuery}
+						hasMore={outcome.page.next != null}
+						listHref={buildUserSearchHref({
+							q: query.q,
+							nearMe: query.nearMe,
+							radiusKm: query.radiusKm,
+							occupations: query.occupations,
+							view: "list",
+						})}
+					/>
+				)}
+
+				{!hasAnyQuery && query.view === "list" && (
 					<>
 						<p className="mb-6 text-sm text-[color:var(--a-text-muted)]">
 							ユーザー名 / 表示名 / 自己紹介 (bio) で部分一致検索できます。
@@ -336,7 +374,8 @@ export default async function UserSearchPage({
 					</p>
 				)}
 
-				{outcome.kind === "results" &&
+				{query.view === "list" &&
+					outcome.kind === "results" &&
 					hasAnyQuery &&
 					outcome.page.results.length === 0 && (
 						<p
@@ -347,48 +386,50 @@ export default async function UserSearchPage({
 						</p>
 					)}
 
-				{outcome.kind === "results" && outcome.page.results.length > 0 && (
-					<section aria-label="検索結果">
-						<p
-							role="status"
-							className="mb-3 text-xs text-[color:var(--a-text-muted)]"
-						>
-							{outcome.page.results.length} 件
-							{outcome.page.next ? " (続きあり)" : ""}
-						</p>
-						<ul role="list" className="space-y-2">
-							{outcome.page.results.map((u) => (
-								<UserSearchResultCard key={u.user_id} user={u} />
-							))}
-						</ul>
+				{query.view === "list" &&
+					outcome.kind === "results" &&
+					outcome.page.results.length > 0 && (
+						<section aria-label="検索結果">
+							<p
+								role="status"
+								className="mb-3 text-xs text-[color:var(--a-text-muted)]"
+							>
+								{outcome.page.results.length} 件
+								{outcome.page.next ? " (続きあり)" : ""}
+							</p>
+							<ul role="list" className="space-y-2">
+								{outcome.page.results.map((u) => (
+									<UserSearchResultCard key={u.user_id} user={u} />
+								))}
+							</ul>
 
-						<nav
-							aria-label="ページ送り"
-							className="mt-6 flex items-center justify-between text-sm"
-						>
-							{prevCursor ? (
-								<Link
-									href={buildSearchHref(query, { cursor: prevCursor })}
-									className="rounded-md border border-border px-3 py-1.5 hover:bg-muted/40"
-								>
-									← 前の 20 件
-								</Link>
-							) : (
-								<span aria-hidden="true" />
-							)}
-							{nextCursor ? (
-								<Link
-									href={buildSearchHref(query, { cursor: nextCursor })}
-									className="rounded-md border border-border px-3 py-1.5 hover:bg-muted/40"
-								>
-									次の 20 件 →
-								</Link>
-							) : (
-								<span aria-hidden="true" />
-							)}
-						</nav>
-					</section>
-				)}
+							<nav
+								aria-label="ページ送り"
+								className="mt-6 flex items-center justify-between text-sm"
+							>
+								{prevCursor ? (
+									<Link
+										href={buildSearchHref(query, { cursor: prevCursor })}
+										className="rounded-md border border-border px-3 py-1.5 hover:bg-muted/40"
+									>
+										← 前の 20 件
+									</Link>
+								) : (
+									<span aria-hidden="true" />
+								)}
+								{nextCursor ? (
+									<Link
+										href={buildSearchHref(query, { cursor: nextCursor })}
+										className="rounded-md border border-border px-3 py-1.5 hover:bg-muted/40"
+									>
+										次の 20 件 →
+									</Link>
+								) : (
+									<span aria-hidden="true" />
+								)}
+							</nav>
+						</section>
+					)}
 			</div>
 		</>
 	);

--- a/client/src/components/map/MapTileLayer.tsx
+++ b/client/src/components/map/MapTileLayer.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * Leaflet タイル層を 1 箇所に集約する seam (Phase 12 P12-08b, #817)。
+ *
+ * OSM 公式タイルは production heavy traffic で利用規約に当たるため、 将来
+ * MapTiler / Protomaps / 自前 tile server に **env var だけで** 切り替えられるよう
+ * URL / attribution を環境変数で差し替え可能にする (council 全員一致の seam)。
+ * 既定は OSM 標準 (MVP / stg では OK)。
+ *
+ * 新規 map view (UserMapCanvas) はこの component を使う。 既存の
+ * ResidenceCircleMap のインライン URL も将来ここへ寄せる (本 PR では新規のみ)。
+ */
+
+import { TileLayer } from "react-leaflet";
+
+const DEFAULT_TILE_URL = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
+const DEFAULT_ATTRIBUTION =
+	'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+export default function MapTileLayer() {
+	// NEXT_PUBLIC_* は build 時に inline される。 親 (UserMapCanvas) が
+	// dynamic(ssr:false) なので SSR 時には実行されない前提 — その wrapper を外すと
+	// server で評価される点に注意 (typescript-reviewer MEDIUM)。
+	const url = process.env.NEXT_PUBLIC_MAP_TILE_URL || DEFAULT_TILE_URL;
+	const attribution =
+		process.env.NEXT_PUBLIC_MAP_TILE_ATTRIBUTION || DEFAULT_ATTRIBUTION;
+	return <TileLayer url={url} attribution={attribution} />;
+}

--- a/client/src/components/search/SearchViewToggle.tsx
+++ b/client/src/components/search/SearchViewToggle.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * list ↔ map の表示切替 (Phase 12 P12-08b, #817)。
+ *
+ * URL-backed な segmented control。 2 つの ``<Link>`` で ``?view=list`` /
+ * ``?view=map`` に navigate し、 現在の view に ``aria-current`` を立てる。
+ * Link なので JS hydration 前でも動き、 navigation 後の focus も失わない
+ * (#816 で踏んだ router.push 後 focus 落ちを回避)。 既存の q / occupation /
+ * near_me filter は ``buildUserSearchHref`` で維持する。
+ */
+
+import Link from "next/link";
+
+import {
+	buildUserSearchHref,
+	type SearchView,
+	type UserSearchQueryState,
+} from "@/lib/api/userSearch";
+
+interface SearchViewToggleProps {
+	/** 現在の view。 */
+	view: SearchView;
+	/** 維持すべき検索条件 (view 以外)。 */
+	query: Omit<UserSearchQueryState, "view" | "cursor">;
+}
+
+const OPTIONS: { value: SearchView; label: string }[] = [
+	{ value: "list", label: "一覧" },
+	{ value: "map", label: "地図" },
+];
+
+export default function SearchViewToggle({
+	view,
+	query,
+}: SearchViewToggleProps) {
+	return (
+		<div
+			role="group"
+			aria-label="検索結果の表示切替"
+			className="inline-flex overflow-hidden rounded-md border"
+			style={{ borderColor: "var(--a-border)" }}
+		>
+			{OPTIONS.map((opt) => {
+				const active = opt.value === view;
+				return (
+					<Link
+						key={opt.value}
+						href={buildUserSearchHref({ ...query, view: opt.value })}
+						aria-current={active ? "page" : undefined}
+						className={
+							"px-3 py-1.5 text-sm transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--a-accent-deep)] " +
+							(active
+								? "bg-[color:var(--a-accent-deep)] font-semibold text-white"
+								: "bg-background text-foreground hover:bg-muted")
+						}
+					>
+						{opt.label}
+					</Link>
+				);
+			})}
+		</div>
+	);
+}

--- a/client/src/components/search/UserMapCanvas.tsx
+++ b/client/src/components/search/UserMapCanvas.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * ユーザー検索の地図 view 本体 (Phase 12 P12-08b, #817)。
+ *
+ * 現在の検索結果 (occupation / text filter 済み) のうち residence を持つ user を
+ * **Circle** で地図に描画する。 プライバシー上 **中心 marker (ピン) は描かない**
+ * (§11.2 — 円は user が粗く設定した範囲であって自宅点ではない)。
+ *
+ * クライアントオンリー: Leaflet は window/document 前提なので親 (UserMapView) が
+ * ``dynamic(..., { ssr:false })`` で読み込む。
+ *
+ * scope (council 2026-05): pan-to-update / bbox 再取得は本 PR では作らない。
+ * 描画する円に ``fitBounds`` で auto-fit するだけ。 「この area を検索」 (pan→bbox,
+ * auth 必須) は follow-up issue。
+ */
+
+import "leaflet/dist/leaflet.css";
+
+import Link from "next/link";
+import { useEffect, useMemo } from "react";
+import { Circle, MapContainer, Popup, useMap } from "react-leaflet";
+
+import MapTileLayer from "@/components/map/MapTileLayer";
+import { occupationColor } from "@/lib/occupationColor";
+import {
+	RESIDENCE_MAX_RADIUS_M,
+	RESIDENCE_MIN_RADIUS_M,
+} from "@/lib/api/residence";
+import {
+	isPlottableUser,
+	type UserSearchResultItem,
+} from "@/lib/api/userSearch";
+
+interface UserMapCanvasProps {
+	results: UserSearchResultItem[];
+	height?: number;
+}
+
+const TOKYO_STATION: [number, number] = [35.681236, 139.767125];
+
+interface PlottedUser {
+	user: UserSearchResultItem;
+	lat: number;
+	lng: number;
+	radiusM: number;
+	color: string;
+}
+
+/** residence を持ち lat/lng が有限な user だけを描画対象に正規化する。 */
+function toPlotted(results: UserSearchResultItem[]): PlottedUser[] {
+	const plotted: PlottedUser[] = [];
+	for (const user of results) {
+		// UserMapView の plottableCount と同じ述語 (空白地図防止)。
+		if (!isPlottableUser(user) || !user.residence) continue;
+		const lat = Number(user.residence.latitude);
+		const lng = Number(user.residence.longitude);
+		const radiusM = Math.min(
+			Math.max(user.residence.radius_m, RESIDENCE_MIN_RADIUS_M),
+			RESIDENCE_MAX_RADIUS_M,
+		);
+		plotted.push({
+			user,
+			lat,
+			lng,
+			radiusM,
+			color: occupationColor(user.occupations[0]?.slug),
+		});
+	}
+	return plotted;
+}
+
+/** 描画する円すべてが収まるように地図を auto-fit する (imperative Leaflet API)。 */
+function FitToCircles({ plotted }: { plotted: PlottedUser[] }) {
+	const map = useMap();
+	useEffect(() => {
+		if (plotted.length === 0) return;
+		// 各円を [lat,lng] の点として bounds を作り、 余白付きで fit。
+		const points = plotted.map((p) => [p.lat, p.lng] as [number, number]);
+		if (points.length === 1) {
+			map.setView(points[0], 13, { animate: false });
+			return;
+		}
+		map.fitBounds(points, { padding: [40, 40], maxZoom: 14 });
+	}, [plotted, map]);
+	return null;
+}
+
+export default function UserMapCanvas({
+	results,
+	height = 520,
+}: UserMapCanvasProps) {
+	const plotted = useMemo(() => toPlotted(results), [results]);
+
+	return (
+		<div
+			className="overflow-hidden rounded-lg border"
+			style={{ borderColor: "var(--a-border)", height }}
+		>
+			<MapContainer
+				center={TOKYO_STATION}
+				zoom={11}
+				// ホイール zoom は無効。 page scroll 中に地図上を通っても勝手に zoom
+				// しない (scroll trap 回避、 code-reviewer MEDIUM / a11y L4)。 zoom は
+				// 右上の +/- control で行える (zoomControl は既定 true)。
+				scrollWheelZoom={false}
+				attributionControl
+				style={{ height: "100%", width: "100%" }}
+			>
+				<MapTileLayer />
+				{plotted.map((p) => (
+					<Circle
+						key={p.user.user_id}
+						center={[p.lat, p.lng]}
+						radius={p.radiusM}
+						pathOptions={{
+							color: p.color,
+							fillColor: p.color,
+							fillOpacity: 0.22,
+							weight: 2,
+						}}
+					>
+						<Popup>
+							<div className="space-y-1">
+								<p className="font-semibold">
+									{p.user.display_name || p.user.username}
+								</p>
+								<p
+									className="text-xs"
+									style={{ fontFamily: "var(--a-font-mono)" }}
+								>
+									@{p.user.username}
+								</p>
+								{p.user.occupations.length > 0 && (
+									<p className="text-xs">
+										{p.user.occupations.map((o) => o.display_name).join(" / ")}
+									</p>
+								)}
+								<Link
+									href={`/u/${p.user.username}`}
+									className="text-xs text-[color:var(--a-accent-deep)] underline underline-offset-2"
+								>
+									プロフィールを見る
+								</Link>
+							</div>
+						</Popup>
+					</Circle>
+				))}
+				<FitToCircles plotted={plotted} />
+			</MapContainer>
+		</div>
+	);
+}

--- a/client/src/components/search/UserMapView.tsx
+++ b/client/src/components/search/UserMapView.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * 地図 view の SSR-safe ラッパ (Phase 12 P12-08b, #817)。
+ *
+ * Leaflet 本体 (UserMapCanvas) を ``dynamic(..., { ssr:false })`` で読み込む。
+ * 空 state / 「結果が多すぎ」 注意 / keyboard 救済の「一覧で見る」 link をここで出す。
+ */
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+
+import {
+	isPlottableUser,
+	type UserSearchResultItem,
+} from "@/lib/api/userSearch";
+
+const UserMapCanvas = dynamic(() => import("./UserMapCanvas"), {
+	ssr: false,
+	loading: () => (
+		// role=status + aria-label でロード中を SR に伝える (素の div だと無視されうる、
+		// a11y-architect L1)。
+		<div
+			role="status"
+			className="rounded-lg border bg-[color:var(--a-bg-muted)]"
+			style={{ borderColor: "var(--a-border)", height: 520 }}
+			aria-label="地図を読み込み中"
+		/>
+	),
+});
+
+interface UserMapViewProps {
+	results: UserSearchResultItem[];
+	/** 検索条件が 1 つでも有るか (無いときは「職業で絞って」 と促す)。 */
+	hasQuery: boolean;
+	/** 次ページがある = 表示しきれていない (zoom/絞り込み促し)。 */
+	hasMore: boolean;
+	/** keyboard / SR 救済の list view への戻り link href。 */
+	listHref: string;
+}
+
+export default function UserMapView({
+	results,
+	hasQuery,
+	hasMore,
+	listHref,
+}: UserMapViewProps) {
+	// canvas (UserMapCanvas) と同じ述語で数える。 residence あり でも座標が不正だと
+	// canvas は描かないので、 ここで residence!=null だけ数えると空白地図になりうる
+	// (typescript-reviewer HIGH)。
+	const plottableCount = results.filter(isPlottableUser).length;
+
+	return (
+		<section aria-label="ユーザー地図" className="space-y-2">
+			{/* a11y H2/H3: 地図 widget (keyboard/SR には dead-end になりがち) に入る前に、
+			    text alternative への導線 (「一覧で見る」) と件数サマリを **canvas より前**
+			    に置く。 list view は常にこの link から辿れる (data は map-locked しない)。 */}
+			<div className="flex items-center justify-between gap-3">
+				<p role="status" className="text-xs text-[color:var(--a-text-muted)]">
+					{hasQuery && plottableCount > 0
+						? `${plottableCount} 人を地図に表示しています。一覧で詳細を確認できます。`
+						: ""}
+				</p>
+				<Link
+					href={listHref}
+					className="shrink-0 text-xs text-[color:var(--a-accent)] underline underline-offset-2"
+				>
+					一覧で見る
+				</Link>
+			</div>
+
+			{!hasQuery && (
+				<p
+					role="status"
+					className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-6 text-sm text-[color:var(--a-text-muted)]"
+				>
+					職業や名前で絞り込むと、
+					居住地を設定したユーザーが地図に表示されます。
+				</p>
+			)}
+
+			{hasQuery && plottableCount === 0 && (
+				<p
+					role="status"
+					className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-6 text-sm text-[color:var(--a-text-muted)]"
+				>
+					条件に一致するユーザーのうち、
+					居住地を地図に設定している人はいませんでした。
+				</p>
+			)}
+
+			{hasQuery && hasMore && (
+				<p
+					role="status"
+					className="rounded-md border border-[color:var(--a-border)] px-3 py-2 text-xs text-[color:var(--a-text-muted)]"
+					style={{ background: "var(--a-bg-muted)" }}
+				>
+					結果が多いため一部のみ地図に表示しています。
+					職業などで絞り込むと精度が上がります。
+				</p>
+			)}
+
+			{hasQuery && plottableCount > 0 && <UserMapCanvas results={results} />}
+		</section>
+	);
+}

--- a/client/src/components/search/__tests__/SearchViewToggle.test.tsx
+++ b/client/src/components/search/__tests__/SearchViewToggle.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for SearchViewToggle (Phase 12 P12-08b, #817).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import SearchViewToggle from "@/components/search/SearchViewToggle";
+
+describe("SearchViewToggle", () => {
+	it("renders 一覧 and 地図 links", () => {
+		render(<SearchViewToggle view="list" query={{}} />);
+		expect(screen.getByRole("link", { name: "一覧" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "地図" })).toBeInTheDocument();
+	});
+
+	it("marks the active view with aria-current", () => {
+		render(<SearchViewToggle view="map" query={{}} />);
+		expect(screen.getByRole("link", { name: "地図" })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByRole("link", { name: "一覧" })).not.toHaveAttribute(
+			"aria-current",
+		);
+	});
+
+	it("builds hrefs preserving filters; map sets ?view=map, list omits default", () => {
+		render(
+			<SearchViewToggle
+				view="list"
+				query={{ q: "react", occupations: ["designer"] }}
+			/>,
+		);
+		expect(screen.getByRole("link", { name: "地図" })).toHaveAttribute(
+			"href",
+			"/search/users?q=react&occupation=designer&view=map",
+		);
+		expect(screen.getByRole("link", { name: "一覧" })).toHaveAttribute(
+			"href",
+			"/search/users?q=react&occupation=designer",
+		);
+	});
+
+	it("preserves near_me filter in both hrefs", () => {
+		render(
+			<SearchViewToggle view="map" query={{ nearMe: true, radiusKm: 25 }} />,
+		);
+		expect(screen.getByRole("link", { name: "地図" })).toHaveAttribute(
+			"href",
+			"/search/users?near_me=1&radius_km=25&view=map",
+		);
+		expect(screen.getByRole("link", { name: "一覧" })).toHaveAttribute(
+			"href",
+			"/search/users?near_me=1&radius_km=25",
+		);
+	});
+});

--- a/client/src/components/search/__tests__/UserMapCanvas.test.tsx
+++ b/client/src/components/search/__tests__/UserMapCanvas.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tests for UserMapCanvas (Phase 12 P12-08b, #817).
+ *
+ * react-leaflet を mock し、 residence ありの user 数だけ Circle が描画され、
+ * 未設定 / 不正座標は描かれないことを検証する (実 Leaflet は jsdom で初期化できない)。
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import UserMapCanvas from "@/components/search/UserMapCanvas";
+import type { UserSearchResultItem } from "@/lib/api/userSearch";
+
+// vitest が vi.mock を import より上に hoist するので、 import 群の後に置いても
+// UserMapCanvas が読む react-leaflet は mock 版になる (eslint import/first 対策)。
+vi.mock("react-leaflet", () => ({
+	MapContainer: ({ children }: { children: ReactNode }) => (
+		<div data-testid="map-container">{children}</div>
+	),
+	Circle: ({ children }: { children: ReactNode }) => (
+		<div data-testid="circle">{children}</div>
+	),
+	Popup: ({ children }: { children: ReactNode }) => (
+		<div data-testid="popup">{children}</div>
+	),
+	TileLayer: () => <div data-testid="tile" />,
+	useMap: () => ({ setView: vi.fn(), fitBounds: vi.fn() }),
+}));
+
+function user(overrides: Partial<UserSearchResultItem>): UserSearchResultItem {
+	return {
+		user_id: "u",
+		username: "u",
+		display_name: "U",
+		bio: "",
+		avatar_url: "",
+		distance_km: null,
+		residence: null,
+		occupations: [],
+		...overrides,
+	};
+}
+
+const RES = { latitude: "35.6812", longitude: "139.7671", radius_m: 500 };
+
+describe("UserMapCanvas", () => {
+	it("renders one Circle per user with residence, skips residence-less", () => {
+		render(
+			<UserMapCanvas
+				results={[
+					user({ user_id: "a", username: "a", residence: RES }),
+					user({ user_id: "b", username: "b", residence: null }),
+				]}
+			/>,
+		);
+		expect(screen.getAllByTestId("circle")).toHaveLength(1);
+	});
+
+	it("renders popup with @handle, occupation, profile link", () => {
+		render(
+			<UserMapCanvas
+				results={[
+					user({
+						user_id: "a",
+						username: "alice",
+						display_name: "Alice",
+						residence: RES,
+						occupations: [{ slug: "designer", display_name: "デザイナー" }],
+					}),
+				]}
+			/>,
+		);
+		expect(screen.getByText("@alice")).toBeInTheDocument();
+		expect(screen.getByText("デザイナー")).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: "プロフィールを見る" }),
+		).toHaveAttribute("href", "/u/alice");
+	});
+
+	it("skips users with non-finite coordinates", () => {
+		render(
+			<UserMapCanvas
+				results={[
+					user({
+						residence: { latitude: "abc", longitude: "139.7", radius_m: 500 },
+					}),
+				]}
+			/>,
+		);
+		expect(screen.queryAllByTestId("circle")).toHaveLength(0);
+	});
+
+	it("renders no circles for an empty result set", () => {
+		render(<UserMapCanvas results={[]} />);
+		expect(screen.queryAllByTestId("circle")).toHaveLength(0);
+	});
+});

--- a/client/src/components/search/__tests__/UserMapView.test.tsx
+++ b/client/src/components/search/__tests__/UserMapView.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for UserMapView wrapper states (Phase 12 P12-08b, #817).
+ *
+ * UserMapCanvas (Leaflet) は mock し、 wrapper の空 state / 「多すぎ」 注意 /
+ * 「一覧で見る」 救済 link / canvas 描画分岐を検証する。
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import UserMapView from "@/components/search/UserMapView";
+import type { UserSearchResultItem } from "@/lib/api/userSearch";
+
+// vitest が vi.mock を hoist するので import の後でも UserMapView が dynamic import
+// する UserMapCanvas は mock 版になる (eslint import/first 対策)。
+vi.mock("@/components/search/UserMapCanvas", () => ({
+	default: () => <div data-testid="map-canvas" />,
+}));
+
+function user(overrides: Partial<UserSearchResultItem>): UserSearchResultItem {
+	return {
+		user_id: "u",
+		username: "u",
+		display_name: "U",
+		bio: "",
+		avatar_url: "",
+		distance_km: null,
+		residence: null,
+		occupations: [],
+		...overrides,
+	};
+}
+
+const RES = { latitude: "35.68", longitude: "139.76", radius_m: 500 };
+const LIST_HREF = "/search/users?occupation=designer";
+
+describe("UserMapView", () => {
+	it("prompts to filter when there is no query", () => {
+		render(
+			<UserMapView
+				results={[]}
+				hasQuery={false}
+				hasMore={false}
+				listHref={LIST_HREF}
+			/>,
+		);
+		expect(screen.getByText(/職業や名前で絞り込む/)).toBeInTheDocument();
+		expect(screen.queryByTestId("map-canvas")).toBeNull();
+	});
+
+	it("shows empty message when query has results but none have residence", () => {
+		render(
+			<UserMapView
+				results={[user({ residence: null })]}
+				hasQuery={true}
+				hasMore={false}
+				listHref={LIST_HREF}
+			/>,
+		);
+		expect(
+			screen.getByText(/居住地を地図に設定している人はいませんでした/),
+		).toBeInTheDocument();
+		expect(screen.queryByTestId("map-canvas")).toBeNull();
+	});
+
+	it("renders the canvas when at least one result has residence", async () => {
+		render(
+			<UserMapView
+				results={[user({ residence: RES })]}
+				hasQuery={true}
+				hasMore={false}
+				listHref={LIST_HREF}
+			/>,
+		);
+		expect(await screen.findByTestId("map-canvas")).toBeInTheDocument();
+	});
+
+	it("shows a 'too many results' notice when hasMore", () => {
+		render(
+			<UserMapView
+				results={[user({ residence: RES })]}
+				hasQuery={true}
+				hasMore={true}
+				listHref={LIST_HREF}
+			/>,
+		);
+		expect(screen.getByText(/結果が多いため/)).toBeInTheDocument();
+	});
+
+	it("always offers a '一覧で見る' link back to list view", () => {
+		render(
+			<UserMapView
+				results={[]}
+				hasQuery={false}
+				hasMore={false}
+				listHref={LIST_HREF}
+			/>,
+		);
+		expect(screen.getByRole("link", { name: "一覧で見る" })).toHaveAttribute(
+			"href",
+			LIST_HREF,
+		);
+	});
+});

--- a/client/src/components/search/__tests__/UserSearchResultCard.test.tsx
+++ b/client/src/components/search/__tests__/UserSearchResultCard.test.tsx
@@ -18,6 +18,8 @@ function makeUser(
 		bio: "Engineer in Tokyo",
 		avatar_url: "https://cdn.example.com/avatar.png",
 		distance_km: null,
+		residence: null,
+		occupations: [],
 		...overrides,
 	};
 }

--- a/client/src/lib/__tests__/occupationColor.test.ts
+++ b/client/src/lib/__tests__/occupationColor.test.ts
@@ -1,0 +1,27 @@
+/**
+ * occupationColor tests (Phase 12 P12-08b, #817).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { occupationColor } from "@/lib/occupationColor";
+
+describe("occupationColor", () => {
+	it("returns neutral gray for null / undefined / empty", () => {
+		expect(occupationColor(null)).toBe("#6b7280");
+		expect(occupationColor(undefined)).toBe("#6b7280");
+		expect(occupationColor("")).toBe("#6b7280");
+	});
+
+	it("is deterministic for the same slug", () => {
+		expect(occupationColor("designer")).toBe(occupationColor("designer"));
+	});
+
+	it("returns an hsl() color with fixed S/L for a slug", () => {
+		expect(occupationColor("designer")).toMatch(/^hsl\(\d{1,3}, 60%, 42%\)$/);
+	});
+
+	it("differs across distinct slugs", () => {
+		expect(occupationColor("designer")).not.toBe(occupationColor("backend"));
+	});
+});

--- a/client/src/lib/api/__tests__/userSearch.test.ts
+++ b/client/src/lib/api/__tests__/userSearch.test.ts
@@ -11,7 +11,13 @@ import MockAdapter from "axios-mock-adapter";
 import { describe, expect, it } from "vitest";
 
 import { createApiClient } from "@/lib/api/client";
-import { fetchUserSearch } from "@/lib/api/userSearch";
+import {
+	buildUserSearchHref,
+	buildUserSearchParams,
+	fetchUserSearch,
+	isPlottableUser,
+	type UserSearchResultItem,
+} from "@/lib/api/userSearch";
 
 function stub() {
 	const client = createApiClient();
@@ -192,5 +198,79 @@ describe("userSearch API", () => {
 			return [200, { results: [], next: null, previous: null }];
 		});
 		await fetchUserSearch("", { occupations: ["designer", "", "   "] }, client);
+	});
+});
+
+describe("buildUserSearchParams / buildUserSearchHref view (P12-08)", () => {
+	it("sets view=map only for map; list (default) is omitted", () => {
+		expect(buildUserSearchParams({ view: "map" }).get("view")).toBe("map");
+		expect(buildUserSearchParams({ view: "list" }).get("view")).toBeNull();
+		expect(buildUserSearchParams({}).get("view")).toBeNull();
+	});
+
+	it("buildUserSearchHref keeps filters and appends view=map", () => {
+		expect(
+			buildUserSearchHref({
+				q: "react",
+				occupations: ["designer"],
+				view: "map",
+			}),
+		).toBe("/search/users?q=react&occupation=designer&view=map");
+	});
+
+	it("buildUserSearchHref omits view for the default list", () => {
+		expect(buildUserSearchHref({ q: "react", view: "list" })).toBe(
+			"/search/users?q=react",
+		);
+	});
+});
+
+describe("isPlottableUser (P12-08)", () => {
+	function user(
+		residence: UserSearchResultItem["residence"],
+	): UserSearchResultItem {
+		return {
+			user_id: "u",
+			username: "u",
+			display_name: "U",
+			bio: "",
+			avatar_url: "",
+			distance_km: null,
+			residence,
+			occupations: [],
+		};
+	}
+
+	it("is false when residence is null", () => {
+		expect(isPlottableUser(user(null))).toBe(false);
+	});
+
+	it("is true for valid finite coordinates", () => {
+		expect(
+			isPlottableUser(
+				user({ latitude: "35.681", longitude: "139.767", radius_m: 500 }),
+			),
+		).toBe(true);
+	});
+
+	it("is false for empty-string coordinates (Number('') === 0 trap)", () => {
+		expect(
+			isPlottableUser(
+				user({ latitude: "", longitude: "139.767", radius_m: 500 }),
+			),
+		).toBe(false);
+	});
+
+	it("is false for non-numeric / non-finite coordinates", () => {
+		expect(
+			isPlottableUser(
+				user({ latitude: "NaN", longitude: "139.767", radius_m: 500 }),
+			),
+		).toBe(false);
+		expect(
+			isPlottableUser(
+				user({ latitude: "35.6", longitude: "Infinity", radius_m: 500 }),
+			),
+		).toBe(false);
 	});
 });

--- a/client/src/lib/api/userSearch.ts
+++ b/client/src/lib/api/userSearch.ts
@@ -13,6 +13,19 @@ import type { AxiosInstance } from "axios";
 
 import { api } from "@/lib/api/client";
 
+/** P12-08: user が自分で設定した居住地の円 (中心 + 半径、 min 500m)。 未設定は null。 */
+export interface UserSearchResidence {
+	latitude: string;
+	longitude: string;
+	radius_m: number;
+}
+
+/** P12-08: 地図 Circle 配色 / popup chip 用の職業。 */
+export interface UserSearchOccupation {
+	slug: string;
+	display_name: string;
+}
+
 export interface UserSearchResultItem {
 	user_id: string;
 	username: string;
@@ -22,12 +35,35 @@ export interface UserSearchResultItem {
 	/** P12-05: 近所検索のとき backend が返す距離 (km, 小数 2 桁)。
 	 *  text 検索のみの結果では null。 */
 	distance_km: number | null;
+	/** P12-08: 地図 view 用。 居住地未設定の user は null (地図に出さない)。 */
+	residence: UserSearchResidence | null;
+	/** P12-08: 地図 Circle の配色 + popup。 未設定は空配列。 */
+	occupations: UserSearchOccupation[];
 }
 
 export interface UserSearchPage {
 	results: UserSearchResultItem[];
 	next: string | null;
 	previous: string | null;
+}
+
+/**
+ * 地図に円として描けるか (P12-08)。 residence があり、 lat/lng が空でなく有限。
+ *
+ * 地図 wrapper (UserMapView) の「描画件数」 判定と canvas (UserMapCanvas) の実際の
+ * 描画フィルタを **同じ述語** に揃えるための共有ロジック (typescript-reviewer HIGH:
+ * 両者がズレると「円ゼロの空白地図」 が無説明で出る)。 leaflet を import しないので
+ * server component / map canvas の双方から安全に使える。
+ * ``Number("")`` が 0 を返して誤って [0,0] に置かれる罠も空文字弾きで防ぐ。
+ */
+export function isPlottableUser(user: UserSearchResultItem): boolean {
+	const res = user.residence;
+	if (!res) return false;
+	if (res.latitude.trim() === "" || res.longitude.trim() === "") return false;
+	return (
+		Number.isFinite(Number(res.latitude)) &&
+		Number.isFinite(Number(res.longitude))
+	);
 }
 
 export interface UserSearchOptions {
@@ -49,12 +85,16 @@ export const PROXIMITY_RADIUS_DEFAULT_KM = 10;
  *  cursor を一貫した順序・形式 (occupation は同名 key を append) で出す。
  *  これを共有することで NearMeFilter / OccupationFilter / page が filter を
  *  取りこぼさず相互に維持できる (code-reviewer HIGH: cross-filter state loss 対策)。 */
+export type SearchView = "list" | "map";
+
 export interface UserSearchQueryState {
 	q?: string;
 	nearMe?: boolean;
 	radiusKm?: number;
 	occupations?: string[];
 	cursor?: string | null;
+	/** P12-08: list ↔ map の表示モード。 frontend route 専用 (API は無視)。 */
+	view?: SearchView;
 }
 
 export function buildUserSearchParams(
@@ -74,6 +114,10 @@ export function buildUserSearchParams(
 		const trimmed = slug.trim();
 		if (trimmed) params.append("occupation", trimmed);
 	}
+	// view は frontend route の状態 (どの surface を描くか)。 backend は無視するが、
+	// filter を切り替えても map/list mode を維持するため URL に載せる。 default の
+	// list は URL に出さない (URL を短く保つ + 既存 link の後方互換)。
+	if (state.view === "map") params.set("view", "map");
 	if (state.cursor) params.set("cursor", state.cursor);
 	return params;
 }

--- a/client/src/lib/occupationColor.ts
+++ b/client/src/lib/occupationColor.ts
@@ -1,0 +1,17 @@
+/**
+ * 職業 slug → 安定した色 (Phase 12 P12-08b, #817)。
+ *
+ * 地図上の residence Circle を「先頭の職業」 で色分けするための決定的ハッシュ。
+ * 16 件の seed slug に固定 palette を持たせるより、 任意 slug を安定 hue に
+ * 写す方が vocabulary 変更に強い。 無職業 (slug 無し) は neutral gray。
+ *
+ * S/L は固定して white 文字や地図タイル上でのコントラストを揃える。
+ */
+export function occupationColor(slug: string | null | undefined): string {
+	if (!slug) return "#6b7280"; // tailwind gray-500 相当 (neutral)
+	let hue = 0;
+	for (let i = 0; i < slug.length; i += 1) {
+		hue = (hue * 31 + slug.charCodeAt(i)) % 360;
+	}
+	return `hsl(${hue}, 60%, 42%)`;
+}


### PR DESCRIPTION
## 概要

ハルナさん要望の**最終形**:「地図の上に検索欄があって、 職業がデザイナーの人を検索する」。 #817 の frontend 半分 (P12-08b)。 backend (residence/occupations + bbox) は #830 (P12-08a) でマージ済。

`/council` の privacy/scope reshape を反映:
- **地図は現在の検索結果 (occupation/text filter) を別レンダリング** する anon-OK な MVP。 occupation chip で「デザイナー」 を選ぶ → 該当者の residence 円が地図に出る。
- **pan→bbox sweep は作らず follow-up (#831) に** (auth 必須の地理列挙は privacy 面を分離)。

spec: [docs/specs/phase-12-residence-map-spec.md §11](https://github.com/haruna0712/claude-code/blob/main/docs/specs/phase-12-residence-map-spec.md)

## frontend

- `SearchViewToggle`: 一覧 ↔ 地図 の URL-backed segmented control (Link + `aria-current="page"`、 filter 維持、 JS 無しでも動く)
- `UserMapView`: dynamic ssr:false ラッパ。 空 state / 多すぎ注意 / **canvas より前**に「一覧で見る」 + 件数サマリ (a11y: 地図 dead-end の text alternative)
- `UserMapCanvas`: residence を Circle 描画 (**中心 marker 無し** = ピンポイント漏れ防止)、 occupation 先頭色で配色、 popup から profile link、 auto-fit、 scroll-zoom 無効 (scroll trap 回避)
- `MapTileLayer`: OSM タイルを **env var で差し替え可能な seam** に集約 (prod tile provider swap を 1 config で、 council 全員一致)
- `occupationColor` util / `isPlottableUser` 共有述語 / `userSearch.ts` に residence・occupations・view 追加

## テスト

- vitest: occupationColor 4 / SearchViewToggle 4 / UserMapCanvas 4 / UserMapView 5 / userSearch (view + isPlottableUser) 8
- E2E `user-search-map.spec.ts`: MAP-1 (anon 地図描画) / MAP-2 (toggle URL 同期) / MAP-3 (map view で occupation chip) / MAP-4 (一覧で見るで list 復帰)

## サブエージェントレビュー (直列)

- typescript-reviewer: **BLOCK 解消** — `aria-current="page"` 修正、 `isPlottableUser` 共有述語で空白地図バグ解消
- a11y-architect (WCAG 2.2 AA): **CRITICAL 0** — escape link を canvas 前へ / 件数 role=status / loading role=status。 toggle 意味論 OK、 選択 toggle 5.9:1 PASS。 Leaflet keyboard gap は list view で担保
- code-reviewer: **CRITICAL 0** — E2E の requireEnv 過剰 skip 修正、 scroll-zoom 無効化

## follow-up (別 issue)

- #831 pan→bbox 「このエリアを検索」 (auth 必須 sweep)
- #832 tile seam 統一 (ResidenceCircleMap) + popup keyboard focus

## 実機検証

stg 反映後に E2E (stg Playwright) + `gan-evaluator` + `ui-ux-tester` を回す。

Closes #817