### PR TITLE
fix(search): 地図 view で filter 操作すると list に戻る regression (#817)

### DIFF
--- a/client/e2e/user-search-map.spec.ts
+++ b/client/e2e/user-search-map.spec.ts
@@ -128,10 +128,12 @@ test.describe("Phase 12 P12-08b user search map view (#817)", () => {
 		const page = await anon.newPage();
 		await page.goto(`${BASE}/search/users`);
 
-		await page.getByRole("link", { name: "地図" }).click();
+		// exact:true で toggle の「一覧」/「地図」 を、 map view の「一覧で見る」 escape
+		// link と区別する (後者は部分一致で「一覧」 にもマッチするため)。
+		await page.getByRole("link", { name: "地図", exact: true }).click();
 		await expect(page).toHaveURL(/[?&]view=map/);
 
-		await page.getByRole("link", { name: "一覧" }).click();
+		await page.getByRole("link", { name: "一覧", exact: true }).click();
 		await expect(page).not.toHaveURL(/view=map/);
 
 		await anon.close();

--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -249,7 +249,7 @@ export default async function UserSearchPage({
 					ユーザー名、表示名、自己紹介で検索します。投稿を探す場合は「投稿」タブに切り替えてください。
 				</p>
 				<div className="mb-3">
-					<UserSearchBox initialValue={query.q} />
+					<UserSearchBox initialValue={query.q} view={query.view} />
 				</div>
 				<div className="mb-6">
 					{/* key で URL 状態が変わるたびに NearMeFilter を remount し、
@@ -263,6 +263,7 @@ export default async function UserSearchPage({
 						initialRadiusKm={query.radiusKm}
 						loggedIn={loggedIn}
 						occupations={query.occupations}
+						view={query.view}
 					/>
 				</div>
 
@@ -276,6 +277,7 @@ export default async function UserSearchPage({
 						query={query.q}
 						nearMe={query.nearMe}
 						radiusKm={query.radiusKm}
+						view={query.view}
 					/>
 				</div>
 

--- a/client/src/components/search/NearMeFilter.tsx
+++ b/client/src/components/search/NearMeFilter.tsx
@@ -22,6 +22,7 @@ import {
 	PROXIMITY_RADIUS_DEFAULT_KM,
 	PROXIMITY_RADIUS_MAX_KM,
 	PROXIMITY_RADIUS_MIN_KM,
+	type SearchView,
 } from "@/lib/api/userSearch";
 
 interface NearMeFilterProps {
@@ -33,6 +34,8 @@ interface NearMeFilterProps {
 	/** P12-07: 併存する職業 filter。 near_me toggle / slider 操作で取りこぼさず
 	 *  URL を維持する (code-reviewer HIGH: cross-filter state loss 対策)。 */
 	occupations?: string[];
+	/** P12-08: 現在の表示モード。 near_me toggle で list/map を維持する。 */
+	view?: SearchView;
 }
 
 export default function NearMeFilter({
@@ -41,6 +44,7 @@ export default function NearMeFilter({
 	initialRadiusKm,
 	loggedIn,
 	occupations = [],
+	view,
 }: NearMeFilterProps) {
 	const router = useRouter();
 	const [nearMe, setNearMe] = useState(initialNearMe);
@@ -53,6 +57,7 @@ export default function NearMeFilter({
 				nearMe: next.nearMe,
 				radiusKm: next.radiusKm,
 				occupations,
+				view,
 			}),
 		);
 	}
@@ -87,7 +92,7 @@ export default function NearMeFilter({
 				{!loggedIn && (
 					<Link
 						href={`/login?next=${encodeURIComponent(
-							buildUserSearchHref({ q: query, occupations }),
+							buildUserSearchHref({ q: query, occupations, view }),
 						)}`}
 						className="rounded-md border border-[color:var(--a-border)] px-2 py-1 text-[color:var(--a-text-muted)] underline-offset-2 hover:underline"
 						style={{ fontSize: 11.5 }}

--- a/client/src/components/search/OccupationFilter.tsx
+++ b/client/src/components/search/OccupationFilter.tsx
@@ -23,7 +23,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 
 import type { Occupation } from "@/lib/api/occupation";
-import { buildUserSearchHref } from "@/lib/api/userSearch";
+import { buildUserSearchHref, type SearchView } from "@/lib/api/userSearch";
 
 interface OccupationFilterProps {
 	/** GET /api/v1/occupations/ の catalog (is_active のみ、 display_order 順)。 */
@@ -35,6 +35,9 @@ interface OccupationFilterProps {
 	/** 併存する近所検索 state (URL 維持用)。 */
 	nearMe: boolean;
 	radiusKm: number;
+	/** P12-08: 現在の表示モード。 chip toggle で list/map を維持する
+	 *  (地図 view で chip を押すと list に戻る regression を防ぐ)。 */
+	view?: SearchView;
 }
 
 export default function OccupationFilter({
@@ -43,6 +46,7 @@ export default function OccupationFilter({
 	query,
 	nearMe,
 	radiusKm,
+	view,
 }: OccupationFilterProps) {
 	const router = useRouter();
 
@@ -79,6 +83,7 @@ export default function OccupationFilter({
 				nearMe,
 				radiusKm,
 				occupations: nextOccupations,
+				view,
 			}),
 			{ scroll: false },
 		);

--- a/client/src/components/search/UserSearchBox.tsx
+++ b/client/src/components/search/UserSearchBox.tsx
@@ -10,12 +10,18 @@
 import { useRouter } from "next/navigation";
 import { type FormEvent, useState } from "react";
 
+import { buildUserSearchHref, type SearchView } from "@/lib/api/userSearch";
+
 interface UserSearchBoxProps {
 	initialValue?: string;
+	/** P12-08: 現在の表示モード。 検索 submit で list/map を維持する
+	 *  (地図 view で検索すると list に戻る regression を防ぐ)。 */
+	view?: SearchView;
 }
 
 export default function UserSearchBox({
 	initialValue = "",
+	view,
 }: UserSearchBoxProps) {
 	const router = useRouter();
 	const [value, setValue] = useState(initialValue);
@@ -23,11 +29,8 @@ export default function UserSearchBox({
 	const onSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		const trimmed = value.trim();
-		if (!trimmed) {
-			router.push("/search/users");
-			return;
-		}
-		router.push(`/search/users?q=${encodeURIComponent(trimmed)}`);
+		// view を維持して navigate。 occupation / near_me の維持は別 issue (#827)。
+		router.push(buildUserSearchHref({ q: trimmed, view }));
 	};
 
 	return (

--- a/client/src/components/search/__tests__/OccupationFilter.test.tsx
+++ b/client/src/components/search/__tests__/OccupationFilter.test.tsx
@@ -79,6 +79,15 @@ describe("OccupationFilter", () => {
 		});
 	});
 
+	it("preserves view=map when toggling a chip in map view (P12-08 regression)", () => {
+		renderFilter({ view: "map" });
+		fireEvent.click(screen.getByRole("switch", { name: "デザイナー" }));
+		expect(mockPush).toHaveBeenCalledWith(
+			"/search/users?occupation=designer&view=map",
+			{ scroll: false },
+		);
+	});
+
 	it("adds a second occupation while keeping the first (OR set)", () => {
 		renderFilter({ selected: ["designer"] });
 		fireEvent.click(screen.getByRole("switch", { name: "フロントエンド" }));

--- a/client/src/components/search/__tests__/UserSearchBox.test.tsx
+++ b/client/src/components/search/__tests__/UserSearchBox.test.tsx
@@ -45,13 +45,17 @@ describe("UserSearchBox", () => {
 		expect(mockPush).toHaveBeenCalledWith("/search/users");
 	});
 
-	it("encodes special characters in the URL", async () => {
+	it("encodes special characters in the URL (decodes back to the input)", async () => {
 		render(<UserSearchBox />);
 		await userEvent.type(screen.getByRole("searchbox"), "山田 太郎");
 		fireEvent.submit(screen.getByRole("search"));
 		const target = mockPush.mock.calls[0]?.[0] ?? "";
 		expect(target).toContain("/search/users?q=");
-		expect(target).toContain(encodeURIComponent("山田 太郎"));
+		// URLSearchParams で組み立てるため space は `+` 表現になる。 具体的な
+		// エンコード形式ではなく「decode すると元の値に戻る」 契約を検証する
+		// (backend / URLSearchParams は `+` も `%20` も space として解釈)。
+		const q = new URLSearchParams(target.split("?")[1] ?? "").get("q");
+		expect(q).toBe("山田 太郎");
 	});
 
 	it("enforces maxLength=100 on the input", () => {


### PR DESCRIPTION
## 背景

#817 (PR #833) の地図 view を stg で E2E 実行したら **MAP-3 で発覚**: `/search/users?view=map` で職業 chip を押すと `OccupationFilter` が `view` を引き継がず **list view に戻ってしまう**。 #816 で踏んだ cross-filter state loss の `view` 版。

## 修正

- `OccupationFilter` / `NearMeFilter` / `UserSearchBox` に `view` prop を追加し、 `buildUserSearchHref` へ渡す → 全 filter 操作が現在の表示モード (list/map) を維持
- `page.tsx` から `query.view` を 3 component に伝搬
- vitest: OccupationFilter に「map view で chip を押しても view=map 維持」 regression test
- e2e MAP-2: toggle の「一覧」「地図」 を `exact:true` で map view の「一覧で見る」 escape link と区別 (strict-mode violation 修正)

## 検証

修正後 stg で `e2e/user-search-map.spec.ts` 4/4 green を再確認予定 (本 PR merge → CD 反映後)。

## スコープ外

`UserSearchBox` submit が occupation/near_me を落とす件は **pre-existing** で #827 (filter UX polish) に委譲。 本 fix は `view` 維持に限定。

#817 follow-up (regression fix)