### PR TITLE
fix(search): 地図 view の UX polish (ui-ux-tester / gan-evaluator) (#817)

### DIFF
--- a/client/src/app/(template)/search/users/page.tsx
+++ b/client/src/app/(template)/search/users/page.tsx
@@ -251,7 +251,9 @@ export default async function UserSearchPage({
 				<div className="mb-3">
 					<UserSearchBox initialValue={query.q} view={query.view} />
 				</div>
-				<div className="mb-6">
+				{/* mb-3 で filter 群の rhythm を揃える (ui-ux-tester MEDIUM:
+				    near→chips が 68px で浮いていた)。 */}
+				<div className="mb-3">
 					{/* key で URL 状態が変わるたびに NearMeFilter を remount し、
 					    `useState(initialXxx)` の初回 seed を最新値に強制する
 					    (typescript-reviewer HIGH 修正、 client component が

--- a/client/src/components/search/UserMapView.tsx
+++ b/client/src/components/search/UserMapView.tsx
@@ -54,36 +54,34 @@ export default function UserMapView({
 		<section aria-label="ユーザー地図" className="space-y-2">
 			{/* a11y H2/H3: 地図 widget (keyboard/SR には dead-end になりがち) に入る前に、
 			    text alternative への導線 (「一覧で見る」) と件数サマリを **canvas より前**
-			    に置く。 list view は常にこの link から辿れる (data は map-locked しない)。 */}
-			<div className="flex items-center justify-between gap-3">
-				<p role="status" className="text-xs text-[color:var(--a-text-muted)]">
-					{hasQuery && plottableCount > 0
-						? `${plottableCount} 人を地図に表示しています。一覧で詳細を確認できます。`
-						: ""}
-				</p>
-				<Link
-					href={listHref}
-					className="shrink-0 text-xs text-[color:var(--a-accent)] underline underline-offset-2"
-				>
-					一覧で見る
-				</Link>
-			</div>
+			    に置く。 検索条件が無いとき (= 地図も無い) は逃げ先が無いので row ごと隠す
+			    (ui-ux-tester: orphan link 回避)。 count summary だけ role=status を残し、
+			    静的な guidance 文は live region にしない (ui-ux-tester / a11y M6)。 */}
+			{hasQuery && (
+				<div className="flex items-center justify-between gap-3">
+					<p role="status" className="text-xs text-[color:var(--a-text-muted)]">
+						{plottableCount > 0
+							? `${plottableCount} 人を地図に表示しています。一覧で詳細を確認できます。`
+							: ""}
+					</p>
+					<Link
+						href={listHref}
+						className="shrink-0 py-2 text-xs text-[color:var(--a-accent)] underline underline-offset-2"
+					>
+						一覧で見る
+					</Link>
+				</div>
+			)}
 
 			{!hasQuery && (
-				<p
-					role="status"
-					className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-6 text-sm text-[color:var(--a-text-muted)]"
-				>
+				<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-6 text-sm text-[color:var(--a-text-muted)]">
 					職業や名前で絞り込むと、
 					居住地を設定したユーザーが地図に表示されます。
 				</p>
 			)}
 
 			{hasQuery && plottableCount === 0 && (
-				<p
-					role="status"
-					className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-6 text-sm text-[color:var(--a-text-muted)]"
-				>
+				<p className="rounded-lg border border-dashed border-[color:var(--a-border)] px-4 py-6 text-sm text-[color:var(--a-text-muted)]">
 					条件に一致するユーザーのうち、
 					居住地を地図に設定している人はいませんでした。
 				</p>
@@ -91,7 +89,6 @@ export default function UserMapView({
 
 			{hasQuery && hasMore && (
 				<p
-					role="status"
 					className="rounded-md border border-[color:var(--a-border)] px-3 py-2 text-xs text-[color:var(--a-text-muted)]"
 					style={{ background: "var(--a-bg-muted)" }}
 				>

--- a/client/src/components/search/__tests__/UserMapView.test.tsx
+++ b/client/src/components/search/__tests__/UserMapView.test.tsx
@@ -87,11 +87,11 @@ describe("UserMapView", () => {
 		expect(screen.getByText(/結果が多いため/)).toBeInTheDocument();
 	});
 
-	it("always offers a '一覧で見る' link back to list view", () => {
+	it("offers a '一覧で見る' link back to list view when a query is active", () => {
 		render(
 			<UserMapView
-				results={[]}
-				hasQuery={false}
+				results={[user({ residence: RES })]}
+				hasQuery={true}
 				hasMore={false}
 				listHref={LIST_HREF}
 			/>,
@@ -100,5 +100,17 @@ describe("UserMapView", () => {
 			"href",
 			LIST_HREF,
 		);
+	});
+
+	it("hides the '一覧で見る' link when there is no query (no map to escape)", () => {
+		render(
+			<UserMapView
+				results={[]}
+				hasQuery={false}
+				hasMore={false}
+				listHref={LIST_HREF}
+			/>,
+		);
+		expect(screen.queryByRole("link", { name: "一覧で見る" })).toBeNull();
 	});
 });


### PR DESCRIPTION
## 背景

#817 地図 view を stg で `gan-evaluator` (8.0/10 PASS) + `ui-ux-tester` (CRITICAL 0) に通した結果の cheap polish。 ship blocker は無し。

## 修正

- **「一覧で見る」 escape link の tap target 拡大** (`py-2`): 18px → WCAG 2.5.5 AA の 24px 以上 (ui-ux-tester HIGH)
- **orphan escape link 解消**: 検索条件が無い (= 地図も無い) ときは escape row ごと非表示 (ui-ux-tester MEDIUM)
- **role=status を整理**: 静的 guidance 文から外し、 件数 summary のみ live region に (ui-ux-tester / a11y-architect: SSR static 文を live region 化しない)
- **filter spacing 統一**: near→chips の 68px 浮きを `mb-3` で揃える (ui-ux-tester MEDIUM)
- vitest: 「一覧で見る」 を query あり時のみ出す / 無し時は出さない の 2 ケースに更新

## follow-up に回した残り

- **mobile chip stack が地図を押し下げる** (375px で map が y=942、 ui-ux-tester HIGH) → #827 (filter UX polish、 mobile chip layout)
- **occupation 色 legend / circle 視認性 / map 高さ responsive** (gan-evaluator + ui-ux-tester MEDIUM/LOW) → #831 (map follow-up)

#817 follow-up (UX polish)